### PR TITLE
feat: UI/UX enhancement — red design system, nav overhaul, per-event judge management

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { logout, whoami } from './utils/api'
-import { useAuthStore, getActiveEvent } from './utils/auth'
+import { useAuthStore } from './utils/auth'
 import ActionDoneModal from './views/ActionDoneModal.vue'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -62,7 +62,7 @@ const logoutNow = async () => {
   authStore.logout()
 }
 
-const activeEvent = ref(getActiveEvent())
+const activeEvent = computed(() => authStore.activeEvent)
 const eventMenuOpen = ref(false)
 
 function changeEvent() {
@@ -73,6 +73,15 @@ function changeEvent() {
 function goToSection(routeName) {
   eventMenuOpen.value = false
   router.push({ name: routeName })
+}
+
+function goToEventDetails() {
+  eventMenuOpen.value = false
+  if (activeEvent.value) router.push({
+    name: 'Event Details',
+    params: { eventName: activeEvent.value.name },
+    query: activeEvent.value.folderID ? { folderID: activeEvent.value.folderID } : {}
+  })
 }
 
 // ── Theme ───────────────────────────────────────────────────────────────────
@@ -95,7 +104,6 @@ function toggleTheme() {
 watch(route, () => {
   isOpen.value = false
   eventMenuOpen.value = false
-  activeEvent.value = getActiveEvent()
 })
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
@@ -185,6 +193,11 @@ onMounted(async () => {
                   <p class="text-sm font-semibold text-content-primary truncate">{{ activeEvent.name }}</p>
                 </div>
                 <div class="py-1">
+                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+                    @click="goToEventDetails"
+                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+                    <i class="pi pi-info-circle text-xs w-4"></i> Event Details
+                  </button>
                   <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
                     @click="goToSection('Audition List')"
                     class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
@@ -296,6 +309,11 @@ onMounted(async () => {
               <p class="text-[10px] font-bold uppercase tracking-widest text-content-muted">Current Event</p>
               <p class="text-sm font-semibold text-primary-400 truncate">{{ activeEvent.name }}</p>
             </div>
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+              @click="goToEventDetails"
+              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+              <i class="pi pi-info-circle w-4 text-content-muted"></i> Event Details
+            </button>
             <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
               @click="goToSection('Audition List')"
               class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -63,9 +63,16 @@ const logoutNow = async () => {
 }
 
 const activeEvent = ref(getActiveEvent())
+const eventMenuOpen = ref(false)
 
 function changeEvent() {
-  router.push({ name: 'EventSelector' })
+  eventMenuOpen.value = false
+  router.push({ name: 'EventSelector', query: { redirect: router.currentRoute.value.fullPath } })
+}
+
+function goToSection(routeName) {
+  eventMenuOpen.value = false
+  router.push({ name: routeName })
 }
 
 // ── Theme ───────────────────────────────────────────────────────────────────
@@ -87,6 +94,7 @@ function toggleTheme() {
 // ── Watchers ───────────────────────────────────────────────────────────────
 watch(route, () => {
   isOpen.value = false
+  eventMenuOpen.value = false
   activeEvent.value = getActiveEvent()
 })
 
@@ -115,200 +123,130 @@ onMounted(async () => {
            transition-all duration-300"
   >
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between items-center h-16">
+      <div class="grid grid-cols-[auto_1fr_auto] items-center h-16 gap-4">
 
-        <!-- Logo -->
+        <!-- Left: Logo -->
         <router-link to="/" class="flex items-center gap-2 group flex-shrink-0">
-          <div
-            class="w-8 h-8 rounded-lg bg-primary-500 text-white
-                   flex items-center justify-center font-anton text-xl
-                   group-hover:scale-105 transition-transform duration-200"
-            style="box-shadow: 0 0 12px rgba(6,182,212,0.4);"
-          >B</div>
-          <span class="font-anton text-2xl text-content-primary tracking-wide translate-y-[2px]">
-            BES
-          </span>
+          <div class="w-8 h-8 rounded-lg bg-primary-500 text-white flex items-center justify-center font-anton text-xl group-hover:scale-105 transition-transform duration-200"
+            style="box-shadow: 0 0 12px rgba(6,182,212,0.4);">B</div>
+          <span class="font-anton text-2xl text-content-primary tracking-wide translate-y-[2px]">BES</span>
         </router-link>
 
-        <!-- Desktop Nav Links -->
-        <div class="hidden md:flex md:items-center md:gap-1 lg:gap-1.5">
-
+        <!-- Center: Primary nav -->
+        <div class="hidden md:flex items-center justify-center gap-1">
           <router-link to="/" v-slot="{ isActive }">
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                     transition-all duration-200 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]'
-                : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'"
-            >
+            <span class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer"
+              :class="isActive ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]' : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'">
               <i class="pi pi-home text-xs"></i> Home
             </span>
           </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-            to="/events"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                     transition-all duration-200 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]'
-                : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'"
-            >
+          <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
+            <span class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer"
+              :class="isActive ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]' : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'">
               <i class="pi pi-calendar text-xs"></i> Events
             </span>
           </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-            to="/event/update-event-details"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                     transition-all duration-200 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]'
-                : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-users text-xs"></i> Participants
-            </span>
-          </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
-            to="/event/audition-list"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                     transition-all duration-200 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]'
-                : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-list text-xs"></i> Audition
-            </span>
-          </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_EMCEE' || role === 'ROLE_ORGANISER'"
-            to="/event/score"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                     transition-all duration-200 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]'
-                : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-chart-bar text-xs"></i> Scoreboard
-            </span>
-          </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-            to="/battle/control"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                     transition-all duration-200 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]'
-                : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-bolt text-xs"></i> Battle
-            </span>
-          </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN'"
-            to="/admin"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                     transition-all duration-200 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]'
-                : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'"
-            >
+          <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
+            <span class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer"
+              :class="isActive ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]' : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'">
               <i class="pi pi-cog text-xs"></i> Admin
             </span>
           </router-link>
-
         </div>
 
-        <!-- Desktop Right: Event Chip + Role Badge + Auth -->
-        <div class="hidden md:flex items-center gap-3">
+        <!-- Right: Event chip + utilities -->
+        <div class="hidden md:flex items-center gap-2">
 
-          <!-- Active event chip -->
-          <button
-            v-if="isAuthenticated && activeEvent"
-            @click="changeEvent"
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full
-                   bg-surface-700 border border-surface-600 text-content-secondary
-                   text-xs font-medium hover:bg-primary-100 hover:border-primary-500/50
-                   hover:text-primary-400 transition-all duration-200 max-w-[160px]"
-            title="Click to change event"
-          >
-            <i class="pi pi-calendar-clock text-xs flex-shrink-0"></i>
-            <span class="truncate">{{ activeEvent.name }}</span>
-            <i class="pi pi-chevron-down text-xs flex-shrink-0 opacity-60"></i>
-          </button>
+          <!-- Active event dropdown -->
+          <div v-if="isAuthenticated && activeEvent" class="relative">
+            <button @click="eventMenuOpen = !eventMenuOpen"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full
+                     bg-surface-700 border border-surface-600 text-content-secondary
+                     text-xs font-medium hover:bg-surface-600 hover:border-primary-500/50
+                     hover:text-primary-400 transition-all duration-200 max-w-[180px]">
+              <i class="pi pi-calendar-clock text-xs flex-shrink-0"></i>
+              <span class="truncate">{{ activeEvent.name }}</span>
+              <i class="pi pi-chevron-down text-xs flex-shrink-0 opacity-60 transition-transform duration-200"
+                 :class="eventMenuOpen ? 'rotate-180' : ''"></i>
+            </button>
 
-          <!-- Role badge — single neutral style for all roles; label is the differentiator -->
-          <span
-            v-if="isAuthenticated && roleDisplay"
-            class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold
-                   bg-surface-700 text-content-secondary border border-surface-600"
-          >
+            <Transition
+              enter-active-class="transition duration-150 ease-out"
+              enter-from-class="opacity-0 translate-y-1"
+              enter-to-class="opacity-100 translate-y-0"
+              leave-active-class="transition duration-100 ease-in"
+              leave-from-class="opacity-100 translate-y-0"
+              leave-to-class="opacity-0 translate-y-1"
+            >
+              <div v-if="eventMenuOpen"
+                class="absolute right-0 top-full mt-2 w-48 z-50 bg-surface-800 border border-surface-600/60 rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden">
+                <div class="px-3 py-2.5 border-b border-surface-700/60">
+                  <p class="text-[10px] font-bold uppercase tracking-widest text-content-muted mb-0.5">Current Event</p>
+                  <p class="text-sm font-semibold text-content-primary truncate">{{ activeEvent.name }}</p>
+                </div>
+                <div class="py-1">
+                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
+                    @click="goToSection('Audition List')"
+                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+                    <i class="pi pi-list text-xs w-4"></i> Audition
+                  </button>
+                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+                    @click="goToSection('Update Event Details')"
+                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+                    <i class="pi pi-users text-xs w-4"></i> Participants
+                  </button>
+                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'"
+                    @click="goToSection('Score')"
+                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+                    <i class="pi pi-chart-bar text-xs w-4"></i> Scoreboard
+                  </button>
+                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+                    @click="goToSection('Battle Control')"
+                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+                    <i class="pi pi-bolt text-xs w-4"></i> Battle
+                  </button>
+                </div>
+                <div class="border-t border-surface-700/60 py-1">
+                  <button @click="changeEvent"
+                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-muted hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+                    <i class="pi pi-refresh text-xs w-4"></i> Change Event
+                  </button>
+                </div>
+              </div>
+            </Transition>
+            <div v-if="eventMenuOpen" class="fixed inset-0 z-40" @click="eventMenuOpen = false"></div>
+          </div>
+
+          <!-- Divider -->
+          <div v-if="isAuthenticated" class="h-5 w-px bg-surface-600/60"></div>
+
+          <!-- Role badge -->
+          <span v-if="isAuthenticated && roleDisplay"
+            class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-surface-700 text-content-secondary border border-surface-600">
             {{ roleDisplay.label }}
           </span>
 
           <!-- Theme toggle -->
-          <button
-            @click="toggleTheme"
-            class="inline-flex items-center justify-center w-9 h-9 rounded-lg
-                   text-content-muted hover:text-content-primary hover:bg-surface-700
-                   transition-all duration-200"
-            :title="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'"
-          >
+          <button @click="toggleTheme"
+            class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-content-muted hover:text-content-primary hover:bg-surface-700 transition-all duration-200">
             <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
           </button>
 
           <router-link v-if="!isAuthenticated" to="/login">
-            <span
-              class="px-4 py-2 rounded-lg text-sm font-semibold text-white
-                     bg-primary-500 hover:bg-primary-600 transition-colors shadow-sm cursor-pointer btn-glow"
-            >
-              Login
-            </span>
+            <span class="px-4 py-2 rounded-lg text-sm font-semibold text-white bg-primary-500 hover:bg-primary-600 transition-colors shadow-sm cursor-pointer btn-glow">Login</span>
           </router-link>
 
-          <button
-            v-if="isAuthenticated"
+          <button v-if="isAuthenticated"
             @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
-            class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium
-                   text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200"
-          >
-            <i class="pi pi-sign-out text-xs"></i>
-            <span>Logout</span>
+            class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200"
+            title="Logout">
+            <i class="pi pi-sign-out text-sm"></i>
           </button>
-
         </div>
 
         <!-- Mobile Hamburger -->
-        <button
-          @click="isOpen = !isOpen"
-          class="md:hidden inline-flex items-center justify-center w-9 h-9 rounded-lg
-                 text-content-muted hover:text-content-primary hover:bg-surface-700
-                 transition-colors focus:outline-none"
-        >
+        <button @click="isOpen = !isOpen"
+          class="md:hidden inline-flex items-center justify-center w-9 h-9 rounded-lg text-content-muted hover:text-content-primary hover:bg-surface-700 transition-colors focus:outline-none">
           <i class="pi text-lg" :class="isOpen ? 'pi-times' : 'pi-bars'"></i>
         </button>
 
@@ -329,176 +267,82 @@ onMounted(async () => {
         class="md:hidden border-t border-surface-600/30
                bg-surface-900/98 backdrop-blur-md shadow-lg"
       >
+        <!-- Mobile nav links -->
         <div class="px-3 py-3 space-y-0.5">
-
           <router-link to="/" v-slot="{ isActive }">
-            <span
-              class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium
-                     transition-colors duration-150 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-500 text-white'
-                : 'text-content-secondary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-home w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i>
-              Home
+            <span class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors duration-150 cursor-pointer"
+              :class="isActive ? 'bg-primary-500 text-white' : 'text-content-secondary hover:bg-surface-700/60'">
+              <i class="pi pi-home w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i> Home
             </span>
           </router-link>
 
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-            to="/events"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium
-                     transition-colors duration-150 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-500 text-white'
-                : 'text-content-secondary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-calendar w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i>
-              Events
+          <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
+            <span class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors duration-150 cursor-pointer"
+              :class="isActive ? 'bg-primary-500 text-white' : 'text-content-secondary hover:bg-surface-700/60'">
+              <i class="pi pi-calendar w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i> Events
             </span>
           </router-link>
 
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-            to="/event/update-event-details"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium
-                     transition-colors duration-150 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-500 text-white'
-                : 'text-content-secondary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-users w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i>
-              Participants
+          <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
+            <span class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors duration-150 cursor-pointer"
+              :class="isActive ? 'bg-primary-500 text-white' : 'text-content-secondary hover:bg-surface-700/60'">
+              <i class="pi pi-cog w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i> Admin
             </span>
           </router-link>
 
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
-            to="/event/audition-list"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium
-                     transition-colors duration-150 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-500 text-white'
-                : 'text-content-secondary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-list w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i>
-              Audition
-            </span>
-          </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_EMCEE' || role === 'ROLE_ORGANISER'"
-            to="/event/score"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium
-                     transition-colors duration-150 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-500 text-white'
-                : 'text-content-secondary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-chart-bar w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i>
-              Scoreboard
-            </span>
-          </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-            to="/battle/control"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium
-                     transition-colors duration-150 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-500 text-white'
-                : 'text-content-secondary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-bolt w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i>
-              Battle
-            </span>
-          </router-link>
-
-          <router-link
-            v-if="role === 'ROLE_ADMIN'"
-            to="/admin"
-            v-slot="{ isActive }"
-          >
-            <span
-              class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium
-                     transition-colors duration-150 cursor-pointer"
-              :class="isActive
-                ? 'bg-primary-500 text-white'
-                : 'text-content-secondary hover:bg-surface-700/60'"
-            >
-              <i class="pi pi-cog w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i>
-              Admin
-            </span>
-          </router-link>
-
+          <!-- Current event section (mobile) -->
+          <template v-if="isAuthenticated && activeEvent">
+            <div class="px-4 pt-3 pb-1">
+              <p class="text-[10px] font-bold uppercase tracking-widest text-content-muted">Current Event</p>
+              <p class="text-sm font-semibold text-primary-400 truncate">{{ activeEvent.name }}</p>
+            </div>
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
+              @click="goToSection('Audition List')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+              <i class="pi pi-list w-4 text-content-muted"></i> Audition
+            </button>
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+              @click="goToSection('Update Event Details')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+              <i class="pi pi-users w-4 text-content-muted"></i> Participants
+            </button>
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'"
+              @click="goToSection('Score')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+              <i class="pi pi-chart-bar w-4 text-content-muted"></i> Scoreboard
+            </button>
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+              @click="goToSection('Battle Control')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+              <i class="pi pi-bolt w-4 text-content-muted"></i> Battle
+            </button>
+            <button @click="changeEvent"
+              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-muted hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
+              <i class="pi pi-refresh w-4"></i> Change Event
+            </button>
+          </template>
         </div>
 
-        <!-- Mobile auth row -->
+        <!-- Mobile bottom row -->
         <div class="px-3 py-3 border-t border-surface-600/30">
-          <!-- Active event chip (mobile) -->
-          <button
-            v-if="isAuthenticated && activeEvent"
-            @click="changeEvent"
-            class="w-full flex items-center gap-2 px-4 py-2.5 mb-2 rounded-xl
-                   bg-surface-700 border border-surface-600 text-content-secondary
-                   text-sm font-medium hover:bg-primary-100 hover:border-primary-500/50
-                   hover:text-primary-400 transition-all duration-200"
-            title="Click to change event"
-          >
-            <i class="pi pi-calendar-clock text-sm flex-shrink-0"></i>
-            <span class="truncate flex-1 text-left">{{ activeEvent.name }}</span>
-            <i class="pi pi-chevron-down text-xs flex-shrink-0 opacity-60"></i>
-          </button>
           <div v-if="isAuthenticated" class="flex items-center justify-between">
             <div class="flex items-center gap-2">
-              <span
-                v-if="roleDisplay"
-                class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold
-                       bg-surface-700 text-content-secondary border border-surface-600"
-              >
+              <span v-if="roleDisplay"
+                class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-surface-700 text-content-secondary border border-surface-600">
                 {{ roleDisplay.label }}
               </span>
-              <!-- Theme toggle (mobile) -->
-              <button
-                @click="toggleTheme"
-                class="inline-flex items-center justify-center w-8 h-8 rounded-lg
-                       text-content-muted hover:text-content-primary hover:bg-surface-700
-                       transition-all duration-200"
-                :title="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'"
-              >
+              <button @click="toggleTheme"
+                class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-content-muted hover:text-content-primary hover:bg-surface-700 transition-all duration-200">
                 <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
               </button>
             </div>
-            <button
-              @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
-              class="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium
-                     text-red-400 bg-red-950 hover:bg-red-900 transition-colors cursor-pointer"
-            >
+            <button @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
+              class="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-red-400 bg-red-950 hover:bg-red-900 transition-colors cursor-pointer">
               <i class="pi pi-sign-out"></i> Logout
             </button>
           </div>
           <router-link v-else to="/login">
-            <span
-              class="flex items-center justify-center px-4 py-3 rounded-xl text-sm font-semibold
-                     text-white bg-primary-500 hover:bg-primary-600 transition-colors w-full btn-glow"
-            >
-              Login
-            </span>
+            <span class="flex items-center justify-center px-4 py-3 rounded-xl text-sm font-semibold text-white bg-primary-500 hover:bg-primary-600 transition-colors w-full btn-glow">Login</span>
           </router-link>
         </div>
 

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -24,7 +24,7 @@ const isAuthenticated = computed(() => authStore.isAuthenticated)
 
 /** Hide the navbar on full-screen / immersive routes */
 const hideNav = computed(() =>
-  ['Login', 'StreamOverlay', 'BattleJudge'].includes(route.name)
+  ['Login', 'StreamOverlay', 'BattleJudge', 'BracketVisualization'].includes(route.name)
 )
 
 /**

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -91,6 +91,7 @@
     @apply font-sans bg-surface-950 text-content-primary antialiased leading-relaxed min-h-screen;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
+    scrollbar-gutter: stable;
   }
 
   h1, h2, h3, h4, h5, h6 {
@@ -606,15 +607,11 @@ html.theme-transition *::after {
 ───────────────────────────────────────── */
 .page-fade-enter-active,
 .page-fade-leave-active {
-  transition: opacity 0.18s ease, transform 0.18s ease;
+  transition: opacity 0.15s ease;
 }
-.page-fade-enter-from {
-  opacity: 0;
-  transform: translateY(6px);
-}
+.page-fade-enter-from,
 .page-fade-leave-to {
   opacity: 0;
-  transform: translateY(-4px);
 }
 
 /* ─────────────────────────────────────────

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap');
 
 /* Local fonts */
 @font-face {
@@ -28,7 +28,7 @@
    ─────────────────────────────
    60% Neutral  — surface-* scale: backgrounds, borders, text hierarchy
    30% Structure — surface-800/900 + white: nav, table headers, dark surfaces
-   10% Brand     — primary-* (cyan): ALL interactive elements — buttons, links,
+   10% Brand     — primary-* (red): ALL interactive elements — buttons, links,
                    active states, focus rings, selection highlights
 
    Semantic colors (use ONLY for their intended meaning, never decorative):
@@ -40,24 +40,23 @@
    Orange (accent-*):
      → Accent token ONLY — medals, rankings, featured highlights
      → NEVER used for buttons, navigation, badges, or role indicators
-     → Rationale: two competing "action" colors break the visual hierarchy
 ───────────────────────────────────────── */
 @theme {
   /* Typography */
-  --font-sans: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
-  --font-heading: 'Space Grotesk', sans-serif;
-  --font-eagle: 'EagleHorizonP', sans-serif;
-  --font-anton: 'Anton SC', sans-serif;
-  --font-source: 'JetBrains Mono', 'Source Code Pro', monospace;
+  --font-sans:    'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-heading: 'Outfit', sans-serif;
+  --font-eagle:   'EagleHorizonP', sans-serif;
+  --font-anton:   'Anton SC', sans-serif;
+  --font-source:  'JetBrains Mono', 'Source Code Pro', monospace;
 
-  /* Brand — Cyan (the ONE interactive color) */
-  --color-primary-50:  #021920;
-  --color-primary-100: #043040;
-  --color-primary-200: #065e7d;
-  --color-primary-400: #22d3ee;
-  --color-primary-500: #06b6d4;
-  --color-primary-600: #0891b2;
-  --color-primary-700: #0e7490;
+  /* Brand — Red (the ONE interactive color) */
+  --color-primary-50:  #1a0606;
+  --color-primary-100: #2d0a0a;
+  --color-primary-200: #5c1414;
+  --color-primary-400: #f87171;
+  --color-primary-500: #e53935;
+  --color-primary-600: #c62828;
+  --color-primary-700: #b71c1c;
 
   /* Accent — Orange (medals / rankings only — NOT for UI chrome) */
   --color-accent-50:  #1a0d00;
@@ -66,21 +65,21 @@
   --color-accent-600: #ea580c;
   --color-accent-700: #c2410c;
 
-  /* Neutral / Surface — dark navy scale (60% of every screen) */
-  --color-surface-950: #070e1d;
-  --color-surface-900: #0d1829;
-  --color-surface-800: #0f2033;
-  --color-surface-700: #162840;
-  --color-surface-600: #1e3a54;
-  --color-surface-500: #2a4a6e;
-  --color-surface-400: #3d6080;
-  --color-surface-300: #527899;
+  /* Neutral / Surface — true neutral black scale (no blue tinting) */
+  --color-surface-950: #080808;
+  --color-surface-900: #111111;
+  --color-surface-800: #1a1a1a;
+  --color-surface-700: #222222;
+  --color-surface-600: #2c2c2c;
+  --color-surface-500: #3a3a3a;
+  --color-surface-400: #525252;
+  --color-surface-300: #737373;
 
   /* Content / text tokens */
-  --color-content-primary:   #ffffff;
-  --color-content-secondary: #94b8d4;
-  --color-content-muted:     #5c8099;
-  --color-content-disabled:  #3a5570;
+  --color-content-primary:   #f0f0f0;
+  --color-content-secondary: #a0a0a0;
+  --color-content-muted:     #6a6a6a;
+  --color-content-disabled:  #3d3d3d;
 }
 
 /* ─────────────────────────────────────────
@@ -106,18 +105,18 @@
 
   /* PrimeVue compatibility overrides */
   :root {
-    --surface-0: #0f2033;
-    --surface-50: #162840;
-    --surface-100: #1e3a54;
-    --surface-200: #2a4a6e;
-    --surface-900: #ffffff;
-    --text-color: #ffffff;
-    --text-color-secondary: #94b8d4;
+    --surface-0:   #1a1a1a;
+    --surface-50:  #222222;
+    --surface-100: #2c2c2c;
+    --surface-200: #3a3a3a;
+    --surface-900: #f0f0f0;
+    --text-color:           #f0f0f0;
+    --text-color-secondary: #a0a0a0;
   }
 
   /* Global focus-visible ring */
   *:focus-visible {
-    outline: 2px solid rgba(34, 211, 238, 0.7);
+    outline: 2px solid rgba(229, 57, 53, 0.6);
     outline-offset: 2px;
     border-radius: 4px;
   }
@@ -147,28 +146,28 @@
 
   /* Cards */
   .card {
-    @apply bg-surface-800 rounded-2xl border border-surface-600/60;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 4px 16px rgba(0,0,0,0.3);
+    @apply bg-surface-800 rounded-2xl border border-surface-700;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5), 0 4px 16px rgba(0,0,0,0.4);
   }
 
   .card-hover {
-    @apply bg-surface-800 rounded-2xl border border-surface-600/60 transition-all duration-200;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 4px 16px rgba(0,0,0,0.3);
+    @apply bg-surface-800 rounded-2xl border border-surface-700 transition-all duration-200;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5), 0 4px 16px rgba(0,0,0,0.4);
   }
   .card-hover:hover {
-    @apply bg-surface-700 border-primary-500/30;
-    box-shadow: 0 0 0 1px rgba(6,182,212,0.2), 0 4px 24px rgba(6,182,212,0.1);
+    @apply bg-surface-700 border-surface-600;
+    box-shadow: 0 0 0 1px rgba(229,57,53,0.15), 0 4px 24px rgba(229,57,53,0.08);
   }
 
   /* Glassmorphism (use sparingly) */
   .glass-panel {
-    @apply bg-surface-800/70 backdrop-blur-xl border border-surface-600/40 shadow-sm rounded-2xl;
+    @apply bg-surface-800/70 backdrop-blur-xl border border-surface-700/60 shadow-sm rounded-2xl;
   }
 
   .glass-card {
-    @apply bg-surface-800/70 backdrop-blur-md border border-surface-600/40
+    @apply bg-surface-800/70 backdrop-blur-md border border-surface-700/60
            rounded-xl transition-all duration-300;
-    box-shadow: 0 8px 30px rgba(0,0,0,0.3);
+    box-shadow: 0 8px 30px rgba(0,0,0,0.4);
   }
 
   /* Inputs */
@@ -197,7 +196,7 @@
   .badge-danger    { @apply bg-surface-700  text-rose-300   border border-rose-900/30; }
   .badge-neutral   { @apply bg-surface-700  text-content-secondary border border-surface-600; }
 
-  /* Icon wrapper — hook class; dark-mode bg comes from bg-surface-700 on the element */
+  /* Icon wrapper */
   .icon-wrap { }
 
   /* Typography helpers */
@@ -215,18 +214,18 @@
 
   /* Text shadows */
   .text-shadow-sm {
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   }
 
   .text-shadow-strong {
-    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.7);
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.8);
   }
 
   /* Stat cards */
   .stat-card {
-    @apply bg-surface-800 rounded-2xl border border-surface-600/60
+    @apply bg-surface-800 rounded-2xl border border-surface-700
            flex flex-col items-center justify-center p-5 text-center gap-1;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 4px 16px rgba(0,0,0,0.3);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5), 0 4px 16px rgba(0,0,0,0.4);
   }
 
   .stat-value {
@@ -239,7 +238,7 @@
 
   /* Divider */
   .divider {
-    @apply border-t border-surface-600 my-6;
+    @apply border-t border-surface-700 my-6;
   }
 
   /* Focus ring reusable */
@@ -249,7 +248,7 @@
 
   /* Button glow */
   .btn-glow:hover:not(:disabled) {
-    box-shadow: 0 0 20px rgba(6, 182, 212, 0.35);
+    box-shadow: 0 0 20px rgba(229, 57, 53, 0.3);
   }
   .btn-glow:active:not(:disabled) {
     transform: scale(0.96);
@@ -259,7 +258,7 @@
   .skeleton {
     @apply bg-surface-700 rounded-lg;
     animation: skeleton-shimmer 1.4s ease-in-out infinite;
-    background: linear-gradient(90deg, #162840, #1e3a54, #162840);
+    background: linear-gradient(90deg, #222222, #2c2c2c, #222222);
     background-size: 200% 100%;
   }
 
@@ -280,8 +279,8 @@
 
   /* ── Stat card semantic variants ────────────────────────────────── */
   .stat-card-primary {
-    border-top: 2px solid rgba(34, 211, 238, 0.5);
-    background-image: linear-gradient(180deg, rgba(34,211,238,0.05) 0%, transparent 50%);
+    border-top: 2px solid rgba(229, 57, 53, 0.5);
+    background-image: linear-gradient(180deg, rgba(229,57,53,0.05) 0%, transparent 50%);
   }
   .stat-card-success {
     border-top: 2px solid rgba(94, 234, 212, 0.4);
@@ -312,7 +311,7 @@
     position: absolute;
     width: 20px;
     height: 20px;
-    border-color: rgba(34, 211, 238, 0.35);
+    border-color: rgba(229, 57, 53, 0.4);
     border-style: solid;
   }
   .scan-zone::before {
@@ -325,7 +324,6 @@
     border-width: 0 2px 2px 0;
     border-radius: 0 0 4px 0;
   }
-  /* two more corners via a child pseudo — handled by .scan-zone-inner */
   .scan-zone-inner {
     position: relative;
   }
@@ -335,7 +333,7 @@
     position: absolute;
     width: 20px;
     height: 20px;
-    border-color: rgba(34, 211, 238, 0.35);
+    border-color: rgba(229, 57, 53, 0.4);
     border-style: solid;
   }
   .scan-zone-inner::before {
@@ -358,7 +356,7 @@
 
   /* ── Shimmer loading ─────────────────────────────────────────────── */
   .shimmer-text {
-    background: linear-gradient(90deg, #527899 0%, #22d3ee 40%, #527899 80%);
+    background: linear-gradient(90deg, #737373 0%, #f87171 40%, #737373 80%);
     background-size: 200% 100%;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -429,8 +427,8 @@
 }
 
 @keyframes glow-pulse {
-  0%, 100% { box-shadow: 0 0 0 1px rgba(6,182,212,0.2), 0 4px 16px rgba(6,182,212,0.1); }
-  50%       { box-shadow: 0 0 0 1px rgba(6,182,212,0.4), 0 4px 24px rgba(6,182,212,0.25); }
+  0%, 100% { box-shadow: 0 0 0 1px rgba(229,57,53,0.2), 0 4px 16px rgba(229,57,53,0.1); }
+  50%       { box-shadow: 0 0 0 1px rgba(229,57,53,0.4), 0 4px 24px rgba(229,57,53,0.2); }
 }
 
 @keyframes float {
@@ -492,8 +490,8 @@
 ───────────────────────────────────────── */
 ::-webkit-scrollbar        { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track  { background: transparent; }
-::-webkit-scrollbar-thumb  { background: #1e3a54; border-radius: 9999px; }
-::-webkit-scrollbar-thumb:hover { background: #2a4a6e; }
+::-webkit-scrollbar-thumb  { background: #2c2c2c; border-radius: 9999px; }
+::-webkit-scrollbar-thumb:hover { background: #3a3a3a; }
 
 /* ─────────────────────────────────────────
    Light Theme  (data-theme="light" on <html>)
@@ -510,35 +508,35 @@ html.theme-transition *::after {
 }
 
 [data-theme="light"] {
-  /* Surface scale — light neutrals */
-  --color-surface-950: #f8fafc;
-  --color-surface-900: #f1f5f9;
+  /* Surface scale — true neutral light grays, no blue tint */
+  --color-surface-950: #fafafa;
+  --color-surface-900: #f4f4f4;
   --color-surface-800: #ffffff;
-  --color-surface-700: #e2e8f0;
-  --color-surface-600: #cbd5e1;
-  --color-surface-500: #94a3b8;
-  --color-surface-400: #64748b;
-  --color-surface-300: #475569;
+  --color-surface-700: #eeeeee;
+  --color-surface-600: #e2e2e2;
+  --color-surface-500: #c8c8c8;
+  --color-surface-400: #a0a0a0;
+  --color-surface-300: #737373;
 
   /* Content tokens — dark text on light bg */
-  --color-content-primary:   #0f172a;
-  --color-content-secondary: #334155;
-  --color-content-muted:     #64748b;
-  --color-content-disabled:  #94a3b8;
+  --color-content-primary:   #0d0d0d;
+  --color-content-secondary: #404040;
+  --color-content-muted:     #757575;
+  --color-content-disabled:  #b0b0b0;
 
-  /* Primary tints — swap dark hover-bg values for light tints */
-  --color-primary-50:  #ecfeff;
-  --color-primary-100: #cffafe;
-  --color-primary-200: #a5f3fc;
+  /* Primary tints — light red tints for hover/bg */
+  --color-primary-50:  #fff5f5;
+  --color-primary-100: #ffeded;
+  --color-primary-200: #fecaca;
 
   /* PrimeVue compatibility */
   --surface-0:   #ffffff;
-  --surface-50:  #f8fafc;
-  --surface-100: #f1f5f9;
-  --surface-200: #e2e8f0;
-  --surface-900: #0f172a;
-  --text-color:  #0f172a;
-  --text-color-secondary: #334155;
+  --surface-50:  #fafafa;
+  --surface-100: #f4f4f4;
+  --surface-200: #eeeeee;
+  --surface-900: #0d0d0d;
+  --text-color:  #0d0d0d;
+  --text-color-secondary: #404040;
 }
 
 /* Icon wrappers and badges — transparent background on light bg */
@@ -548,59 +546,74 @@ html.theme-transition *::after {
 [data-theme="light"] .badge-danger,
 [data-theme="light"] .badge-neutral { background-color: transparent !important; }
 
-/* Semantic badge text needs darker hues on a light background */
+/* Semantic badge text — darker hues for readability on light bg */
 [data-theme="light"] .badge-success { color: #0f766e !important; border-color: rgba(13,148,136,0.3) !important; }
 [data-theme="light"] .badge-warning { color: #b45309 !important; border-color: rgba(180,83,9,0.3)   !important; }
 [data-theme="light"] .badge-danger  { color: #be123c !important; border-color: rgba(190,18,60,0.3)  !important; }
 
 /* Hardcoded semantic text colours — swap light pastels for dark readable hues on light bg */
-[data-theme="light"] .text-teal-300  { color: #0f766e !important; } /* teal-700  */
-[data-theme="light"] .text-teal-400  { color: #0d9488 !important; } /* teal-600  */
-[data-theme="light"] .text-rose-300  { color: #be123c !important; } /* rose-700  */
-[data-theme="light"] .text-rose-400  { color: #e11d48 !important; } /* rose-600  */
-[data-theme="light"] .text-amber-300 { color: #b45309 !important; } /* amber-700 */
-[data-theme="light"] .text-amber-400 { color: #d97706 !important; } /* amber-600 */
-[data-theme="light"] .text-red-400   { color: #dc2626 !important; } /* red-600   */
-[data-theme="light"] .text-primary-400 { color: #0891b2 !important; } /* primary-600 (darker cyan for light bg) */
+[data-theme="light"] .text-teal-300    { color: #0f766e !important; }
+[data-theme="light"] .text-teal-400    { color: #0d9488 !important; }
+[data-theme="light"] .text-rose-300    { color: #be123c !important; }
+[data-theme="light"] .text-rose-400    { color: #e11d48 !important; }
+[data-theme="light"] .text-amber-300   { color: #b45309 !important; }
+[data-theme="light"] .text-amber-400   { color: #d97706 !important; }
+[data-theme="light"] .text-red-400     { color: #dc2626 !important; }
+/* primary-400 on light bg: use a darker red so it stays legible */
+[data-theme="light"] .text-primary-400 { color: #c62828 !important; }
 
 /* Border tints — darken on light so they remain visible */
 [data-theme="light"] .border-teal-900\/30  { border-color: rgba(15, 118, 110, 0.4) !important; }
 [data-theme="light"] .border-rose-900\/30  { border-color: rgba(190,  18,  60, 0.4) !important; }
 [data-theme="light"] .border-amber-900\/30 { border-color: rgba(180,  83,   9, 0.4) !important; }
 
-/* Dark semantic bg-*-950 overrides — these are dark-only and must flip on light bg */
+/* Dark semantic bg-*-950 overrides — flip to light pastels on light bg */
 [data-theme="light"] .bg-emerald-950 { background-color: #d1fae5 !important; }
 [data-theme="light"] .bg-amber-950   { background-color: #fef3c7 !important; }
 [data-theme="light"] .bg-red-950     { background-color: #fee2e2 !important; }
 [data-theme="light"] .bg-rose-950    { background-color: #ffe4e6 !important; }
-[data-theme="light"] .text-emerald-400 { color: #059669 !important; } /* emerald-600 — readable on light green bg */
+[data-theme="light"] .text-emerald-400 { color: #059669 !important; }
+[data-theme="light"] .text-amber-200\/80 { color: #92400e !important; }
 
 /* Softer card / stat-card shadows on light */
 [data-theme="light"] .card,
 [data-theme="light"] .card-hover,
 [data-theme="light"] .stat-card {
-  box-shadow: 0 1px 3px rgba(0,0,0,0.07), 0 4px 16px rgba(0,0,0,0.05) !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 4px 16px rgba(0,0,0,0.04) !important;
+  border-color: #e2e2e2 !important;
 }
 [data-theme="light"] .card-hover:hover {
-  box-shadow: 0 0 0 1px rgba(6,182,212,0.25), 0 4px 20px rgba(6,182,212,0.08) !important;
+  box-shadow: 0 0 0 1px rgba(229,57,53,0.2), 0 4px 20px rgba(229,57,53,0.06) !important;
 }
 
 /* Nav shadow on light */
 [data-theme="light"] nav {
-  box-shadow: 0 1px 8px rgba(0,0,0,0.08) !important;
+  box-shadow: 0 1px 8px rgba(0,0,0,0.07) !important;
 }
 
-/* Scan-zone bracket colour — stronger on light so it remains visible */
+/* Skeleton on light */
+[data-theme="light"] .skeleton {
+  background: linear-gradient(90deg, #eeeeee, #f4f4f4, #eeeeee) !important;
+  background-size: 200% 100% !important;
+}
+
+/* Scan-zone bracket colour — stronger on light */
 [data-theme="light"] .scan-zone::before,
 [data-theme="light"] .scan-zone::after,
 [data-theme="light"] .scan-zone-inner::before,
 [data-theme="light"] .scan-zone-inner::after {
-  border-color: rgba(8, 145, 178, 0.45);
+  border-color: rgba(198, 40, 40, 0.4);
+}
+
+/* Shimmer text on light */
+[data-theme="light"] .shimmer-text {
+  background: linear-gradient(90deg, #a0a0a0 0%, #e53935 40%, #a0a0a0 80%) !important;
+  background-size: 200% 100% !important;
 }
 
 /* Scrollbar — light */
-[data-theme="light"] ::-webkit-scrollbar-thumb       { background: #cbd5e1; }
-[data-theme="light"] ::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
+[data-theme="light"] ::-webkit-scrollbar-thumb       { background: #e2e2e2; }
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover { background: #c8c8c8; }
 
 /* ─────────────────────────────────────────
    Page Transitions (must be outside @layer so Tailwind does not purge them)

--- a/BES-frontend/src/components/CreateParticipantForm.vue
+++ b/BES-frontend/src/components/CreateParticipantForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ActionDoneModal from '@/views/ActionDoneModal.vue';
-import { onMounted, ref, reactive, watch } from 'vue';
+import { onMounted, ref, reactive, watch, computed } from 'vue';
 import { addWalkinToSystem, fetchAllGenres, getAllJudges } from '@/utils/api';
 
 const props = defineProps({
@@ -14,28 +14,57 @@ const emit = defineEmits(['createNewEntry', 'close'])
 
 const name = ref("")
 const selectedJudge = ref("")
-const genreOptions = ref([])
+const genreOptions = ref([])  // array of { genreName, format }
 const allJudges = ref([])
 const createTable = reactive({ genres: [] })
 const showError = ref(false)
+const teamMemberNames = ref([])
+const teamName = ref("")
+
+// First crew format among selected genres (e.g. "3v3")
+const crewFormat = computed(() => {
+  for (const genreName of createTable.genres) {
+    const option = genreOptions.value.find(o => o.genreName === genreName)
+    if (option && option.format && option.format.toLowerCase() !== '1v1') {
+      return option.format
+    }
+  }
+  return null
+})
+
+// How many additional member fields to show (crew size minus the representative)
+const additionalMembersCount = computed(() => {
+  if (!crewFormat.value) return 0
+  const match = crewFormat.value.match(/^(\d+)v\d+$/i)
+  return match ? parseInt(match[1]) - 1 : 0
+})
+
+// Keep teamMemberNames array sized to additionalMembersCount
+watch(additionalMembersCount, (count) => {
+  while (teamMemberNames.value.length < count) teamMemberNames.value.push("")
+  teamMemberNames.value.splice(count)
+})
 
 const submitNewEntry = async () => {
-  if (name.value == "") {
+  if (name.value.trim() === "") {
     showError.value = true
     return
   }
+  const members = teamMemberNames.value.filter(m => m.trim() !== "")
   for (const g of createTable.genres) {
-    await addWalkinToSystem(name.value, props.event, g, selectedJudge.value)
+    await addWalkinToSystem(name.value, props.event, g, selectedJudge.value, members, teamName.value)
   }
   name.value = ""
+  teamName.value = ""
   createTable.genres = []
+  teamMemberNames.value = []
   emit("createNewEntry")
 }
 
 // Watch eventGenres prop so genres update when the parent fetches them
 watch(() => props.eventGenres, (newGenres) => {
   if (newGenres && newGenres.length > 0) {
-    genreOptions.value = newGenres.map(g => g.genreName)
+    genreOptions.value = newGenres.map(g => ({ genreName: g.genreName, format: g.format || null }))
   }
 }, { immediate: true })
 
@@ -43,7 +72,7 @@ onMounted(async () => {
   // Fallback to all genres only if no event-specific genres were provided
   if (!props.eventGenres || props.eventGenres.length === 0) {
     const genres = await fetchAllGenres()
-    genreOptions.value = genres.map(g => g.genreName)
+    genreOptions.value = genres.map(g => ({ genreName: g.genreName, format: g.format || null }))
   }
   const res = await getAllJudges()
   allJudges.value = ["", ...Object.values(res).map(item => item.judgeName)]
@@ -59,7 +88,7 @@ onMounted(async () => {
     @close="$emit('close')"
   >
     <div class="space-y-4 mt-1">
-      <!-- Name field -->
+      <!-- Stage name field -->
       <div>
         <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1.5">
           Stage Name
@@ -81,22 +110,61 @@ onMounted(async () => {
         <div class="grid grid-cols-2 gap-2">
           <label
             v-for="g in genreOptions"
-            :key="g"
+            :key="g.genreName"
             class="flex items-center gap-2.5 px-3 py-2.5 rounded-xl border cursor-pointer transition-all"
-            :class="createTable.genres.includes(g)
+            :class="createTable.genres.includes(g.genreName)
               ? 'bg-primary-100 border-primary-400 text-primary-400'
               : 'bg-surface-800 border-surface-600 text-content-secondary hover:border-surface-500'"
           >
             <input
               type="checkbox"
-              :value="g"
+              :value="g.genreName"
               v-model="createTable.genres"
               class="w-4 h-4 rounded accent-primary-600"
             />
-            <span class="text-sm font-medium">{{ g }}</span>
+            <span class="text-sm font-medium">{{ g.genreName }}</span>
+            <span
+              v-if="g.format"
+              class="ml-auto text-xs font-source opacity-50"
+            >{{ g.format }}</span>
           </label>
         </div>
       </div>
+
+      <!-- Team name + members — shown only when a crew-format genre is selected -->
+      <template v-if="additionalMembersCount > 0">
+        <div>
+          <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1.5">
+            Team Name
+            <span class="ml-1 text-primary-400 normal-case font-normal font-source">{{ crewFormat }}</span>
+          </label>
+          <input
+            v-model="teamName"
+            type="text"
+            placeholder="Enter team name…"
+            class="input-base"
+          />
+        </div>
+
+        <div>
+          <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1">
+            Team Members
+          </label>
+          <p class="text-xs text-surface-500 mb-2">
+            Stage name is Member 1 (representative). Enter the other {{ additionalMembersCount }}.
+          </p>
+          <div class="space-y-2">
+            <input
+              v-for="i in additionalMembersCount"
+              :key="i"
+              v-model="teamMemberNames[i - 1]"
+              type="text"
+              :placeholder="`Member ${i + 1} stage name…`"
+              class="input-base"
+            />
+          </div>
+        </div>
+      </template>
     </div>
   </ActionDoneModal>
 

--- a/BES-frontend/src/components/CreateParticipantForm.vue
+++ b/BES-frontend/src/components/CreateParticipantForm.vue
@@ -20,6 +20,7 @@ const createTable = reactive({ genres: [] })
 const showError = ref(false)
 const teamMemberNames = ref([])
 const teamName = ref("")
+const entryMode = ref('team') // 'team' | 'solo'
 
 // First crew format among selected genres (e.g. "3v3")
 const crewFormat = computed(() => {
@@ -32,9 +33,12 @@ const crewFormat = computed(() => {
   return null
 })
 
+// Show team/solo toggle only when a crew-format genre is selected
+const showEntryModeToggle = computed(() => crewFormat.value !== null)
+
 // How many additional member fields to show (crew size minus the representative)
 const additionalMembersCount = computed(() => {
-  if (!crewFormat.value) return 0
+  if (!crewFormat.value || entryMode.value === 'solo') return 0
   const match = crewFormat.value.match(/^(\d+)v\d+$/i)
   return match ? parseInt(match[1]) - 1 : 0
 })
@@ -45,19 +49,26 @@ watch(additionalMembersCount, (count) => {
   teamMemberNames.value.splice(count)
 })
 
+// Reset entryMode when crew-format genres are all deselected
+watch(showEntryModeToggle, (show) => {
+  if (!show) entryMode.value = 'team'
+})
+
 const submitNewEntry = async () => {
   if (name.value.trim() === "") {
     showError.value = true
     return
   }
-  const members = teamMemberNames.value.filter(m => m.trim() !== "")
+  const members = entryMode.value === 'solo' ? [] : teamMemberNames.value.filter(m => m.trim() !== "")
+  const tName = entryMode.value === 'solo' ? '' : teamName.value
   for (const g of createTable.genres) {
-    await addWalkinToSystem(name.value, props.event, g, selectedJudge.value, members, teamName.value)
+    await addWalkinToSystem(name.value, props.event, g, selectedJudge.value, members, tName)
   }
   name.value = ""
   teamName.value = ""
   createTable.genres = []
   teamMemberNames.value = []
+  entryMode.value = 'team'
   emit("createNewEntry")
 }
 
@@ -131,7 +142,40 @@ onMounted(async () => {
         </div>
       </div>
 
-      <!-- Team name + members — shown only when a crew-format genre is selected -->
+      <!-- Solo / Team toggle — shown only when a crew-format genre is selected -->
+      <div v-if="showEntryModeToggle">
+        <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-2">
+          Entry Type
+          <span class="ml-1 text-primary-400 normal-case font-normal font-source">{{ crewFormat }}</span>
+        </label>
+        <div class="flex rounded-xl border border-surface-600/60 overflow-hidden text-sm font-semibold">
+          <button
+            type="button"
+            @click="entryMode = 'team'"
+            class="flex-1 px-4 py-2 transition-all"
+            :class="entryMode === 'team'
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >
+            Team entry
+          </button>
+          <button
+            type="button"
+            @click="entryMode = 'solo'"
+            class="flex-1 px-4 py-2 border-l border-surface-600/60 transition-all"
+            :class="entryMode === 'solo'
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >
+            Solo (pickup crew)
+          </button>
+        </div>
+        <p v-if="entryMode === 'solo'" class="text-xs text-content-muted mt-1.5">
+          Auditions individually. Can be grouped into a crew after auditions.
+        </p>
+      </div>
+
+      <!-- Team name + members — shown only when team entry mode and a crew-format genre is selected -->
       <template v-if="additionalMembersCount > 0">
         <div>
           <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1.5">

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -200,6 +200,9 @@ const swipeHint = computed(() => {
                   <div class="font-heading font-bold text-xl text-content-primary truncate leading-tight">
                     {{ slot.participantName }}
                   </div>
+                  <div v-if="slot.memberNames?.length" class="text-xs text-primary-300/80 truncate mt-0.5">
+                    <i class="pi pi-users mr-1" style="font-size:0.6rem"></i>{{ slot.memberNames.join(', ') }}
+                  </div>
                   <div v-if="slot.judgeName" class="text-xs text-content-muted truncate mt-0.5">
                     {{ slot.judgeName }}
                   </div>
@@ -269,6 +272,9 @@ const swipeHint = computed(() => {
               <div class="flex-1 min-w-0">
                 <div class="font-heading font-bold text-base text-content-primary truncate leading-tight">
                   {{ slot.participantName }}
+                </div>
+                <div v-if="slot.memberNames?.length" class="text-xs text-primary-300/80 truncate mt-0.5">
+                  <i class="pi pi-users mr-1" style="font-size:0.6rem"></i>{{ slot.memberNames.join(', ') }}
                 </div>
                 <div v-if="slot.judgeName" class="text-xs text-content-muted truncate mt-0.5">
                   {{ slot.judgeName }}

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -197,8 +197,14 @@ const swipeHint = computed(() => {
                   {{ slot.auditionNumber }}
                 </div>
                 <div class="flex-1 min-w-0">
-                  <div class="font-heading font-bold text-xl text-content-primary truncate leading-tight">
-                    {{ slot.participantName }}
+                  <div class="flex items-center gap-2 leading-tight">
+                    <div class="font-heading font-bold text-xl text-content-primary truncate">
+                      {{ slot.participantName }}
+                    </div>
+                    <span
+                      v-if="slot.format && slot.format !== '1v1'"
+                      class="flex-shrink-0 px-1.5 py-0.5 rounded-md text-xs font-source font-bold bg-surface-600 text-primary-400 border border-surface-500"
+                    >{{ slot.format }}</span>
                   </div>
                   <div v-if="slot.memberNames?.length" class="text-xs text-primary-300/80 truncate mt-0.5">
                     <i class="pi pi-users mr-1" style="font-size:0.6rem"></i>{{ slot.memberNames.join(', ') }}
@@ -270,8 +276,14 @@ const swipeHint = computed(() => {
                 {{ slot.auditionNumber }}
               </div>
               <div class="flex-1 min-w-0">
-                <div class="font-heading font-bold text-base text-content-primary truncate leading-tight">
-                  {{ slot.participantName }}
+                <div class="flex items-center gap-2 leading-tight">
+                  <div class="font-heading font-bold text-base text-content-primary truncate">
+                    {{ slot.participantName }}
+                  </div>
+                  <span
+                    v-if="slot.format && slot.format !== '1v1'"
+                    class="flex-shrink-0 px-1.5 py-0.5 rounded-md text-xs font-source font-bold bg-surface-600 text-primary-400 border border-surface-500"
+                  >{{ slot.format }}</span>
                 </div>
                 <div v-if="slot.memberNames?.length" class="text-xs text-primary-300/80 truncate mt-0.5">
                   <i class="pi pi-users mr-1" style="font-size:0.6rem"></i>{{ slot.memberNames.join(', ') }}

--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -66,10 +66,15 @@ const cancelEdit = (e) => {
               {{ codeVisible ? codeDisplay : '••••' }}
             </span>
             <button
-              @click.stop="codeVisible = !codeVisible"
+              @mousedown.stop="codeVisible = true"
+              @mouseup.stop="codeVisible = false"
+              @mouseleave.stop="codeVisible = false"
+              @touchstart.prevent.stop="codeVisible = true"
+              @touchend.stop="codeVisible = false"
+              @touchcancel.stop="codeVisible = false"
               class="w-5 h-5 rounded flex items-center justify-center text-content-muted hover:text-primary-400
-                     hover:bg-primary-100 transition-colors duration-150"
-              :title="codeVisible ? 'Hide code' : 'Show code'"
+                     hover:bg-primary-100 transition-colors duration-150 select-none touch-none"
+              title="Hold to reveal code"
             >
               <i class="pi text-xs" :class="codeVisible ? 'pi-eye-slash' : 'pi-eye'"></i>
             </button>

--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -1,125 +1,124 @@
 <script setup>
 import { ref, watch } from 'vue'
-import { updateEventAccessCode } from '@/utils/api'
 
 const props = defineProps({
   buttonName: { type: String, required: true, default: '' },
-  accessCode: { type: String, default: null }
+  accessCode: { type: String, default: null },
+  expanded:   { type: Boolean, default: false },  // controlled by parent
 })
 
-const emit = defineEmits(['onClick'])
+const emit = defineEmits(['onDetails', 'onAudition', 'onParticipants', 'onScoreboard', 'onBattle', 'updateCode', 'toggle'])
+
+const isHovered = ref(false)  // desktop only
 
 const editingCode = ref(false)
-const newCode = ref('')
-const saving = ref(false)
+const newCode     = ref('')
+const saving      = ref(false)
 const codeDisplay = ref(props.accessCode)
 const codeVisible = ref(false)
 
 watch(() => props.accessCode, (val) => { codeDisplay.value = val })
 
-const startEdit = (e) => {
-  e.stopPropagation()
-  newCode.value = codeDisplay.value || ''
-  editingCode.value = true
+const startEdit  = (e) => { e.stopPropagation(); newCode.value = codeDisplay.value || ''; editingCode.value = true }
+const saveCode   = async (e) => {
+  e.stopPropagation(); saving.value = true
+  try { emit('updateCode', newCode.value); codeDisplay.value = newCode.value; editingCode.value = false }
+  finally { saving.value = false }
 }
+const cancelEdit = (e) => { e.stopPropagation(); editingCode.value = false }
 
-const saveCode = async (e, eventId) => {
-  e.stopPropagation()
-  saving.value = true
-  try {
-    emit('updateCode', newCode.value)
-    codeDisplay.value = newCode.value
-    editingCode.value = false
-  } finally {
-    saving.value = false
-  }
-}
-
-const cancelEdit = (e) => {
-  e.stopPropagation()
-  editingCode.value = false
-}
+const actions = [
+  { key: 'onDetails',      icon: 'pi-cog',      label: 'Details'  },
+  { key: 'onAudition',     icon: 'pi-list',      label: 'Audition' },
+  { key: 'onParticipants', icon: 'pi-users',     label: 'People'   },
+  { key: 'onScoreboard',   icon: 'pi-chart-bar', label: 'Score'    },
+  { key: 'onBattle',       icon: 'pi-bolt',      label: 'Battle'   },
+]
 </script>
 
 <template>
   <div
-    class="group relative bg-surface-800 rounded-2xl border border-surface-600/50
-           border-l-[4px] border-l-primary-500
-           transition-all duration-200 cursor-pointer overflow-hidden w-full"
-    style="box-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 4px 16px rgba(0,0,0,0.3);"
-    :style="{}"
-    @mouseenter="$el.style.boxShadow = '0 0 0 1px rgba(6,182,212,0.25), 0 4px 24px rgba(6,182,212,0.1)'"
-    @mouseleave="$el.style.boxShadow = '0 1px 3px rgba(0,0,0,0.4), 0 4px 16px rgba(0,0,0,0.3)'"
-    @click="emit('onClick')"
+    class="relative"
+    @mouseenter="isHovered = true"
+    @mouseleave="isHovered = false"
   >
-    <div class="flex items-center justify-between p-5 gap-4">
-      <!-- Event name + access code -->
-      <div class="flex-1 min-w-0">
-        <h3 class="font-heading font-bold text-base text-content-primary leading-snug line-clamp-2">
+    <!-- ── Header card (always visible, fixed height) ── -->
+    <div
+      class="bg-surface-800 border border-surface-600/50 border-l-[4px] border-l-primary-500
+             transition-all duration-150 cursor-pointer"
+      :class="isHovered || props.expanded
+        ? 'rounded-t-2xl border-b-transparent shadow-[0_0_0_1px_rgba(6,182,212,0.2)]'
+        : 'rounded-2xl'"
+      @click.stop="emit('toggle')"
+    >
+      <div class="flex items-center gap-3 px-4 py-4">
+        <h3 class="font-heading font-bold text-sm text-content-primary leading-snug line-clamp-2 flex-1">
           {{ props.buttonName }}
         </h3>
+
         <!-- Access code (admin only) -->
-        <div v-if="props.accessCode !== null" class="mt-2 flex items-center gap-2" @click.stop>
+        <div v-if="props.accessCode !== null" class="flex items-center gap-1.5 flex-shrink-0" @click.stop>
           <template v-if="!editingCode">
-            <span class="text-xs text-content-muted font-medium">Code:</span>
-            <span class="font-source font-bold tracking-widest text-sm text-content-secondary min-w-[2rem]">
+            <span class="font-source text-xs text-content-muted tracking-widest">
               {{ codeVisible ? codeDisplay : '••••' }}
             </span>
             <button
-              @mousedown.stop="codeVisible = true"
-              @mouseup.stop="codeVisible = false"
-              @mouseleave.stop="codeVisible = false"
-              @touchstart.prevent.stop="codeVisible = true"
+              @mousedown.stop="codeVisible = true" @mouseup.stop="codeVisible = false"
+              @mouseleave.stop="codeVisible = false" @touchstart.prevent.stop="codeVisible = true"
               @touchend.stop="codeVisible = false"
-              @touchcancel.stop="codeVisible = false"
-              class="w-5 h-5 rounded flex items-center justify-center text-content-muted hover:text-primary-400
-                     hover:bg-primary-100 transition-colors duration-150 select-none touch-none"
-              title="Hold to reveal code"
-            >
-              <i class="pi text-xs" :class="codeVisible ? 'pi-eye-slash' : 'pi-eye'"></i>
-            </button>
-            <button
-              @click="startEdit"
-              class="w-5 h-5 rounded flex items-center justify-center text-content-muted hover:text-primary-400
-                     hover:bg-primary-100 transition-colors duration-150"
-              title="Edit access code"
-            >
-              <i class="pi pi-pencil text-xs"></i>
-            </button>
+              class="text-content-muted hover:text-primary-400 transition-colors select-none touch-none"
+            ><i class="pi pi-eye text-xs"></i></button>
+            <button @click.stop="startEdit" class="text-content-muted hover:text-primary-400 transition-colors"
+            ><i class="pi pi-pencil text-xs"></i></button>
           </template>
           <template v-else>
-            <input
-              v-model="newCode"
-              type="text"
-              inputmode="numeric"
-              maxlength="4"
-              class="w-16 px-2 py-0.5 rounded border border-primary-400 bg-surface-900 font-source text-sm tracking-widest text-center text-content-primary focus:outline-none focus:ring-1 focus:ring-primary-500"
-              @click.stop
+            <input v-model="newCode" type="text" inputmode="numeric" maxlength="4" @click.stop
+              class="w-14 px-1.5 py-0.5 rounded border border-primary-400 bg-surface-900 font-source text-xs tracking-widest text-center text-content-primary focus:outline-none"
             />
-            <button
-              @click="saveCode"
-              :disabled="saving"
-              class="text-xs px-2 py-0.5 rounded bg-primary-600 text-white hover:bg-primary-700 transition-colors"
+            <button @click.stop="saveCode" :disabled="saving"
+              class="text-xs px-1.5 py-0.5 rounded bg-primary-600 text-white hover:bg-primary-700 transition-colors"
             >{{ saving ? '…' : 'Save' }}</button>
-            <button
-              @click="cancelEdit"
-              class="text-xs px-2 py-0.5 rounded border border-surface-600 text-content-secondary hover:bg-surface-700 transition-colors"
-            >Cancel</button>
+            <button @click.stop="cancelEdit"
+              class="text-xs px-1.5 py-0.5 rounded border border-surface-600 text-content-secondary hover:bg-surface-700 transition-colors"
+            >✕</button>
           </template>
         </div>
-      </div>
 
-      <!-- Chevron indicator -->
-      <div
-        class="icon-wrap flex-shrink-0 w-8 h-8 rounded-full bg-surface-700
-               group-hover:bg-primary-100 flex items-center justify-center
-               transition-colors duration-200"
-      >
-        <i
-          class="pi pi-chevron-right text-content-muted group-hover:text-primary-400 text-xs
-                 group-hover:translate-x-0.5 transition-all duration-200"
-        ></i>
+        <i class="pi pi-chevron-down text-xs text-surface-500 transition-all duration-200 flex-shrink-0"
+           :class="isHovered || props.expanded ? 'text-primary-400 rotate-180' : ''"></i>
       </div>
     </div>
+
+    <!-- ── Action panel (absolutely positioned, expands over content below) ── -->
+    <Transition
+      enter-active-class="transition-all duration-200 ease-out"
+      enter-from-class="opacity-0 -translate-y-1"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition-all duration-150 ease-in"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 -translate-y-1"
+    >
+      <div
+        v-if="isHovered || props.expanded"
+        class="absolute top-full left-0 right-0 z-20
+               bg-surface-800 border border-t-0 border-primary-500/40
+               border-l-[4px] border-l-primary-500 rounded-b-2xl overflow-hidden
+               shadow-[0_8px_24px_rgba(0,0,0,0.5)]"
+        @click.stop="emit('toggle')"
+      >
+        <div class="grid grid-cols-5 divide-x divide-surface-700/60">
+          <button
+            v-for="action in actions"
+            :key="action.key"
+            @click.stop="emit(action.key)"
+            class="flex flex-col items-center gap-1.5 py-3.5 text-content-muted
+                   hover:text-primary-400 hover:bg-primary-500/10 transition-all duration-150"
+          >
+            <i class="pi text-base" :class="action.icon"></i>
+            <span class="text-[9px] font-bold uppercase tracking-wide leading-none">{{ action.label }}</span>
+          </button>
+        </div>
+      </div>
+    </Transition>
   </div>
 </template>

--- a/BES-frontend/src/components/ReusableButton.vue
+++ b/BES-frontend/src/components/ReusableButton.vue
@@ -1,9 +1,9 @@
 <script setup>
 /**
  * Button variants follow the 60-30-10 color rule:
- *   primary   → cyan brand color  (the ONE "do this" action)
+ *   primary   → red brand color   (the ONE "do this" action)
  *   secondary → dark surface fill  (strong secondary — no competing hue)
- *   ghost     → transparent + cyan text  (soft tertiary)
+ *   ghost     → transparent + red text  (soft tertiary)
  *   outline   → bordered, neutral text   (low-emphasis action)
  *   danger    → red fill          (destructive / irreversible only)
  *

--- a/BES-frontend/src/components/SwipeableCardsV2.vue
+++ b/BES-frontend/src/components/SwipeableCardsV2.vue
@@ -86,7 +86,7 @@ onMounted(observeCards)
     <div
       ref="scrollRef"
       v-if="props.cards && props.cards.length"
-      class="flex overflow-x-auto snap-x snap-mandatory scroll-smooth gap-4 px-4 pb-4"
+      class="flex overflow-x-auto snap-x snap-mandatory scroll-smooth gap-2 px-1 pb-3"
       style="scrollbar-width: none;"
     >
       <div
@@ -94,24 +94,23 @@ onMounted(observeCards)
         :key="idx"
         :data-index="idx"
         data-card
-        class="flex-shrink-0 w-[88%] md:w-[70%] snap-center"
+        class="flex-shrink-0 w-[97%] md:w-[70%] snap-center"
       >
         <!-- Score card -->
         <div
-          class="rounded-2xl border p-5 md:p-8 transition-all duration-200"
+          class="rounded-2xl border p-2 md:p-8 transition-all duration-200"
           :class="idx === currentIndex
             ? 'bg-surface-800 border-primary-500/40 shadow-[0_0_0_1px_rgba(6,182,212,0.2),0_8px_32px_rgba(6,182,212,0.12)]'
             : 'bg-surface-900 border-surface-600/30 opacity-50'"
         >
           <!-- Participant info -->
-          <div class="flex items-start justify-between mb-5">
+          <div class="flex items-start justify-between mb-2">
             <div>
-              <div class="inline-flex items-center px-2.5 py-1 rounded-lg bg-surface-700/60 border border-surface-600/50 mb-2">
-                <span class="text-xs font-bold text-primary-400 uppercase tracking-widest">
-                  Audition #{{ card.auditionNumber }}
-                </span>
+              <div class="flex items-baseline gap-2 mb-1">
+                <span class="font-source font-extrabold text-4xl text-primary-400 tabular-nums leading-none">#{{ card.auditionNumber }}</span>
+                <span class="text-[10px] font-bold text-primary-400/60 uppercase tracking-widest">Audition</span>
               </div>
-              <h3 class="font-heading font-bold text-2xl text-content-primary leading-tight">
+              <h3 class="font-heading font-bold text-xl text-content-primary leading-tight">
                 {{ card.participantName }}
               </h3>
             </div>
@@ -147,7 +146,7 @@ onMounted(observeCards)
           <!-- Feedback preview -->
           <div
             v-if="feedbackData?.get(card.auditionNumber)"
-            class="mb-4 p-3 rounded-xl bg-surface-700/30 border border-surface-600/40"
+            class="mb-2 p-2 rounded-xl bg-surface-700/30 border border-surface-600/40"
           >
             <!-- Tags -->
             <div
@@ -186,12 +185,12 @@ onMounted(observeCards)
             </div>
           </div>
 
-          <div class="h-px bg-surface-600/50 mb-4"></div>
+          <div class="h-px bg-surface-600/50 mb-2"></div>
 
           <!-- ── Multi-criteria mode (tabbed) ── -->
           <template v-if="hasCriteria">
             <!-- Tab bar -->
-            <div class="flex gap-1 mb-4 overflow-x-auto" style="scrollbar-width: none;">
+            <div class="flex gap-1 mb-2 overflow-x-auto" style="scrollbar-width: none;">
               <button
                 v-for="criterion in criteria"
                 :key="criterion.id"
@@ -214,7 +213,7 @@ onMounted(observeCards)
             <template v-for="criterion in criteria" :key="criterion.id">
               <div v-if="getActiveCriterion(idx) === criterion.name">
                 <!-- Criterion score + full score button -->
-                <div class="flex items-center justify-between mb-3">
+                <div class="flex items-center justify-between mb-2">
                   <div class="flex items-center gap-2">
                     <span class="text-xs font-bold text-content-secondary uppercase tracking-widest">{{ criterion.name }}</span>
                     <span v-if="criterion.weight != null" class="text-xs text-primary-400/70">×{{ criterion.weight }}</span>
@@ -230,38 +229,38 @@ onMounted(observeCards)
                 <button
                   :disabled="idx !== currentIndex"
                   @click="setCriteriaScore(card, criterion.name, 10)"
-                  class="w-full py-2.5 mb-3 rounded-xl text-sm font-bold border-2 border-primary-600 text-primary-400
+                  class="w-full py-2 mb-2 rounded-xl text-sm font-bold border-2 border-primary-600 text-primary-400
                          hover:bg-primary-600 hover:text-white active:bg-primary-700 active:text-white
                          disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-200"
                 >
                   {{ 10 }} — Full Score
                 </button>
 
-                <div class="grid grid-cols-2 gap-2">
-                  <div class="bg-surface-700/40 border border-surface-600/50 rounded-xl p-2.5">
-                    <div class="text-xs font-bold text-content-secondary uppercase tracking-widest mb-2 text-center">Whole</div>
-                    <div class="grid grid-cols-3 gap-1.5">
+                <div class="grid grid-cols-2 gap-1.5">
+                  <div class="bg-surface-700/40 border border-surface-600/50 rounded-xl p-1.5">
+                    <div class="text-xs font-bold text-content-secondary uppercase tracking-widest mb-1 text-center">Whole</div>
+                    <div class="grid grid-cols-3 gap-1">
                       <button
                         v-for="value in 9"
                         :key="'w'+criterion.name+value"
                         :disabled="idx !== currentIndex"
                         @click="setCriteriaScore(card, criterion.name, Number(value))"
-                        class="py-2.5 rounded-xl text-sm font-bold border transition-all duration-150"
+                        class="py-4 rounded-xl text-sm font-bold border transition-all duration-150"
                         :class="Math.floor(criteriaScore(card, criterion.name)) === value && criteriaScore(card, criterion.name) === value
                           ? 'bg-primary-600 text-white border-primary-600 shadow-[0_0_8px_rgba(6,182,212,0.4)]'
                           : 'bg-surface-600/60 border-surface-500/50 text-content-primary hover:border-primary-500/60 hover:bg-surface-600 disabled:opacity-30'"
                       >{{ value }}</button>
                     </div>
                   </div>
-                  <div class="bg-primary-500/8 border border-primary-500/25 rounded-xl p-2.5">
-                    <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-2 text-center">Decimal</div>
-                    <div class="grid grid-cols-3 gap-1.5">
+                  <div class="bg-primary-500/8 border border-primary-500/25 rounded-xl p-1.5">
+                    <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-1 text-center">Decimal</div>
+                    <div class="grid grid-cols-3 gap-1">
                       <button
                         v-for="value in 9"
                         :key="'d'+criterion.name+value"
                         :disabled="idx !== currentIndex"
                         @click="updateCriteriaDecimal(card, criterion.name, value)"
-                        class="py-2.5 rounded-xl text-sm font-semibold border transition-all duration-150"
+                        class="py-4 rounded-xl text-sm font-semibold border transition-all duration-150"
                         :class="(criteriaScore(card, criterion.name) * 10 % 10).toFixed(0) == value
                           ? 'bg-primary-500/30 text-primary-300 border-primary-500/60 shadow-[0_0_8px_rgba(6,182,212,0.25)]'
                           : 'bg-primary-500/5 border-primary-500/15 text-primary-300/70 hover:border-primary-500/40 hover:bg-primary-500/15 disabled:opacity-30'"
@@ -279,7 +278,7 @@ onMounted(observeCards)
             <button
               :disabled="idx !== currentIndex"
               @click="card.score = 10"
-              class="w-full py-3 mb-4 rounded-xl text-sm font-bold border-2 border-primary-600 text-primary-400
+              class="w-full py-2 mb-2 rounded-xl text-sm font-bold border-2 border-primary-600 text-primary-400
                      hover:bg-primary-600 hover:text-white active:bg-primary-700 active:text-white
                      disabled:opacity-30 disabled:cursor-not-allowed
                      transition-all duration-200 btn-glow"
@@ -288,19 +287,19 @@ onMounted(observeCards)
             </button>
 
             <!-- Scoring grid -->
-            <div class="grid grid-cols-2 gap-3">
+            <div class="grid grid-cols-2 gap-1.5">
               <!-- Whole numbers 1-9 -->
-              <div class="bg-surface-700/40 border border-surface-600/50 rounded-xl p-3">
-                <div class="text-xs font-bold text-content-secondary uppercase tracking-widest mb-2.5 text-center">
+              <div class="bg-surface-700/40 border border-surface-600/50 rounded-xl p-1.5">
+                <div class="text-xs font-bold text-content-secondary uppercase tracking-widest mb-1 text-center">
                   Whole
                 </div>
-                <div class="grid grid-cols-3 gap-1.5">
+                <div class="grid grid-cols-3 gap-1">
                   <button
                     v-for="value in 9"
                     :key="'w'+value"
                     :disabled="idx !== currentIndex"
                     @click="card.score = Number(value)"
-                    class="py-2.5 rounded-xl text-sm font-bold border transition-all duration-150"
+                    class="py-4 rounded-xl text-sm font-bold border transition-all duration-150"
                     :class="Math.floor(card.score) === value && card.score === value
                       ? 'bg-primary-600 text-white border-primary-600 shadow-[0_0_8px_rgba(6,182,212,0.4)]'
                       : 'bg-surface-600/60 border-surface-500/50 text-content-primary hover:border-primary-500/60 hover:bg-surface-600 disabled:opacity-30'"
@@ -311,17 +310,17 @@ onMounted(observeCards)
               </div>
 
               <!-- Decimals .1-.9 -->
-              <div class="bg-primary-500/8 border border-primary-500/25 rounded-xl p-3">
-                <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-2.5 text-center">
+              <div class="bg-primary-500/8 border border-primary-500/25 rounded-xl p-1.5">
+                <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-1 text-center">
                   Decimal
                 </div>
-                <div class="grid grid-cols-3 gap-1.5">
+                <div class="grid grid-cols-3 gap-1">
                   <button
                     v-for="value in 9"
                     :key="'d'+value"
                     :disabled="idx !== currentIndex"
                     @click="card.score = updateDecimal(card.score, value)"
-                    class="py-2.5 rounded-xl text-sm font-semibold border transition-all duration-150"
+                    class="py-4 rounded-xl text-sm font-semibold border transition-all duration-150"
                     :class="(card.score * 10 % 10).toFixed(0) == value
                       ? 'bg-primary-500/30 text-primary-300 border-primary-500/60 shadow-[0_0_8px_rgba(6,182,212,0.25)]'
                       : 'bg-primary-500/5 border-primary-500/15 text-primary-300/70 hover:border-primary-500/40 hover:bg-primary-500/15 disabled:opacity-30'"
@@ -335,7 +334,7 @@ onMounted(observeCards)
         </div>
 
         <!-- Card position indicator -->
-        <div class="flex justify-center gap-1 mt-3">
+        <div class="flex justify-center gap-1 mt-2">
           <div
             v-for="(_, i) in props.cards"
             :key="i"

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -3,18 +3,30 @@ import { ref, computed, onBeforeUnmount } from "vue";
 import ReusableButton from "./ReusableButton.vue";
 
 const selectedTime = ref(0)
-const timeLeft = ref(0);
-let timer = null;
+const timeLeft = ref(0)
+const countUp = ref(false)
+let timer = null
 
 const isRunning = computed(() => timer !== null)
 const isFinished = computed(() => selectedTime.value > 0 && timeLeft.value >= selectedTime.value)
-const isNearEnd = computed(() => selectedTime.value > 0 && timeLeft.value >= selectedTime.value - 5 && !isFinished.value)
+const isNearEnd = computed(() =>
+  !countUp.value &&
+  selectedTime.value > 0 &&
+  timeLeft.value >= selectedTime.value - 5 &&
+  !isFinished.value
+)
 
 const displayTime = computed(() => {
   if (selectedTime.value === 0) return '—'
-  const remaining = selectedTime.value - timeLeft.value
-  if (remaining <= 0) return '0'
-  return String(remaining)
+  if (countUp.value) {
+    // show elapsed
+    return String(Math.min(timeLeft.value, selectedTime.value))
+  } else {
+    // show remaining
+    const remaining = selectedTime.value - timeLeft.value
+    if (remaining <= 0) return '0'
+    return String(remaining)
+  }
 })
 
 const progressPct = computed(() => {
@@ -23,22 +35,32 @@ const progressPct = computed(() => {
 })
 
 function startTimer(seconds) {
-  if (timer) clearInterval(timer);
+  if (timer) clearInterval(timer)
   selectedTime.value = seconds
-  timeLeft.value = 0;
+  timeLeft.value = 0
   timer = setInterval(() => {
     if (timeLeft.value < seconds) {
-      timeLeft.value++;
+      timeLeft.value++
     } else {
-      clearInterval(timer);
-      timer = null;
+      clearInterval(timer)
+      timer = null
     }
-  }, 1000);
+  }, 1000)
+}
+
+function toggleMode() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+  selectedTime.value = 0
+  timeLeft.value = 0
+  countUp.value = !countUp.value
 }
 
 onBeforeUnmount(() => {
-  if (timer) clearInterval(timer);
-});
+  if (timer) clearInterval(timer)
+})
 </script>
 
 <template>
@@ -48,7 +70,7 @@ onBeforeUnmount(() => {
     :class="isRunning && isNearEnd ? 'animate-glow-pulse' : ''"
   >
     <div class="flex items-center gap-4">
-      <!-- Countdown display -->
+      <!-- Time display -->
       <div class="flex-shrink-0 text-center min-w-[80px]">
         <div
           class="text-5xl font-heading font-extrabold tabular-nums transition-all duration-500"
@@ -65,7 +87,7 @@ onBeforeUnmount(() => {
         </div>
       </div>
 
-      <!-- Progress bar -->
+      <!-- Progress bar + controls -->
       <div class="flex-1">
         <div class="h-1.5 bg-surface-600 rounded-full overflow-hidden mb-3">
           <div
@@ -75,8 +97,22 @@ onBeforeUnmount(() => {
           ></div>
         </div>
 
-        <!-- Quick-start buttons -->
-        <div class="flex gap-2 flex-wrap">
+        <div class="flex items-center gap-2 flex-wrap">
+          <!-- Mode toggle -->
+          <button
+            @click="toggleMode"
+            class="px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all duration-150 flex items-center gap-1"
+            :class="countUp
+              ? 'bg-surface-600 border-primary-500/50 text-primary-300'
+              : 'bg-surface-700 border-surface-600 text-content-secondary hover:border-primary-500/50'"
+          >
+            <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="text-[10px]"></i>
+            {{ countUp ? 'Count Up' : 'Count Down' }}
+          </button>
+
+          <div class="w-px h-4 bg-surface-600"></div>
+
+          <!-- Duration presets -->
           <button
             v-for="t in [30, 45, 60, 90]"
             :key="t"

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -17,6 +17,7 @@ import AdminPage from "@/views/AdminPage.vue";
 import EventSelector from "@/views/EventSelector.vue";
 import Results from "@/views/Results.vue";
 import ResultsQR from "@/views/ResultsQR.vue";
+import CrewFormation from "@/views/CrewFormation.vue";
 import { whoami } from "@/utils/api";
 import { getActiveEvent, useAuthStore } from "@/utils/auth";
 
@@ -117,6 +118,12 @@ const routes = [
         path: '/results-qr',
         name: 'ResultsQR',
         component: ResultsQR
+    },
+    {
+        path: '/event/crew-formation',
+        name: 'Crew Formation',
+        component: CrewFormation,
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'], requiresEvent: true }
     }
 ]
 

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -18,6 +18,7 @@ import EventSelector from "@/views/EventSelector.vue";
 import Results from "@/views/Results.vue";
 import ResultsQR from "@/views/ResultsQR.vue";
 import CrewFormation from "@/views/CrewFormation.vue";
+import BracketVisualization from "@/views/BracketVisualization.vue";
 import { whoami } from "@/utils/api";
 import { getActiveEvent, useAuthStore } from "@/utils/auth";
 
@@ -124,6 +125,11 @@ const routes = [
         name: 'Crew Formation',
         component: CrewFormation,
         meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'], requiresEvent: true }
+    },
+    {
+        path: '/battle/bracket',
+        name: 'BracketVisualization',
+        component: BracketVisualization
     }
 ]
 
@@ -132,7 +138,7 @@ const router = createRouter({
     routes
 })
 
-const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Battle Judge', 'Smoke', 'Results', 'ResultsQR']
+const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Battle Judge', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization']
 
 router.beforeEach(async (to) => {
     if (PUBLIC_ROUTES.includes(to.name)) return true

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -266,7 +266,7 @@ export const addParticipantToSystem = async (fileId, eventName)=>{
   }
 }
 
-export const addWalkinToSystem = async (participantName, eventName, genreName, judgeName)=>{
+export const addWalkinToSystem = async (participantName, eventName, genreName, judgeName, teamMembers = [], teamName = '')=>{
   try{
   return await fetch(`${domain}/api/v1/event/walkins/`, {
     method: 'POST',
@@ -279,7 +279,9 @@ export const addWalkinToSystem = async (participantName, eventName, genreName, j
         name: participantName,
         eventName: eventName,
         genre: genreName,
-        judgeName: judgeName
+        judgeName: judgeName,
+        teamMembers: teamMembers,
+        teamName: teamName
     })
   })
   }catch(e){
@@ -510,6 +512,19 @@ export const updateEmailTemplate = async (eventName, subject, body) => {
       },
       body: JSON.stringify({ subject, body })
     })
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const resetEmailTemplate = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/email-template/reset`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+    if (res.ok) return await res.json()
+    return null
   } catch (e) {
     console.log(e)
   }

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -228,7 +228,7 @@ export const insertEventInTable = async (eventName, paymentRequired = false) =>{
   }
 }
 
-export const linkGenreToEvent = async(eventName, genres) =>{
+export const linkGenreToEvent = async(eventName, genres, genreFormats = {}) =>{
   try{
     return await fetch(`${domain}/api/v1/event/genre`, {
       method: 'POST',
@@ -239,7 +239,8 @@ export const linkGenreToEvent = async(eventName, genres) =>{
       },
       body: JSON.stringify({
           eventName: eventName,
-          genreName: genres
+          genreName: genres,
+          genreFormats: genreFormats
       })
   })
   }catch(e){
@@ -873,5 +874,62 @@ export const getResultsByRefCode = async (refCode) => {
   } catch (e) {
     console.log(e)
     return { error: 'Network error' }
+  }
+}
+export const getPickupCrews = async (eventName, genreName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/crews/${encodeURIComponent(eventName)}/${encodeURIComponent(genreName)}`, {
+      credentials: 'include'
+    })
+    if (res.ok) return await res.json()
+    return []
+  } catch (e) {
+    console.log(e)
+    return []
+  }
+}
+
+export const createPickupCrew = async (eventName, genreName, crewName, memberParticipantIds) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/crews`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventName, genreName, crewName, memberParticipantIds })
+    })
+    if (res.ok) return await res.json()
+    const body = await res.json().catch(() => ({}))
+    return { error: body.error || 'Failed to create crew' }
+  } catch (e) {
+    console.log(e)
+    return { error: 'Network error' }
+  }
+}
+
+export const deletePickupCrew = async (crewId) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/crews/${crewId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    return res.ok
+  } catch (e) {
+    console.log(e)
+    return false
+  }
+}
+
+export const updateEventGenreFormat = async (eventName, genreName, format) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/genres/${encodeURIComponent(genreName)}/format`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ format })
+    })
+    return res.ok
+  } catch (e) {
+    console.log(e)
+    return false
   }
 }

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -440,6 +440,24 @@ export const setBattleScore = async() =>{
   }
 }
 
+export const setBracketState = async (rounds, topSize) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/bracket`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rounds, topSize: String(topSize) })
+    })
+  } catch (e) { console.error(e) }
+}
+
+export const getBracketState = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/bracket`, { credentials: 'include' })
+    return res.ok ? res.json() : null
+  } catch (e) { return null }
+}
+
 export const uploadImage = async(file)=>{
   try{
     const formData = new FormData();

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -173,6 +173,33 @@ export const getAllJudges = async() =>{
   }
 }
 
+export const getEventJudges = async(eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/judges`, { credentials: 'include' })
+    return res.ok ? await res.json() : []
+  } catch(err) { console.log(err); return [] }
+}
+
+export const addEventJudge = async(eventName, judgeName) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/judge`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ judgeName })
+    })
+  } catch(err) { console.log(err) }
+}
+
+export const removeEventJudge = async(eventName, judgeId) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/judge/${judgeId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+  } catch(err) { console.log(err) }
+}
+
 export const addJudges = async(judgeList) => {
   try{
     await fetch(`${domain}/api/v1/event/judges`, {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -496,6 +496,24 @@ export const getImage = async (filename) => {
   }
 };
 
+export const getBattlePhase = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/phase`, { credentials: 'include' })
+    return res.ok ? res.json() : { phase: 'IDLE' }
+  } catch (e) { return { phase: 'IDLE' } }
+}
+
+export const setBattlePhase = async (phase) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/phase`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phase })
+    })
+  } catch (e) { console.log(e) }
+}
+
 export const getSmokeList = async()=>{
   try{
     const res = await fetch(`${domain}/api/v1/battle/smoke`,{

--- a/BES-frontend/src/utils/auth.js
+++ b/BES-frontend/src/utils/auth.js
@@ -24,8 +24,14 @@ export const markEventVerified = (eventId) => {
     sessionStorage.setItem(VERIFIED_KEY, JSON.stringify(ids))
 }
 
-export const setActiveEvent = (id, name) => {
-    sessionStorage.setItem(ACTIVE_KEY, JSON.stringify({ id: Number(id), name }))
+export const setActiveEvent = (id, name, folderID = null) => {
+    try {
+        const store = useAuthStore()
+        store.setActive(id, name, folderID)
+    } catch {
+        // called outside Pinia context — fall back to sessionStorage only
+        sessionStorage.setItem(ACTIVE_KEY, JSON.stringify({ id: Number(id), name, folderID }))
+    }
 }
 
 export const getActiveEvent = () => {
@@ -42,7 +48,8 @@ export const clearVerifiedEvents = () => {
 export const useAuthStore = defineStore('auth',{
     state: ()=>({
         user: null,
-        isAuthenticated: false
+        isAuthenticated: false,
+        activeEvent: getActiveEvent()
     }),
     actions:{
         login(userData){
@@ -52,11 +59,17 @@ export const useAuthStore = defineStore('auth',{
         logout(){
             this.user = null;
             this.isAuthenticated = false;
+            this.activeEvent = null;
             clearVerifiedEvents();
             localStorage.removeItem('selectedEvent');
             localStorage.removeItem('selectedRole');
             localStorage.removeItem('selectedGenre');
             localStorage.removeItem('currentJudge');
+        },
+        setActive(id, name, folderID = null) {
+            const event = { id: Number(id), name, folderID: folderID ?? null }
+            sessionStorage.setItem(ACTIVE_KEY, JSON.stringify(event))
+            this.activeEvent = event
         }
     },
     getters:{

--- a/BES-frontend/src/utils/eventUtils.js
+++ b/BES-frontend/src/utils/eventUtils.js
@@ -1,13 +1,13 @@
 import { ref } from "vue";
-import { getAllJudges } from "./api";
+import { getEventJudges } from "./api";
 
 export function useEventUtils(){
     const allJudges = ref([])
     const allEvents = ref([])
     const participants = ref([])
-    
-    const fetchAllJudges = async ()=>{
-        allJudges.value = await getAllJudges()
+
+    const fetchAllJudges = async (eventName) => {
+        allJudges.value = eventName ? await getEventJudges(eventName) : []
     }
     return {allJudges, fetchAllJudges, allEvents, participants}
 }

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -1,13 +1,12 @@
 <script setup>
 import ReusableButton from '@/components/ReusableButton.vue';
-import { addGenre, addJudge, deleteGenre, deleteImage, deleteJudge, deleteScore, getAllImages, updateGenre, updateJudge, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag } from '@/utils/adminApi';
+import { addGenre, deleteGenre, deleteImage, deleteScore, getAllImages, updateGenre, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag } from '@/utils/adminApi';
 import { checkInputNull } from '@/utils/utils';
 import { onMounted, ref } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { fetchAllEvents, fetchAllGenres, getAllJudges } from '@/utils/api';
+import { fetchAllEvents, fetchAllGenres } from '@/utils/api';
 import UpdateFieldForm from '@/components/UpdateFieldForm.vue';
 
-const addJudgeInput = ref('');
 const addGenreInput = ref('');
 
 const modalTitle = ref("")
@@ -37,12 +36,7 @@ const selectId = (id, field) => {
 }
 
 const submitUpdate = (value) => {
-  if (updateField.value === "judge") {
-    submitUpdateJudge(selectedId.value, value)
-    judges.value = judges.value.map(x =>
-      x.judgeId === selectedId.value ? { ...x, judgeName: value } : x
-    )
-  } else if (updateField.value === "genre") {
+  if (updateField.value === "genre") {
     submitUpdateGenre(selectedId.value, value)
     genres.value = genres.value.map(x =>
       x.id === selectedId.value ? { ...x, genreName: value } : x
@@ -51,7 +45,6 @@ const submitUpdate = (value) => {
   showUpdateModal.value = false
 }
 
-const judges = ref([])
 const genres = ref([])
 const events = ref([])
 const images = ref([])
@@ -82,17 +75,6 @@ const confirmRemoveImage = (name, title, message) => {
   }
 }
 
-const confirmRemoveJudge = (id, title, message) => {
-  modalTitle.value = title
-  modalMessage.value = message
-  modalVariant.value = 'warning'
-  showModal.value = true
-  dynamicHandler.value = async () => {
-    await submitDeleteJudge(id)
-    showModal.value = false
-  }
-}
-
 const confirmRemoveGenre = (id, title, message) => {
   modalTitle.value = title
   modalMessage.value = message
@@ -114,23 +96,7 @@ const submitAddGenre = async () => {
   }
 }
 
-const submitAddJudge = async () => {
-  if (checkInputNull(addJudgeInput.value)) {
-    openModal("Validation Error", "Judge name cannot be empty.", "error")
-  } else {
-    const res = await addJudge(addJudgeInput.value)
-    judges.value = await res.json()
-    addJudgeInput.value = ''
-  }
-}
-
 const submitUpdateGenre = async (id, value) => { await updateGenre(id, value) }
-const submitUpdateJudge = async (id, value) => { await updateJudge(id, value) }
-
-const submitDeleteJudge = async (id) => {
-  const res = await deleteJudge(id)
-  if (res.ok) judges.value = judges.value.filter(j => j.judgeId !== id)
-}
 
 const submitDeleteGenre = async (id) => {
   const res = await deleteGenre(id)
@@ -177,7 +143,6 @@ const submitDeleteTag = async (tagId) => {
 
 onMounted(async () => {
   genres.value = await fetchAllGenres() ?? []
-  judges.value = await getAllJudges() ?? []
   events.value = await fetchAllEvents() ?? []
   images.value = await getAllImages() ?? []
   feedbackGroups.value = await getFeedbackGroups() ?? []
@@ -190,64 +155,8 @@ onMounted(async () => {
     <!-- Page header -->
     <div>
       <h1 class="page-title">Admin</h1>
-      <p class="text-muted mt-1">Manage judges, genres, events, and system settings</p>
+      <p class="text-muted mt-1">Manage genres, events, and system settings</p>
     </div>
-
-    <!-- Judges section -->
-    <section class="card p-6">
-      <div class="flex items-center gap-3 mb-6">
-        <div class="w-8 h-8 rounded-xl bg-primary-100 flex items-center justify-center">
-          <i class="pi pi-user text-primary-400 text-sm"></i>
-        </div>
-        <h2 class="font-heading font-bold text-content-secondary text-lg">Judges</h2>
-        <span class="badge-neutral text-xs">{{ judges.length }}</span>
-      </div>
-
-      <!-- Add judge -->
-      <div class="flex gap-3 mb-5">
-        <input
-          v-model="addJudgeInput"
-          type="text"
-          placeholder="Judge name…"
-          class="input-base flex-1 max-w-xs"
-          @keyup.enter="submitAddJudge"
-        />
-        <button
-          @click="submitAddJudge"
-          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl bg-primary-600 text-white text-sm
-                 font-semibold hover:bg-primary-700 transition-all duration-200 shadow-sm"
-        >
-          <i class="pi pi-plus text-xs"></i>
-          Add Judge
-        </button>
-      </div>
-
-      <!-- Judge list -->
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
-        <div
-          v-for="j in judges"
-          :key="j.judgeId"
-          class="flex items-center justify-between px-3 py-2.5 rounded-xl border border-surface-600 bg-surface-800 hover:border-surface-500 transition-all"
-        >
-          <button
-            @click="selectId(j.judgeId, 'judge')"
-            class="text-sm font-medium text-content-secondary hover:text-primary-400 text-left truncate flex-1 transition-colors"
-          >
-            {{ j.judgeName }}
-          </button>
-          <button
-            @click="confirmRemoveJudge(j.judgeId, 'Remove Judge?', `Are you sure you want to remove ${j.judgeName}?`)"
-            class="ml-2 flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center
-                   text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
-          >
-            <i class="pi pi-times text-xs"></i>
-          </button>
-        </div>
-        <div v-if="judges.length === 0" class="col-span-full text-sm text-content-muted py-4">
-          No judges added yet
-        </div>
-      </div>
-    </section>
 
     <!-- Genres section -->
     <section class="card p-6">

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -20,6 +20,7 @@ const roles = ref(["Emcee", "Judge"])
 const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem("selectedEvent") || "")
 const selectedRole = ref(localStorage.getItem("selectedRole") || "")
 const selectedGenre = ref(localStorage.getItem("selectedGenre") || "")
+const selectedEntryType = ref('Teams') // 'Teams' | 'Solo'
 const filteredJudge = ref("")
 const currentJudge = ref(localStorage.getItem("currentJudge") || "")
 const allJudges = ref([])
@@ -55,6 +56,19 @@ const dynamicRole = async () => {
 
 const hasJudge = computed(() => participants.value.some(item => item.judgeName !== null))
 
+const hasTeamAndSoloMix = computed(() => {
+  const gp = participants.value.filter(p => p.genreName === selectedGenre.value)
+  const hasTeam = gp.some(p => p.format && p.format !== '1v1')
+  const hasSolo = gp.some(p => !p.format)
+  return hasTeam && hasSolo
+})
+
+const matchesEntryType = (p) => {
+  if (selectedEntryType.value === 'Teams') return p.format && p.format !== '1v1'
+  if (selectedEntryType.value === 'Solo') return !p.format
+  return true
+}
+
 const openModal = (title, message, variant = 'info') => {
   modalTitle.value = title
   modalMessage.value = message
@@ -89,7 +103,8 @@ const filteredParticipantsForJudge = computed({
       .filter(p =>
         p.genreName === selectedGenre.value &&
         p.judgeName === (filteredJudge.value === "" ? null : filteredJudge.value) &&
-        p.auditionNumber !== null
+        p.auditionNumber !== null &&
+        matchesEntryType(p)
       )
       .sort((a, b) => a.auditionNumber - b.auditionNumber)
   },
@@ -112,18 +127,18 @@ watch(filteredParticipantsForJudge, (newVal) => {
 
 const filteredParticipantsForEmceeView = computed(() => {
   const base = filteredJudge.value === ""
-    ? participants.value.filter(p => p.genreName === selectedGenre.value && p.auditionNumber !== null)
-    : participants.value.filter(p => p.genreName === selectedGenre.value && p.judgeName === filteredJudge.value && p.auditionNumber !== null)
+    ? participants.value.filter(p => p.genreName === selectedGenre.value && p.auditionNumber !== null && matchesEntryType(p))
+    : participants.value.filter(p => p.genreName === selectedGenre.value && p.judgeName === filteredJudge.value && p.auditionNumber !== null && matchesEntryType(p))
   return base.sort((a, b) => a.auditionNumber - b.auditionNumber)
 })
 
 const filteredParticipantsForEmcee = computed({
   get() {
     if (filteredJudge.value === "") {
-      return transformForTable(participants.value.filter(p => p.genreName === selectedGenre.value && p.auditionNumber != null))
+      return transformForTable(participants.value.filter(p => p.genreName === selectedGenre.value && p.auditionNumber != null && matchesEntryType(p)))
     }
     return transformForTable(participants.value.filter(p =>
-      p.genreName === selectedGenre.value && p.judgeName === filteredJudge.value && p.auditionNumber !== null
+      p.genreName === selectedGenre.value && p.judgeName === filteredJudge.value && p.auditionNumber !== null && matchesEntryType(p)
     ))
   },
   set(updatedSubset) {
@@ -166,7 +181,10 @@ watch(selectedEvent, async (newVal, oldVal) => {
   }
 }, { immediate: true });
 
-watch(selectedGenre, (newVal) => { if (newVal) localStorage.setItem("selectedGenre", newVal); }, { immediate: true });
+watch(selectedGenre, (newVal) => {
+  if (newVal) localStorage.setItem("selectedGenre", newVal)
+  selectedEntryType.value = 'Teams'
+}, { immediate: true });
 watch(selectedRole, (newVal) => { if (newVal) localStorage.setItem("selectedRole", newVal); }, { immediate: true });
 watch(currentJudge, (newVal) => { if (newVal) localStorage.setItem("currentJudge", newVal); }, { immediate: true });
 
@@ -392,6 +410,7 @@ onMounted(async () => {
           walkin: msg.walkin,
           emailSent: false,
           score: 0,
+          format: msg.format || null,
           rowId: participants.value.length
         })
       }
@@ -502,6 +521,12 @@ onMounted(async () => {
             <span class="badge-neutral text-sm px-3 py-1.5 self-start">{{ selectedEvent }}</span>
           </div>
           <ReusableDropdown v-if="hasJudge" v-model="filteredJudge" labelId="Judge" :options="allJudges" />
+          <ReusableDropdown
+            v-if="hasTeamAndSoloMix"
+            v-model="selectedEntryType"
+            labelId="Type"
+            :options="['Teams', 'Solo']"
+          />
           <ReusableDropdown
             v-if="isAdmin && selectedEvent"
             v-model="judgingMode"

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -514,33 +514,78 @@ onMounted(async () => {
       leave-to-class="opacity-0 -translate-y-2"
     >
       <div v-if="showFilters" class="card p-5 mb-6">
-        <div class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          <ReusableDropdown v-model="selectedRole"  labelId="Role"  :options="roles" />
-          <ReusableDropdown v-model="selectedGenre" labelId="Genre" :options="uniqueGenres" />
-          <div class="flex flex-col gap-1">
-            <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Event</span>
-            <span class="badge-neutral text-sm px-3 py-1.5 self-start">{{ selectedEvent }}</span>
-          </div>
-          <ReusableDropdown v-if="hasJudge" v-model="filteredJudge" labelId="Judge" :options="allJudges" />
-          <ReusableDropdown
-            v-if="hasTeamAndSoloMix"
-            v-model="selectedEntryType"
-            labelId="Type"
-            :options="['Teams', 'Solo']"
-          />
-          <ReusableDropdown
-            v-if="isAdmin && selectedEvent"
-            v-model="judgingMode"
-            labelId="Judging Mode"
-            :options="['SOLO', 'PAIR']"
-            @update:modelValue="(val) => setJudgingMode(selectedEvent, val)"
-          />
-        </div>
+        <div class="flex flex-wrap items-center gap-3">
+          <!-- Event name -->
+          <span class="font-heading font-bold text-base text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
+          <span class="text-surface-600 select-none">|</span>
 
-        <!-- Current judge selector (judge role only) -->
-        <div v-if="selectedRole === 'Judge'" class="mt-4 pt-4 border-t border-surface-600/30">
-          <div class="max-w-xs">
-            <ReusableDropdown v-model="currentJudge" labelId="You are judging as" :options="allJudges" />
+          <!-- Role toggle -->
+          <div class="flex rounded-xl overflow-hidden border border-surface-600">
+            <button
+              v-for="r in roles"
+              :key="r"
+              @click="selectedRole = r"
+              class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+              :class="selectedRole === r
+                ? 'bg-primary-600 text-white'
+                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+            >{{ r }}</button>
+          </div>
+          <span class="text-surface-600 select-none">|</span>
+
+          <!-- Genre toggle -->
+          <div class="flex rounded-xl overflow-hidden border border-surface-600">
+            <button
+              v-for="g in uniqueGenres"
+              :key="g"
+              @click="selectedGenre = g"
+              class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+              :class="selectedGenre === g
+                ? 'bg-primary-600 text-white'
+                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+            >{{ g }}</button>
+          </div>
+
+          <!-- Type toggle (conditional) -->
+          <template v-if="hasTeamAndSoloMix">
+            <span class="text-surface-600 select-none">|</span>
+            <div class="flex rounded-xl overflow-hidden border border-surface-600">
+              <button
+                v-for="t in ['Teams', 'Solo']"
+                :key="t"
+                @click="selectedEntryType = t"
+                class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+                :class="selectedEntryType === t
+                  ? 'bg-primary-600 text-white'
+                  : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              >{{ t }}</button>
+            </div>
+          </template>
+
+          <!-- Judging mode toggle (admin only) -->
+          <template v-if="isAdmin && selectedEvent">
+            <span class="text-surface-600 select-none">|</span>
+            <div class="flex rounded-xl overflow-hidden border border-surface-600">
+              <button
+                v-for="m in ['SOLO', 'PAIR']"
+                :key="m"
+                @click="judgingMode = m; setJudgingMode(selectedEvent, m)"
+                class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+                :class="judgingMode === m
+                  ? 'bg-primary-600 text-white'
+                  : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              >{{ m }}</button>
+            </div>
+          </template>
+
+          <!-- Judge filter + identity dropdowns pushed to the right -->
+          <div class="ml-auto flex items-center gap-3">
+            <div v-if="hasJudge" class="w-40">
+              <ReusableDropdown v-model="filteredJudge" labelId="Judge" :options="allJudges" />
+            </div>
+            <div v-if="selectedRole === 'Judge'" class="w-44">
+              <ReusableDropdown v-model="currentJudge" labelId="You are judging as" :options="allJudges" />
+            </div>
           </div>
         </div>
       </div>

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -2,10 +2,11 @@
 import DynamicTable from '@/components/DynamicTable.vue';
 import ReusableButton from '@/components/ReusableButton.vue';
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getAllJudges, getRegisteredParticipantsByEvent, submitParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria } from '@/utils/api';
+import { getEventJudges, getRegisteredParticipantsByEvent, submitParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria } from '@/utils/api';
 import { getFeedbackGroups } from '@/utils/adminApi';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch, toRaw } from 'vue';
+import { RouterLink } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
 import FeedbackPopout from '@/components/FeedbackPopout.vue';
 import Timer from '@/components/Timer.vue';
@@ -55,6 +56,8 @@ const dynamicRole = async () => {
 }
 
 const hasJudge = computed(() => participants.value.some(item => item.judgeName !== null))
+
+const noJudgesConfigured = computed(() => selectedEvent.value && allJudges.value.length <= 1)
 
 const hasTeamAndSoloMix = computed(() => {
   const gp = participants.value.filter(p => p.genreName === selectedGenre.value)
@@ -158,10 +161,20 @@ watch(selectedEvent, async (newVal, oldVal) => {
       selectedGenre.value = ""
     }
     participants.value = []
-    const [res, modeRes] = await Promise.all([
+    const [res, modeRes, judgeRes] = await Promise.all([
       getRegisteredParticipantsByEvent(newVal),
-      getJudgingMode(newVal)
+      getJudgingMode(newVal),
+      getEventJudges(newVal)
     ])
+    const judgeNames = judgeRes.map(item => item.judgeName)
+    allJudges.value = ["", ...judgeNames]
+    if (!judgeNames.includes(currentJudge.value)) {
+      currentJudge.value = ""
+      localStorage.removeItem("currentJudge")
+    }
+    if (!judgeNames.includes(filteredJudge.value)) {
+      filteredJudge.value = ""
+    }
     if (selectedEvent.value !== newVal) return
     participants.value = res.map((r, i) => ({ ...r, rowId: r.rowId ?? i, score: 0 }))
     if (modeRes?.judgingMode) judgingMode.value = modeRes.judgingMode
@@ -374,8 +387,8 @@ onUnmounted(() => {
 
 onMounted(async () => {
   await dynamicRole()
-  const [judgeRes, groupRes] = await Promise.all([getAllJudges(), getFeedbackGroups()])
-  allJudges.value = ["", ...Object.values(judgeRes).map(item => item.judgeName)]
+  const [judgeRes, groupRes] = await Promise.all([getEventJudges(selectedEvent.value), getFeedbackGroups()])
+  allJudges.value = ["", ...judgeRes.map(item => item.judgeName)]
   tagGroups.value = groupRes ?? []
 
   // On page refresh, judge/genre/event are restored from localStorage so the watch
@@ -590,6 +603,23 @@ onMounted(async () => {
         </div>
       </div>
     </Transition>
+
+    <!-- No judges banner -->
+    <div
+      v-if="noJudgesConfigured"
+      class="flex items-center gap-3 px-4 py-3 mb-4 rounded-xl border border-amber-800/40 bg-amber-950/30 text-sm"
+    >
+      <i class="pi pi-exclamation-triangle text-amber-400 text-sm flex-shrink-0"></i>
+      <span class="text-amber-200/80">
+        No judges configured for <strong class="text-amber-200">{{ selectedEvent }}</strong>.
+      </span>
+      <RouterLink
+        :to="`/events/${selectedEvent}`"
+        class="ml-auto flex-shrink-0 text-xs font-semibold text-primary-400 hover:text-primary-300 underline underline-offset-2 transition-colors"
+      >
+        Add judges in Event Details →
+      </RouterLink>
+    </div>
 
     <!-- Emcee view: Timer + round view -->
     <template v-if="selectedRole === 'Emcee' && filteredParticipantsForEmceeView.length > 0">

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -64,6 +64,7 @@ const hasTeamAndSoloMix = computed(() => {
 })
 
 const matchesEntryType = (p) => {
+  if (!hasTeamAndSoloMix.value) return true
   if (selectedEntryType.value === 'Teams') return p.format && p.format !== '1v1'
   if (selectedEntryType.value === 'Solo') return !p.format
   return true

--- a/BES-frontend/src/views/AuditionNumber.vue
+++ b/BES-frontend/src/views/AuditionNumber.vue
@@ -17,6 +17,8 @@ const modalTitle = ref("")
 const modalMessage = ref("")
 const showModal = ref(false)
 
+const revealingRef = ref(null)
+
 const groupedHistory = computed(() => {
   const order = []
   const map = new Map()
@@ -25,14 +27,15 @@ const groupedHistory = computed(() => {
       const idx = order.indexOf(a.name)
       order.splice(idx, 1)
     } else {
-      map.set(a.name, new Map())
+      map.set(a.name, { refCode: a.refCode || '', genres: new Map() })
     }
     order.push(a.name)
-    map.get(a.name).set(a.genre, a)
+    map.get(a.name).genres.set(a.genre, a)
   }
   return order.reverse().map(name => ({
     name,
-    entries: [...map.get(name).values()]
+    refCode: map.get(name).refCode,
+    entries: [...map.get(name).genres.values()]
   }))
 })
 
@@ -157,7 +160,7 @@ onBeforeUnmount(() => {
               : 'text-sm font-semibold text-content-secondary w-28 shrink-0 truncate'"
           >{{ group.name }}</span>
           <!-- Genre + number pills -->
-          <div class="flex flex-wrap gap-1.5">
+          <div class="flex flex-wrap gap-1.5 flex-1">
             <span
               v-for="a in group.entries"
               :key="a.genre"
@@ -172,6 +175,27 @@ onBeforeUnmount(() => {
               >#{{ a.auditionNumber }}</span>
             </span>
           </div>
+          <!-- Hold-to-reveal ref code -->
+          <span
+            v-if="group.refCode"
+            class="relative shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-surface-800 border border-surface-600 cursor-pointer select-none touch-none"
+            @mousedown="revealingRef = group.name"
+            @mouseup="revealingRef = null"
+            @mouseleave="revealingRef = null"
+            @touchstart.prevent="revealingRef = group.name"
+            @touchend="revealingRef = null"
+            @touchcancel="revealingRef = null"
+          >
+            <i class="pi pi-eye text-content-muted" style="font-size:0.65rem"></i>
+            <span class="text-content-muted">Ref code</span>
+            <span
+              v-if="revealingRef === group.name"
+              class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-4 py-2.5 rounded-xl bg-surface-700 border border-surface-500 shadow-xl whitespace-nowrap z-50 pointer-events-none"
+            >
+              <span class="font-source tracking-widest text-primary-400 text-base font-bold">{{ group.refCode }}</span>
+              <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-500"></span>
+            </span>
+          </span>
         </div>
       </div>
     </div>

--- a/BES-frontend/src/views/AuditionNumber.vue
+++ b/BES-frontend/src/views/AuditionNumber.vue
@@ -100,7 +100,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="w-full flex flex-col items-center justify-center min-h-[180px] text-center">
+  <div class="w-full max-w-2xl mx-auto px-6 flex flex-col items-center justify-center min-h-[180px] text-center">
 
     <!-- Animating state -->
     <div v-if="loading" class="space-y-3">
@@ -160,7 +160,7 @@ onBeforeUnmount(() => {
               : 'text-sm font-semibold text-content-secondary w-28 shrink-0 truncate'"
           >{{ group.name }}</span>
           <!-- Genre + number pills -->
-          <div class="flex flex-wrap gap-1.5 flex-1">
+          <div class="flex flex-wrap gap-1.5 min-w-0">
             <span
               v-for="a in group.entries"
               :key="a.genre"
@@ -178,7 +178,7 @@ onBeforeUnmount(() => {
           <!-- Hold-to-reveal ref code -->
           <span
             v-if="group.refCode"
-            class="relative shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-surface-800 border border-surface-600 cursor-pointer select-none touch-none"
+            class="relative ml-auto shrink-0 inline-flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-semibold bg-surface-700 border border-surface-500 text-content-secondary cursor-pointer select-none touch-none hover:border-primary-500/50 hover:text-primary-400 transition-colors"
             @mousedown="revealingRef = group.name"
             @mouseup="revealingRef = null"
             @mouseleave="revealingRef = null"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -139,6 +139,12 @@ const nextPair = async () => {
       await setBattlePair(left, right)
       currentWinner.value = -2
       currentRound.value += 1
+    } else {
+      // Last battle of this round — end match and return to IDLE
+      await setBattlePhase('IDLE')
+      battlePhase.value = 'IDLE'
+      currentWinner.value = -2
+      currentBattle.value = []
     }
   }
 }
@@ -488,6 +494,7 @@ watch(selectedEvent, async (newVal) => {
     const res = await getParticipantScore(newVal)
     participants.value = res.sort((a, b) => b.score - a.score)
     pickupCrews.value = []
+    await fetchAllJudges(newVal)
   }
 }, { immediate: true })
 
@@ -516,7 +523,7 @@ watch(topSize, async (newVal) => {
 
 onMounted(async () => {
   iintialiseDropdown()
-  await fetchAllJudges()
+  await fetchAllJudges(selectedEvent.value)
   battleJudges.value = await getBattleJudges()
   const phaseData = await getBattlePhase()
   battlePhase.value = phaseData?.phase ?? 'IDLE'

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,7 +1,7 @@
 <script setup>
 import ReusableButton from '@/components/ReusableButton.vue'
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattleScore, setBracketState, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getBattlePhase, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattlePhase, setBattleScore, setBracketState, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -18,6 +18,8 @@ const currentBattle = ref([])
 const currentWinner = ref(-2)
 const currentRound = ref(0)
 const currentTop = ref('')
+const battlePhase = ref('IDLE')
+const showResetConfirm = ref(false)
 
 const pickupCrews = ref([])
 const crewSortMode = ref('leader')  // 'leader' | 'avg'
@@ -458,10 +460,20 @@ const submitGetScore = async () => {
   if (data.winner === 1 || data.winner === 0) { setWinner(currentTop.value, currentRound.value, data.winner) }
 }
 
-const clearLocalStorage = () => {
+const openVoting = async () => {
+  await setBattlePhase('VOTING')
+  battlePhase.value = 'VOTING'
+}
+
+const confirmResetBracket = async () => {
+  showResetConfirm.value = false
   localStorage.removeItem(`Top${topSize.value}${selectedGenre.value}Rounds`)
   rounds.value = initRounds()
   broadcastBracket()
+  await setBattlePhase('IDLE')
+  battlePhase.value = 'IDLE'
+  currentWinner.value = -2
+  currentBattle.value = []
 }
 
 watch(selectedEvent, async (newVal) => {
@@ -500,6 +512,11 @@ onMounted(async () => {
   iintialiseDropdown()
   await fetchAllJudges()
   battleJudges.value = await getBattleJudges()
+  const phaseData = await getBattlePhase()
+  battlePhase.value = phaseData?.phase ?? 'IDLE'
+  subscribeToChannel(createClient(), '/topic/battle/phase', (msg) => {
+    battlePhase.value = msg.phase
+  })
 })
 </script>
 
@@ -986,9 +1003,41 @@ onMounted(async () => {
       </div>
     </div>
 
+    <!-- Reset bracket confirmation modal -->
+    <Transition name="fade">
+      <div v-if="showResetConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+        <div class="bg-surface-800 rounded-2xl border border-surface-600 p-6 max-w-sm w-full mx-4 shadow-xl">
+          <h3 class="font-heading font-bold text-content-primary text-lg mb-2">Reset Bracket?</h3>
+          <p class="text-sm text-content-muted mb-6">This will clear all bracket data and set the battle phase to IDLE. This cannot be undone.</p>
+          <div class="flex gap-3 justify-end">
+            <button
+              @click="showResetConfirm = false"
+              class="px-4 py-2 rounded-xl border border-surface-600 bg-surface-700 text-sm font-semibold
+                     text-content-secondary hover:bg-surface-600 transition-all"
+            >Cancel</button>
+            <button
+              @click="confirmResetBracket"
+              class="px-4 py-2 rounded-xl bg-red-600 text-white text-sm font-semibold hover:bg-red-700 transition-all"
+            >Reset</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
     <!-- Live match tracker -->
     <div class="card p-5">
-      <h2 class="font-heading font-bold text-content-secondary mb-4">Live Match</h2>
+      <div class="flex items-center gap-3 mb-4">
+        <h2 class="font-heading font-bold text-content-secondary">Live Match</h2>
+        <span
+          class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold uppercase tracking-wide"
+          :class="{
+            'bg-surface-700 text-surface-400': battlePhase === 'IDLE',
+            'bg-amber-500/20 text-amber-400 border border-amber-500/40': battlePhase === 'LOCKED',
+            'bg-primary-500/20 text-primary-400 border border-primary-500/40 animate-pulse': battlePhase === 'VOTING',
+            'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40': battlePhase === 'REVEALED',
+          }"
+        >{{ battlePhase }}</span>
+      </div>
 
       <!-- Winner announcement -->
       <div
@@ -1053,7 +1102,30 @@ onMounted(async () => {
 
       <!-- Action buttons -->
       <div class="flex flex-wrap gap-2">
-        <template v-if="Number(currentWinner) !== -2 && Number(currentWinner) !== -3 && (Number(currentWinner) !== -1 || isSmoke)">
+        <!-- LOCKED: open voting -->
+        <button
+          v-if="battlePhase === 'LOCKED'"
+          @click="openVoting"
+          class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-primary-600 text-white text-sm
+                 font-semibold hover:bg-primary-700 transition-all shadow-sm"
+        >
+          <i class="pi pi-lock-open text-xs"></i>
+          Open Voting
+        </button>
+
+        <!-- VOTING: get score / rematch -->
+        <button
+          v-if="battlePhase === 'VOTING'"
+          @click="submitGetScore"
+          class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-primary-600 text-white text-sm
+                 font-semibold hover:bg-primary-700 transition-all shadow-sm"
+        >
+          <i class="pi pi-bolt text-xs"></i>
+          {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}
+        </button>
+
+        <!-- REVEALED: previous + next -->
+        <template v-if="battlePhase === 'REVEALED'">
           <button
             @click="prevPair"
             class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
@@ -1071,19 +1143,9 @@ onMounted(async () => {
             <i class="pi pi-chevron-right text-xs"></i>
           </button>
         </template>
-        <template v-else>
-          <button
-            @click="submitGetScore"
-            class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-primary-600 text-white text-sm
-                   font-semibold hover:bg-primary-700 transition-all shadow-sm"
-          >
-            <i class="pi pi-bolt text-xs"></i>
-            {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}
-          </button>
-        </template>
 
         <button
-          @click="clearLocalStorage"
+          @click="showResetConfirm = true"
           class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-red-200 bg-surface-800
                  text-sm font-semibold text-red-400 hover:bg-red-950 transition-all"
         >

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,7 +1,7 @@
 <script setup>
 import ReusableButton from '@/components/ReusableButton.vue'
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getParticipantScore, removeBattleJudge, setBattlePair, setBattleScore, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattleScore, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -18,6 +18,9 @@ const currentBattle = ref([])
 const currentWinner = ref(-2)
 const currentRound = ref(0)
 const currentTop = ref('')
+
+const pickupCrews = ref([])
+const crewSortMode = ref('leader')  // 'leader' | 'avg'
 
 const uploadedFiles = ref([])
 
@@ -138,6 +141,53 @@ const topParticipants = computed(() => {
   return [...new Set(participants.value.filter(p => p.genreName === selectedGenre.value).map(p => p.participantName))]
 })
 
+// Pre-formed teams: registered with a format (e.g. "2v2"), deduped by name, sorted by avg score
+const preFormedTeams = computed(() => {
+  const seen = new Map()
+  for (const p of participants.value) {
+    if (p.genreName !== selectedGenre.value) continue
+    if (!p.format || p.format === '') continue
+    if (!seen.has(p.participantName)) {
+      seen.set(p.participantName, { name: p.participantName, totalScore: 0, count: 0 })
+    }
+    const entry = seen.get(p.participantName)
+    entry.totalScore += p.score ?? 0
+    entry.count++
+  }
+  return [...seen.values()]
+    .map(e => ({ name: e.name, avgScore: e.count > 0 ? e.totalScore / e.count : 0 }))
+    .sort((a, b) => b.avgScore - a.avgScore)
+})
+
+// Pickup crews sorted by leader score or team avg score
+const sortedPickupCrews = computed(() =>
+  [...pickupCrews.value].sort((a, b) => {
+    const sa = crewSortMode.value === 'leader' ? (a.leaderScore ?? 0) : (a.avgScore ?? 0)
+    const sb = crewSortMode.value === 'leader' ? (b.leaderScore ?? 0) : (b.avgScore ?? 0)
+    return sb - sa
+  })
+)
+
+// True only when BOTH pre-formed teams AND pickup crews exist — Split bracket is only relevant then
+const isMixedBracket = computed(() => preFormedTeams.value.length > 0 && pickupCrews.value.length > 0)
+
+// Pool used by bracket slot dropdowns, seeding picker, and all sort/fill functions.
+// When pre-formed teams exist, exclude raw individual names from the pool — team names only.
+const bracketPool = computed(() => {
+  if (isMixedBracket.value) {
+    return [
+      ...preFormedTeams.value.map(t => t.name),
+      ...sortedPickupCrews.value.map(c => c.crewName),
+    ]
+  }
+  // Pure team genre (pre-formed teams, no pickup crews) — only team names
+  if (preFormedTeams.value.length > 0) {
+    return preFormedTeams.value.map(t => t.name)
+  }
+  // Pure solo genre — original behavior
+  return topNParticipants.value
+})
+
 // Bracket seeding
 const bracketSize = computed(() => Number(topSize.value) === 7 ? 8 : Number(topSize.value))
 
@@ -158,7 +208,7 @@ const seeds = ref([])
 const activeSeedIdx = ref(null)
 
 const seededNames = computed(() => new Set(seeds.value.filter(Boolean)))
-const availableForSeeding = computed(() => topNParticipants.value.filter(p => !seededNames.value.has(p)))
+const availableForSeeding = computed(() => bracketPool.value.filter(p => !seededNames.value.has(p)))
 const allSeeded = computed(() => seeds.value.every(Boolean))
 
 const resetSeeds = () => {
@@ -166,28 +216,74 @@ const resetSeeds = () => {
   activeSeedIdx.value = null
 }
 const rankAsc = ref(false) // false = desc (highest first), true = asc (lowest first)
+// Helper: fill a fixed-length array with items from a pool, padding with nulls
+const fillHalf = (pool, size) => [
+  ...pool.slice(0, size),
+  ...Array(Math.max(0, size - pool.length)).fill(null),
+]
+
 const autoFillSeeds = () => {
-  const pool = topNParticipants.value
-  const ordered = rankAsc.value ? [...pool].reverse() : pool
-  seeds.value = [...ordered, ...Array(Math.max(0, bracketSize.value - ordered.length)).fill(null)]
+  if (isMixedBracket.value) {
+    const half = Math.floor(bracketSize.value / 2)
+    const preformed = preFormedTeams.value.map(t => t.name)
+    const pickup = sortedPickupCrews.value.map(c => c.crewName)
+    const orderedPre = rankAsc.value ? [...preformed].reverse() : preformed
+    const orderedPick = rankAsc.value ? [...pickup].reverse() : pickup
+    seeds.value = [...fillHalf(orderedPre, half), ...fillHalf(orderedPick, half)]
+  } else {
+    const pool = bracketPool.value.slice(0, bracketSize.value)
+    const ordered = rankAsc.value ? [...pool].reverse() : pool
+    seeds.value = [...ordered, ...Array(Math.max(0, bracketSize.value - ordered.length)).fill(null)]
+  }
   activeSeedIdx.value = null
 }
 
 const highVsLowFill = () => {
-  const pool = topNParticipants.value
-  const n = pool.length
-  const result = Array(bracketSize.value).fill(null)
-  for (let i = 0; i < Math.ceil(n / 2); i++) {
-    result[i * 2] = pool[i]
-    if (n - 1 - i !== i) result[i * 2 + 1] = pool[n - 1 - i]
+  const hvl = (pool, size) => {
+    const n = pool.length
+    const result = Array(size).fill(null)
+    for (let i = 0; i < Math.ceil(n / 2); i++) {
+      result[i * 2] = pool[i]
+      if (n - 1 - i !== i) result[i * 2 + 1] = pool[n - 1 - i]
+    }
+    return result
   }
-  seeds.value = result
+  if (isMixedBracket.value) {
+    const half = Math.floor(bracketSize.value / 2)
+    seeds.value = [
+      ...hvl(preFormedTeams.value.map(t => t.name), half),
+      ...hvl(sortedPickupCrews.value.map(c => c.crewName), half),
+    ]
+  } else {
+    seeds.value = hvl(bracketPool.value.slice(0, bracketSize.value), bracketSize.value)
+  }
   activeSeedIdx.value = null
 }
 
 const randomFill = () => {
-  const pool = [...topNParticipants.value].sort(() => Math.random() - 0.5)
-  seeds.value = [...pool, ...Array(Math.max(0, bracketSize.value - pool.length)).fill(null)]
+  if (isMixedBracket.value) {
+    const half = Math.floor(bracketSize.value / 2)
+    const preformed = [...preFormedTeams.value.map(t => t.name)].sort(() => Math.random() - 0.5)
+    const pickup = [...sortedPickupCrews.value.map(c => c.crewName)].sort(() => Math.random() - 0.5)
+    seeds.value = [...fillHalf(preformed, half), ...fillHalf(pickup, half)]
+  } else {
+    const pool = [...bracketPool.value.slice(0, bracketSize.value)].sort(() => Math.random() - 0.5)
+    seeds.value = [...pool, ...Array(Math.max(0, bracketSize.value - pool.length)).fill(null)]
+  }
+  activeSeedIdx.value = null
+}
+
+// Split: pre-formed teams fill the first half of the bracket, pickup crews fill the second half.
+// This guarantees pre-formed teams only face each other and pickup crews only face each other
+// until the final — where one side winner meets the other.
+const splitBracketFill = () => {
+  const half = Math.floor(bracketSize.value / 2)
+  const preformed = preFormedTeams.value.slice(0, half).map(t => t.name)
+  const pickup = sortedPickupCrews.value.slice(0, half).map(c => c.crewName)
+  const newSeeds = Array(bracketSize.value).fill(null)
+  preformed.forEach((name, i) => { newSeeds[i] = name })
+  pickup.forEach((name, i) => { newSeeds[half + i] = name })
+  seeds.value = newSeeds
   activeSeedIdx.value = null
 }
 const clickSeedSlot = (idx) => {
@@ -362,6 +458,7 @@ watch(selectedEvent, async (newVal) => {
     localStorage.setItem("selectedEvent", newVal)
     const res = await getParticipantScore(newVal)
     participants.value = res.sort((a, b) => b.score - a.score)
+    pickupCrews.value = []
   }
 }, { immediate: true })
 
@@ -370,6 +467,9 @@ watch(selectedGenre, async (newVal) => {
     localStorage.setItem("selectedGenre", newVal)
     const storedRounds = localStorage.getItem(`Top${topSize.value}${newVal}Rounds`)
     rounds.value = JSON.parse(storedRounds) || initRounds()
+    pickupCrews.value = await getPickupCrews(selectedEvent.value, newVal)
+  } else {
+    pickupCrews.value = []
   }
 }, { immediate: true })
 
@@ -504,6 +604,25 @@ onMounted(async () => {
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-2">
+            <!-- Pickup crew sort toggle — only shown in mixed bracket mode -->
+            <div v-if="isMixedBracket" class="flex items-center gap-1.5 text-xs">
+              <span class="text-content-muted font-semibold">Pickup sort:</span>
+              <div class="flex rounded-lg border border-surface-600/60 overflow-hidden bg-surface-800/60 font-semibold">
+                <button
+                  @click="crewSortMode = 'leader'"
+                  class="px-2.5 py-1 transition-all"
+                  :class="crewSortMode === 'leader' ? 'bg-primary-600 text-white' : 'text-content-muted hover:text-content-primary'"
+                  title="Sort pickup crews by their leader's individual audition score"
+                >Leader</button>
+                <button
+                  @click="crewSortMode = 'avg'"
+                  class="px-2.5 py-1 transition-all"
+                  :class="crewSortMode === 'avg' ? 'bg-primary-600 text-white' : 'text-content-muted hover:text-content-primary'"
+                  title="Sort pickup crews by average score of all members"
+                >Avg</button>
+              </div>
+            </div>
+
             <!-- Fill strategy buttons -->
             <div class="flex rounded-xl border border-surface-600/60 overflow-hidden bg-surface-800/60 text-xs font-semibold">
               <button
@@ -531,12 +650,22 @@ onMounted(async () => {
               </button>
               <button
                 @click="randomFill"
-                class="flex items-center gap-1 px-2.5 py-1.5 text-content-secondary
-                       hover:bg-surface-700 hover:text-content-primary transition-all"
+                class="flex items-center gap-1 px-2.5 py-1.5 text-content-secondary transition-all"
+                :class="isMixedBracket ? 'border-r border-surface-600/60 hover:bg-surface-700 hover:text-content-primary' : 'hover:bg-surface-700 hover:text-content-primary'"
                 title="Random shuffle"
               >
                 <i class="pi pi-refresh text-xs"></i>
                 Random
+              </button>
+              <!-- Split: only shown when both pre-formed teams and pickup crews exist -->
+              <button
+                v-if="isMixedBracket"
+                @click="splitBracketFill"
+                class="flex items-center gap-1 px-2.5 py-1.5 text-primary-400 hover:bg-primary-500/10 transition-all"
+                title="Pre-formed teams on left half, pickup crews on right half — final is pre-formed winner vs pickup winner"
+              >
+                <i class="pi pi-table text-xs"></i>
+                Split
               </button>
             </div>
 
@@ -555,8 +684,75 @@ onMounted(async () => {
           </div>
         </div>
 
-        <!-- Seed slots grid -->
-        <div class="grid grid-cols-4 gap-2 mb-3">
+        <!-- Seed slots: two labeled sections when mixed, single grid otherwise -->
+        <template v-if="isMixedBracket">
+          <!-- Pre-formed teams side (first half) -->
+          <div class="mb-3">
+            <p class="text-xs font-semibold text-primary-400 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
+              <i class="pi pi-users text-xs"></i>
+              Pre-formed Teams — Slots 1–{{ Math.floor(bracketSize / 2) }}
+            </p>
+            <div class="grid grid-cols-4 gap-2">
+              <button
+                v-for="j in Math.floor(bracketSize / 2)"
+                :key="j - 1"
+                @click="clickSeedSlot(j - 1)"
+                class="relative flex items-center gap-2 px-3 py-2.5 rounded-xl border text-left transition-all duration-150"
+                :class="[
+                  activeSeedIdx === j - 1
+                    ? 'border-primary-500/70 bg-primary-500/10 ring-1 ring-primary-500/30'
+                    : seeds[j - 1]
+                      ? 'border-surface-600/60 bg-surface-700/60 hover:border-surface-500'
+                      : 'border-dashed border-surface-600/40 bg-surface-800/30 hover:border-surface-500/60',
+                ]"
+              >
+                <span
+                  class="flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-xs font-source font-bold"
+                  :class="seeds[j - 1] ? 'bg-primary-500/20 text-primary-400' : 'bg-surface-700 text-surface-500'"
+                >{{ j }}</span>
+                <span class="text-sm font-semibold truncate flex-1"
+                  :class="seeds[j - 1] ? 'text-content-primary' : 'text-content-muted'"
+                >{{ seeds[j - 1] || 'Empty' }}</span>
+                <i v-if="seeds[j - 1]" class="pi pi-times text-xs text-surface-500 hover:text-red-400 transition-colors flex-shrink-0"></i>
+              </button>
+            </div>
+          </div>
+
+          <!-- Pickup crews side (second half) -->
+          <div class="mb-3">
+            <p class="text-xs font-semibold text-amber-400 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
+              <i class="pi pi-users text-xs"></i>
+              Pickup Crews — Slots {{ Math.floor(bracketSize / 2) + 1 }}–{{ bracketSize }}
+            </p>
+            <div class="grid grid-cols-4 gap-2">
+              <button
+                v-for="j in Math.floor(bracketSize / 2)"
+                :key="Math.floor(bracketSize / 2) + j - 1"
+                @click="clickSeedSlot(Math.floor(bracketSize / 2) + j - 1)"
+                class="relative flex items-center gap-2 px-3 py-2.5 rounded-xl border text-left transition-all duration-150"
+                :class="[
+                  activeSeedIdx === Math.floor(bracketSize / 2) + j - 1
+                    ? 'border-amber-500/70 bg-amber-500/10 ring-1 ring-amber-500/30'
+                    : seeds[Math.floor(bracketSize / 2) + j - 1]
+                      ? 'border-surface-600/60 bg-surface-700/60 hover:border-surface-500'
+                      : 'border-dashed border-surface-600/40 bg-surface-800/30 hover:border-surface-500/60',
+                ]"
+              >
+                <span
+                  class="flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-xs font-source font-bold"
+                  :class="seeds[Math.floor(bracketSize / 2) + j - 1] ? 'bg-amber-500/20 text-amber-400' : 'bg-surface-700 text-surface-500'"
+                >{{ Math.floor(bracketSize / 2) + j }}</span>
+                <span class="text-sm font-semibold truncate flex-1"
+                  :class="seeds[Math.floor(bracketSize / 2) + j - 1] ? 'text-content-primary' : 'text-content-muted'"
+                >{{ seeds[Math.floor(bracketSize / 2) + j - 1] || 'Empty' }}</span>
+                <i v-if="seeds[Math.floor(bracketSize / 2) + j - 1]" class="pi pi-times text-xs text-surface-500 hover:text-red-400 transition-colors flex-shrink-0"></i>
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <!-- Standard single grid (pure solo or pure pre-formed) -->
+        <div v-else class="grid grid-cols-4 gap-2 mb-3">
           <button
             v-for="(name, i) in seeds"
             :key="i"
@@ -639,7 +835,7 @@ onMounted(async () => {
                 @change="updateMatch(`Top${size}`, mIdx, 0, rounds[`Top${size}`][mIdx][0])"
               >
                 <option :value="null" disabled>Select participant…</option>
-                <option v-for="p in topNParticipants" :key="p" :value="p">{{ p }}</option>
+                <option v-for="p in bracketPool" :key="p" :value="p">{{ p }}</option>
               </select>
               <button
                 :disabled="!match[0]"
@@ -676,7 +872,7 @@ onMounted(async () => {
                 @change="updateMatch(`Top${size}`, mIdx, 1, rounds[`Top${size}`][mIdx][1])"
               >
                 <option :value="null" disabled>Select participant…</option>
-                <option v-for="p in topNParticipants" :key="p" :value="p">{{ p }}</option>
+                <option v-for="p in bracketPool" :key="p" :value="p">{{ p }}</option>
               </select>
               <button
                 :disabled="!match[1]"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,7 +1,7 @@
 <script setup>
 import ReusableButton from '@/components/ReusableButton.vue'
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattleScore, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattleScore, setBracketState, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -94,6 +94,9 @@ const updateSmokePair = async () => {
 }
 
 const initiateBattlePair = async (top, pairList) => {
+  // Reset winner FIRST so the winnerAnnouncement computed doesn't fire setWinner
+  // with stale winner + new round/top values when reactive state updates below.
+  currentWinner.value = -2
   await resetJudgeVote()
   if (isSmoke.value) {
     await setBattlePair(rounds.value[0].name, rounds.value[1].name)
@@ -306,6 +309,7 @@ const applyToFirstRound = () => {
       name: name ?? rounds.value[i]?.name ?? null,
       score: rounds.value[i]?.score ?? 0,
     }))
+    broadcastBracket()
     return
   }
   const key = `Top${bracketSize.value}`
@@ -315,6 +319,7 @@ const applyToFirstRound = () => {
     rounds.value[key][i][1] = seeds.value[i * 2 + 1] ?? null
   }
   localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  broadcastBracket()
 }
 
 watch([bracketSize, selectedGenre], resetSeeds, { immediate: true })
@@ -346,9 +351,12 @@ function initRounds() {
   return standardBattleRound()
 }
 
+const broadcastBracket = () => setBracketState(toRaw(rounds.value), topSize.value)
+
 function updateMatch(roundKey, matchIdx, slotIdx, value) {
   rounds.value[roundKey][matchIdx][slotIdx] = value
   localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  broadcastBracket()
 }
 
 async function update7toSmokeMatch(winner) {
@@ -378,12 +386,13 @@ function setWinner(roundKey, matchIdx, slotIdx) {
   match[2] = winner
   const roundIndex = roundSizes.value.indexOf(parseInt(roundKey.replace("Top", "")))
   const nextRoundSize = roundSizes.value[roundIndex + 1]
-  if (!nextRoundSize) { localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value))); return }
+  if (!nextRoundSize) { localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value))); broadcastBracket(); return }
   const nextRoundKey = `Top${nextRoundSize}`
   const nextMatchIdx = Math.floor(matchIdx / 2)
   const nextSlotIdx = matchIdx % 2
   rounds.value[nextRoundKey][nextMatchIdx][nextSlotIdx] = winner
   localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  broadcastBracket()
 }
 
 function clearWinner(roundKey, matchIdx) {
@@ -397,6 +406,7 @@ function clearWinner(roundKey, matchIdx) {
   }
   match[2] = null
   localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  broadcastBracket()
 }
 
 
@@ -451,6 +461,7 @@ const submitGetScore = async () => {
 const clearLocalStorage = () => {
   localStorage.removeItem(`Top${topSize.value}${selectedGenre.value}Rounds`)
   rounds.value = initRounds()
+  broadcastBracket()
 }
 
 watch(selectedEvent, async (newVal) => {
@@ -468,6 +479,7 @@ watch(selectedGenre, async (newVal) => {
     const storedRounds = localStorage.getItem(`Top${topSize.value}${newVal}Rounds`)
     rounds.value = JSON.parse(storedRounds) || initRounds()
     pickupCrews.value = await getPickupCrews(selectedEvent.value, newVal)
+    broadcastBracket()
   } else {
     pickupCrews.value = []
   }
@@ -480,6 +492,7 @@ watch(topSize, async (newVal) => {
     rounds.value = JSON.parse(storedRounds) || initRounds()
     currentBattle.value = []
     currentWinner.value = -2
+    broadcastBracket()
   }
 }, { immediate: true })
 
@@ -535,6 +548,18 @@ onMounted(async () => {
       >
         <i class="pi pi-users text-xs"></i>
         Judge View
+        <i class="pi pi-external-link text-xs text-content-muted"></i>
+      </a>
+      <a
+        href="/battle/bracket"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
+               text-sm font-semibold text-content-secondary hover:border-primary-400 hover:text-primary-400
+               transition-all duration-200"
+      >
+        <i class="pi pi-sitemap text-xs"></i>
+        Live Bracket
         <i class="pi pi-external-link text-xs text-content-muted"></i>
       </a>
     </div>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -20,6 +20,7 @@ const currentRound = ref(0)
 const currentTop = ref('')
 const battlePhase = ref('IDLE')
 const showResetConfirm = ref(false)
+const activeRoundIdx = ref(0)
 
 const pickupCrews = ref([])
 const crewSortMode = ref('leader')  // 'leader' | 'avg'
@@ -241,6 +242,7 @@ const autoFillSeeds = () => {
     seeds.value = [...ordered, ...Array(Math.max(0, bracketSize.value - ordered.length)).fill(null)]
   }
   activeSeedIdx.value = null
+  applyToFirstRound()
 }
 
 const highVsLowFill = () => {
@@ -263,6 +265,7 @@ const highVsLowFill = () => {
     seeds.value = hvl(bracketPool.value.slice(0, bracketSize.value), bracketSize.value)
   }
   activeSeedIdx.value = null
+  applyToFirstRound()
 }
 
 const randomFill = () => {
@@ -276,6 +279,7 @@ const randomFill = () => {
     seeds.value = [...pool, ...Array(Math.max(0, bracketSize.value - pool.length)).fill(null)]
   }
   activeSeedIdx.value = null
+  applyToFirstRound()
 }
 
 // Split: pre-formed teams fill the first half of the bracket, pickup crews fill the second half.
@@ -290,6 +294,7 @@ const splitBracketFill = () => {
   pickup.forEach((name, i) => { newSeeds[half + i] = name })
   seeds.value = newSeeds
   activeSeedIdx.value = null
+  applyToFirstRound()
 }
 const clickSeedSlot = (idx) => {
   if (seeds.value[idx]) {
@@ -304,6 +309,7 @@ const assignSeed = (name) => {
   const s = [...seeds.value]; s[activeSeedIdx.value] = name; seeds.value = s
   const next = s.findIndex((v, i) => i > activeSeedIdx.value && !v)
   activeSeedIdx.value = next !== -1 ? next : null
+  if (s.every(Boolean)) applyToFirstRound()
 }
 const applyToFirstRound = () => {
   if (isSmoke.value) {
@@ -581,427 +587,287 @@ onMounted(async () => {
       </a>
     </div>
 
-    <!-- Config bar -->
+    <!-- Config bar + Bracket (merged) -->
     <div class="card p-5">
-      <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-4">
-        <div class="flex flex-col gap-1">
-          <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Event</span>
-          <span class="badge-neutral text-sm px-3 py-1.5 self-start">{{ selectedEvent }}</span>
+      <div class="flex flex-wrap items-center gap-3 mb-4">
+        <!-- Event name -->
+        <span class="font-heading font-bold text-base text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
+        <span class="text-surface-600 select-none">|</span>
+
+        <!-- Genre toggle -->
+        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <button
+            v-for="g in uniqueGenres"
+            :key="g"
+            @click="selectedGenre = g"
+            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            :class="selectedGenre === g
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >{{ g }}</button>
         </div>
-        <ReusableDropdown v-model="selectedGenre" labelId="Genre" :options="uniqueGenres" />
-        <ReusableDropdown v-model="topSize" labelId="Format" :options="sizes" />
+        <span class="text-surface-600 select-none">|</span>
+
+        <!-- Format toggle -->
+        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <button
+            v-for="s in sizes"
+            :key="s"
+            @click="topSize = s"
+            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            :class="topSize === s
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >{{ s === 7 ? '7 to Smoke' : `Top ${s}` }}</button>
+        </div>
       </div>
 
       <!-- Judge management -->
-      <div class="flex flex-wrap items-end gap-3 pt-4 border-t border-surface-600/30">
-        <div class="w-48">
-          <ReusableDropdown v-model="selectedJudge" labelId="Add Judge" :options="allJudgeOptions" />
-        </div>
-        <button
-          @click="submitAddBattleJudge(selectedJudge)"
-          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl bg-surface-800 text-white text-sm
-                 font-semibold hover:bg-surface-900 transition-all duration-200"
-        >
-          <i class="pi pi-plus text-xs"></i>
-          Add
-        </button>
+      <div class="flex flex-wrap items-center gap-3 pt-4 border-t border-surface-600/30">
+        <span class="text-xs font-semibold text-content-muted uppercase tracking-wide whitespace-nowrap">Judges</span>
 
-        <!-- Active judges -->
+        <!-- Active judge pills -->
         <div class="flex flex-wrap gap-2">
           <span
             v-for="(j, index) in battleJudges?.judges || []"
             :key="index"
-            class="badge-neutral inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-surface-700
-                   text-sm font-medium text-content-secondary border border-surface-600"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-semibold
+                   text-content-secondary bg-surface-700 border border-surface-600"
           >
             {{ j.name }}
             <button
               @click="submitRemoveBattleJudge(j.name)"
-              class="w-4 h-4 rounded-full flex items-center justify-center
-                     hover:bg-surface-300 transition-colors"
+              class="flex items-center justify-center hover:text-red-400 transition-colors"
             >
-              <i class="pi pi-times text-xs text-content-muted"></i>
+              <i class="pi pi-times text-xs"></i>
             </button>
           </span>
+          <span v-if="!battleJudges?.judges?.length" class="text-xs text-content-muted italic">None added</span>
+        </div>
+
+        <!-- Add control pushed to the right -->
+        <div class="ml-auto flex items-center gap-2">
+          <div class="w-44">
+            <ReusableDropdown v-model="selectedJudge" labelId="" :options="allJudgeOptions" />
+          </div>
+          <button
+            @click="submitAddBattleJudge(selectedJudge)"
+            class="flex items-center gap-1.5 px-3.5 py-2 rounded-xl bg-primary-600 text-white text-sm
+                   font-semibold hover:bg-primary-700 transition-all duration-200 whitespace-nowrap"
+          >
+            <i class="pi pi-plus text-xs"></i>
+            Add
+          </button>
         </div>
       </div>
-    </div>
 
-    <!-- Bracket setup -->
-    <div class="card p-5">
-      <h2 class="font-heading font-bold text-content-secondary mb-5">Bracket</h2>
+      <div class="h-px bg-surface-600/30 my-4"></div>
 
-      <!-- ── Seeding panel ─────────────────────────────── -->
-      <div class="mb-6">
-        <div class="flex items-center justify-between mb-3">
-          <div>
-            <h3 class="text-sm font-bold text-content-primary">
-              Participant Seeding
-              <span class="ml-2 text-xs font-normal text-content-muted">
-                {{ seededNames.size }} / {{ bracketSize }} selected
-              </span>
-            </h3>
-            <p class="text-xs text-content-muted mt-0.5">
-              Select {{ bracketSize }} participants, then apply to bracket
-            </p>
+      <!-- ── Seeding quick-fill ───────────────────────────── -->
+      <div class="flex flex-wrap items-center gap-3 mb-5">
+        <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Seed by</span>
+
+        <!-- Pickup crew sort toggle (mixed bracket only) -->
+        <template v-if="isMixedBracket">
+          <div class="flex rounded-lg border border-surface-600/60 overflow-hidden text-xs font-semibold">
+            <button
+              @click="crewSortMode = 'leader'"
+              class="px-2.5 py-1.5 transition-all"
+              :class="crewSortMode === 'leader' ? 'bg-primary-600 text-white' : 'bg-surface-800 text-content-muted hover:text-content-primary'"
+              title="Sort pickup crews by their leader's individual audition score"
+            >Leader</button>
+            <button
+              @click="crewSortMode = 'avg'"
+              class="px-2.5 py-1.5 transition-all"
+              :class="crewSortMode === 'avg' ? 'bg-primary-600 text-white' : 'bg-surface-800 text-content-muted hover:text-content-primary'"
+              title="Sort pickup crews by average score of all members"
+            >Avg</button>
           </div>
-          <div class="flex flex-wrap items-center gap-2">
-            <!-- Pickup crew sort toggle — only shown in mixed bracket mode -->
-            <div v-if="isMixedBracket" class="flex items-center gap-1.5 text-xs">
-              <span class="text-content-muted font-semibold">Pickup sort:</span>
-              <div class="flex rounded-lg border border-surface-600/60 overflow-hidden bg-surface-800/60 font-semibold">
-                <button
-                  @click="crewSortMode = 'leader'"
-                  class="px-2.5 py-1 transition-all"
-                  :class="crewSortMode === 'leader' ? 'bg-primary-600 text-white' : 'text-content-muted hover:text-content-primary'"
-                  title="Sort pickup crews by their leader's individual audition score"
-                >Leader</button>
-                <button
-                  @click="crewSortMode = 'avg'"
-                  class="px-2.5 py-1 transition-all"
-                  :class="crewSortMode === 'avg' ? 'bg-primary-600 text-white' : 'text-content-muted hover:text-content-primary'"
-                  title="Sort pickup crews by average score of all members"
-                >Avg</button>
+          <span class="text-surface-600 select-none">|</span>
+        </template>
+
+        <div class="flex rounded-xl border border-surface-600/60 overflow-hidden text-xs font-semibold">
+          <button
+            @click="autoFillSeeds"
+            class="flex items-center gap-1 px-3 py-1.5 text-content-secondary border-r border-surface-600/60
+                   hover:bg-surface-700 hover:text-content-primary transition-all"
+            :title="rankAsc ? 'Lowest score first' : 'Highest score first'"
+          >
+            <i :class="rankAsc ? 'pi pi-sort-amount-up' : 'pi pi-sort-amount-down'" class="text-xs"></i>
+            By Rank
+            <button
+              @click.stop="rankAsc = !rankAsc; autoFillSeeds()"
+              class="ml-0.5 px-1 py-0.5 rounded font-mono text-primary-400 hover:bg-primary-500/20 transition-all"
+              :title="rankAsc ? 'Switch to highest first' : 'Switch to lowest first'"
+            >{{ rankAsc ? '↑' : '↓' }}</button>
+          </button>
+          <button
+            @click="highVsLowFill"
+            class="flex items-center gap-1 px-3 py-1.5 text-content-secondary border-r border-surface-600/60
+                   hover:bg-surface-700 hover:text-content-primary transition-all"
+            title="Pair highest with lowest (1st vs last, 2nd vs 2nd-last...)"
+          >
+            <i class="pi pi-arrows-v text-xs"></i>
+            High ↔ Low
+          </button>
+          <button
+            @click="randomFill"
+            class="flex items-center gap-1 px-3 py-1.5 text-content-secondary transition-all"
+            :class="isMixedBracket ? 'border-r border-surface-600/60 hover:bg-surface-700 hover:text-content-primary' : 'hover:bg-surface-700 hover:text-content-primary'"
+            title="Random shuffle"
+          >
+            <i class="pi pi-refresh text-xs"></i>
+            Random
+          </button>
+          <button
+            v-if="isMixedBracket"
+            @click="splitBracketFill"
+            class="flex items-center gap-1 px-3 py-1.5 text-primary-400 hover:bg-primary-500/10 transition-all"
+            title="Pre-formed teams on left half, pickup crews on right half"
+          >
+            <i class="pi pi-table text-xs"></i>
+            Split
+          </button>
+        </div>
+      </div>
+
+      <!-- ── Standard bracket ──────────────────────────── -->
+      <div v-if="Number(topSize) !== 7">
+        <!-- Round tabs -->
+        <div class="flex rounded-xl overflow-hidden border border-surface-600 self-start mb-4 w-fit">
+          <button
+            v-for="(size, idx) in roundSizes"
+            :key="idx"
+            @click="activeRoundIdx = idx"
+            class="px-5 py-2 text-sm font-semibold transition-all duration-150"
+            :class="activeRoundIdx === idx
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >Top {{ size }}</button>
+        </div>
+
+        <!-- Active round matches -->
+        <template v-for="(size, idx) in roundSizes" :key="idx">
+          <div v-if="activeRoundIdx === idx" class="bg-surface-900/60 rounded-2xl p-4 border border-surface-600/50">
+            <!-- 2-col grid for 4+ matches, single col otherwise -->
+            <div
+              class="mb-3"
+              :class="rounds[`Top${size}`]?.length >= 4 ? 'grid grid-cols-2 gap-2' : 'flex flex-col gap-2'"
+            >
+              <div
+                v-for="(match, mIdx) in rounds[`Top${size}`]"
+                :key="mIdx"
+                class="rounded-lg border border-surface-600/40 bg-surface-800/50 overflow-hidden"
+              >
+                <!-- Player 0 -->
+                <div
+                  class="flex items-center gap-1.5 px-2 py-1.5 transition-colors"
+                  :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/10' : ''"
+                >
+                  <i
+                    class="pi pi-crown text-xs flex-shrink-0 transition-colors"
+                    :class="match[2] === match[0] && match[0] ? 'text-amber-400' : 'text-surface-600'"
+                  ></i>
+                  <select
+                    class="flex-1 min-w-0 bg-transparent text-xs font-semibold outline-none cursor-pointer
+                           text-content-primary disabled:text-content-muted"
+                    :class="match[2] === match[0] && match[0] ? 'text-emerald-400' : ''"
+                    v-model="rounds[`Top${size}`][mIdx][0]"
+                    @change="updateMatch(`Top${size}`, mIdx, 0, rounds[`Top${size}`][mIdx][0])"
+                  >
+                    <option :value="null" disabled>Select…</option>
+                    <option v-for="p in bracketPool" :key="p" :value="p">{{ p }}</option>
+                  </select>
+                  <button
+                    :disabled="!match[0]"
+                    @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : setWinner(`Top${size}`, mIdx, 0)"
+                    class="flex-shrink-0 w-10 text-center rounded text-xs font-bold transition-all
+                           disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    :class="match[2] === match[0] && match[0]
+                      ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40'
+                      : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+                    :title="match[2] === match[0] && match[0] ? 'Click to unselect winner' : 'Set as winner'"
+                  >{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
+                </div>
+
+                <!-- VS divider -->
+                <div class="flex items-center gap-1.5 px-2 border-y border-surface-600/30 bg-surface-900/30">
+                  <div class="flex-1 h-px bg-surface-600/20"></div>
+                  <span class="text-xs font-bold text-surface-600 py-0.5">VS</span>
+                  <div class="flex-1 h-px bg-surface-600/20"></div>
+                </div>
+
+                <!-- Player 1 -->
+                <div
+                  class="flex items-center gap-1.5 px-2 py-1.5 transition-colors"
+                  :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/10' : ''"
+                >
+                  <i
+                    class="pi pi-crown text-xs flex-shrink-0 transition-colors"
+                    :class="match[2] === match[1] && match[1] ? 'text-amber-400' : 'text-surface-600'"
+                  ></i>
+                  <select
+                    class="flex-1 min-w-0 bg-transparent text-xs font-semibold outline-none cursor-pointer text-content-primary"
+                    :class="match[2] === match[1] && match[1] ? 'text-emerald-400' : ''"
+                    v-model="rounds[`Top${size}`][mIdx][1]"
+                    @change="updateMatch(`Top${size}`, mIdx, 1, rounds[`Top${size}`][mIdx][1])"
+                  >
+                    <option :value="null" disabled>Select…</option>
+                    <option v-for="p in bracketPool" :key="p" :value="p">{{ p }}</option>
+                  </select>
+                  <button
+                    :disabled="!match[1]"
+                    @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : setWinner(`Top${size}`, mIdx, 1)"
+                    class="flex-shrink-0 w-10 text-center rounded text-xs font-bold transition-all
+                           disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    :class="match[2] === match[1] && match[1]
+                      ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40'
+                      : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+                    :title="match[2] === match[1] && match[1] ? 'Click to unselect winner' : 'Set as winner'"
+                  >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
+                </div>
               </div>
             </div>
 
-            <!-- Fill strategy buttons -->
-            <div class="flex rounded-xl border border-surface-600/60 overflow-hidden bg-surface-800/60 text-xs font-semibold">
-              <button
-                @click="autoFillSeeds"
-                class="flex items-center gap-1 px-2.5 py-1.5 text-content-secondary border-r border-surface-600/60
-                       hover:bg-surface-700 hover:text-content-primary transition-all"
-                :title="rankAsc ? 'Lowest score first — click to fill' : 'Highest score first — click to fill'"
-              >
-                <i :class="rankAsc ? 'pi pi-sort-amount-up' : 'pi pi-sort-amount-down'" class="text-xs"></i>
-                By Rank
-                <button
-                  @click.stop="rankAsc = !rankAsc; autoFillSeeds()"
-                  class="ml-0.5 px-1 py-0.5 rounded text-xs font-mono text-primary-400 hover:bg-primary-500/20 transition-all"
-                  :title="rankAsc ? 'Switch to highest first' : 'Switch to lowest first'"
-                >{{ rankAsc ? '↑' : '↓' }}</button>
-              </button>
-              <button
-                @click="highVsLowFill"
-                class="flex items-center gap-1 px-2.5 py-1.5 text-content-secondary border-r border-surface-600/60
-                       hover:bg-surface-700 hover:text-content-primary transition-all"
-                title="Pair highest with lowest (1st vs last, 2nd vs 2nd-last...)"
-              >
-                <i class="pi pi-arrows-v text-xs"></i>
-                High ↔ Low
-              </button>
-              <button
-                @click="randomFill"
-                class="flex items-center gap-1 px-2.5 py-1.5 text-content-secondary transition-all"
-                :class="isMixedBracket ? 'border-r border-surface-600/60 hover:bg-surface-700 hover:text-content-primary' : 'hover:bg-surface-700 hover:text-content-primary'"
-                title="Random shuffle"
-              >
-                <i class="pi pi-refresh text-xs"></i>
-                Random
-              </button>
-              <!-- Split: only shown when both pre-formed teams and pickup crews exist -->
-              <button
-                v-if="isMixedBracket"
-                @click="splitBracketFill"
-                class="flex items-center gap-1 px-2.5 py-1.5 text-primary-400 hover:bg-primary-500/10 transition-all"
-                title="Pre-formed teams on left half, pickup crews on right half — final is pre-formed winner vs pickup winner"
-              >
-                <i class="pi pi-table text-xs"></i>
-                Split
-              </button>
-            </div>
-
             <button
-              @click="applyToFirstRound"
-              :disabled="!allSeeded"
-              class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-bold transition-all
-                     disabled:opacity-30 disabled:cursor-not-allowed"
-              :class="allSeeded
-                ? 'bg-primary-600 text-white hover:bg-primary-700'
-                : 'bg-surface-700 text-content-muted border border-surface-600'"
+              @click="initiateBattlePair(`Top${size}`, rounds[`Top${size}`])"
+              class="w-full py-2 rounded-xl bg-primary-600 text-white text-xs font-bold
+                     hover:bg-primary-700 active:bg-primary-800 transition-all duration-200"
             >
-              <i class="pi pi-check text-xs"></i>
-              Apply to Bracket
+              <i class="pi pi-play text-xs mr-1.5"></i>
+              Start Round
             </button>
           </div>
-        </div>
-
-        <!-- Seed slots: two labeled sections when mixed, single grid otherwise -->
-        <template v-if="isMixedBracket">
-          <!-- Pre-formed teams side (first half) -->
-          <div class="mb-3">
-            <p class="text-xs font-semibold text-primary-400 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
-              <i class="pi pi-users text-xs"></i>
-              Pre-formed Teams — Slots 1–{{ Math.floor(bracketSize / 2) }}
-            </p>
-            <div class="grid grid-cols-4 gap-2">
-              <button
-                v-for="j in Math.floor(bracketSize / 2)"
-                :key="j - 1"
-                @click="clickSeedSlot(j - 1)"
-                class="relative flex items-center gap-2 px-3 py-2.5 rounded-xl border text-left transition-all duration-150"
-                :class="[
-                  activeSeedIdx === j - 1
-                    ? 'border-primary-500/70 bg-primary-500/10 ring-1 ring-primary-500/30'
-                    : seeds[j - 1]
-                      ? 'border-surface-600/60 bg-surface-700/60 hover:border-surface-500'
-                      : 'border-dashed border-surface-600/40 bg-surface-800/30 hover:border-surface-500/60',
-                ]"
-              >
-                <span
-                  class="flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-xs font-source font-bold"
-                  :class="seeds[j - 1] ? 'bg-primary-500/20 text-primary-400' : 'bg-surface-700 text-surface-500'"
-                >{{ j }}</span>
-                <span class="text-sm font-semibold truncate flex-1"
-                  :class="seeds[j - 1] ? 'text-content-primary' : 'text-content-muted'"
-                >{{ seeds[j - 1] || 'Empty' }}</span>
-                <i v-if="seeds[j - 1]" class="pi pi-times text-xs text-surface-500 hover:text-red-400 transition-colors flex-shrink-0"></i>
-              </button>
-            </div>
-          </div>
-
-          <!-- Pickup crews side (second half) -->
-          <div class="mb-3">
-            <p class="text-xs font-semibold text-amber-400 uppercase tracking-wide mb-1.5 flex items-center gap-1.5">
-              <i class="pi pi-users text-xs"></i>
-              Pickup Crews — Slots {{ Math.floor(bracketSize / 2) + 1 }}–{{ bracketSize }}
-            </p>
-            <div class="grid grid-cols-4 gap-2">
-              <button
-                v-for="j in Math.floor(bracketSize / 2)"
-                :key="Math.floor(bracketSize / 2) + j - 1"
-                @click="clickSeedSlot(Math.floor(bracketSize / 2) + j - 1)"
-                class="relative flex items-center gap-2 px-3 py-2.5 rounded-xl border text-left transition-all duration-150"
-                :class="[
-                  activeSeedIdx === Math.floor(bracketSize / 2) + j - 1
-                    ? 'border-amber-500/70 bg-amber-500/10 ring-1 ring-amber-500/30'
-                    : seeds[Math.floor(bracketSize / 2) + j - 1]
-                      ? 'border-surface-600/60 bg-surface-700/60 hover:border-surface-500'
-                      : 'border-dashed border-surface-600/40 bg-surface-800/30 hover:border-surface-500/60',
-                ]"
-              >
-                <span
-                  class="flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-xs font-source font-bold"
-                  :class="seeds[Math.floor(bracketSize / 2) + j - 1] ? 'bg-amber-500/20 text-amber-400' : 'bg-surface-700 text-surface-500'"
-                >{{ Math.floor(bracketSize / 2) + j }}</span>
-                <span class="text-sm font-semibold truncate flex-1"
-                  :class="seeds[Math.floor(bracketSize / 2) + j - 1] ? 'text-content-primary' : 'text-content-muted'"
-                >{{ seeds[Math.floor(bracketSize / 2) + j - 1] || 'Empty' }}</span>
-                <i v-if="seeds[Math.floor(bracketSize / 2) + j - 1]" class="pi pi-times text-xs text-surface-500 hover:text-red-400 transition-colors flex-shrink-0"></i>
-              </button>
-            </div>
-          </div>
         </template>
-
-        <!-- Standard single grid (pure solo or pure pre-formed) -->
-        <div v-else class="grid grid-cols-4 gap-2 mb-3">
-          <button
-            v-for="(name, i) in seeds"
-            :key="i"
-            @click="clickSeedSlot(i)"
-            class="relative flex items-center gap-2 px-3 py-2.5 rounded-xl border text-left transition-all duration-150"
-            :class="[
-              activeSeedIdx === i
-                ? 'border-primary-500/70 bg-primary-500/10 ring-1 ring-primary-500/30'
-                : name
-                  ? 'border-surface-600/60 bg-surface-700/60 hover:border-surface-500'
-                  : 'border-dashed border-surface-600/40 bg-surface-800/30 hover:border-surface-500/60',
-            ]"
-          >
-            <span
-              class="flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-xs font-source font-bold"
-              :class="name ? 'bg-primary-500/20 text-primary-400' : 'bg-surface-700 text-surface-500'"
-            >{{ i + 1 }}</span>
-            <span
-              class="text-sm font-semibold truncate flex-1"
-              :class="name ? 'text-content-primary' : 'text-content-muted'"
-            >{{ name || 'Empty' }}</span>
-            <i v-if="name" class="pi pi-times text-xs text-surface-500 hover:text-red-400 transition-colors flex-shrink-0"></i>
-          </button>
-        </div>
-
-        <!-- Available participants picker -->
-        <Transition name="fade-down">
-          <div v-if="activeSeedIdx !== null" class="rounded-xl border border-primary-500/30 bg-surface-800/80 p-3">
-            <p class="text-xs font-semibold text-primary-400 mb-2 uppercase tracking-wider">
-              Selecting for slot #{{ activeSeedIdx + 1 }} — click a participant
-            </p>
-            <div v-if="availableForSeeding.length" class="flex flex-wrap gap-1.5">
-              <button
-                v-for="p in availableForSeeding"
-                :key="p"
-                @click="assignSeed(p)"
-                class="px-3 py-1.5 rounded-lg border border-surface-600/60 bg-surface-700/60 text-sm font-semibold
-                       text-content-secondary hover:border-primary-500/60 hover:bg-primary-500/10 hover:text-primary-400
-                       transition-all duration-150"
-              >{{ p }}</button>
-            </div>
-            <p v-else class="text-xs text-content-muted">All participants have been assigned.</p>
-          </div>
-        </Transition>
-      </div>
-
-      <div class="h-px bg-surface-600/30 mb-5"></div>
-
-      <!-- ── Standard bracket ──────────────────────────── -->
-      <div v-if="Number(topSize) !== 7" class="overflow-x-auto -mx-1 px-1 pb-2">
-        <div class="flex gap-4" :style="`min-width: ${roundSizes.length * 220}px`">
-        <div
-          v-for="(size, idx) in roundSizes"
-          :key="idx"
-          class="bg-surface-900/60 rounded-2xl p-4 border border-surface-600/50 flex-1 min-w-[200px]"
-        >
-          <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-3">
-            Top {{ size }}
-          </div>
-
-          <div
-            v-for="(match, mIdx) in rounds[`Top${size}`]"
-            :key="mIdx"
-            class="mb-3 rounded-xl border border-surface-600/40 bg-surface-800/50 overflow-hidden"
-          >
-            <!-- Player 0 -->
-            <div
-              class="flex items-center gap-2 px-3 py-2.5 transition-colors"
-              :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/10' : ''"
-            >
-              <i
-                class="pi pi-crown text-xs flex-shrink-0 transition-colors"
-                :class="match[2] === match[0] && match[0] ? 'text-amber-400' : 'text-surface-600'"
-              ></i>
-              <select
-                class="flex-1 min-w-0 bg-transparent text-sm font-semibold outline-none cursor-pointer
-                       text-content-primary disabled:text-content-muted"
-                :class="match[2] === match[0] && match[0] ? 'text-emerald-400' : ''"
-                v-model="rounds[`Top${size}`][mIdx][0]"
-                @change="updateMatch(`Top${size}`, mIdx, 0, rounds[`Top${size}`][mIdx][0])"
-              >
-                <option :value="null" disabled>Select participant…</option>
-                <option v-for="p in bracketPool" :key="p" :value="p">{{ p }}</option>
-              </select>
-              <button
-                :disabled="!match[0]"
-                @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : setWinner(`Top${size}`, mIdx, 0)"
-                class="flex-shrink-0 w-14 py-0.5 rounded-lg text-xs font-bold text-center transition-all
-                       disabled:opacity-20 disabled:cursor-not-allowed"
-                :class="match[2] === match[0] && match[0]
-                  ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40'
-                  : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
-                :title="match[2] === match[0] && match[0] ? 'Click to unselect winner' : 'Set as winner'"
-              >{{ match[2] === match[0] && match[0] ? '✓ Win' : 'Win' }}</button>
-            </div>
-
-            <!-- VS divider -->
-            <div class="flex items-center gap-2 px-3 py-1 border-y border-surface-600/30 bg-surface-900/30">
-              <div class="flex-1 h-px bg-surface-600/20"></div>
-              <span class="text-xs font-bold text-surface-500">VS</span>
-              <div class="flex-1 h-px bg-surface-600/20"></div>
-            </div>
-
-            <!-- Player 1 -->
-            <div
-              class="flex items-center gap-2 px-3 py-2.5 transition-colors"
-              :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/10' : ''"
-            >
-              <i
-                class="pi pi-crown text-xs flex-shrink-0 transition-colors"
-                :class="match[2] === match[1] && match[1] ? 'text-amber-400' : 'text-surface-600'"
-              ></i>
-              <select
-                class="flex-1 min-w-0 bg-transparent text-sm font-semibold outline-none cursor-pointer text-content-primary"
-                :class="match[2] === match[1] && match[1] ? 'text-emerald-400' : ''"
-                v-model="rounds[`Top${size}`][mIdx][1]"
-                @change="updateMatch(`Top${size}`, mIdx, 1, rounds[`Top${size}`][mIdx][1])"
-              >
-                <option :value="null" disabled>Select participant…</option>
-                <option v-for="p in bracketPool" :key="p" :value="p">{{ p }}</option>
-              </select>
-              <button
-                :disabled="!match[1]"
-                @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : setWinner(`Top${size}`, mIdx, 1)"
-                class="flex-shrink-0 w-14 py-0.5 rounded-lg text-xs font-bold text-center transition-all
-                       disabled:opacity-20 disabled:cursor-not-allowed"
-                :class="match[2] === match[1] && match[1]
-                  ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40'
-                  : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
-                :title="match[2] === match[1] && match[1] ? 'Click to unselect winner' : 'Set as winner'"
-              >{{ match[2] === match[1] && match[1] ? '✓ Win' : 'Win' }}</button>
-            </div>
-          </div>
-
-          <button
-            @click="initiateBattlePair(`Top${size}`, rounds[`Top${size}`])"
-            class="w-full mt-1 py-2.5 rounded-xl bg-primary-600 text-white text-xs font-bold
-                   hover:bg-primary-700 active:bg-primary-800 transition-all duration-200"
-          >
-            <i class="pi pi-play text-xs mr-1.5"></i>
-            Start Round
-          </button>
-        </div>
-        </div>
       </div>
 
       <!-- ── 7 to Smoke bracket ──────────────────────────── -->
       <div v-else class="bg-surface-900/60 rounded-2xl p-4 border border-surface-600/50">
-        <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-4">7 to Smoke</div>
+        <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-3">7 to Smoke — Queue</div>
 
-        <!-- Slot grid -->
-        <div class="grid grid-cols-2 gap-2 mb-3">
-          <button
-            v-for="(match, mIdx) in (Array.isArray(rounds.value) ? rounds.value : [])"
+        <!-- Queue: ordered chips, populated by fill buttons above -->
+        <div v-if="Array.isArray(rounds) && rounds.some(r => r.name)" class="flex flex-wrap gap-2 mb-4">
+          <div
+            v-for="(match, mIdx) in rounds"
             :key="mIdx"
-            @click="clickSmokeSlot(mIdx)"
-            class="relative flex items-center gap-2 px-3 py-2.5 rounded-xl border text-left transition-all duration-150"
-            :class="[
-              activeSmokeIdx === mIdx
-                ? 'border-primary-500/70 bg-primary-500/10 ring-1 ring-primary-500/30'
-                : match.name
-                  ? 'border-surface-600/60 bg-surface-700/60 hover:border-surface-500'
-                  : 'border-dashed border-surface-600/40 bg-surface-800/30 hover:border-surface-500/60',
-            ]"
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-surface-600/40 bg-surface-800/50 text-sm font-semibold text-content-secondary"
           >
-            <span
-              class="flex-shrink-0 w-6 h-6 rounded-lg flex items-center justify-center text-xs font-source font-bold"
-              :class="match.name ? 'bg-primary-500/20 text-primary-400' : 'bg-surface-700 text-surface-500'"
-            >{{ mIdx + 1 }}</span>
-            <span
-              class="text-sm font-semibold truncate flex-1"
-              :class="match.name ? 'text-content-primary' : 'text-content-muted'"
-            >{{ match.name || 'Empty' }}</span>
-            <i v-if="match.name" class="pi pi-times text-xs text-surface-500 hover:text-red-400 transition-colors flex-shrink-0"></i>
-          </button>
-        </div>
-
-        <!-- Participant picker -->
-        <Transition name="fade-down">
-          <div v-if="activeSmokeIdx !== null" class="rounded-xl border border-primary-500/30 bg-surface-800/80 p-3 mb-3">
-            <p class="text-xs font-semibold text-primary-400 mb-2 uppercase tracking-wider">
-              Selecting for slot #{{ activeSmokeIdx + 1 }} — click a participant
-            </p>
-            <div v-if="availableForSmoke.length" class="flex flex-wrap gap-1.5">
-              <button
-                v-for="p in availableForSmoke"
-                :key="p"
-                @click="assignSmokeSlot(p)"
-                class="px-3 py-1.5 rounded-lg border border-surface-600/60 bg-surface-700/60 text-sm font-semibold
-                       text-content-secondary hover:border-primary-500/60 hover:bg-primary-500/10 hover:text-primary-400
-                       transition-all duration-150"
-              >{{ p }}</button>
-            </div>
-            <p v-else class="text-xs text-content-muted">All participants have been assigned.</p>
+            <span class="text-xs font-source text-primary-400 font-bold">{{ mIdx + 1 }}</span>
+            <span>{{ match.name || '—' }}</span>
           </div>
-        </Transition>
+        </div>
+        <p v-else class="text-xs text-content-muted mb-4">Use the Seed by buttons above to fill the queue.</p>
 
         <button
           @click="initiateBattlePair(0, 0)"
-          class="w-full py-2.5 rounded-xl bg-primary-600 text-white text-xs font-bold
+          class="w-full py-2 rounded-xl bg-primary-600 text-white text-xs font-bold
                  hover:bg-primary-700 transition-all duration-200"
         >
           <i class="pi pi-play text-xs mr-1.5"></i>
           Start Round
         </button>
       </div>
-    </div>
+    </div> <!-- end merged card -->
 
     <!-- Reset bracket confirmation modal -->
     <Transition name="fade">

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -3,7 +3,8 @@ import leftHand from '@/assets/lefthand.png'
 import rightHand from '@/assets/righthand.png'
 import tie from '@/assets/no.png'
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { battleJudgeVote, getBattleJudges } from '@/utils/api'
+import { battleJudgeVote, getBattleJudges, getBattlePhase, getCurrentBattlePair } from '@/utils/api'
+import { subscribeToChannel, createClient } from '@/utils/websocket'
 import { computed, onMounted, ref } from 'vue'
 
 const active = ref(null)
@@ -15,7 +16,13 @@ const battleJudgesName = computed(() => {
   return judges.map(j => j.name)
 })
 
+const battlePhase = ref('IDLE')
+const leftName = ref('')
+const rightName = ref('')
+const revealedWinner = ref(-2)
+
 async function handleClick(side) {
+  if (battlePhase.value !== 'VOTING') return
   if (active.value === side) {
     const judges = battleJudges.value?.judges ?? []
     const id = judges.filter(j => j.name === selectedJudge.value).map(j => j.id)
@@ -30,11 +37,48 @@ async function handleClick(side) {
 
 onMounted(async () => {
   battleJudges.value = await getBattleJudges()
+
+  const phaseData = await getBattlePhase()
+  battlePhase.value = phaseData?.phase ?? 'IDLE'
+
+  const pairData = await getCurrentBattlePair()
+  if (pairData) {
+    leftName.value = pairData.left ?? ''
+    rightName.value = pairData.right ?? ''
+  }
+
+  subscribeToChannel(createClient(), '/topic/battle/phase', (msg) => {
+    battlePhase.value = msg.phase
+    if (msg.phase === 'LOCKED') {
+      active.value = null
+      confirmed.value = null
+      revealedWinner.value = -2
+    }
+  })
+
+  subscribeToChannel(createClient(), '/topic/battle/battle-pair', (msg) => {
+    leftName.value = msg.left ?? ''
+    rightName.value = msg.right ?? ''
+  })
+
+  subscribeToChannel(createClient(), '/topic/battle/score', (msg) => {
+    revealedWinner.value = msg.message
+  })
 })
 </script>
 
 <template>
   <div class="judge-root" role="main" aria-label="Battle Judge voting panel">
+
+    <!-- ── IDLE overlay ───────────────────────────── -->
+    <Transition name="phase-fade">
+      <div v-if="battlePhase === 'IDLE'" class="phase-blocker idle-blocker" aria-live="polite">
+        <div class="phase-blocker-inner">
+          <span class="phase-blocker-icon">⏳</span>
+          <p class="phase-blocker-title">Waiting for battle setup…</p>
+        </div>
+      </div>
+    </Transition>
 
     <!-- ── Header bar ─────────────────────────────── -->
     <header class="judge-header">
@@ -43,6 +87,18 @@ onMounted(async () => {
         <span class="brand-wordmark">BATTLE JUDGE</span>
         <span class="brand-pip pip-blue"></span>
       </div>
+
+      <!-- Phase pill + pair names -->
+      <div class="header-center" aria-live="polite">
+        <span
+          class="phase-pill"
+          :class="`phase-pill--${battlePhase.toLowerCase()}`"
+        >{{ battlePhase }}</span>
+        <span v-if="leftName && (battlePhase === 'LOCKED' || battlePhase === 'VOTING')" class="pair-label">
+          {{ leftName }} <span class="vs-sep">vs</span> {{ rightName }}
+        </span>
+      </div>
+
       <div class="selector-wrap" role="group" aria-label="Voting as">
         <span class="selector-eyebrow" aria-hidden="true">VOTING AS</span>
         <div class="w-52">
@@ -58,6 +114,36 @@ onMounted(async () => {
 
     <!-- ── Voting panels ──────────────────────────── -->
     <div class="panels-wrap" role="group" aria-label="Vote options">
+
+      <!-- LOCKED overlay: voting not yet open -->
+      <Transition name="phase-fade">
+        <div v-if="battlePhase === 'LOCKED'" class="panels-overlay locked-overlay" aria-live="polite">
+          <div class="panels-overlay-inner">
+            <i class="overlay-lock-icon">🔒</i>
+            <p class="overlay-title">VOTING NOT OPEN</p>
+            <p class="overlay-sub">Waiting for the organiser to open voting</p>
+          </div>
+        </div>
+      </Transition>
+
+      <!-- REVEALED overlay: winner announced -->
+      <Transition name="phase-fade">
+        <div v-if="battlePhase === 'REVEALED'" class="panels-overlay revealed-overlay" aria-live="assertive">
+          <div class="panels-overlay-inner">
+            <template v-if="revealedWinner === 0">
+              <p class="overlay-winner-name">{{ leftName }}</p>
+              <p class="overlay-winner-label">WINS</p>
+            </template>
+            <template v-else-if="revealedWinner === 1">
+              <p class="overlay-winner-name">{{ rightName }}</p>
+              <p class="overlay-winner-label">WINS</p>
+            </template>
+            <template v-else>
+              <p class="overlay-winner-label">TIE</p>
+            </template>
+          </div>
+        </div>
+      </Transition>
 
       <!-- ── Left ── -->
       <button
@@ -230,11 +316,141 @@ onMounted(async () => {
   white-space: nowrap;
 }
 
+/* ── Phase blocker (IDLE — covers entire root) ────── */
+.phase-blocker {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(6, 10, 20, 0.96);
+  backdrop-filter: blur(6px);
+}
+.phase-blocker-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+.phase-blocker-icon { font-size: 2.5rem; }
+.phase-blocker-title {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(16px, 3vw, 24px);
+  letter-spacing: 0.15em;
+  color: rgba(255,255,255,0.5);
+  text-transform: uppercase;
+}
+
+/* ── Header center (phase pill + pair names) ──────── */
+.header-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+.phase-pill {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+.phase-pill--idle    { background: rgba(71,85,105,0.3); color: rgba(148,163,184,0.6); border-color: rgba(71,85,105,0.4); }
+.phase-pill--locked  { background: rgba(245,158,11,0.15); color: rgba(251,191,36,0.9); border-color: rgba(245,158,11,0.4); }
+.phase-pill--voting  { background: rgba(6,182,212,0.15); color: rgba(6,182,212,0.95); border-color: rgba(6,182,212,0.4); animation: votingPulse 1.6s ease-in-out infinite; }
+.phase-pill--revealed { background: rgba(16,185,129,0.15); color: rgba(52,211,153,0.95); border-color: rgba(16,185,129,0.4); }
+
+.pair-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.7);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 240px;
+}
+.vs-sep {
+  color: rgba(255,255,255,0.35);
+  font-weight: 400;
+  margin: 0 4px;
+}
+
 /* ── Panels container ─────────────────────────────── */
 .panels-wrap {
   flex: 1;
   display: flex;
   overflow: hidden;
+  position: relative;
+}
+
+/* ── Phase overlays (inside panels-wrap) ──────────── */
+.panels-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.locked-overlay  { background: rgba(6, 10, 20, 0.72); backdrop-filter: blur(3px); }
+.revealed-overlay { background: rgba(6, 10, 20, 0.82); backdrop-filter: blur(4px); }
+
+.panels-overlay-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  padding: 0 20px;
+}
+.overlay-lock-icon { font-size: 2rem; }
+.overlay-title {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(14px, 2.5vw, 20px);
+  letter-spacing: 0.18em;
+  color: rgba(251,191,36,0.85);
+}
+.overlay-sub {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.4);
+}
+.overlay-winner-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(24px, 5vw, 52px);
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.95);
+  line-height: 1;
+  text-transform: uppercase;
+}
+.overlay-winner-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(16px, 3.5vw, 36px);
+  letter-spacing: 0.25em;
+  color: rgba(52,211,153,0.9);
+}
+
+/* ── Phase transition ─────────────────────────────── */
+.phase-fade-enter-active,
+.phase-fade-leave-active { transition: opacity 0.35s ease; }
+.phase-fade-enter-from,
+.phase-fade-leave-to { opacity: 0; }
+
+@keyframes votingPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(6,182,212,0.4); }
+  50% { box-shadow: 0 0 0 4px rgba(6,182,212,0); }
 }
 
 .vote-panel {

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -64,6 +64,10 @@ onMounted(async () => {
   subscribeToChannel(createClient(), '/topic/battle/score', (msg) => {
     revealedWinner.value = msg.message
   })
+
+  subscribeToChannel(createClient(), '/topic/battle/judges', (msg) => {
+    battleJudges.value = msg
+  })
 })
 </script>
 
@@ -76,6 +80,17 @@ onMounted(async () => {
         <div class="phase-blocker-inner">
           <span class="phase-blocker-icon">⏳</span>
           <p class="phase-blocker-title">Waiting for battle setup…</p>
+          <div class="idle-selector-wrap" role="group" aria-label="Select your judge name">
+            <span class="idle-selector-eyebrow">VOTING AS</span>
+            <div class="w-64">
+              <ReusableDropdown
+                v-model="selectedJudge"
+                labelId=""
+                :options="battleJudgesName"
+                placeholder="Select your name…"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </Transition>
@@ -340,6 +355,23 @@ onMounted(async () => {
   font-size: clamp(16px, 3vw, 24px);
   letter-spacing: 0.15em;
   color: rgba(255,255,255,0.5);
+  text-transform: uppercase;
+}
+
+.idle-selector-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.idle-selector-eyebrow {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  color: rgba(255, 255, 255, 0.3);
   text-transform: uppercase;
 }
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -147,6 +147,8 @@ watch(battleJudges, (newVal) => {
 onMounted(async () => {
   document.documentElement.classList.add("transparent-page");
   document.body.classList.add("transparent-page");
+  // Subscribe to phase for future phase-aware overlay behaviour
+  subscribeToChannel(createClient(), "/topic/battle/phase", () => {})
   if (isSmoke.value) {
     battleJudges.value = await getBattleJudges()
     subscribeToChannel(createClient(), "/topic/battle/judges", (msg) => updateBattleJudge(msg))

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -1,0 +1,703 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
+import { getBracketState } from '@/utils/api'
+import { createClient } from '@/utils/websocket'
+
+const bracketState   = ref(null)
+const activePair     = ref(null)
+const currentGenre   = ref(null)
+let   wsClient       = null
+
+// ── animation state ──────────────────────────────────────
+const pendingBracket  = ref(null)
+const glowSlotKey     = ref(null)   // "roundKey-matchIdx-slot" → glow effect
+const hiddenSlotKey   = ref(null)   // dest slot name hidden until ball arrives
+const ballVisible     = ref(false)
+const ballOrigin      = ref({ x: 0, y: 0 })
+let   animRunning     = false
+// Saves the bracket state that existed BEFORE the most recent bracket update.
+// Used when the bracket WebSocket message arrives before the score message.
+let   prevBracketUpdate = null  // { state, timestamp }
+
+// DOM registry for every battler slot
+const slotEls = {}
+const regSlot = (el, key, mIdx, s) => {
+  const k = `${key}-${mIdx}-${s}`
+  if (el) slotEls[k] = el; else delete slotEls[k]
+}
+
+// ── bracket data ──────────────────────────────────────────
+const topSize      = computed(() => Number(bracketState.value?.topSize ?? 0))
+const isSmoke      = computed(() => topSize.value === 7)
+
+const roundKeys = computed(() => {
+  if (!bracketState.value?.rounds || isSmoke.value) return []
+  return Object.keys(bracketState.value.rounds).sort((a, b) =>
+    parseInt(b.replace('Top', '')) - parseInt(a.replace('Top', ''))
+  )
+})
+
+const sideRoundKeys  = computed(() => roundKeys.value.filter(k => k !== 'Top2'))
+const finalMatch     = computed(() => bracketState.value?.rounds?.Top2?.[0] ?? null)
+const champion       = computed(() => finalMatch.value?.[2] ?? null)
+const rightRoundKeys = computed(() => [...sideRoundKeys.value].reverse())
+
+const smokeList = computed(() => {
+  if (!isSmoke.value) return []
+  const r = bracketState.value?.rounds
+  return Array.isArray(r) ? r : []
+})
+
+const isEmpty = computed(() => {
+  if (!bracketState.value) return true
+  if (isSmoke.value) return smokeList.value.length === 0
+  return roundKeys.value.length === 0
+})
+
+const getMatches   = (key) => bracketState.value?.rounds?.[key] ?? []
+const leftMatches  = (key) => { const m = getMatches(key); return m.slice(0, Math.ceil(m.length / 2)) }
+const rightMatches = (key) => { const m = getMatches(key); return m.slice(Math.ceil(m.length / 2)) }
+// right-side slots need original indices (not slice-local indices)
+const rightBase    = (key) => Math.ceil(getMatches(key).length / 2)
+
+const isActiveMatch = (match) => {
+  if (!activePair.value || !match) return false
+  const [l, r] = match
+  return (l === activePair.value.left  && r === activePair.value.right) ||
+         (l === activePair.value.right && r === activePair.value.left)
+}
+
+const slotClass = (match, slot) => ({
+  'slot-winner': match[2] && match[2] === match[slot],
+  'slot-loser':  match[2] && match[2] !== match[slot] && match[slot],
+})
+
+const formatLabel = (key) => key === 'Top2' ? 'FINAL' : key.replace('Top', 'TOP ')
+
+// ── ticker ────────────────────────────────────────────────
+const nextMatch = computed(() => {
+  if (!bracketState.value?.rounds) return null
+  for (const key of roundKeys.value) {
+    for (const m of getMatches(key)) {
+      if (!m[2] && !isActiveMatch(m) && (m[0] || m[1])) return m
+    }
+  }
+  return null
+})
+
+const activeRoundLabel = computed(() => {
+  if (!activePair.value) return null
+  for (const key of roundKeys.value) {
+    if (getMatches(key).some(m => isActiveMatch(m))) return formatLabel(key)
+  }
+  return null
+})
+
+const tickerItems = computed(() => {
+  const items = []
+  if (activePair.value) {
+    if (activeRoundLabel.value) items.push({ type: 'label', text: activeRoundLabel.value })
+    items.push({ type: 'now', text: `${activePair.value.left}  ⚔  ${activePair.value.right}` })
+  }
+  if (nextMatch.value) {
+    items.push({ type: 'next', text: `${nextMatch.value[0] || '—'}  ⚔  ${nextMatch.value[1] || '—'}` })
+  }
+  if (currentGenre.value) items.push({ type: 'genre', text: currentGenre.value })
+  if (!items.length) items.push({ type: 'label', text: 'LIVE BATTLE' })
+  return items
+})
+
+// ── animation helpers ─────────────────────────────────────
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+// Find the slot in newState that gained a new name vs oldState (slot 0 or 1 only)
+function findDestSlot(oldS, newS) {
+  for (const key of Object.keys(newS?.rounds ?? {})) {
+    const oldMs = oldS?.rounds?.[key] ?? []
+    const newMs = newS.rounds[key]
+    for (let i = 0; i < newMs.length; i++) {
+      for (let s = 0; s < 2; s++) {
+        if (!oldMs[i]?.[s] && newMs[i]?.[s]) return `${key}-${i}-${s}`
+      }
+    }
+  }
+  return null
+}
+
+async function travelBall(winnerKey, destKey) {
+  const winEl = slotEls[winnerKey]
+  if (!winEl) return
+
+  const wr    = winEl.getBoundingClientRect()
+  const pg    = winEl.closest('.pair-group')
+  const pgR   = pg?.getBoundingClientRect()
+  const COL_GAP = 24
+
+  // Determine side by comparing slot center to viewport center
+  const isLeft = (wr.left + wr.right) / 2 < window.innerWidth / 2
+
+  const startX = isLeft ? wr.right      : wr.left
+  const startY = wr.top + wr.height / 2
+  const midY   = pgR ? pgR.top + pgR.height / 2 : startY
+  const armX   = isLeft ? startX + COL_GAP : startX - COL_GAP
+
+  let endX = armX, endY = midY
+  if (destKey && slotEls[destKey]) {
+    const dr = slotEls[destKey].getBoundingClientRect()
+    endX = dr.left + dr.width / 2
+    endY = dr.top  + dr.height / 2
+  }
+
+  // Place ball origin at start position (ball is 12×12, center offset 6px)
+  ballOrigin.value = { x: startX - 6, y: startY - 6 }
+  ballVisible.value = true
+  await nextTick()
+
+  const ballEl = document.querySelector('.anim-ball')
+  if (!ballEl) { ballVisible.value = false; return }
+
+  // Path: start → arm edge (horizontal) → midpoint (vertical) → destination
+  await ballEl.animate([
+    { transform: 'translate(0px, 0px)',                                          offset: 0    },
+    { transform: `translate(${armX - startX}px, 0px)`,                          offset: 0.15 },
+    { transform: `translate(${armX - startX}px, ${midY - startY}px)`,           offset: 0.50 },
+    { transform: `translate(${endX - startX}px, ${endY - startY}px)`,           offset: 1.00 },
+  ], { duration: 5000, easing: 'ease-in-out', fill: 'forwards' }).finished
+
+  ballVisible.value = false
+}
+
+async function runWinnerAnimation(winnerKey, pending) {
+  // Phase 1 — winner glow (2.5 s)
+  glowSlotKey.value = winnerKey
+  await sleep(2500)
+  glowSlotKey.value = null
+
+  // Phase 2 — ball travel (5 s)
+  const destKey = findDestSlot(bracketState.value, pending)
+  if (destKey) {
+    hiddenSlotKey.value = destKey   // hide dest name before applying update
+    bracketState.value  = pending
+    await nextTick()
+    await travelBall(winnerKey, destKey)
+
+    // Phase 3 — name reveal (1 s CSS fade)
+    hiddenSlotKey.value = null
+    await sleep(1200)
+  } else {
+    // Final match or no advancement: just apply + short pause
+    bracketState.value = pending
+    await sleep(500)
+  }
+
+  animRunning = false
+}
+
+function getActiveMatchInfo() {
+  if (!activePair.value) return null
+  for (const key of roundKeys.value) {
+    const ms = getMatches(key)
+    for (let i = 0; i < ms.length; i++) {
+      if (isActiveMatch(ms[i])) return { key, i }
+    }
+  }
+  return null
+}
+
+// ── lifecycle ─────────────────────────────────────────────
+onMounted(async () => {
+  const state = await getBracketState()
+  if (state && (state.topSize || state.rounds)) bracketState.value = state
+
+  wsClient = createClient()
+  wsClient.onConnect = () => {
+
+    wsClient.subscribe('/topic/battle/bracket', (msg) => {
+      const newState = JSON.parse(msg.body)
+      if (animRunning) {
+        pendingBracket.value = newState   // defer until animation finishes
+      } else {
+        // Save snapshot before applying — needed if score arrives after this
+        prevBracketUpdate = { state: bracketState.value, timestamp: Date.now() }
+        bracketState.value = newState
+      }
+    })
+
+    wsClient.subscribe('/topic/battle/battle-pair', (msg) => {
+      const data = JSON.parse(msg.body)
+      activePair.value = { left: data.left, right: data.right }
+    })
+
+    wsClient.subscribe('/topic/battle/genre', (msg) => {
+      const data = JSON.parse(msg.body)
+      currentGenre.value = data.genre ?? data.message ?? null
+    })
+
+    wsClient.subscribe('/topic/battle/score', (msg) => {
+      const data = JSON.parse(msg.body)
+      if (data.message !== 0 && data.message !== 1) return
+      if (animRunning) return
+
+      const info = getActiveMatchInfo()
+      if (!info) return
+
+      animRunning = true   // set before any await so bracket handler defers immediately
+      const winKey = `${info.key}-${info.i}-${data.message}`;
+
+      (async () => {
+        // Wait up to 500 ms for the bracket update to arrive after the score
+        for (let i = 0; i < 5; i++) {
+          if (pendingBracket.value) break
+          await sleep(100)
+        }
+
+        let pending
+
+        if (pendingBracket.value) {
+          // Normal case: bracket arrived AFTER score — snapshot is current bracketState
+          pending = pendingBracket.value
+          pendingBracket.value = null
+
+        } else if (prevBracketUpdate && Date.now() - prevBracketUpdate.timestamp < 2000) {
+          // Bracket arrived BEFORE score — restore old state so dest slot appears empty,
+          // then use the already-applied new state as the pending target
+          pending = bracketState.value          // currently the new state
+          bracketState.value = prevBracketUpdate.state  // restore to pre-update state
+          prevBracketUpdate = null
+          await nextTick()
+
+        } else {
+          // No bracket update detected — glow only, no ball
+          pending = bracketState.value
+        }
+
+        await runWinnerAnimation(winKey, pending)
+      })()
+    })
+  }
+  wsClient.activate()
+})
+
+onUnmounted(() => { if (wsClient) wsClient.deactivate() })
+</script>
+
+<template>
+  <div class="bracket-root">
+
+    <!-- ── Header ─────────────────────────────────────── -->
+    <header class="bracket-header">
+      <div class="header-brand">
+        <span class="brand-dot"></span>
+        <span class="brand-title">LIVE BRACKET</span>
+        <span class="brand-dot"></span>
+      </div>
+      <div v-if="activePair" class="active-pill">
+        <span class="pill-dot"></span>
+        {{ activePair.left }}
+        <span class="vs-sep">vs</span>
+        {{ activePair.right }}
+      </div>
+    </header>
+
+    <!-- ── Empty state ────────────────────────────────── -->
+    <div v-if="isEmpty" class="empty-state">
+      <div class="empty-icon">⏳</div>
+      <p class="empty-title">Waiting for bracket</p>
+      <p class="empty-sub">The organiser hasn't set up the bracket yet</p>
+    </div>
+
+    <!-- ── 7-to-Smoke ─────────────────────────────────── -->
+    <div v-else-if="isSmoke" class="smoke-wrap">
+      <h2 class="round-label mb-4">7 TO SMOKE — QUEUE</h2>
+      <div class="smoke-list">
+        <div
+          v-for="(battler, idx) in smokeList" :key="idx"
+          class="smoke-slot"
+          :class="{ 'smoke-active': idx < 2, 'smoke-next': idx === 2 }"
+        >
+          <span class="smoke-pos">{{ idx + 1 }}</span>
+          <span class="smoke-name">{{ battler.name || '—' }}</span>
+          <span class="smoke-score">{{ battler.score }}</span>
+          <span v-if="idx < 2" class="smoke-badge">FIGHTING</span>
+          <span v-else-if="idx === 2" class="smoke-badge smoke-badge-next">NEXT</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Standard bracket ───────────────────────────── -->
+    <div v-else class="bracket-area">
+
+      <!-- LEFT half -->
+      <div class="bracket-half bracket-left">
+        <div v-for="key in sideRoundKeys" :key="key" class="round-col">
+          <div class="round-label">{{ formatLabel(key) }}</div>
+          <div class="matches-col">
+            <div
+              v-for="(match, mIdx) in leftMatches(key)" :key="mIdx"
+              class="pair-group"
+              :class="{ 'match-active': isActiveMatch(match) }"
+            >
+              <div class="match-wrap">
+                <div
+                  class="battler-slot"
+                  :ref="el => regSlot(el, key, mIdx, 0)"
+                  :class="[
+                    slotClass(match, 0),
+                    glowSlotKey  === `${key}-${mIdx}-0` ? 'slot-glow'   : '',
+                    hiddenSlotKey === `${key}-${mIdx}-0` ? 'name-hidden' : '',
+                  ]"
+                >
+                  <span class="battler-name">{{ match[0] || '—' }}</span>
+                  <i v-if="match[2] === match[0] && match[0]" class="pi pi-crown crown-icon"></i>
+                </div>
+              </div>
+              <div class="match-wrap">
+                <div
+                  class="battler-slot"
+                  :ref="el => regSlot(el, key, mIdx, 1)"
+                  :class="[
+                    slotClass(match, 1),
+                    glowSlotKey  === `${key}-${mIdx}-1` ? 'slot-glow'   : '',
+                    hiddenSlotKey === `${key}-${mIdx}-1` ? 'name-hidden' : '',
+                  ]"
+                >
+                  <span class="battler-name">{{ match[1] || '—' }}</span>
+                  <i v-if="match[2] === match[1] && match[1]" class="pi pi-crown crown-icon"></i>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- CENTER: Final + Champion -->
+      <div class="center-col">
+        <div class="round-label">FINAL</div>
+        <div class="final-area">
+          <div v-if="finalMatch" class="final-match" :class="{ 'match-active': isActiveMatch(finalMatch) }">
+            <div
+              class="battler-slot"
+              :ref="el => regSlot(el, 'Top2', 0, 0)"
+              :class="[
+                slotClass(finalMatch, 0),
+                glowSlotKey  === 'Top2-0-0' ? 'slot-glow'   : '',
+                hiddenSlotKey === 'Top2-0-0' ? 'name-hidden' : '',
+              ]"
+            >
+              <span class="battler-name">{{ finalMatch[0] || '—' }}</span>
+              <i v-if="finalMatch[2] === finalMatch[0] && finalMatch[0]" class="pi pi-crown crown-icon"></i>
+            </div>
+            <div class="final-vs">VS</div>
+            <div
+              class="battler-slot"
+              :ref="el => regSlot(el, 'Top2', 0, 1)"
+              :class="[
+                slotClass(finalMatch, 1),
+                glowSlotKey  === 'Top2-0-1' ? 'slot-glow'   : '',
+                hiddenSlotKey === 'Top2-0-1' ? 'name-hidden' : '',
+              ]"
+            >
+              <span class="battler-name">{{ finalMatch[1] || '—' }}</span>
+              <i v-if="finalMatch[2] === finalMatch[1] && finalMatch[1]" class="pi pi-crown crown-icon"></i>
+            </div>
+          </div>
+          <div v-if="champion" class="champion-card">
+            <i class="pi pi-crown champ-icon"></i>
+            <span class="champ-name">{{ champion }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT half -->
+      <div class="bracket-half bracket-right">
+        <div v-for="key in rightRoundKeys" :key="key" class="round-col">
+          <div class="round-label">{{ formatLabel(key) }}</div>
+          <div class="matches-col">
+            <div
+              v-for="(match, mIdx) in rightMatches(key)" :key="mIdx"
+              class="pair-group"
+              :class="{ 'match-active': isActiveMatch(match) }"
+            >
+              <div class="match-wrap">
+                <div
+                  class="battler-slot"
+                  :ref="el => regSlot(el, key, rightBase(key) + mIdx, 0)"
+                  :class="[
+                    slotClass(match, 0),
+                    glowSlotKey  === `${key}-${rightBase(key) + mIdx}-0` ? 'slot-glow'   : '',
+                    hiddenSlotKey === `${key}-${rightBase(key) + mIdx}-0` ? 'name-hidden' : '',
+                  ]"
+                >
+                  <span class="battler-name">{{ match[0] || '—' }}</span>
+                  <i v-if="match[2] === match[0] && match[0]" class="pi pi-crown crown-icon"></i>
+                </div>
+              </div>
+              <div class="match-wrap">
+                <div
+                  class="battler-slot"
+                  :ref="el => regSlot(el, key, rightBase(key) + mIdx, 1)"
+                  :class="[
+                    slotClass(match, 1),
+                    glowSlotKey  === `${key}-${rightBase(key) + mIdx}-1` ? 'slot-glow'   : '',
+                    hiddenSlotKey === `${key}-${rightBase(key) + mIdx}-1` ? 'name-hidden' : '',
+                  ]"
+                >
+                  <span class="battler-name">{{ match[1] || '—' }}</span>
+                  <i v-if="match[2] === match[1] && match[1]" class="pi pi-crown crown-icon"></i>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- ── LED Ticker ─────────────────────────────────── -->
+    <div class="ticker-bar">
+      <div class="ticker-label">
+        <span class="ticker-dot"></span>
+        LIVE
+      </div>
+      <div class="ticker-track">
+        <div class="ticker-reel" :style="{ '--item-count': tickerItems.length }">
+          <template v-for="pass in 2" :key="pass">
+            <span
+              v-for="(item, idx) in tickerItems" :key="`${pass}-${idx}`"
+              class="ticker-item" :class="`ticker-${item.type}`"
+            >
+              <span v-if="item.type === 'now'"   class="ticker-tag">NOW BATTLING</span>
+              <span v-else-if="item.type === 'next'"  class="ticker-tag">NEXT UP</span>
+              <span v-else-if="item.type === 'genre'" class="ticker-tag">GENRE</span>
+              <span v-else-if="item.type === 'label'" class="ticker-tag">{{ item.text }}</span>
+              <span v-if="item.type !== 'label'" class="ticker-text">{{ item.text }}</span>
+              <span class="ticker-sep">◆</span>
+            </span>
+          </template>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── Travelling ball (outside bracket-root to avoid overflow clipping) ── -->
+  <Teleport to="body">
+    <div
+      v-if="ballVisible"
+      class="anim-ball"
+      :style="{ left: ballOrigin.x + 'px', top: ballOrigin.y + 'px' }"
+    ></div>
+  </Teleport>
+</template>
+
+<style scoped>
+/* ── Theme tokens ─────────────────────────────────────── */
+.bracket-root {
+  --c-bg:         #0f172a;
+  --c-surface:    #1e293b;
+  --c-border:     rgba(255,255,255,0.08);
+  --c-border-act: #06b6d4;
+  --c-text:       #f8fafc;
+  --c-muted:      rgba(255,255,255,0.35);
+  --c-accent:     #06b6d4;
+  --c-win-bg:     rgba(6,182,212,0.1);
+  --c-lose-text:  rgba(255,255,255,0.2);
+  --c-connector:  rgba(255,255,255,0.2);
+  --c-champ-bg:   rgba(245,158,11,0.1);
+  --c-champ:      #f59e0b;
+  --col-gap:      24px;
+  --header-h:     48px;
+  --slot-h:       34px;
+}
+:global([data-theme="light"]) .bracket-root {
+  --c-bg:         #f1f5f9;
+  --c-surface:    #ffffff;
+  --c-border:     rgba(0,0,0,0.1);
+  --c-border-act: #0891b2;
+  --c-text:       #0f172a;
+  --c-muted:      rgba(0,0,0,0.35);
+  --c-accent:     #0891b2;
+  --c-win-bg:     rgba(8,145,178,0.08);
+  --c-lose-text:  rgba(0,0,0,0.25);
+  --c-connector:  rgba(0,0,0,0.18);
+  --c-champ-bg:   rgba(245,158,11,0.08);
+  --c-champ:      #d97706;
+}
+
+/* ── Root ─────────────────────────────────────────────── */
+.bracket-root {
+  height: 100dvh; background: var(--c-bg);
+  display: flex; flex-direction: column;
+  font-family: 'Inter', sans-serif; color: var(--c-text);
+  overflow: hidden;
+}
+
+/* ── Header ───────────────────────────────────────────── */
+.bracket-header {
+  flex-shrink: 0; height: var(--header-h);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 20px; background: var(--c-surface);
+  border-bottom: 1px solid var(--c-border);
+}
+.header-brand { display: flex; align-items: center; gap: 8px; }
+.brand-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--c-accent); box-shadow: 0 0 8px var(--c-accent);
+  animation: dotPulse 2s ease-in-out infinite;
+}
+.brand-title { font-family: 'Anton SC', sans-serif; font-size: 13px; letter-spacing: 0.3em; color: var(--c-muted); }
+.active-pill {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12px; font-weight: 600; color: var(--c-accent);
+  background: var(--c-win-bg); border: 1px solid rgba(6,182,212,0.25);
+  border-radius: 999px; padding: 3px 12px;
+}
+.pill-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--c-accent); animation: dotPulse 1s ease-in-out infinite; }
+.vs-sep { color: var(--c-muted); font-weight: 400; }
+
+/* ── Empty / Smoke ────────────────────────────────────── */
+.empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; }
+.empty-icon { font-size: 36px; }
+.empty-title { font-family: 'Outfit', sans-serif; font-size: 18px; font-weight: 700; color: var(--c-muted); }
+.empty-sub   { font-size: 13px; color: var(--c-muted); opacity: 0.7; }
+
+.smoke-wrap  { flex: 1; display: flex; flex-direction: column; align-items: center; padding: 24px; overflow-y: auto; }
+.smoke-list  { width: 100%; max-width: 420px; display: flex; flex-direction: column; gap: 8px; }
+.smoke-slot  { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-radius: 12px; background: var(--c-surface); border: 1px solid var(--c-border); }
+.smoke-active{ background: var(--c-win-bg); border-color: rgba(6,182,212,0.3); }
+.smoke-next  { border-color: var(--c-connector); }
+.smoke-pos   { font-family: 'Source Code Pro', monospace; font-size: 12px; color: var(--c-muted); width: 18px; }
+.smoke-name  { flex: 1; font-size: 14px; font-weight: 600; color: var(--c-text); }
+.smoke-score { font-family: 'Source Code Pro', monospace; font-size: 13px; font-weight: 700; color: var(--c-accent); }
+.smoke-badge { font-size: 9px; font-weight: 700; letter-spacing: 0.15em; padding: 2px 7px; border-radius: 999px; background: var(--c-win-bg); color: var(--c-accent); border: 1px solid rgba(6,182,212,0.25); }
+.smoke-badge-next { background: var(--c-border); color: var(--c-muted); border-color: var(--c-border); }
+
+/* ── Round label ──────────────────────────────────────── */
+.round-label {
+  flex-shrink: 0; font-family: 'Outfit', sans-serif; font-size: 10px;
+  font-weight: 700; letter-spacing: 0.18em; color: var(--c-accent);
+  text-align: center; padding: 6px 0; opacity: 0.75;
+}
+.mb-4 { margin-bottom: 16px; }
+
+/* ── Bracket layout ───────────────────────────────────── */
+.bracket-area  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); padding: 8px 16px 12px; overflow: hidden; min-height: 0; }
+.bracket-half  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); min-width: 0; }
+.round-col     { flex: 1; display: flex; flex-direction: column; min-width: 0; position: relative; }
+.matches-col   { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+
+/* Each match = one pair-group. flex:1 → outer rounds shorter, inner rounds taller. */
+.pair-group {
+  flex: 1; display: flex; flex-direction: column; position: relative;
+  min-height: calc(var(--slot-h) * 2 + 16px);
+}
+
+/* Bracket arm — left side extends RIGHT */
+.bracket-left .pair-group::after {
+  content: ''; position: absolute;
+  right: calc(-1 * var(--col-gap)); top: 25%; height: 50%; width: var(--col-gap);
+  border-top: 1px solid var(--c-connector);
+  border-right: 1px solid var(--c-connector);
+  border-bottom: 1px solid var(--c-connector);
+  pointer-events: none; z-index: 1;
+}
+/* Bracket arm — right side extends LEFT */
+.bracket-right .pair-group::after {
+  content: ''; position: absolute;
+  left: calc(-1 * var(--col-gap)); top: 25%; height: 50%; width: var(--col-gap);
+  border-top: 1px solid var(--c-connector);
+  border-left: 1px solid var(--c-connector);
+  border-bottom: 1px solid var(--c-connector);
+  pointer-events: none; z-index: 1;
+}
+
+.match-wrap { flex: 1; display: flex; align-items: center; padding: 0 2px; }
+
+/* ── Battler slot ─────────────────────────────────────── */
+.battler-slot {
+  width: 100%; height: var(--slot-h);
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 0 8px;
+  background: var(--c-surface); border: 1px solid var(--c-border); border-radius: 7px;
+  transition: background 0.25s, border-color 0.25s;
+}
+.match-active .battler-slot {
+  border-color: var(--c-border-act);
+  box-shadow: 0 0 0 1px rgba(6,182,212,0.12), 0 1px 10px rgba(6,182,212,0.10);
+}
+.slot-winner { background: var(--c-win-bg); border-color: rgba(6,182,212,0.4) !important; }
+.slot-winner .battler-name { color: var(--c-accent); font-weight: 700; }
+.slot-loser .battler-name  { color: var(--c-lose-text); text-decoration: line-through; }
+
+.battler-name {
+  font-size: 12px; font-weight: 600; color: var(--c-text); opacity: 0.85;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center;
+  transition: opacity 1s ease;
+}
+.name-hidden .battler-name { opacity: 0; transition: none; }
+
+.crown-icon { font-size: 12px; color: var(--c-champ); flex-shrink: 0; }
+
+/* ── Winner glow animation ────────────────────────────── */
+.slot-glow {
+  animation: slotGlow 2.5s ease-in-out forwards;
+  z-index: 10; position: relative;
+}
+@keyframes slotGlow {
+  0%   { background: var(--c-surface);       border-color: var(--c-border);  box-shadow: none; }
+  20%  { background: rgba(6,182,212,0.22);   border-color: var(--c-accent);  box-shadow: 0 0 0 2px rgba(6,182,212,0.4), 0 0 18px rgba(6,182,212,0.65), 0 0 36px rgba(6,182,212,0.3); }
+  70%  { background: rgba(6,182,212,0.16);   border-color: var(--c-accent);  box-shadow: 0 0 0 2px rgba(6,182,212,0.3), 0 0 14px rgba(6,182,212,0.5),  0 0 28px rgba(6,182,212,0.2); }
+  100% { background: var(--c-surface);       border-color: var(--c-border);  box-shadow: none; }
+}
+.slot-glow .battler-name { color: var(--c-accent); opacity: 1; }
+
+/* ── Center column ────────────────────────────────────── */
+.center-col { flex-shrink: 0; width: 170px; display: flex; flex-direction: column; }
+.final-area { flex: 1; display: flex; flex-direction: column; align-items: stretch; justify-content: center; gap: 6px; min-height: 0; }
+.final-match { display: flex; flex-direction: column; gap: 6px; }
+.final-match.match-active .battler-slot { border-color: var(--c-border-act); box-shadow: 0 0 0 1px rgba(6,182,212,0.12), 0 1px 10px rgba(6,182,212,0.10); }
+.final-vs { text-align: center; font-size: 8px; font-weight: 700; letter-spacing: 0.15em; color: var(--c-muted); }
+
+/* ── Champion card ────────────────────────────────────── */
+.champion-card { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 10px 14px; border-radius: 12px; background: var(--c-champ-bg); border: 1px solid rgba(245,158,11,0.25); }
+.champ-icon { font-size: 14px; color: var(--c-champ); }
+.champ-name { font-family: 'Outfit', sans-serif; font-size: 13px; font-weight: 700; color: var(--c-champ); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── LED Ticker ───────────────────────────────────────── */
+.ticker-bar   { flex-shrink: 0; height: 30px; display: flex; align-items: stretch; background: #080f1e; border-top: 1px solid var(--c-border); overflow: hidden; }
+.ticker-label { flex-shrink: 0; display: flex; align-items: center; gap: 6px; padding: 0 14px; background: var(--c-accent); font-family: 'Anton SC', sans-serif; font-size: 10px; letter-spacing: 0.2em; color: #080f1e; z-index: 1; }
+.ticker-dot   { width: 5px; height: 5px; border-radius: 50%; background: #080f1e; animation: dotPulse 1s ease-in-out infinite; }
+.ticker-track { flex: 1; overflow: hidden; position: relative; mask-image: linear-gradient(to right, transparent 0%, black 3%, black 97%, transparent 100%); }
+.ticker-reel  { display: inline-flex; align-items: center; white-space: nowrap; height: 100%; animation: tickerScroll calc(var(--item-count, 4) * 8s) linear infinite; }
+.ticker-item  { display: inline-flex; align-items: center; gap: 8px; padding: 0 6px; font-family: 'Source Code Pro', monospace; }
+.ticker-tag   { font-size: 9px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: var(--c-muted); opacity: 0.7; }
+.ticker-now   .ticker-tag  { color: var(--c-accent); opacity: 1; }
+.ticker-next  .ticker-tag  { color: rgba(249,115,22,0.85); }
+.ticker-genre .ticker-tag  { color: rgba(167,139,250,0.85); }
+.ticker-text  { font-size: 11px; font-weight: 700; letter-spacing: 0.06em; color: var(--c-text); }
+.ticker-now   .ticker-text { color: var(--c-accent); }
+.ticker-next  .ticker-text { color: rgba(249,115,22,0.9); }
+.ticker-genre .ticker-text { color: rgba(167,139,250,0.9); }
+.ticker-sep   { font-size: 7px; color: var(--c-muted); opacity: 0.3; padding: 0 16px; }
+
+/* ── Travelling ball (rendered via Teleport, position:fixed) ── */
+:global(.anim-ball) {
+  position: fixed;
+  width: 12px; height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #ffffff 0%, #06b6d4 55%, transparent 100%);
+  box-shadow: 0 0 6px #06b6d4, 0 0 14px #06b6d4, 0 0 28px rgba(6,182,212,0.6);
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* ── Animations ───────────────────────────────────────── */
+@keyframes dotPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.4; transform: scale(0.7); }
+}
+@keyframes tickerScroll {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+</style>

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -228,6 +228,10 @@ onMounted(async () => {
       activePair.value = { left: data.left, right: data.right }
     })
 
+    wsClient.subscribe('/topic/battle/phase', () => {
+      // Phase subscription for future phase-aware bracket display
+    })
+
     wsClient.subscribe('/topic/battle/genre', (msg) => {
       const data = JSON.parse(msg.body)
       currentGenre.value = data.genre ?? data.message ?? null

--- a/BES-frontend/src/views/CrewFormation.vue
+++ b/BES-frontend/src/views/CrewFormation.vue
@@ -1,0 +1,488 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { getActiveEvent } from '@/utils/auth'
+import { getParticipantScore, getScoringCriteria } from '@/utils/api'
+import { getPickupCrews, createPickupCrew, deletePickupCrew } from '@/utils/api'
+import ReusableDropdown from '@/components/ReusableDropdown.vue'
+import ActionDoneModal from '@/views/ActionDoneModal.vue'
+
+const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem('selectedEvent') || '')
+const selectedGenre = ref('')
+const participants = ref([])   // raw score entries for the genre
+const crews = ref([])
+const criteria = ref([])
+const topN = ref(null)  // null = no filter; 4/8/16/32 = show only top N as leaders
+
+// Modal state
+const showCrewModal = ref(false)
+const pendingCrewName = ref('')
+const pendingMembers = ref([])   // [{participantId, displayName}]
+const modalError = ref('')
+
+// Error/success feedback
+const toast = ref({ show: false, message: '', variant: 'success' })
+const showToast = (message, variant = 'success') => {
+  toast.value = { show: true, message, variant }
+  setTimeout(() => { toast.value.show = false }, 3000)
+}
+
+// ── Derived data ───────────────────────────────────────────────────────────────
+
+// Unique genres that have at least one solo pickup entry (format = null or empty)
+const uniqueGenres = computed(() => {
+  const genres = participants.value.map(p => p.genreName)
+  return [...new Set(genres)].sort()
+})
+
+// All solo pickup entries for the selected genre (format null/empty)
+const soloEntries = computed(() => {
+  if (!selectedGenre.value) return []
+  // Dedupe by participantName — score rows can be one per judge
+  const seen = new Map()
+  for (const p of participants.value) {
+    if (p.genreName !== selectedGenre.value) continue
+    if (p.format && p.format !== '') continue  // skip pre-formed team entries
+    if (!seen.has(p.participantName)) {
+      seen.set(p.participantName, {
+        participantId: p.participantId,
+        displayName: p.participantName,
+        totalScore: 0,
+        scoreCount: 0,
+      })
+    }
+    const entry = seen.get(p.participantName)
+    entry.totalScore += p.score ?? 0
+    entry.scoreCount++
+  }
+  return [...seen.values()]
+    .map(e => ({ ...e, avgScore: e.scoreCount > 0 ? Math.round(e.totalScore / e.scoreCount * 100) / 100 : null }))
+    .sort((a, b) => (b.avgScore ?? -1) - (a.avgScore ?? -1))
+})
+
+// Participant IDs already assigned to a crew
+const assignedIds = computed(() => {
+  const ids = new Set()
+  for (const crew of crews.value) {
+    for (const m of crew.members) ids.add(m.participantId)
+  }
+  return ids
+})
+
+// IDs of the overall top-N ranked solos (ignoring crew assignment — positions are fixed)
+const topNIds = computed(() => {
+  if (!topN.value) return new Set()
+  const ranked = soloEntries.value.filter(p => p.avgScore !== null)
+  return new Set(ranked.slice(0, topN.value).map(p => p.participantId))
+})
+
+// Ranked solos (has a score, not yet in a crew); limited to top N when filter is active
+const rankedSolos = computed(() =>
+  soloEntries.value.filter(p => {
+    if (p.avgScore === null) return false
+    if (assignedIds.value.has(p.participantId)) return false
+    if (topN.value && !topNIds.value.has(p.participantId)) return false
+    return true
+  })
+)
+
+// Available pool (no score OR not ranked, not yet in a crew)
+const availablePool = computed(() =>
+  soloEntries.value.filter(p => !assignedIds.value.has(p.participantId) && p.avgScore === null)
+)
+
+// Crew size from genre format (e.g. "2v2" → 2)
+const crewSize = computed(() => {
+  // Try to infer from existing crews
+  if (crews.value.length > 0 && crews.value[0].members.length > 0) {
+    return crews.value[0].members.length
+  }
+  return null
+})
+
+// ── Draft state ────────────────────────────────────────────────────────────────
+const draftLeader = ref(null)       // solo from rankedSolos
+const selectedPartners = ref([])    // solos from the pool (all non-assigned non-leader entries)
+
+const partnerPool = computed(() =>
+  soloEntries.value.filter(p => {
+    if (assignedIds.value.has(p.participantId)) return false
+    if (p.participantId === draftLeader.value?.participantId) return false
+    // When top-N filter active, Top N members cannot be partners
+    if (topN.value && topNIds.value.has(p.participantId)) return false
+    return true
+  })
+)
+
+// How many more partners needed
+const partnersNeeded = computed(() => {
+  if (!crewSize.value || !draftLeader.value) return 0
+  return crewSize.value - 1 - selectedPartners.value.length
+})
+
+const selectLeader = (solo) => {
+  if (draftLeader.value?.participantId === solo.participantId) {
+    draftLeader.value = null
+    selectedPartners.value = []
+  } else {
+    draftLeader.value = solo
+    selectedPartners.value = []
+  }
+}
+
+const togglePartner = (solo) => {
+  const idx = selectedPartners.value.findIndex(p => p.participantId === solo.participantId)
+  if (idx !== -1) {
+    selectedPartners.value.splice(idx, 1)
+  } else {
+    const needed = crewSize.value ? crewSize.value - 1 : Infinity
+    if (selectedPartners.value.length < needed) {
+      selectedPartners.value.push(solo)
+    }
+  }
+}
+
+const canFormCrew = computed(() => {
+  if (!draftLeader.value) return false
+  if (crewSize.value) return selectedPartners.value.length === crewSize.value - 1
+  return selectedPartners.value.length > 0
+})
+
+const openCrewModal = () => {
+  pendingCrewName.value = ''
+  modalError.value = ''
+  pendingMembers.value = [
+    { participantId: draftLeader.value.participantId, displayName: draftLeader.value.displayName },
+    ...selectedPartners.value.map(p => ({ participantId: p.participantId, displayName: p.displayName })),
+  ]
+  showCrewModal.value = true
+}
+
+const submitCrew = async () => {
+  if (!pendingCrewName.value.trim()) {
+    modalError.value = 'Please enter a crew name.'
+    return
+  }
+  const ids = pendingMembers.value.map(m => m.participantId)
+  const result = await createPickupCrew(selectedEvent.value, selectedGenre.value, pendingCrewName.value.trim(), ids)
+  if (result?.error) {
+    modalError.value = result.error
+    return
+  }
+  showCrewModal.value = false
+  draftLeader.value = null
+  selectedPartners.value = []
+  await loadCrews()
+  showToast(`Crew "${pendingCrewName.value}" created!`)
+}
+
+const removeCrew = async (crewId) => {
+  await deletePickupCrew(crewId)
+  await loadCrews()
+  showToast('Crew removed.', 'warning')
+}
+
+// ── Data loading ───────────────────────────────────────────────────────────────
+
+const loadCrews = async () => {
+  if (!selectedEvent.value || !selectedGenre.value) { crews.value = []; return }
+  crews.value = await getPickupCrews(selectedEvent.value, selectedGenre.value)
+}
+
+watch(topN, () => {
+  draftLeader.value = null
+  selectedPartners.value = []
+})
+
+watch(selectedGenre, async (val) => {
+  draftLeader.value = null
+  selectedPartners.value = []
+  crews.value = []
+  topN.value = null
+  if (!val) return
+  await loadCrews()
+})
+
+watch(selectedEvent, async (val) => {
+  if (!val) return
+  selectedGenre.value = ''
+  const res = await getParticipantScore(val)
+  participants.value = res.map((r, i) => ({ ...r, id: i + 1 }))
+}, { immediate: true })
+</script>
+
+<template>
+  <div class="page-container">
+
+    <!-- Header -->
+    <div class="mb-6">
+      <h1 class="page-title">Crew Formation</h1>
+      <p class="text-muted mt-1">Form pickup crews from solo auditioners for team-format battles</p>
+    </div>
+
+    <!-- Filters -->
+    <div class="card p-5 mb-6">
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="flex flex-col gap-1">
+          <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Event</span>
+          <span class="badge-neutral text-sm px-3 py-1.5 self-start">{{ selectedEvent }}</span>
+        </div>
+        <ReusableDropdown v-model="selectedGenre" labelId="Genre" :options="uniqueGenres" />
+        <div v-if="selectedGenre" class="flex flex-col gap-1">
+          <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Draft Mode</span>
+          <div class="flex gap-1 flex-wrap">
+            <button
+              v-for="n in [null, 4, 8, 16, 32]"
+              :key="n ?? 'all'"
+              @click="topN = n"
+              class="px-2.5 py-1 rounded-lg text-xs font-semibold transition-all"
+              :class="topN === n
+                ? 'bg-primary-600 text-white shadow-sm'
+                : 'bg-surface-700 text-content-muted hover:text-content-primary hover:bg-surface-600'"
+            >
+              {{ n === null ? 'All' : `Top ${n}` }}
+            </button>
+          </div>
+        </div>
+        <div v-else-if="crewSize" class="flex flex-col gap-1">
+          <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Format</span>
+          <span class="badge-neutral text-sm px-3 py-1.5 self-start font-source">
+            {{ crewSize }}v{{ crewSize }} · {{ crewSize }} members per crew
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- No genre selected -->
+    <div v-if="!selectedGenre" class="flex flex-col items-center justify-center py-24 text-center">
+      <div class="w-14 h-14 rounded-2xl bg-surface-700 flex items-center justify-center mb-4">
+        <i class="pi pi-users text-content-muted text-xl"></i>
+      </div>
+      <p class="font-heading font-semibold text-content-secondary">Select a genre to begin</p>
+      <p class="text-muted text-sm mt-1">Only genres with solo pickup entries will be listed</p>
+    </div>
+
+    <template v-else>
+
+      <!-- Toast -->
+      <Transition enter-active-class="transition duration-200" enter-from-class="opacity-0 -translate-y-2"
+        enter-to-class="opacity-100 translate-y-0" leave-active-class="transition duration-150"
+        leave-from-class="opacity-100" leave-to-class="opacity-0">
+        <div v-if="toast.show"
+          class="fixed top-20 left-1/2 -translate-x-1/2 z-50 px-5 py-3 rounded-xl shadow-xl text-sm font-semibold border"
+          :class="toast.variant === 'success'
+            ? 'bg-emerald-500/10 border-emerald-500/40 text-emerald-400'
+            : 'bg-amber-500/10 border-amber-500/40 text-amber-400'"
+        >
+          {{ toast.message }}
+        </div>
+      </Transition>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+        <!-- Left column: Ranked solos + pool -->
+        <div class="flex flex-col gap-4">
+
+          <!-- Draft hint -->
+          <div v-if="draftLeader" class="flex items-center gap-3 px-4 py-3 rounded-xl border border-primary-500/30 bg-primary-500/8">
+            <i class="pi pi-info-circle text-primary-400 flex-shrink-0"></i>
+            <div class="text-sm text-primary-300">
+              <span class="font-bold">{{ draftLeader.displayName }}</span> selected as leader.
+              <template v-if="crewSize">
+                Pick {{ crewSize - 1 - selectedPartners.length }} more partner{{ crewSize - 1 - selectedPartners.length !== 1 ? 's' : '' }}.
+              </template>
+              <template v-else>Pick partners from below.</template>
+            </div>
+            <button @click="draftLeader = null; selectedPartners = []"
+              class="ml-auto flex-shrink-0 text-xs px-2 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:text-content-primary hover:border-surface-500 transition-all">
+              Cancel
+            </button>
+          </div>
+
+          <!-- Ranked solos -->
+          <div class="card overflow-hidden">
+            <div class="px-4 pt-4 pb-3 border-b border-surface-600/30">
+              <h2 class="font-heading font-bold text-content-primary text-sm">
+                Ranked Solos
+                <span v-if="topN" class="ml-1.5 px-1.5 py-0.5 rounded-md bg-primary-500/20 text-primary-400 text-xs font-source">Top {{ topN }}</span>
+              </h2>
+              <p class="text-xs text-content-muted mt-0.5">Click to select as crew leader</p>
+            </div>
+            <div v-if="rankedSolos.length === 0" class="px-4 py-8 text-center text-sm text-content-muted">
+              No ranked solos available
+            </div>
+            <ul v-else class="divide-y divide-surface-600/20">
+              <li
+                v-for="(solo, idx) in rankedSolos"
+                :key="solo.participantId"
+                @click="selectLeader(solo)"
+                class="flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors"
+                :class="draftLeader?.participantId === solo.participantId
+                  ? 'bg-primary-500/15 border-l-2 border-primary-500'
+                  : 'hover:bg-surface-700/40'"
+              >
+                <!-- Rank badge -->
+                <div class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-source font-bold"
+                  :class="idx === 0 ? 'bg-amber-500/20 text-amber-400' : idx === 1 ? 'bg-surface-500/30 text-surface-300' : idx === 2 ? 'bg-orange-900/30 text-orange-400' : 'bg-surface-700 text-surface-400'">
+                  {{ idx + 1 }}
+                </div>
+                <div class="flex-1 min-w-0">
+                  <div class="font-heading font-bold text-content-primary truncate">{{ solo.displayName }}</div>
+                  <div class="text-xs text-content-muted">#{{ solo.auditionNumber ?? '—' }}</div>
+                </div>
+                <div class="flex-shrink-0 text-right">
+                  <div class="font-source font-bold text-primary-400 text-sm">{{ solo.avgScore }}</div>
+                  <div class="text-xs text-content-muted">avg</div>
+                </div>
+                <i v-if="draftLeader?.participantId === solo.participantId" class="pi pi-check-circle text-primary-400 flex-shrink-0"></i>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Partner pool (only shown when a leader is selected) -->
+          <div v-if="draftLeader" class="card overflow-hidden">
+            <div class="px-4 pt-4 pb-3 border-b border-surface-600/30">
+              <h2 class="font-heading font-bold text-content-primary text-sm">Partner Pool</h2>
+              <p class="text-xs text-content-muted mt-0.5">
+                <template v-if="topN">Non-Top {{ topN }} pool · click to add/remove</template>
+                <template v-else>Click to add/remove partners</template>
+              </p>
+            </div>
+            <div v-if="partnerPool.length === 0" class="px-4 py-8 text-center text-sm text-content-muted">
+              No available partners
+            </div>
+            <ul v-else class="divide-y divide-surface-600/20">
+              <li
+                v-for="solo in partnerPool"
+                :key="solo.participantId"
+                @click="togglePartner(solo)"
+                class="flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors"
+                :class="selectedPartners.some(p => p.participantId === solo.participantId)
+                  ? 'bg-primary-500/15 border-l-2 border-primary-500'
+                  : partnersNeeded === 0 && !selectedPartners.some(p => p.participantId === solo.participantId)
+                    ? 'opacity-40 cursor-not-allowed'
+                    : 'hover:bg-surface-700/40'"
+              >
+                <div class="flex-1 min-w-0">
+                  <div class="font-heading font-bold text-content-primary truncate">{{ solo.displayName }}</div>
+                  <div class="text-xs text-content-muted">
+                    #{{ solo.auditionNumber ?? '—' }}
+                    <span v-if="solo.avgScore !== null" class="ml-2 text-primary-400 font-source font-bold">{{ solo.avgScore }}</span>
+                    <span v-else class="ml-2 italic">no score</span>
+                  </div>
+                </div>
+                <i v-if="selectedPartners.some(p => p.participantId === solo.participantId)"
+                  class="pi pi-check-circle text-primary-400 flex-shrink-0"></i>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Form crew button -->
+          <button
+            v-if="draftLeader"
+            @click="openCrewModal"
+            :disabled="!canFormCrew"
+            class="w-full py-3 rounded-xl font-semibold text-sm transition-all duration-200"
+            :class="canFormCrew
+              ? 'bg-primary-600 text-white hover:bg-primary-700 shadow-sm btn-glow'
+              : 'bg-surface-700 text-surface-500 cursor-not-allowed'"
+          >
+            <i class="pi pi-users mr-2"></i>
+            Form Crew
+            <span v-if="crewSize" class="ml-1 opacity-70">({{ 1 + selectedPartners.length }}/{{ crewSize }})</span>
+          </button>
+        </div>
+
+        <!-- Right column: Formed crews -->
+        <div>
+          <div class="card overflow-hidden">
+            <div class="px-4 pt-4 pb-3 border-b border-surface-600/30 flex items-center justify-between">
+              <div>
+                <h2 class="font-heading font-bold text-content-primary text-sm">Formed Crews</h2>
+                <p class="text-xs text-content-muted mt-0.5">{{ crews.length }} crew{{ crews.length !== 1 ? 's' : '' }} formed</p>
+              </div>
+            </div>
+
+            <div v-if="crews.length === 0" class="px-4 py-12 text-center">
+              <i class="pi pi-users text-surface-600 text-3xl mb-3 block"></i>
+              <p class="text-sm text-content-muted">No crews formed yet</p>
+              <p class="text-xs text-surface-500 mt-1">Select a leader and partners on the left</p>
+            </div>
+
+            <ul v-else class="divide-y divide-surface-600/20">
+              <li v-for="crew in crews" :key="crew.id" class="p-4">
+                <div class="flex items-start justify-between gap-3 mb-2">
+                  <div>
+                    <div class="font-heading font-bold text-content-primary">{{ crew.crewName }}</div>
+                    <div v-if="crew.avgScore !== null" class="text-xs text-content-muted mt-0.5">
+                      Avg score: <span class="font-source font-bold text-primary-400">{{ crew.avgScore }}</span>
+                    </div>
+                  </div>
+                  <button
+                    @click="removeCrew(crew.id)"
+                    class="flex-shrink-0 p-1.5 rounded-lg text-surface-500 hover:text-red-400 hover:bg-red-950/50 transition-all"
+                  >
+                    <i class="pi pi-trash text-xs"></i>
+                  </button>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <span
+                    v-for="(member, idx) in crew.members"
+                    :key="member.participantId"
+                    class="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-semibold border"
+                    :class="idx === 0
+                      ? 'bg-primary-500/15 border-primary-500/30 text-primary-300'
+                      : 'bg-surface-700/50 border-surface-600/40 text-content-secondary'"
+                  >
+                    <i v-if="idx === 0" class="pi pi-star-fill" style="font-size: 0.55rem"></i>
+                    {{ member.displayName }}
+                  </span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+      </div>
+    </template>
+
+  </div>
+
+  <!-- Crew name modal -->
+  <ActionDoneModal
+    :show="showCrewModal"
+    title="Name Your Crew"
+    variant="info"
+    @accept="submitCrew"
+    @close="showCrewModal = false"
+  >
+    <div class="space-y-4 mt-1">
+      <!-- Members preview -->
+      <div class="flex flex-wrap gap-2 p-3 rounded-xl bg-surface-900 border border-surface-600/50">
+        <span
+          v-for="(m, idx) in pendingMembers"
+          :key="m.participantId"
+          class="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-semibold border"
+          :class="idx === 0
+            ? 'bg-primary-500/15 border-primary-500/30 text-primary-300'
+            : 'bg-surface-700/50 border-surface-600/40 text-content-secondary'"
+        >
+          <i v-if="idx === 0" class="pi pi-star-fill" style="font-size: 0.55rem"></i>
+          {{ m.displayName }}
+        </span>
+      </div>
+      <div>
+        <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1.5">
+          Crew Name
+        </label>
+        <input
+          v-model="pendingCrewName"
+          type="text"
+          placeholder="Enter crew name…"
+          class="input-base"
+          @keyup.enter="submitCrew"
+        />
+        <p v-if="modalError" class="text-xs text-red-400 mt-1.5">{{ modalError }}</p>
+      </div>
+    </div>
+  </ActionDoneModal>
+</template>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -246,6 +246,11 @@ watch(adjustParticipantGenres, (genres) => {
   }
 })
 
+// Clear selected participant when search input is cleared
+watch(adjustSearch, (val) => {
+  if (!val.trim()) adjustParticipant.value = null
+})
+
 function normalizeGenreName(name) {
   const normalized = name.trim().toLowerCase().replace(/\s+/g, '');
   if (normalized.includes('7tosmoke')) return 'smoke';
@@ -1103,42 +1108,46 @@ onMounted(async () => {
         <!-- Body -->
         <div class="flex-1 overflow-y-auto px-6 py-5 space-y-5">
           <!-- Search -->
-          <div>
+          <div class="relative">
             <label class="block text-sm font-semibold text-content-secondary mb-1.5">Search Participant</label>
-            <input
-              v-model="adjustSearch"
-              type="text"
-              placeholder="Type a name…"
-              class="w-full px-4 py-2.5 rounded-xl border border-surface-600 text-sm text-content-primary
-                     focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
-            />
-          </div>
-
-          <!-- Search results (only shown when no participant selected) -->
-          <div v-if="adjustSearchResults.length > 0 && !adjustParticipant" class="flex flex-wrap gap-2">
-            <button
-              v-for="name in adjustSearchResults"
-              :key="name"
-              @click="adjustParticipant = name"
-              class="badge-neutral px-3 py-1.5 rounded-full text-sm font-medium bg-surface-700 text-content-secondary
-                     hover:bg-primary-100 hover:text-primary-400 border border-surface-600 transition-colors"
+            <div class="relative">
+              <input
+                v-model="adjustSearch"
+                type="text"
+                placeholder="Type a name…"
+                autocomplete="off"
+                class="w-full px-4 py-2.5 pr-9 rounded-xl border border-surface-600 text-sm text-content-primary
+                       focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+              />
+              <button
+                v-if="adjustSearch"
+                @click="adjustSearch = ''; adjustParticipant = null"
+                class="absolute right-2.5 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-secondary transition-colors"
+              >
+                <i class="pi pi-times text-xs"></i>
+              </button>
+            </div>
+            <!-- Realtime dropdown results -->
+            <div
+              v-if="adjustSearchResults.length > 0 && adjustSearch !== adjustParticipant"
+              class="absolute z-20 left-0 right-0 mt-1 rounded-xl border border-surface-600
+                     bg-surface-800 shadow-xl overflow-hidden"
             >
-              {{ name }}
-            </button>
+              <button
+                v-for="name in adjustSearchResults"
+                :key="name"
+                @click="adjustParticipant = name; adjustSearch = name"
+                class="w-full text-left px-4 py-2.5 text-sm font-medium text-content-secondary
+                       hover:bg-primary-500/10 hover:text-primary-400 transition-colors border-b border-surface-700
+                       last:border-b-0"
+              >
+                {{ name }}
+              </button>
+            </div>
           </div>
 
           <!-- Selected participant view -->
           <div v-if="adjustParticipant">
-            <div class="flex items-center gap-2 mb-4">
-              <span class="font-heading font-bold text-content-primary">{{ adjustParticipant }}</span>
-              <button
-                @click="adjustParticipant = null; adjustSearch = ''"
-                class="text-content-muted hover:text-content-secondary transition-colors"
-              >
-                <i class="pi pi-times-circle text-sm"></i>
-              </button>
-            </div>
-
             <!-- Current genres -->
             <div class="mb-5">
               <p class="text-xs font-semibold text-content-muted uppercase tracking-wider mb-2">Current Genres</p>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,9 +1,12 @@
 <script setup>
-import { ref, onMounted, reactive, watch, computed } from 'vue';
+import { ref, onMounted, onUnmounted, reactive, watch, computed } from 'vue';
+import { RouterLink } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
 import DynamicTable from '@/components/DynamicTable.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, addJudges, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, getEmailTemplate, updateEmailTemplate, resetEmailTemplate, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyAndEmailParticipant, verifyAndEmailBatch, updateEventGenreFormat } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, addJudges, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, getEmailTemplate, updateEmailTemplate, resetEmailTemplate, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyAndEmailParticipant, verifyAndEmailBatch, updateEventGenreFormat, getEventJudges, addEventJudge, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents } from '@/utils/api';
+import { setActiveEvent } from '@/utils/auth';
 import { filterObject, useDelay } from '@/utils/utils';
+import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import ReusableButton from '@/components/ReusableButton.vue';
 import AuditionNumber from './AuditionNumber.vue';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
@@ -11,6 +14,8 @@ import CreateParticipantForm from '@/components/CreateParticipantForm.vue'
 import ScoringCriteriaModal from '@/components/ScoringCriteriaModal.vue';
 
 const fileId = ref('')
+const dbEventId = ref(null)
+const activeFolderID = ref(null)
 const modalTitle = ref("")
 const modalMessage = ref("")
 const modalVariant = ref("success")
@@ -57,6 +62,10 @@ const showCriteriaModal = ref(false)
 // Walk-in form
 const showWalkInForm = ref(false)
 const revealingRef = ref(null) // name of participant whose ref code is being held/revealed
+const activeTab = ref('setup') // 'setup' | 'event-day'
+const activeGenreTab = ref(null)
+let refreshInterval = null
+let wsClient = null
 
 // Genre adjustment modal
 const showAdjustModal = ref(false)
@@ -218,6 +227,38 @@ const registeredList = computed(() => {
     .sort((a, b) => a.name.localeCompare(b.name))
 })
 
+const registeredSearch = ref('')
+const registeredGenreFilter = ref('')
+const registeredPage = ref(1)
+const REGISTERED_PAGE_SIZE = 10
+
+const registeredGenreOptions = computed(() => {
+  const genres = new Set()
+  registeredList.value.forEach(p => p.entries.forEach(e => genres.add(e.genre)))
+  return [...genres].sort()
+})
+
+const filteredRegisteredList = computed(() => {
+  let list = registeredList.value
+  const q = registeredSearch.value.trim().toLowerCase()
+  if (q) list = list.filter(p =>
+    p.name.toLowerCase().includes(q) ||
+    p.entries.some(e => e.genre.toLowerCase().includes(q))
+  )
+  if (registeredGenreFilter.value)
+    list = list.filter(p => p.entries.some(e => e.genre === registeredGenreFilter.value))
+  return list
+})
+
+const registeredTotalPages = computed(() => Math.max(1, Math.ceil(filteredRegisteredList.value.length / REGISTERED_PAGE_SIZE)))
+
+const paginatedRegisteredList = computed(() => {
+  const start = (registeredPage.value - 1) * REGISTERED_PAGE_SIZE
+  return filteredRegisteredList.value.slice(start, start + REGISTERED_PAGE_SIZE)
+})
+
+watch([registeredSearch, registeredGenreFilter], () => { registeredPage.value = 1 })
+
 const adjustSearchResults = computed(() => {
   if (!adjustSearch.value.trim()) return []
   const q = adjustSearch.value.toLowerCase()
@@ -309,12 +350,18 @@ const onSubmit = async () => {
   await addJudges(inputs.value)
   await insertEventInTable(props.eventName, paymentRequired.value)
   const resp = await linkGenreToEvent(props.eventName, createTable.genres, createTable.genreFormats)
-  resp.json().then(result => {
+  resp.json().then(async result => {
     loading.value = false
     getTitle(resp.status)
     modalMessage.value = result
     showModal.value = true
     tableExist.value = true
+    if (!dbEventId.value) {
+      const dbEvents = await fetchAllEvents() ?? []
+      const dbEvent = dbEvents.find(e => e.name === props.eventName)
+      if (dbEvent) dbEventId.value = dbEvent.id
+    }
+    if (dbEventId.value) setActiveEvent(dbEventId.value, props.eventName, activeFolderID.value)
   })
 }
 
@@ -339,9 +386,14 @@ const refreshParticipant = async () => {
   loading.value = false
 }
 
+const refreshFromDb = async () => {
+  verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
+  unverifiedParticipants.value = await getUnverifiedParticipantsDB(props.eventName)
+}
+
 const handleWalkInCreated = async () => {
   showWalkInForm.value = false
-  verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
+  await refreshFromDb()
 }
 
 const closeAdjustModal = () => {
@@ -376,6 +428,35 @@ const addGenre = async (genreName) => {
   verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
   adjustLoading.value = false
 }
+
+// ── Scoring criteria (per-genre, for inline display) ────────────────────────
+const criteriaByGenre = ref({}) // genreName → array of { id, name, weight }
+
+const loadCriteriaForAllGenres = async (genres) => {
+  const map = {}
+  await Promise.all(genres.map(async (g) => {
+    map[g.genreName] = await getScoringCriteria(props.eventName, g.genreName) ?? []
+  }))
+  criteriaByGenre.value = map
+}
+// ───────────────────────────────────────────────────────────────────────────
+
+// ── Judges ──────────────────────────────────────────────────────────────────
+const eventJudges = ref([])
+const addJudgeInput = ref('')
+
+const submitAddJudge = async () => {
+  if (!addJudgeInput.value.trim()) return
+  const res = await addEventJudge(props.eventName, addJudgeInput.value.trim())
+  if (res?.ok) eventJudges.value = await res.json()
+  addJudgeInput.value = ''
+}
+
+const submitRemoveJudge = async (judgeId) => {
+  const res = await removeEventJudge(props.eventName, judgeId)
+  if (res?.ok) eventJudges.value = await res.json()
+}
+// ───────────────────────────────────────────────────────────────────────────
 
 // ── Genre format editing ────────────────────────────────────────────────────
 const formatOptions = ['1v1', '2v2', '3v3', '4v4']
@@ -446,9 +527,9 @@ const handleBatchVerify = async () => {
 watch(
   fileId,
   async () => {
-    if (fileId.value !== null) {
+    if (fileId.value) {
       participantsNumBreakdown.value = await getResponseDetails(fileId.value)
-      totalParticipants.value = await getSheetSize(fileId.value)
+      totalParticipants.value = await getSheetSize(fileId.value) ?? 0
     }
   }
 )
@@ -456,9 +537,26 @@ watch(
 onMounted(async () => {
   onStartLoading.value = true
   tableExist.value = checkTableExist(eventName, tableExist)
-  fileId.value = await getFileId(props.folderID)
+  // folderID may be absent when navigating from the navbar dropdown or EventSelector redirect
+  let resolvedFolderID = props.folderID
+  if (!resolvedFolderID) {
+    const folderEvents = await fetchAllFolderEvents()
+    const match = folderEvents?.find(e => e.folderName === props.eventName)
+    resolvedFolderID = match?.folderID ?? null
+  }
+  activeFolderID.value = resolvedFolderID
+  fileId.value = await getFileId(resolvedFolderID)
+  const dbEvents = await fetchAllEvents() ?? []
+  const dbEvent = dbEvents.find(e => e.name === props.eventName)
+  if (dbEvent) {
+    dbEventId.value = dbEvent.id
+    setActiveEvent(dbEvent.id, dbEvent.name, resolvedFolderID)
+  }
   genreOptions.value = await fetchAllGenres()
   eventGenres.value = await getGenresByEvent(props.eventName)
+  if (eventGenres.value.length > 0) activeGenreTab.value = eventGenres.value[0].genreName
+  await loadCriteriaForAllGenres(eventGenres.value)
+  eventJudges.value = await getEventJudges(props.eventName)
   if (tableExist.value) {
     verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
     verifiedFormParticipants.value = await getVerifiedParticipantsByEvent(eventName.value)
@@ -466,6 +564,23 @@ onMounted(async () => {
   }
   await useDelay().wait(2500)
   onStartLoading.value = false
+  if (tableExist.value) {
+    refreshInterval = setInterval(refreshFromDb, 30000)
+    wsClient = createClient()
+    let refreshPending = false
+    subscribeToChannel(wsClient, '/topic/audition/', (msg) => {
+      if (msg.eventName !== props.eventName) return
+      if (!refreshPending) {
+        refreshPending = true
+        refreshFromDb().finally(() => { refreshPending = false })
+      }
+    })
+  }
+})
+
+onUnmounted(() => {
+  if (refreshInterval) clearInterval(refreshInterval)
+  if (wsClient) deactivateClient(wsClient)
 })
 </script>
 
@@ -473,10 +588,10 @@ onMounted(async () => {
   <div class="page-container">
 
     <!-- Page header -->
-    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
+    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
       <div>
         <h1 class="page-title">{{ props.eventName }}</h1>
-        <p class="text-muted mt-1">Event overview and participant registration status</p>
+        <p class="text-muted mt-1">Event overview and participant management</p>
       </div>
       <div class="flex flex-wrap gap-2 self-start">
         <button
@@ -506,6 +621,15 @@ onMounted(async () => {
           <i class="pi pi-envelope text-sm"></i>
           Email Template
         </button>
+        <RouterLink
+          to="/event/audition-number"
+          class="flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-600 bg-surface-800 text-sm
+                 font-semibold text-content-secondary hover:bg-surface-700 hover:border-surface-500
+                 transition-all duration-200"
+        >
+          <i class="pi pi-hashtag text-sm"></i>
+          Audition Screen
+        </RouterLink>
         <button
           @click="refreshParticipant"
           :disabled="loading"
@@ -513,146 +637,72 @@ onMounted(async () => {
                  font-semibold text-content-secondary hover:bg-surface-700 hover:border-surface-500
                  disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
         >
-          <i class="pi text-sm" :class="loading ? 'pi-spinner pi-spin text-primary-500' : 'pi-refresh'"></i>
-          {{ loading ? 'Refreshing…' : 'Refresh Participants' }}
+          <i class="pi text-sm" :class="loading ? 'pi-spinner pi-spin text-primary-500' : 'pi-cloud-download'"></i>
+          {{ loading ? 'Importing…' : 'Import from Sheets' }}
         </button>
       </div>
     </div>
 
-    <!-- Audition Number -->
-    <div class="card p-4 mb-6">
-      <AuditionNumber />
+    <!-- Tab toggle -->
+    <div class="flex rounded-xl overflow-hidden border border-surface-600 w-fit mb-6">
+      <button
+        @click="activeTab = 'setup'"
+        class="px-5 py-2 text-sm font-semibold transition-all duration-150"
+        :class="activeTab === 'setup'
+          ? 'bg-primary-600 text-white'
+          : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+      >
+        <i class="pi pi-cog text-xs mr-1.5"></i>
+        Setup
+      </button>
+      <button
+        @click="activeTab = 'event-day'"
+        class="px-5 py-2 text-sm font-semibold transition-all duration-150"
+        :class="activeTab === 'event-day'
+          ? 'bg-primary-600 text-white'
+          : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+      >
+        <i class="pi pi-calendar text-xs mr-1.5"></i>
+        Event Day
+        <span
+          v-if="totalNotShownUp > 0"
+          class="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold bg-amber-500 text-white"
+        >{{ totalNotShownUp }}</span>
+        <span
+          v-else-if="unverifiedParticipants.length > 0 && activeTab !== 'event-day'"
+          class="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold bg-rose-500 text-white"
+        >{{ unverifiedParticipants.length }}</span>
+      </button>
     </div>
 
-    <!-- Stats cards -->
-    <div class="grid grid-cols-1 sm:grid-cols-4 gap-4 mb-8">
-      <!-- Total -->
-      <div class="stat-card stat-card-primary p-5 hover:bg-surface-700 transition-colors duration-200">
-        <div class="flex items-center gap-3 mb-3">
-          <div class="icon-wrap w-9 h-9 rounded-xl bg-surface-700 flex items-center justify-center">
-            <i class="pi pi-users text-primary-400 text-sm"></i>
-          </div>
-          <span class="label-caps font-semibold text-content-muted uppercase">Total Participants</span>
-        </div>
-        <p class="text-3xl font-heading font-extrabold text-content-primary stat-number mt-1">
-          {{ totalParticipants + totalWalkIn }}
-        </p>
-        <div class="flex gap-4 mt-3">
-          <span class="text-[13px] text-content-secondary">Form: <strong class="text-content-primary">{{ totalParticipants }}</strong></span>
-          <span class="text-[13px] text-content-secondary">Walk-in: <strong class="text-content-primary">{{ totalWalkIn }}</strong></span>
+    <!-- ── SETUP TAB ─────────────────────────────────────────────────────── -->
+    <template v-if="activeTab === 'setup'">
+
+    <!-- Stat strip -->
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">
+      <div class="card p-4">
+        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Total</p>
+        <p class="text-2xl font-heading font-extrabold text-content-primary">{{ (totalParticipants || 0) + totalWalkIn }}</p>
+        <div class="flex gap-3 mt-1">
+          <span class="text-xs text-content-muted">Form: <strong class="text-content-secondary">{{ totalParticipants || 0 }}</strong></span>
+          <span class="text-xs text-content-muted">Walk-in: <strong class="text-content-secondary">{{ totalWalkIn }}</strong></span>
         </div>
       </div>
-
-      <!-- Verified -->
-      <div class="stat-card stat-card-success p-5 hover:bg-surface-700 transition-colors duration-200">
-        <div class="flex items-center gap-3 mb-3">
-          <div class="icon-wrap w-9 h-9 rounded-xl bg-surface-700 flex items-center justify-center">
-            <i class="pi pi-check-circle text-teal-400 text-sm"></i>
-          </div>
-          <span class="label-caps font-semibold text-content-muted uppercase">Verification</span>
-        </div>
-        <p class="text-3xl font-heading font-extrabold text-content-primary stat-number mt-1">
-          {{ totalVerified }}
+      <div class="card p-4">
+        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Pending Verification</p>
+        <p class="text-2xl font-heading font-extrabold" :class="unverifiedParticipants.length > 0 ? 'text-rose-300' : 'text-content-primary'">
+          {{ unverifiedParticipants.length }}
         </p>
-        <div class="flex flex-col gap-1 mt-3">
-          <span class="text-[13px] text-content-secondary">
-            Pending: <strong class="text-rose-300">{{ unverifiedParticipants.length }}</strong>
-          </span>
-        </div>
+        <span class="text-xs text-content-muted">{{ totalVerified }} verified</span>
       </div>
-
-      <!-- Registered -->
-      <div class="stat-card stat-card-warning p-5 hover:bg-surface-700 transition-colors duration-200">
-        <div class="flex items-center gap-3 mb-3">
-          <div class="icon-wrap w-9 h-9 rounded-xl bg-surface-700 flex items-center justify-center">
-            <i class="pi pi-id-card text-amber-300/60 text-sm"></i>
-          </div>
-          <span class="label-caps font-semibold text-content-muted uppercase">Registered</span>
-        </div>
-        <p class="text-3xl font-heading font-extrabold text-content-primary stat-number mt-1">
-          {{ totalDbRegistered.length }}
-        </p>
-        <div class="flex gap-4 mt-3">
-          <span class="text-[13px] text-content-secondary">Audition assigned</span>
-          <span v-if="totalNotShownUp > 0" class="text-[13px] text-content-secondary">
-            Absent: <strong class="text-amber-300">{{ totalNotShownUp }}</strong>
-          </span>
-        </div>
-      </div>
-
-      <!-- Email Progress -->
-      <div class="stat-card stat-card-primary p-5 hover:bg-surface-700 transition-colors duration-200">
-        <div class="flex items-center gap-3 mb-3">
-          <div class="icon-wrap w-9 h-9 rounded-xl bg-surface-700 flex items-center justify-center">
-            <i class="pi pi-send text-primary-400 text-sm"></i>
-          </div>
-          <span class="label-caps font-semibold text-content-muted uppercase">Email Progress</span>
-        </div>
-        <p class="text-3xl font-heading font-extrabold text-content-primary stat-number mt-1">
-          {{ emailedCount }} / {{ totalVerified }}
-        </p>
-        <div class="flex gap-4 mt-3">
-          <span class="text-[13px] text-content-secondary">QR emails sent</span>
-        </div>
+      <div class="card p-4">
+        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Emails Sent</p>
+        <p class="text-2xl font-heading font-extrabold text-content-primary">{{ emailedCount }}<span class="text-base font-medium text-content-muted"> / {{ totalVerified }}</span></p>
+        <span class="text-xs text-content-muted">QR emails</span>
       </div>
     </div>
 
-    <!-- Participant detail panels -->
-    <div v-if="verifiedDbParticipants.length > 0" class="space-y-2 mb-8">
-
-      <!-- Not shown up -->
-      <div v-if="notShownUpList.length > 0" class="card overflow-hidden panel-warning">
-        <button
-          @click="expandedPeople.has('notShownUp') ? expandedPeople.delete('notShownUp') : expandedPeople.add('notShownUp'); expandedPeople = new Set(expandedPeople)"
-          :aria-expanded="expandedPeople.has('notShownUp')"
-          aria-controls="panel-not-shown-up"
-          class="w-full flex items-center justify-between px-5 py-4 bg-surface-900/40 hover:bg-surface-700/60 transition-colors duration-150 text-left"
-        >
-          <div class="flex items-center gap-3">
-            <div class="icon-wrap w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
-              <i class="pi pi-clock text-amber-300 text-xs"></i>
-            </div>
-            <span class="font-heading font-bold text-content-secondary">Not Shown Up</span>
-            <span class="badge-warning inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-amber-300 border border-amber-900/30">
-              {{ notShownUpList.length }}
-            </span>
-          </div>
-          <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
-             :class="{ 'rotate-180': expandedPeople.has('notShownUp') }"></i>
-        </button>
-        <div v-if="expandedPeople.has('notShownUp')" id="panel-not-shown-up" class="px-4 pb-4 border-t border-surface-600/30 pt-4 shadow-[inset_0_4px_8px_rgba(0,0,0,0.2)]">
-          <div class="space-y-2">
-            <div
-              v-for="p in notShownUpList"
-              :key="p.name"
-              class="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-surface-700/50 border border-surface-600"
-            >
-              <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-sm font-semibold text-content-secondary">{{ p.name }}</span>
-                <span
-                  v-if="verifiedDbParticipants.find(v => v.participantName === p.name)?.emailSent"
-                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-teal-300 border border-teal-900/30"
-                >
-                  <i class="pi pi-check text-xs"></i> Email Sent
-                </span>
-              </div>
-              <div class="flex flex-wrap gap-1">
-                <span
-                  v-for="g in p.genres"
-                  :key="g"
-                  class="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-surface-800 border border-surface-600 text-content-muted"
-                >{{ g }}</span>
-              </div>
-              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted mt-0.5">
-                <i class="pi pi-users" style="font-size:0.65rem"></i>
-                <span>{{ p.memberNames.join(', ') }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Unverified (payment pending — DB-driven) -->
+    <!-- Unverified (payment pending — DB-driven) -->
       <div v-if="unverifiedParticipants.length > 0" class="card overflow-hidden panel-danger">
         <button
           @click="expandedPeople.has('unverified') ? expandedPeople.delete('unverified') : expandedPeople.add('unverified'); expandedPeople = new Set(expandedPeople)"
@@ -744,177 +794,6 @@ onMounted(async () => {
         </div>
       </div>
 
-      <!-- Registered -->
-      <div v-if="registeredList.length > 0" class="card overflow-hidden panel-success">
-        <button
-          @click="expandedPeople.has('registered') ? expandedPeople.delete('registered') : expandedPeople.add('registered'); expandedPeople = new Set(expandedPeople)"
-          :aria-expanded="expandedPeople.has('registered')"
-          aria-controls="panel-registered"
-          class="w-full flex items-center justify-between px-5 py-4 bg-surface-900/40 hover:bg-surface-700/60 transition-colors duration-150 text-left"
-        >
-          <div class="flex items-center gap-3">
-            <div class="icon-wrap w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
-              <i class="pi pi-check-circle text-teal-400 text-xs"></i>
-            </div>
-            <span class="font-heading font-bold text-content-secondary">Registered</span>
-            <span class="badge-success inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-teal-300 border border-teal-900/30">
-              {{ registeredList.length }}
-            </span>
-          </div>
-          <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
-             :class="{ 'rotate-180': expandedPeople.has('registered') }"></i>
-        </button>
-        <div v-if="expandedPeople.has('registered')" id="panel-registered" class="px-5 pb-4 border-t border-surface-600/30 pt-4 shadow-[inset_0_4px_8px_rgba(0,0,0,0.2)]">
-          <div class="space-y-2">
-            <div
-              v-for="p in registeredList"
-              :key="p.name"
-              class="flex flex-col gap-2 px-3 py-2.5 rounded-xl bg-surface-900 border border-surface-600"
-            >
-              <!-- Row 1: name + status badge -->
-              <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-sm font-semibold text-content-secondary">{{ p.name }}</span>
-                <span
-                  v-if="p.walkin"
-                  class="shrink-0 inline-flex px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-content-muted border border-surface-600"
-                >walk-in</span>
-                <!-- Hold-to-reveal reference code for walk-ins -->
-                <span
-                  v-if="p.walkin && p.referenceCode"
-                  class="relative shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-surface-800 border border-surface-600 cursor-pointer select-none touch-none"
-                  @mousedown="revealingRef = p.name"
-                  @mouseup="revealingRef = null"
-                  @mouseleave="revealingRef = null"
-                  @touchstart.prevent="revealingRef = p.name"
-                  @touchend="revealingRef = null"
-                  @touchcancel="revealingRef = null"
-                >
-                  <i class="pi pi-eye text-content-muted" style="font-size:0.65rem"></i>
-                  <span class="text-content-muted">Ref code</span>
-                  <!-- Tooltip above, away from cursor -->
-                  <span
-                    v-if="revealingRef === p.name"
-                    class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-4 py-2.5 rounded-xl bg-surface-700 border border-surface-500 shadow-xl whitespace-nowrap z-50 pointer-events-none"
-                  >
-                    <span class="font-source tracking-widest text-primary-400 text-base font-bold">{{ p.referenceCode }}</span>
-                    <!-- Arrow -->
-                    <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-500"></span>
-                  </span>
-                </span>
-                <span
-                  v-else-if="p.entries.length > 0 && verifiedDbParticipants.find(v => v.participantName === p.name)?.emailSent"
-                  class="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-teal-300 border border-teal-900/30"
-                >
-                  <i class="pi pi-check text-xs"></i> Email Sent
-                </span>
-                <span
-                  v-else-if="!p.walkin"
-                  class="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-amber-300 border border-amber-900/30"
-                >
-                  <i class="pi pi-clock text-xs"></i> Email Pending
-                </span>
-              </div>
-              <!-- Row 2: genre + audition number badges -->
-              <div class="flex flex-wrap gap-1.5">
-                <span
-                  v-for="e in p.entries"
-                  :key="e.genre"
-                  class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-surface-800 border border-primary-200 text-sm"
-                >
-                  <span class="text-content-muted capitalize text-xs">{{ e.genre }}</span>
-                  <span class="font-heading font-extrabold text-primary-400">#{{ e.auditionNumber }}</span>
-                </span>
-              </div>
-              <!-- Row 3: team members (only for team entries) -->
-              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted">
-                <i class="pi pi-users" style="font-size:0.65rem"></i>
-                <span>{{ p.memberNames.join(', ') }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-    </div>
-
-    <!-- Genre breakdown -->
-    <div v-if="completeBreakdown.length > 0" class="mb-8">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="font-heading font-bold text-content-secondary text-lg">Genre Breakdown</h2>
-        <button
-          @click="showCriteriaModal = true"
-          class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-surface-600 bg-surface-700/60
-                 text-xs font-semibold text-content-muted hover:border-primary-500/50 hover:text-primary-400 transition-all duration-150"
-        >
-          <i class="pi pi-sliders-h text-xs" />
-          Scoring Criteria
-        </button>
-      </div>
-      <div class="space-y-2">
-        <div
-          v-for="genre in completeBreakdown"
-          :key="genre.genre"
-          class="card overflow-hidden"
-        >
-          <!-- Genre header (always visible) -->
-          <button
-            @click="toggleGenre(genre.genre)"
-            :aria-expanded="expandedGenres.has(genre.genre)"
-            class="w-full flex items-center justify-between px-5 py-4 bg-surface-900/40 hover:bg-surface-700/60 transition-colors duration-150 text-left"
-          >
-            <div class="flex items-center gap-4">
-              <span class="font-heading font-bold text-content-primary capitalize">{{ genre.genre }}</span>
-              <div class="flex items-center gap-3">
-                <span class="badge-neutral text-xs">Total: {{ genre.total }}</span>
-                <span class="badge-success inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-teal-300 border border-teal-900/30">
-                  Reg: {{ genre.registered }}
-                </span>
-                <span
-                  v-if="genre.unregistered > 0"
-                  class="badge-danger inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-rose-300 border border-rose-900/30"
-                >
-                  Unreg: {{ genre.unregistered }}
-                </span>
-              </div>
-            </div>
-            <i
-              class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
-              :class="{ 'rotate-180': expandedGenres.has(genre.genre) }"
-            ></i>
-          </button>
-
-          <!-- Expanded: unregistered list -->
-          <div
-            v-if="expandedGenres.has(genre.genre)"
-            class="px-5 pb-4 border-t border-surface-600/30"
-          >
-            <div class="pt-4">
-              <template v-if="getUnregistered(genre.genre).unregistered.length > 0">
-                <p class="label-caps font-semibold text-content-muted uppercase mb-2">
-                  Unregistered Participants
-                </p>
-                <div class="flex flex-wrap gap-2">
-                  <span
-                    v-for="p in getUnregistered(genre.genre).unregistered"
-                    :key="p.participantName"
-                    class="inline-flex items-center px-2.5 py-1 rounded-full bg-surface-800 text-rose-300 text-xs font-medium border border-rose-300/20 font-source"
-                  >
-                    {{ p.participantName }}
-                  </span>
-                </div>
-              </template>
-              <template v-else>
-                <div class="flex items-center gap-2 text-teal-300 text-sm">
-                  <i class="pi pi-check-circle"></i>
-                  <span>All verified participants have registered</span>
-                </div>
-              </template>
-            </div>
-
-          </div>
-        </div>
-      </div>
-    </div>
 
     <!-- Setup section (when no table exists) -->
     <div v-if="!tableExist" class="card p-6">
@@ -993,67 +872,366 @@ onMounted(async () => {
       </div>
     </div>
 
-  </div>
+  <!-- Genre Configuration — unified per-genre tabs (participants, format, criteria, judges) -->
+  <div v-if="tableExist && eventGenres.length > 0" class="card overflow-hidden mt-6">
 
-  <!-- Genre Format Management (shown when event is set up) -->
-  <div v-if="tableExist && eventGenres.length > 0" class="card p-5 mt-6">
-    <div class="flex items-center gap-3 mb-4">
-      <div class="icon-wrap w-8 h-8 rounded-xl bg-surface-700 flex items-center justify-center">
-        <i class="pi pi-tag text-content-muted text-sm"></i>
-      </div>
-      <div>
-        <h2 class="font-heading font-bold text-content-secondary text-sm">Genre Formats</h2>
-        <p class="text-xs text-content-muted mt-0.5">Set battle format per genre (e.g. 2v2). Required for team vs solo audition splitting.</p>
-      </div>
-    </div>
-    <div class="flex flex-col gap-2">
-      <div
+    <!-- Genre tab bar -->
+    <div class="flex border-b border-surface-700/50 bg-surface-900/30 overflow-x-auto">
+      <button
         v-for="g in eventGenres"
         :key="g.genreName"
-        class="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-surface-800/60 border border-surface-600/30"
+        @click="activeGenreTab = g.genreName"
+        class="px-5 py-3 text-sm font-semibold whitespace-nowrap transition-all duration-150 border-b-2"
+        :class="activeGenreTab === g.genreName
+          ? 'border-primary-500 text-content-primary bg-surface-800/50'
+          : 'border-transparent text-content-muted hover:text-content-secondary hover:bg-surface-700/30'"
       >
-        <span class="font-heading font-semibold text-content-secondary text-sm flex-1 capitalize">{{ g.genreName }}</span>
+        {{ g.genreName }}
+        <span
+          v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.genreName))"
+          class="ml-1.5 text-xs font-normal opacity-60"
+        >{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.genreName)).total }}</span>
+      </button>
+    </div>
 
-        <!-- Viewing mode -->
-        <template v-if="editingFormatFor !== g.genreName">
-          <span class="font-source text-xs px-2 py-0.5 rounded-md"
-            :class="g.format ? 'bg-primary-500/15 text-primary-400 border border-primary-500/30' : 'bg-surface-700 text-surface-500 border border-surface-600/30'">
-            {{ g.format || 'No format' }}
-          </span>
-          <button
-            @click="startEditFormat(g)"
-            class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-surface-500 hover:text-content-primary transition-all"
-          >
-            <i class="pi pi-pencil" style="font-size:0.65rem"></i>
-            Edit
-          </button>
+    <!-- Tab content for each genre -->
+    <template v-for="g in eventGenres" :key="g.genreName + '-content'">
+      <div v-if="activeGenreTab === g.genreName" class="p-5 space-y-4">
+
+        <!-- Participant counts (only when data available) -->
+        <template v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.genreName))">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="badge-neutral text-xs">Total: {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.genreName)).total }}</span>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-teal-300 border border-teal-900/30">
+              Reg: {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.genreName)).registered }}
+            </span>
+            <span
+              v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.genreName)).unregistered > 0"
+              class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-rose-300 border border-rose-900/30"
+            >Unreg: {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.genreName)).unregistered }}</span>
+          </div>
+
+          <!-- Unregistered list -->
+          <div v-if="getUnregistered(normalizeGenreName(g.genreName)).unregistered.length > 0">
+            <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1.5">Unregistered Participants</p>
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-for="p in getUnregistered(normalizeGenreName(g.genreName)).unregistered"
+                :key="p.participantName"
+                class="inline-flex items-center px-2.5 py-1 rounded-full bg-surface-800 text-rose-300 text-xs font-medium border border-rose-300/20 font-source"
+              >{{ p.participantName }}</span>
+            </div>
+          </div>
+          <div v-else class="flex items-center gap-2 text-teal-300 text-xs">
+            <i class="pi pi-check-circle"></i>
+            <span>All participants registered</span>
+          </div>
+
+          <div class="h-px bg-surface-700/40"></div>
         </template>
 
-        <!-- Editing mode -->
-        <template v-else>
-          <select
-            v-model="editingFormatValue"
-            class="text-xs px-2.5 py-1.5 rounded-lg bg-surface-700 border border-primary-500/50 text-content-primary focus:outline-none focus:ring-1 focus:ring-primary-500/40"
-          >
-            <option value="">No format</option>
-            <option v-for="opt in formatOptions" :key="opt" :value="opt">{{ opt }}</option>
-          </select>
-          <button
-            @click="saveFormat(g.genreName)"
-            class="text-xs px-2.5 py-1 rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-all font-semibold"
-          >
-            Save
-          </button>
-          <button
-            @click="editingFormatFor = null"
-            class="text-xs px-2 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-surface-500 transition-all"
-          >
-            Cancel
-          </button>
-        </template>
+        <!-- Format + Scoring Criteria -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+
+          <!-- Battle Format -->
+          <div class="flex flex-col gap-2 p-3 rounded-xl bg-surface-800/60 border border-surface-600/30">
+            <p class="text-xs font-semibold text-content-muted uppercase tracking-wide">Battle Format</p>
+            <template v-if="editingFormatFor !== g.genreName">
+              <div class="flex items-center justify-between">
+                <span class="font-source text-sm" :class="g.format ? 'text-primary-400' : 'text-content-muted'">
+                  {{ g.format || 'No format' }}
+                </span>
+                <button
+                  @click="startEditFormat(g)"
+                  class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-surface-500 hover:text-content-primary transition-all"
+                ><i class="pi pi-pencil" style="font-size:0.65rem"></i> Edit</button>
+              </div>
+            </template>
+            <template v-else>
+              <div class="flex items-center gap-2">
+                <select
+                  v-model="editingFormatValue"
+                  class="flex-1 text-xs px-2.5 py-1.5 rounded-lg bg-surface-700 border border-primary-500/50 text-content-primary focus:outline-none focus:ring-1 focus:ring-primary-500/40"
+                >
+                  <option value="">No format</option>
+                  <option v-for="opt in formatOptions" :key="opt" :value="opt">{{ opt }}</option>
+                </select>
+                <button @click="saveFormat(g.genreName)" class="text-xs px-2.5 py-1 rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-all font-semibold">Save</button>
+                <button @click="editingFormatFor = null" class="text-xs px-2 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-surface-500 transition-all">Cancel</button>
+              </div>
+            </template>
+          </div>
+
+          <!-- Scoring Criteria -->
+          <div class="flex flex-col gap-2 p-3 rounded-xl bg-surface-800/60 border border-surface-600/30">
+            <div class="flex items-center justify-between">
+              <p class="text-xs font-semibold text-content-muted uppercase tracking-wide">Scoring Criteria</p>
+              <button
+                @click="showCriteriaModal = true"
+                class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-primary-500/50 hover:text-primary-400 transition-all whitespace-nowrap"
+              ><i class="pi pi-sliders-h" style="font-size:0.65rem"></i> Configure</button>
+            </div>
+            <template v-if="criteriaByGenre[g.genreName]?.length">
+              <div class="flex flex-wrap gap-1.5">
+                <span
+                  v-for="c in criteriaByGenre[g.genreName]"
+                  :key="c.id"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-700 border border-surface-600/50 text-xs text-content-secondary"
+                >
+                  {{ c.name }}
+                  <span v-if="c.weight != null" class="font-source text-primary-400">×{{ c.weight }}</span>
+                </span>
+              </div>
+            </template>
+            <span v-else class="text-xs text-content-muted">Default (single score)</span>
+          </div>
+        </div>
+
+        <!-- Judges -->
+        <div>
+          <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-2">
+            Judges <span class="normal-case font-normal opacity-60">(shared across all genres)</span>
+          </p>
+          <div class="flex flex-col gap-1.5">
+            <div
+              v-for="j in eventJudges"
+              :key="j.judgeId"
+              class="flex items-center gap-3 px-3 py-2 rounded-xl bg-surface-800/60 border border-surface-600/30"
+            >
+              <i class="pi pi-user text-content-muted text-xs shrink-0"></i>
+              <span class="font-heading font-semibold text-content-secondary text-sm flex-1">{{ j.judgeName }}</span>
+              <button
+                @click="submitRemoveJudge(j.judgeId)"
+                class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-red-800/50 hover:text-red-400 transition-all"
+              >Remove</button>
+            </div>
+            <div class="flex items-center gap-2 px-3 py-2 rounded-xl border border-dashed border-surface-600/40 mt-0.5">
+              <input
+                v-model="addJudgeInput"
+                type="text"
+                placeholder="Add judge…"
+                class="flex-1 bg-transparent text-sm text-content-secondary placeholder:text-content-muted focus:outline-none"
+                @keyup.enter="submitAddJudge"
+              />
+              <button
+                @click="submitAddJudge"
+                class="flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-surface-600 text-content-secondary hover:bg-surface-500 transition-colors"
+              ><i class="pi pi-plus" style="font-size:0.65rem"></i> Add</button>
+            </div>
+            <p v-if="eventJudges.length === 0" class="text-xs text-content-muted px-1">No judges added yet</p>
+          </div>
+        </div>
+
+      </div>
+    </template>
+  </div>
+
+  </template>
+  <!-- ── END SETUP TAB ─────────────────────────────────────────────────────── -->
+
+  <!-- ── EVENT DAY TAB ─────────────────────────────────────────────────────── -->
+  <template v-if="activeTab === 'event-day'">
+
+    <!-- Stat strip -->
+    <div class="grid grid-cols-2 gap-3 mb-6">
+      <div class="card p-4">
+        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Registered</p>
+        <p class="text-2xl font-heading font-extrabold text-content-primary">{{ totalDbRegistered.length }}</p>
+        <span class="text-xs text-content-muted">Have audition numbers</span>
+      </div>
+      <div class="card p-4">
+        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Not Shown Up</p>
+        <p class="text-2xl font-heading font-extrabold" :class="totalNotShownUp > 0 ? 'text-amber-300' : 'text-content-primary'">
+          {{ totalNotShownUp }}
+        </p>
+        <span class="text-xs text-content-muted">Verified but no audition number yet</span>
       </div>
     </div>
-  </div>
+
+    <!-- Not Shown Up panel -->
+    <div class="space-y-2 mb-6">
+      <div v-if="notShownUpList.length > 0" class="card overflow-hidden panel-warning">
+        <button
+          @click="expandedPeople.has('notShownUp') ? expandedPeople.delete('notShownUp') : expandedPeople.add('notShownUp'); expandedPeople = new Set(expandedPeople)"
+          :aria-expanded="expandedPeople.has('notShownUp')"
+          class="w-full flex items-center justify-between px-5 py-4 bg-surface-900/40 hover:bg-surface-700/60 transition-colors duration-150 text-left"
+        >
+          <div class="flex items-center gap-3">
+            <div class="icon-wrap w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
+              <i class="pi pi-clock text-amber-300 text-xs"></i>
+            </div>
+            <span class="font-heading font-bold text-content-secondary">Not Shown Up</span>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-amber-300 border border-amber-900/30">
+              {{ notShownUpList.length }}
+            </span>
+          </div>
+          <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
+             :class="{ 'rotate-180': expandedPeople.has('notShownUp') }"></i>
+        </button>
+        <div v-if="expandedPeople.has('notShownUp')" class="px-4 pb-4 border-t border-surface-600/30 pt-4">
+          <div class="space-y-2">
+            <div
+              v-for="p in notShownUpList"
+              :key="p.name"
+              class="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-surface-700/50 border border-surface-600"
+            >
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-sm font-semibold text-content-secondary">{{ p.name }}</span>
+                <span
+                  v-if="verifiedDbParticipants.find(v => v.participantName === p.name)?.emailSent"
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-teal-300 border border-teal-900/30"
+                ><i class="pi pi-check text-xs"></i> Email Sent</span>
+              </div>
+              <div class="flex flex-wrap gap-1">
+                <span v-for="g in p.genres" :key="g"
+                  class="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-surface-800 border border-surface-600 text-content-muted"
+                >{{ g }}</span>
+              </div>
+              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted mt-0.5">
+                <i class="pi pi-users" style="font-size:0.65rem"></i>
+                <span>{{ p.memberNames.join(', ') }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p v-else class="text-sm text-teal-300 flex items-center gap-2 px-1">
+        <i class="pi pi-check-circle"></i> All verified participants have shown up
+      </p>
+    </div>
+
+    <!-- Registered panel -->
+    <div v-if="registeredList.length > 0" class="card overflow-hidden panel-success">
+      <button
+        @click="expandedPeople.has('registered') ? expandedPeople.delete('registered') : expandedPeople.add('registered'); expandedPeople = new Set(expandedPeople)"
+        :aria-expanded="expandedPeople.has('registered')"
+        class="w-full flex items-center justify-between px-5 py-4 bg-surface-900/40 hover:bg-surface-700/60 transition-colors duration-150 text-left"
+      >
+        <div class="flex items-center gap-3">
+          <div class="icon-wrap w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
+            <i class="pi pi-check-circle text-teal-400 text-xs"></i>
+          </div>
+          <span class="font-heading font-bold text-content-secondary">Registered</span>
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-teal-300 border border-teal-900/30">
+            {{ registeredList.length }}
+          </span>
+        </div>
+        <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
+           :class="{ 'rotate-180': expandedPeople.has('registered') }"></i>
+      </button>
+      <div v-if="expandedPeople.has('registered')" class="px-5 pb-4 border-t border-surface-600/30 pt-4">
+        <!-- Search + genre filter -->
+        <div class="flex gap-2 mb-3">
+          <div class="relative flex-1">
+            <i class="pi pi-search absolute left-3 top-1/2 -translate-y-1/2 text-content-muted text-xs pointer-events-none"></i>
+            <input
+              v-model="registeredSearch"
+              type="text"
+              placeholder="Search by name or genre…"
+              autocomplete="off"
+              class="w-full pl-8 pr-8 py-2 rounded-lg border border-surface-600 bg-surface-900 text-sm text-content-primary placeholder-content-muted
+                     focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+            />
+            <button v-if="registeredSearch" @click="registeredSearch = ''"
+              class="absolute right-2.5 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-secondary transition-colors">
+              <i class="pi pi-times text-xs"></i>
+            </button>
+          </div>
+          <select
+            v-model="registeredGenreFilter"
+            class="px-3 py-2 rounded-lg border border-surface-600 bg-surface-900 text-sm text-content-secondary
+                   focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+          >
+            <option value="">All genres</option>
+            <option v-for="g in registeredGenreOptions" :key="g" :value="g">{{ g }}</option>
+          </select>
+        </div>
+        <!-- Result count -->
+        <p v-if="registeredSearch || registeredGenreFilter" class="text-xs text-content-muted mb-2">
+          {{ filteredRegisteredList.length }} result{{ filteredRegisteredList.length !== 1 ? 's' : '' }}
+        </p>
+        <div class="space-y-2">
+          <div
+            v-for="p in paginatedRegisteredList"
+            :key="p.name"
+            class="flex flex-col gap-2 px-3 py-2.5 rounded-xl bg-surface-900 border border-surface-600"
+          >
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="text-sm font-semibold text-content-secondary">{{ p.name }}</span>
+              <span v-if="p.walkin"
+                class="shrink-0 inline-flex px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-content-muted border border-surface-600"
+              >walk-in</span>
+              <span
+                v-if="p.walkin && p.referenceCode"
+                class="relative shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-surface-800 border border-surface-600 cursor-pointer select-none touch-none"
+                @mousedown="revealingRef = p.name" @mouseup="revealingRef = null" @mouseleave="revealingRef = null"
+                @touchstart.prevent="revealingRef = p.name" @touchend="revealingRef = null" @touchcancel="revealingRef = null"
+              >
+                <i class="pi pi-eye text-content-muted" style="font-size:0.65rem"></i>
+                <span class="text-content-muted">Ref code</span>
+                <span v-if="revealingRef === p.name"
+                  class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-4 py-2.5 rounded-xl bg-surface-700 border border-surface-500 shadow-xl whitespace-nowrap z-50 pointer-events-none"
+                >
+                  <span class="font-source tracking-widest text-primary-400 text-base font-bold">{{ p.referenceCode }}</span>
+                  <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-500"></span>
+                </span>
+              </span>
+              <span v-else-if="p.entries.length > 0 && verifiedDbParticipants.find(v => v.participantName === p.name)?.emailSent"
+                class="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-teal-300 border border-teal-900/30"
+              ><i class="pi pi-check text-xs"></i> Email Sent</span>
+              <span v-else-if="!p.walkin"
+                class="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-amber-300 border border-amber-900/30"
+              ><i class="pi pi-clock text-xs"></i> Email Pending</span>
+            </div>
+            <div class="flex flex-wrap gap-1.5">
+              <span v-for="e in p.entries" :key="e.genre"
+                class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-surface-800 border border-primary-200 text-sm"
+              >
+                <span class="text-content-muted capitalize text-xs">{{ e.genre }}</span>
+                <span class="font-heading font-extrabold text-primary-400">#{{ e.auditionNumber }}</span>
+              </span>
+            </div>
+            <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted">
+              <i class="pi pi-users" style="font-size:0.65rem"></i>
+              <span>{{ p.memberNames.join(', ') }}</span>
+            </div>
+          </div>
+        </div>
+        <!-- Pagination -->
+        <div v-if="registeredTotalPages > 1" class="flex items-center justify-between mt-4 pt-3 border-t border-surface-600/30">
+          <span class="text-xs text-content-muted">
+            Page {{ registeredPage }} of {{ registeredTotalPages }}
+          </span>
+          <div class="flex items-center gap-1">
+            <button
+              @click="registeredPage--"
+              :disabled="registeredPage === 1"
+              class="w-7 h-7 flex items-center justify-center rounded-lg border border-surface-600 text-content-muted
+                     hover:bg-surface-700 hover:text-content-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            ><i class="pi pi-chevron-left text-xs"></i></button>
+            <button
+              v-for="n in registeredTotalPages"
+              :key="n"
+              @click="registeredPage = n"
+              :class="n === registeredPage
+                ? 'w-7 h-7 flex items-center justify-center rounded-lg text-xs font-semibold bg-primary-500 text-white'
+                : 'w-7 h-7 flex items-center justify-center rounded-lg text-xs font-medium border border-surface-600 text-content-muted hover:bg-surface-700 hover:text-content-secondary transition-colors'"
+            >{{ n }}</button>
+            <button
+              @click="registeredPage++"
+              :disabled="registeredPage === registeredTotalPages"
+              class="w-7 h-7 flex items-center justify-center rounded-lg border border-surface-600 text-content-muted
+                     hover:bg-surface-700 hover:text-content-secondary disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            ><i class="pi pi-chevron-right text-xs"></i></button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </template>
+  <!-- ── END EVENT DAY TAB ──────────────────────────────────────────────────── -->
+
+  </div><!-- end page-container -->
 
   <ActionDoneModal
     :show="showModal"
@@ -1108,7 +1286,10 @@ onMounted(async () => {
         <!-- Body -->
         <div class="flex-1 overflow-y-auto px-6 py-5 space-y-5">
           <!-- Search -->
-          <div class="relative">
+          <div
+            class="relative"
+            :style="adjustSearchResults.length > 0 && adjustSearch !== adjustParticipant ? 'padding-bottom: 200px' : ''"
+          >
             <label class="block text-sm font-semibold text-content-secondary mb-1.5">Search Participant</label>
             <div class="relative">
               <input
@@ -1339,6 +1520,7 @@ onMounted(async () => {
   <ScoringCriteriaModal
     v-model="showCriteriaModal"
     :eventName="props.eventName"
-    :genres="completeBreakdown.map(g => g.genre)"
+    :genres="eventGenres.map(g => g.genreName)"
+    @update:modelValue="(v) => { if (!v) loadCriteriaForAllGenres(eventGenres) }"
   />
 </template>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, reactive, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
 import DynamicTable from '@/components/DynamicTable.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, addJudges, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, getEmailTemplate, updateEmailTemplate, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyAndEmailParticipant, verifyAndEmailBatch } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, addJudges, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, getEmailTemplate, updateEmailTemplate, resetEmailTemplate, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyAndEmailParticipant, verifyAndEmailBatch } from '@/utils/api';
 import { filterObject, useDelay } from '@/utils/utils';
 import ReusableButton from '@/components/ReusableButton.vue';
 import AuditionNumber from './AuditionNumber.vue';
@@ -86,6 +86,16 @@ const saveTemplate = async () => {
     openModal('Template Saved', 'Email template updated successfully.', 'success')
   } else {
     openModal('Error', 'Failed to save email template.', 'error')
+  }
+}
+
+const resetTemplate = async () => {
+  templateLoading.value = true
+  const tpl = await resetEmailTemplate(props.eventName)
+  templateLoading.value = false
+  if (tpl) {
+    templateSubject.value = tpl.subject
+    templateBody.value = tpl.body
   }
 }
 
@@ -1148,10 +1158,27 @@ onMounted(async () => {
             />
           </div>
           <div>
-            <label class="block text-sm font-semibold text-content-secondary mb-1.5">
-              Body
-              <span class="font-normal text-content-muted ml-1">— use <code class="font-source text-xs bg-surface-700 px-1 rounded">{name}</code> for participant name, <code class="font-source text-xs bg-surface-700 px-1 rounded">{refCode}</code> for results reference code</span>
-            </label>
+            <label class="block text-sm font-semibold text-content-secondary mb-2">Body</label>
+
+            <!-- Variable reference -->
+            <div class="mb-3 p-3 rounded-xl bg-surface-900/60 border border-surface-600/40 space-y-2 text-xs text-content-muted">
+              <p class="font-semibold text-content-secondary uppercase tracking-wider text-[10px]">Available Variables</p>
+              <div class="grid grid-cols-2 gap-x-4 gap-y-1">
+                <div><code class="font-source bg-surface-700 px-1 rounded text-primary-300">{name}</code> — display name (team name or stage name)</div>
+                <div><code class="font-source bg-surface-700 px-1 rounded text-primary-300">{stageName}</code> — representative's stage name</div>
+                <div><code class="font-source bg-surface-700 px-1 rounded text-primary-300">{teamName}</code> — crew/team name</div>
+                <div><code class="font-source bg-surface-700 px-1 rounded text-primary-300">{members}</code> — all team members (comma-separated)</div>
+                <div><code class="font-source bg-surface-700 px-1 rounded text-primary-300">{soloCategories}</code> — solo (1v1) categories entered</div>
+                <div><code class="font-source bg-surface-700 px-1 rounded text-primary-300">{teamCategories}</code> — team categories entered</div>
+                <div><code class="font-source bg-surface-700 px-1 rounded text-primary-300">{refCode}</code> — results reference code</div>
+              </div>
+              <p class="font-semibold text-content-secondary uppercase tracking-wider text-[10px] pt-1">Conditional Blocks (for mixed events)</p>
+              <div class="space-y-1">
+                <div><code class="font-source bg-surface-700 px-1 rounded text-amber-300">{if:team}...{endif:team}</code> — shown only if participant has team categories</div>
+                <div><code class="font-source bg-surface-700 px-1 rounded text-amber-300">{if:solo}...{endif:solo}</code> — shown only if participant has solo categories</div>
+              </div>
+            </div>
+
             <textarea
               v-model="templateBody"
               rows="10"
@@ -1163,23 +1190,35 @@ onMounted(async () => {
         </div>
 
         <!-- Footer -->
-        <div class="flex items-center justify-end gap-3 px-6 py-4 border-t border-surface-600/30">
+        <div class="flex items-center justify-between gap-3 px-6 py-4 border-t border-surface-600/30">
           <button
-            @click="showTemplateModal = false"
-            class="px-4 py-2 rounded-xl border border-surface-600 text-sm font-semibold text-content-secondary
-                   hover:bg-surface-700 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            @click="saveTemplate"
+            @click="resetTemplate"
             :disabled="templateLoading"
-            class="flex items-center gap-2 px-4 py-2 rounded-xl bg-primary-500 text-white text-sm font-semibold
-                   hover:bg-primary-600 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold text-content-muted
+                   hover:text-content-secondary hover:bg-surface-700 disabled:opacity-50 transition-colors"
+            title="Regenerate smart default based on event genre formats"
           >
-            <i class="pi pi-check text-xs"></i>
-            Save Template
+            <i class="pi pi-refresh text-xs"></i>
+            Reset to default
           </button>
+          <div class="flex items-center gap-3">
+            <button
+              @click="showTemplateModal = false"
+              class="px-4 py-2 rounded-xl border border-surface-600 text-sm font-semibold text-content-secondary
+                     hover:bg-surface-700 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              @click="saveTemplate"
+              :disabled="templateLoading"
+              class="flex items-center gap-2 px-4 py-2 rounded-xl bg-primary-500 text-white text-sm font-semibold
+                     hover:bg-primary-600 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            >
+              <i class="pi pi-check text-xs"></i>
+              Save Template
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -121,18 +121,19 @@ const genreCounts = computed(() => {
   return counts
 })
 
-const totalWalkIn = computed(() => {
-  const uniqueParticipants = [
-    ...new Map(verifiedDbParticipants.value.map(p => [p.participantName, p])).values()
-  ]
-  return uniqueParticipants.filter(p => p.walkin == true).length
-})
+const totalWalkIn = computed(() =>
+  new Set(
+    verifiedDbParticipants.value
+      .filter(p => p.walkin)
+      .map(p => p.participantId)
+  ).size
+)
 
 const totalDbRegistered = computed(() => {
   const grouped = {}
   verifiedDbParticipants.value.forEach(p => {
-    if (!grouped[p.participantName]) grouped[p.participantName] = []
-    grouped[p.participantName].push(p)
+    if (!grouped[p.participantId]) grouped[p.participantId] = []
+    grouped[p.participantId].push(p)
   })
   // Walk-ins always count as registered (they showed up in person).
   // Form participants count only when all genres have audition numbers.
@@ -146,7 +147,7 @@ const totalVerified = computed(() =>
   new Set(
     verifiedDbParticipants.value
       .filter(p => !p.walkin)
-      .map(p => p.participantName)
+      .map(p => p.participantId)
   ).size
 )
 
@@ -155,8 +156,8 @@ const totalNotShownUp = computed(() => {
   verifiedDbParticipants.value
     .filter(p => !p.walkin)
     .forEach(p => {
-      if (!grouped[p.participantName]) grouped[p.participantName] = []
-      grouped[p.participantName].push(p)
+      if (!grouped[p.participantId]) grouped[p.participantId] = []
+      grouped[p.participantId].push(p)
     })
   return Object.values(grouped)
     .filter(rows => rows.every(r => r.auditionNumber === null)).length
@@ -172,7 +173,11 @@ const notShownUpList = computed(() => {
     })
   return Object.entries(grouped)
     .filter(([, rows]) => rows.every(r => r.auditionNumber === null))
-    .map(([name, rows]) => ({ name, genres: rows.map(r => r.genreName) }))
+    .map(([name, rows]) => ({
+      name,
+      genres: rows.map(r => r.genreName),
+      memberNames: rows.find(r => r.memberNames?.length)?.memberNames || []
+    }))
     .sort((a, b) => a.name.localeCompare(b.name))
 })
 
@@ -188,6 +193,7 @@ const registeredList = computed(() => {
       name,
       walkin: rows[0].walkin,
       referenceCode: rows[0].referenceCode || null,
+      memberNames: rows.find(r => r.memberNames?.length)?.memberNames || [],
       entries: rows
         .filter(r => r.auditionNumber !== null)
         .map(r => ({ genre: r.genreName, auditionNumber: r.auditionNumber }))
@@ -350,14 +356,13 @@ const addGenre = async (genreName) => {
   adjustLoading.value = false
 }
 
-const emailedCount = computed(() => {
-  const names = new Set(
+const emailedCount = computed(() =>
+  new Set(
     verifiedDbParticipants.value
       .filter(p => !p.walkin && p.emailSent)
-      .map(p => p.participantName)
-  )
-  return names.size
-})
+      .map(p => p.participantId)
+  ).size
+)
 
 const toggleUnverifiedSelect = (participantId) => {
   if (selectedUnverified.value.has(participantId)) {
@@ -600,6 +605,10 @@ onMounted(async () => {
                   class="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-surface-800 border border-surface-600 text-content-muted"
                 >{{ g }}</span>
               </div>
+              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted mt-0.5">
+                <i class="pi pi-users" style="font-size:0.65rem"></i>
+                <span>{{ p.memberNames.join(', ') }}</span>
+              </div>
             </div>
           </div>
         </div>
@@ -770,6 +779,11 @@ onMounted(async () => {
                   <span class="text-content-muted capitalize text-xs">{{ e.genre }}</span>
                   <span class="font-heading font-extrabold text-primary-400">#{{ e.auditionNumber }}</span>
                 </span>
+              </div>
+              <!-- Row 3: team members (only for team entries) -->
+              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted">
+                <i class="pi pi-users" style="font-size:0.65rem"></i>
+                <span>{{ p.memberNames.join(', ') }}</span>
               </div>
             </div>
           </div>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, reactive, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
 import DynamicTable from '@/components/DynamicTable.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, addJudges, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, getEmailTemplate, updateEmailTemplate, resetEmailTemplate, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyAndEmailParticipant, verifyAndEmailBatch } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, addJudges, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, getEmailTemplate, updateEmailTemplate, resetEmailTemplate, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyAndEmailParticipant, verifyAndEmailBatch, updateEventGenreFormat } from '@/utils/api';
 import { filterObject, useDelay } from '@/utils/utils';
 import ReusableButton from '@/components/ReusableButton.vue';
 import AuditionNumber from './AuditionNumber.vue';
@@ -39,7 +39,13 @@ const props = defineProps({
 
 const eventName = ref(props.eventName.split(" ").join("%20"));
 
-const createTable = reactive({ genres: [] })
+const createTable = reactive({ genres: [], genreFormats: {} })
+
+watch(() => [...createTable.genres], (newGenres) => {
+  Object.keys(createTable.genreFormats).forEach(g => {
+    if (!newGenres.includes(g)) delete createTable.genreFormats[g]
+  })
+})
 const paymentRequired = ref(false)
 
 const showModal = ref(false)
@@ -297,7 +303,7 @@ const onSubmit = async () => {
   loading.value = true
   await addJudges(inputs.value)
   await insertEventInTable(props.eventName, paymentRequired.value)
-  const resp = await linkGenreToEvent(props.eventName, createTable.genres)
+  const resp = await linkGenreToEvent(props.eventName, createTable.genres, createTable.genreFormats)
   resp.json().then(result => {
     loading.value = false
     getTitle(resp.status)
@@ -365,6 +371,23 @@ const addGenre = async (genreName) => {
   verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
   adjustLoading.value = false
 }
+
+// ── Genre format editing ────────────────────────────────────────────────────
+const formatOptions = ['1v1', '2v2', '3v3', '4v4']
+const editingFormatFor = ref(null)  // genreName currently being edited
+const editingFormatValue = ref('')
+
+const startEditFormat = (genre) => {
+  editingFormatFor.value = genre.genreName
+  editingFormatValue.value = genre.format || ''
+}
+
+const saveFormat = async (genreName) => {
+  await updateEventGenreFormat(props.eventName, genreName, editingFormatValue.value || null)
+  eventGenres.value = await getGenresByEvent(props.eventName)
+  editingFormatFor.value = null
+}
+// ───────────────────────────────────────────────────────────────────────────
 
 const emailedCount = computed(() =>
   new Set(
@@ -753,18 +776,25 @@ onMounted(async () => {
                 <!-- Hold-to-reveal reference code for walk-ins -->
                 <span
                   v-if="p.walkin && p.referenceCode"
-                  class="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-surface-800 border border-surface-600 cursor-pointer select-none touch-none"
+                  class="relative shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-surface-800 border border-surface-600 cursor-pointer select-none touch-none"
                   @mousedown="revealingRef = p.name"
                   @mouseup="revealingRef = null"
                   @mouseleave="revealingRef = null"
                   @touchstart.prevent="revealingRef = p.name"
                   @touchend="revealingRef = null"
                   @touchcancel="revealingRef = null"
-                  title="Hold to reveal reference code"
                 >
                   <i class="pi pi-eye text-content-muted" style="font-size:0.65rem"></i>
-                  <span v-if="revealingRef === p.name" class="font-source tracking-widest text-primary-400">{{ p.referenceCode }}</span>
-                  <span v-else class="text-content-muted">Hold for ref code</span>
+                  <span class="text-content-muted">Ref code</span>
+                  <!-- Tooltip above, away from cursor -->
+                  <span
+                    v-if="revealingRef === p.name"
+                    class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-4 py-2.5 rounded-xl bg-surface-700 border border-surface-500 shadow-xl whitespace-nowrap z-50 pointer-events-none"
+                  >
+                    <span class="font-source tracking-widest text-primary-400 text-base font-bold">{{ p.referenceCode }}</span>
+                    <!-- Arrow -->
+                    <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-500"></span>
+                  </span>
                 </span>
                 <span
                   v-else-if="p.entries.length > 0 && verifiedDbParticipants.find(v => v.participantName === p.name)?.emailSent"
@@ -898,23 +928,35 @@ onMounted(async () => {
           Genres / Categories
         </label>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
-          <label
+          <div
             v-for="g in genreOptions"
             :key="g.genreName"
-            class="flex items-center gap-2.5 px-4 py-3 rounded-xl border cursor-pointer transition-all duration-150"
+            class="flex flex-col gap-2 px-4 py-3 rounded-xl border transition-all duration-150"
             :class="createTable.genres.includes(g.genreName)
-              ? 'bg-primary-100 border-primary-300 text-primary-400'
-              : 'bg-surface-800 border-surface-600 text-content-secondary hover:border-surface-500'"
+              ? 'bg-primary-100 border-primary-300'
+              : 'bg-surface-800 border-surface-600 hover:border-surface-500'"
           >
-            <input
-              type="checkbox"
-              :id="g.genreName"
-              :value="g.genreName"
-              v-model="createTable.genres"
-              class="w-4 h-4 rounded accent-primary-600"
-            />
-            <span class="text-sm font-medium">{{ g.genreName }}</span>
-          </label>
+            <label class="flex items-center gap-2.5 cursor-pointer"
+              :class="createTable.genres.includes(g.genreName) ? 'text-primary-400' : 'text-content-secondary'"
+            >
+              <input
+                type="checkbox"
+                :id="g.genreName"
+                :value="g.genreName"
+                v-model="createTable.genres"
+                class="w-4 h-4 rounded accent-primary-600"
+              />
+              <span class="text-sm font-medium capitalize">{{ g.genreName }}</span>
+            </label>
+            <select
+              v-if="createTable.genres.includes(g.genreName)"
+              v-model="createTable.genreFormats[g.genreName]"
+              class="text-xs px-2 py-1 rounded-lg bg-white/70 border border-primary-300 text-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-500/40 w-full"
+            >
+              <option value="">No format</option>
+              <option v-for="opt in formatOptions" :key="opt" :value="opt">{{ opt }}</option>
+            </select>
+          </div>
         </div>
       </div>
 
@@ -946,6 +988,66 @@ onMounted(async () => {
       </div>
     </div>
 
+  </div>
+
+  <!-- Genre Format Management (shown when event is set up) -->
+  <div v-if="tableExist && eventGenres.length > 0" class="card p-5 mt-6">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="icon-wrap w-8 h-8 rounded-xl bg-surface-700 flex items-center justify-center">
+        <i class="pi pi-tag text-content-muted text-sm"></i>
+      </div>
+      <div>
+        <h2 class="font-heading font-bold text-content-secondary text-sm">Genre Formats</h2>
+        <p class="text-xs text-content-muted mt-0.5">Set battle format per genre (e.g. 2v2). Required for team vs solo audition splitting.</p>
+      </div>
+    </div>
+    <div class="flex flex-col gap-2">
+      <div
+        v-for="g in eventGenres"
+        :key="g.genreName"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-surface-800/60 border border-surface-600/30"
+      >
+        <span class="font-heading font-semibold text-content-secondary text-sm flex-1 capitalize">{{ g.genreName }}</span>
+
+        <!-- Viewing mode -->
+        <template v-if="editingFormatFor !== g.genreName">
+          <span class="font-source text-xs px-2 py-0.5 rounded-md"
+            :class="g.format ? 'bg-primary-500/15 text-primary-400 border border-primary-500/30' : 'bg-surface-700 text-surface-500 border border-surface-600/30'">
+            {{ g.format || 'No format' }}
+          </span>
+          <button
+            @click="startEditFormat(g)"
+            class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-surface-500 hover:text-content-primary transition-all"
+          >
+            <i class="pi pi-pencil" style="font-size:0.65rem"></i>
+            Edit
+          </button>
+        </template>
+
+        <!-- Editing mode -->
+        <template v-else>
+          <select
+            v-model="editingFormatValue"
+            class="text-xs px-2.5 py-1.5 rounded-lg bg-surface-700 border border-primary-500/50 text-content-primary focus:outline-none focus:ring-1 focus:ring-primary-500/40"
+          >
+            <option value="">No format</option>
+            <option v-for="opt in formatOptions" :key="opt" :value="opt">{{ opt }}</option>
+          </select>
+          <button
+            @click="saveFormat(g.genreName)"
+            class="text-xs px-2.5 py-1 rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-all font-semibold"
+          >
+            Save
+          </button>
+          <button
+            @click="editingFormatFor = null"
+            class="text-xs px-2 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-surface-500 transition-all"
+          >
+            Cancel
+          </button>
+        </template>
+      </div>
+    </div>
   </div>
 
   <ActionDoneModal

--- a/BES-frontend/src/views/EventSelector.vue
+++ b/BES-frontend/src/views/EventSelector.vue
@@ -71,29 +71,29 @@ const handleSubmit = async () => {
 
         <form @submit.prevent="handleSubmit" class="space-y-5">
 
-          <!-- Event list -->
+          <!-- Event grid -->
           <div>
             <label class="block text-sm font-semibold text-content-secondary mb-2">Event</label>
-            <div class="space-y-2 max-h-64 overflow-y-auto pr-1">
+            <div class="grid gap-2" :class="events.length > 4 ? 'grid-cols-2' : 'grid-cols-1'">
               <button
                 v-for="event in events"
                 :key="event.id"
                 type="button"
                 @click="selectedEventId = event.id; accessCode = ''; error = ''"
                 :class="[
-                  'w-full text-left px-4 py-3 rounded-xl border transition-all duration-150',
+                  'text-center px-3 py-4 rounded-xl border transition-all duration-150',
                   selectedEventId === event.id
-                    ? 'border-primary-500 bg-primary-100 text-primary-400 font-semibold'
+                    ? 'border-primary-500 bg-primary-500/15 text-primary-400 font-semibold'
                     : 'border-surface-600 bg-surface-700 hover:border-primary-500/50 hover:bg-surface-600 text-content-primary'
                 ]"
               >
-                <span class="font-heading text-sm">{{ event.name }}</span>
-                <span
+                <div class="font-heading font-semibold text-sm leading-snug">{{ event.name }}</div>
+                <div
                   v-if="isAdmin && event.accessCode"
-                  class="ml-2 font-source text-xs text-content-muted tracking-widest"
+                  class="font-source text-xs text-content-muted tracking-widest mt-0.5"
                 >
-                  ({{ event.accessCode }})
-                </span>
+                  {{ event.accessCode }}
+                </div>
               </button>
             </div>
             <p v-if="events.length === 0" class="text-sm text-muted mt-2">No events found.</p>

--- a/BES-frontend/src/views/EventSelector.vue
+++ b/BES-frontend/src/views/EventSelector.vue
@@ -36,7 +36,9 @@ const handleSubmit = async () => {
     if (isAdmin.value || alreadyVerified.value) {
       setActiveEvent(selectedEventId.value, selectedEvent.value.name)
       markEventVerified(selectedEventId.value)
-      router.push(route.query.redirect || '/')
+      const redirect = String(route.query.redirect || '/')
+      // If coming from an EventDetails page, go to new event's details instead
+      router.push(redirect.startsWith('/events/') ? `/events/${selectedEvent.value.name}` : redirect)
       return
     }
     if (!accessCode.value || accessCode.value.length !== 4) {
@@ -47,7 +49,8 @@ const handleSubmit = async () => {
     if (res?.valid) {
       setActiveEvent(selectedEventId.value, selectedEvent.value.name)
       markEventVerified(selectedEventId.value)
-      router.push(route.query.redirect || '/')
+      const redirect = String(route.query.redirect || '/')
+      router.push(redirect.startsWith('/events/') ? `/events/${selectedEvent.value.name}` : redirect)
     } else {
       error.value = 'Incorrect access code. Please try again.'
       accessCode.value = ''

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -46,6 +46,8 @@ async function handleUpdateCode(folderName, newCode) {
 
 async function goToEventDetails(eventName, folderID) {
   await useDelay().wait(200)
+  const dbEvent = dbEvents.value.find(e => e.name === eventName)
+  if (dbEvent) setActiveEvent(dbEvent.id, dbEvent.name, folderID)
   router.push({ name: 'Event Details', params: { eventName }, query: { folderID } })
 }
 

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { fetchAllFolderEvents, fetchAllEvents, updateEventAccessCode } from '@/utils/api'
-import { useAuthStore } from '@/utils/auth'
+import { useAuthStore, setActiveEvent } from '@/utils/auth'
 import EventCard from '@/components/EventCard.vue'
 import { useDelay } from '@/utils/utils'
 
@@ -11,6 +11,13 @@ const dbEvents = ref([])
 const search  = ref('')
 const router  = useRouter()
 const isAdmin = ref(false)
+
+// Only one card expanded at a time (mobile)
+const expandedId = ref(null)
+const toggleExpanded = (id) => { expandedId.value = expandedId.value === id ? null : id }
+const closeExpanded = () => { expandedId.value = null }
+onMounted(()  => document.addEventListener('click', closeExpanded))
+onUnmounted(() => document.removeEventListener('click', closeExpanded))
 
 const filtered = computed(() =>
   events.value.filter(e =>
@@ -42,13 +49,17 @@ async function goToEventDetails(eventName, folderID) {
   router.push({ name: 'Event Details', params: { eventName }, query: { folderID } })
 }
 
+function activateAndGo(folderName, routeName) {
+  const dbEvent = dbEvents.value.find(e => e.name === folderName)
+  if (dbEvent) setActiveEvent(dbEvent.id, dbEvent.name)
+  router.push({ name: routeName })
+}
+
 onMounted(async () => {
   const authStore = useAuthStore()
   isAdmin.value = authStore.user?.role?.[0]?.authority === 'ROLE_ADMIN'
   events.value = await fetchAllFolderEvents()
-  if (isAdmin.value) {
-    dbEvents.value = await fetchAllEvents() ?? []
-  }
+  dbEvents.value = await fetchAllEvents() ?? []
 })
 </script>
 
@@ -82,14 +93,20 @@ onMounted(async () => {
     <!-- Events grid -->
     <div
       v-if="filtered.length"
-      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 items-start"
     >
       <EventCard
         v-for="event in filtered"
         :key="event.folderID"
         :buttonName="event.folderName"
         :accessCode="getAccessCode(event.folderName)"
-        @onClick="goToEventDetails(event.folderName, event.folderID)"
+        :expanded="expandedId === event.folderID"
+        @toggle="toggleExpanded(event.folderID)"
+        @onDetails="goToEventDetails(event.folderName, event.folderID)"
+        @onAudition="activateAndGo(event.folderName, 'Audition List')"
+        @onParticipants="activateAndGo(event.folderName, 'Update Event Details')"
+        @onScoreboard="activateAndGo(event.folderName, 'Score')"
+        @onBattle="activateAndGo(event.folderName, 'Battle Control')"
         @updateCode="(code) => handleUpdateCode(event.folderName, code)"
       />
     </div>

--- a/BES-frontend/src/views/MainMenu.vue
+++ b/BES-frontend/src/views/MainMenu.vue
@@ -62,6 +62,13 @@ const quickActions = computed(() => {
       roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'],
     },
     {
+      icon: 'pi-sitemap',
+      title: 'Crew Formation',
+      desc: 'Form pickup crews from solo auditioners',
+      route: '/event/crew-formation',
+      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'],
+    },
+    {
       icon: 'pi-thumbs-up',
       title: 'Battle Judge',
       desc: 'Cast your vote during live battle rounds',

--- a/BES-frontend/src/views/Results.vue
+++ b/BES-frontend/src/views/Results.vue
@@ -8,7 +8,6 @@ const results = ref(null)
 const errorMsg = ref('')
 
 const formatRefCode = (val) => {
-  // Auto-format as user types: XXXX-XXXX
   const clean = val.toUpperCase().replace(/[^A-Z0-9]/g, '')
   if (clean.length <= 4) return clean
   return clean.slice(0, 4) + '-' + clean.slice(4, 8)
@@ -43,7 +42,6 @@ const isMultiCriteria = (scores) => scores?.some(s => s.aspect && s.aspect !== '
 const totalScore = (scores) => {
   if (!scores || scores.length === 0) return '—'
   if (isMultiCriteria(scores)) {
-    // For multi-criteria: sum the per-judge averages
     const byJudge = groupScoresByJudge(scores)
     const total = Object.values(byJudge).reduce((acc, aspects) => {
       const vals = Object.values(aspects)
@@ -78,7 +76,7 @@ const groupTags = (tags) => {
   <div class="min-h-screen bg-surface-900 flex flex-col">
     <!-- Header -->
     <header class="border-b border-surface-700/50 bg-surface-900/80 backdrop-blur-sm">
-      <div class="max-w-2xl mx-auto px-4 py-4 flex items-center gap-3">
+      <div class="max-w-5xl mx-auto px-4 py-4 flex items-center gap-3">
         <div class="w-8 h-8 rounded-lg bg-primary-600 flex items-center justify-center flex-shrink-0">
           <i class="pi pi-star text-white text-sm"></i>
         </div>
@@ -89,10 +87,10 @@ const groupTags = (tags) => {
       </div>
     </header>
 
-    <main class="flex-1 max-w-2xl w-full mx-auto px-4 py-10">
+    <main class="flex-1 max-w-5xl w-full mx-auto px-4 py-10">
 
       <!-- Lookup card -->
-      <div class="card p-6 mb-6">
+      <div class="card p-6 mb-8 max-w-xl mx-auto">
         <h1 class="font-heading font-bold text-content-primary text-xl mb-1">View Your Results</h1>
         <p class="text-sm text-content-muted mb-5">Enter the reference code from your registration email to view your scores and judge feedback.</p>
 
@@ -120,7 +118,6 @@ const groupTags = (tags) => {
           </button>
         </div>
 
-        <!-- Error message -->
         <div
           v-if="errorMsg"
           class="mt-4 flex items-start gap-2.5 px-4 py-3 rounded-xl border border-red-500/30 bg-red-500/8"
@@ -133,7 +130,7 @@ const groupTags = (tags) => {
       <!-- Results -->
       <template v-if="results">
         <!-- Participant header -->
-        <div class="flex items-center gap-4 mb-6">
+        <div class="flex items-center gap-4 mb-6 max-w-xl mx-auto">
           <div class="w-12 h-12 rounded-2xl bg-primary-600/20 border border-primary-500/30 flex items-center justify-center flex-shrink-0">
             <i class="pi pi-user text-primary-400 text-lg"></i>
           </div>
@@ -143,129 +140,136 @@ const groupTags = (tags) => {
           </div>
         </div>
 
-        <!-- Genre results -->
+        <!-- Genre results — row layout, centered when single -->
         <div
-          v-for="genre in results.genres"
-          :key="genre.genreName"
-          class="card p-5 mb-5"
+          :class="results.genres.length === 1
+            ? 'flex justify-center'
+            : 'grid grid-cols-1 sm:grid-cols-2 gap-4'"
         >
-          <!-- Genre header -->
-          <div class="flex items-center justify-between mb-4">
-            <div class="flex items-center gap-3">
-              <span class="px-3 py-1 rounded-full bg-primary-500/15 text-primary-400 text-xs font-bold border border-primary-500/25 uppercase tracking-wide">
-                {{ genre.genreName }}
-              </span>
-              <span v-if="genre.auditionNumber" class="text-xs text-content-muted">
-                Audition #{{ genre.auditionNumber }}
-              </span>
-            </div>
-            <div v-if="genre.scores && genre.scores.length > 0" class="text-right">
-              <p class="text-xs text-content-muted">Total</p>
-              <p class="font-source font-bold text-primary-400 text-xl">{{ totalScore(genre.scores) }}</p>
-            </div>
-          </div>
-
-          <!-- Scores -->
-          <div v-if="genre.scores && genre.scores.length > 0" class="mb-4">
-            <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-2">Scores</p>
-
-            <!-- Multi-criteria: group by judge, show per-criterion rows -->
-            <template v-if="isMultiCriteria(genre.scores)">
-              <div class="space-y-3">
-                <div
-                  v-for="(aspects, judge) in groupScoresByJudge(genre.scores)"
-                  :key="judge"
-                  class="rounded-xl bg-surface-700/50 border border-surface-600/40 px-3 py-2.5"
+          <div
+            v-for="genre in results.genres"
+            :key="genre.genreName"
+            class="card p-5"
+            :class="results.genres.length === 1 ? 'w-full max-w-xl' : ''"
+          >
+            <!-- Genre header -->
+            <div class="flex items-center justify-between mb-4">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="px-3 py-1 rounded-full bg-primary-500/15 text-primary-400 text-xs font-bold border border-primary-500/25 uppercase tracking-wide">
+                  {{ genre.genreName }}
+                </span>
+                <span
+                  v-if="genre.format"
+                  class="px-2 py-0.5 rounded-full bg-surface-700 text-content-muted text-xs font-source border border-surface-600/60"
                 >
-                  <p class="text-xs font-semibold text-content-muted mb-2">{{ judge }}</p>
-                  <div class="space-y-1">
-                    <div
-                      v-for="(score, aspect) in aspects"
-                      :key="aspect"
-                      class="flex items-center justify-between"
-                    >
-                      <span class="text-xs text-content-secondary">{{ aspect }}</span>
-                      <span class="font-source font-bold text-primary-400 text-sm">{{ score }}</span>
-                    </div>
-                  </div>
-                </div>
+                  {{ genre.format }}
+                </span>
+                <span v-if="genre.auditionNumber" class="text-xs text-content-muted">
+                  Audition #{{ genre.auditionNumber }}
+                </span>
               </div>
-            </template>
-
-            <!-- Legacy: single score per judge -->
-            <template v-else>
-              <div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                <div
-                  v-for="score in genre.scores"
-                  :key="score.judgeName"
-                  class="rounded-xl bg-surface-700/50 border border-surface-600/40 px-3 py-2.5"
-                >
-                  <p class="text-xs text-content-muted truncate">{{ score.judgeName }}</p>
-                  <p class="font-source font-bold text-content-primary text-lg">{{ score.score }}</p>
-                </div>
+              <div v-if="genre.scores && genre.scores.length > 0" class="text-right ml-2 flex-shrink-0">
+                <p class="text-xs text-content-muted">Total</p>
+                <p class="font-source font-bold text-primary-400 text-xl">{{ totalScore(genre.scores) }}</p>
               </div>
-            </template>
-          </div>
-          <div v-else class="mb-4">
-            <p class="text-sm text-content-muted italic">No scores recorded yet</p>
-          </div>
+            </div>
 
-          <!-- Feedback -->
-          <template v-if="genre.feedback && genre.feedback.length > 0">
-            <div class="border-t border-surface-700/50 pt-4">
-              <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-3">Judge Feedback</p>
-              <div class="space-y-4">
-                <div
-                  v-for="entry in genre.feedback"
-                  :key="entry.judgeName"
-                  class="rounded-xl border border-surface-600/40 bg-surface-700/20 p-3.5"
-                >
-                  <p class="text-xs font-bold text-content-secondary mb-2">{{ entry.judgeName }}</p>
+            <!-- Scores -->
+            <div v-if="genre.scores && genre.scores.length > 0" class="mb-4">
+              <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-2">Scores</p>
 
-                  <!-- Tags by group -->
-                  <template v-if="entry.tags && entry.tags.length > 0">
-                    <div
-                      v-for="(tags, groupName) in groupTags(entry.tags)"
-                      :key="groupName"
-                      class="mb-2"
-                    >
-                      <p class="text-xs text-content-muted mb-1">{{ groupName }}</p>
-                      <div class="flex flex-wrap gap-1.5">
-                        <span
-                          v-for="tag in tags"
-                          :key="tag.label"
-                          class="text-xs px-2.5 py-1 rounded-full font-medium border"
-                          :class="groupName === 'Strengths'
-                            ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
-                            : 'bg-amber-500/10 text-amber-400 border-amber-500/30'"
-                        >{{ tag.label }}</span>
+              <template v-if="isMultiCriteria(genre.scores)">
+                <div class="space-y-3">
+                  <div
+                    v-for="(aspects, judge) in groupScoresByJudge(genre.scores)"
+                    :key="judge"
+                    class="rounded-xl bg-surface-700/50 border border-surface-600/40 px-3 py-2.5"
+                  >
+                    <p class="text-xs font-semibold text-content-muted mb-2">{{ judge }}</p>
+                    <div class="space-y-1">
+                      <div
+                        v-for="(score, aspect) in aspects"
+                        :key="aspect"
+                        class="flex items-center justify-between"
+                      >
+                        <span class="text-xs text-content-secondary">{{ aspect }}</span>
+                        <span class="font-source font-bold text-primary-400 text-sm">{{ score }}</span>
                       </div>
                     </div>
-                  </template>
-
-                  <!-- Note -->
-                  <div v-if="entry.note" class="mt-2 pt-2 border-t border-surface-600/30">
-                    <p class="text-xs text-content-secondary italic">"{{ entry.note }}"</p>
                   </div>
+                </div>
+              </template>
 
-                  <!-- No tags or note -->
-                  <p
-                    v-if="(!entry.tags || entry.tags.length === 0) && !entry.note"
-                    class="text-xs text-content-muted italic"
-                  >No feedback provided</p>
+              <template v-else>
+                <div class="grid grid-cols-2 gap-2">
+                  <div
+                    v-for="score in genre.scores"
+                    :key="score.judgeName"
+                    class="rounded-xl bg-surface-700/50 border border-surface-600/40 px-3 py-2.5"
+                  >
+                    <p class="text-xs text-content-muted truncate">{{ score.judgeName }}</p>
+                    <p class="font-source font-bold text-content-primary text-lg">{{ score.score }}</p>
+                  </div>
+                </div>
+              </template>
+            </div>
+            <div v-else class="mb-4">
+              <p class="text-sm text-content-muted italic">No scores recorded yet</p>
+            </div>
+
+            <!-- Feedback -->
+            <template v-if="genre.feedback && genre.feedback.length > 0">
+              <div class="border-t border-surface-700/50 pt-4">
+                <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-3">Judge Feedback</p>
+                <div class="space-y-4">
+                  <div
+                    v-for="entry in genre.feedback"
+                    :key="entry.judgeName"
+                    class="rounded-xl border border-surface-600/40 bg-surface-700/20 p-3.5"
+                  >
+                    <p class="text-xs font-bold text-content-secondary mb-2">{{ entry.judgeName }}</p>
+
+                    <template v-if="entry.tags && entry.tags.length > 0">
+                      <div
+                        v-for="(tags, groupName) in groupTags(entry.tags)"
+                        :key="groupName"
+                        class="mb-2"
+                      >
+                        <p class="text-xs text-content-muted mb-1">{{ groupName }}</p>
+                        <div class="flex flex-wrap gap-1.5">
+                          <span
+                            v-for="tag in tags"
+                            :key="tag.label"
+                            class="text-xs px-2.5 py-1 rounded-full font-medium border"
+                            :class="groupName === 'Strengths'
+                              ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
+                              : 'bg-amber-500/10 text-amber-400 border-amber-500/30'"
+                          >{{ tag.label }}</span>
+                        </div>
+                      </div>
+                    </template>
+
+                    <div v-if="entry.note" class="mt-2 pt-2 border-t border-surface-600/30">
+                      <p class="text-xs text-content-secondary italic">"{{ entry.note }}"</p>
+                    </div>
+
+                    <p
+                      v-if="(!entry.tags || entry.tags.length === 0) && !entry.note"
+                      class="text-xs text-content-muted italic"
+                    >No feedback provided</p>
+                  </div>
                 </div>
               </div>
+            </template>
+            <div v-else class="border-t border-surface-700/50 pt-4">
+              <p class="text-xs text-content-muted italic">No judge feedback for this genre</p>
             </div>
-          </template>
-          <div v-else class="border-t border-surface-700/50 pt-4">
-            <p class="text-xs text-content-muted italic">No judge feedback for this genre</p>
           </div>
         </div>
       </template>
 
     </main>
 
-    <!-- Footer -->
     <footer class="border-t border-surface-700/50 py-4">
       <p class="text-center text-xs text-content-muted">Battle Event System · Results Portal</p>
     </footer>

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -11,6 +11,7 @@ const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem("select
 const selectedGenre = ref(localStorage.getItem("selectedGenre") || "All")
 const selectedTabulation = ref(localStorage.getItem("selectedTabMethod") || "")
 const selectedTopN = ref("All")
+const selectedEntryType = ref('Teams') // 'Teams' | 'Solo'
 const participants = ref([])
 const tabulationMethod = ref(["By Total", "By Judge"])
 const topNOptions = ["All", "Top 8", "Top 16", "Top 32"]
@@ -92,6 +93,20 @@ const uniqueGenres = computed(() => {
   return [...new Set(genres)].sort();
 })
 
+const hasTeamAndSoloMix = computed(() => {
+  const gp = participants.value.filter(p => p.genreName === selectedGenre.value)
+  const hasTeam = gp.some(p => p.format && p.format !== '1v1')
+  const hasSolo = gp.some(p => !p.format)
+  return hasTeam && hasSolo
+})
+
+const matchesEntryType = (p) => {
+  if (!hasTeamAndSoloMix.value) return true
+  if (selectedEntryType.value === 'Teams') return p.format && p.format !== '1v1'
+  if (selectedEntryType.value === 'Solo') return !p.format
+  return true
+}
+
 // Load admin/organiser specific data for an event
 const loadAdminData = async (eventName) => {
   if (!isAdminOrOrganiser.value || !eventName) return
@@ -116,6 +131,7 @@ watch(selectedGenre, async (newVal) => {
   if (newVal) {
     localStorage.setItem("selectedGenre", newVal)
     selectedTopN.value = 'All'
+    selectedEntryType.value = 'Teams'
     if (selectedEvent.value && newVal !== 'All') {
       criteriaForGenre.value = await getScoringCriteria(selectedEvent.value, newVal)
     } else {
@@ -132,7 +148,7 @@ watch(tbKey, loadTieBreaker, { immediate: true })
 
 const filteredParticipantsForScore = computed({
   get() {
-    return transformForScore(participants.value.filter(p => p.genreName === selectedGenre.value))
+    return transformForScore(participants.value.filter(p => p.genreName === selectedGenre.value && matchesEntryType(p)))
   }
 })
 
@@ -424,6 +440,12 @@ function transformForScore(data) {
         <ReusableDropdown v-model="selectedGenre"      labelId="Genre"    :options="uniqueGenres" />
         <ReusableDropdown v-model="selectedTabulation" labelId="Group By" :options="tabulationMethod" />
         <ReusableDropdown v-model="selectedTopN"       labelId="Show Top" :options="topNOptions" />
+        <ReusableDropdown
+          v-if="hasTeamAndSoloMix"
+          v-model="selectedEntryType"
+          labelId="Type"
+          :options="['Teams', 'Solo']"
+        />
       </div>
 
       <!-- Release Results toggle (admin/organiser only) -->

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
 import { getParticipantScore, getParticipantFeedback, getResultsStatus, releaseResults, getParticipantRefs, getScoringCriteria } from '@/utils/api';
-import ReusableDropdown from '@/components/ReusableDropdown.vue';
 import DynamicTable from '@/components/DynamicTable.vue';
 import { getActiveEvent } from '@/utils/auth';
 import { useAuthStore } from '@/utils/auth';
@@ -230,6 +229,15 @@ const finalRows = computed(() => {
   return [...above, ...winners].map((r, i) => ({ ...r, id: i + 1 }))
 })
 
+// Pagination for the admin/organiser table
+const PAGE_SIZE = 10
+const tablePage = ref(1)
+watch(finalRows, () => { tablePage.value = 1 })
+const totalTablePages = computed(() => Math.max(1, Math.ceil(finalRows.value.length / PAGE_SIZE)))
+const pagedFinalRows = computed(() =>
+  finalRows.value.slice((tablePage.value - 1) * PAGE_SIZE, tablePage.value * PAGE_SIZE)
+)
+
 // Judge column keys for the custom admin table
 const judgeColumnKeys = computed(() => {
   if (!topNResult.value.columns) return []
@@ -432,20 +440,67 @@ function transformForScore(data) {
 
     <!-- Filter card -->
     <div class="card p-5 mb-6">
-      <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
-        <div class="flex flex-col gap-1">
-          <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Event</span>
-          <span class="badge-neutral text-sm px-3 py-1.5 self-start">{{ selectedEvent }}</span>
+      <div class="flex flex-wrap items-center gap-3">
+        <!-- Event name -->
+        <span class="font-heading font-bold text-base text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
+        <span class="text-surface-600 select-none">|</span>
+
+        <!-- Genre toggle -->
+        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <button
+            v-for="g in uniqueGenres"
+            :key="g"
+            @click="selectedGenre = g"
+            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            :class="selectedGenre === g
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >{{ g }}</button>
         </div>
-        <ReusableDropdown v-model="selectedGenre"      labelId="Genre"    :options="uniqueGenres" />
-        <ReusableDropdown v-model="selectedTabulation" labelId="Group By" :options="tabulationMethod" />
-        <ReusableDropdown v-model="selectedTopN"       labelId="Show Top" :options="topNOptions" />
-        <ReusableDropdown
-          v-if="hasTeamAndSoloMix"
-          v-model="selectedEntryType"
-          labelId="Type"
-          :options="['Teams', 'Solo']"
-        />
+        <span class="text-surface-600 select-none">|</span>
+
+        <!-- Group By toggle -->
+        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <button
+            v-for="t in tabulationMethod"
+            :key="t"
+            @click="selectedTabulation = t"
+            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            :class="selectedTabulation === t
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >{{ t }}</button>
+        </div>
+        <span class="text-surface-600 select-none">|</span>
+
+        <!-- Show Top toggle -->
+        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <button
+            v-for="n in topNOptions"
+            :key="n"
+            @click="selectedTopN = n"
+            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            :class="selectedTopN === n
+              ? 'bg-primary-600 text-white'
+              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          >{{ n }}</button>
+        </div>
+
+        <!-- Type toggle (conditional) -->
+        <template v-if="hasTeamAndSoloMix">
+          <span class="text-surface-600 select-none">|</span>
+          <div class="flex rounded-xl overflow-hidden border border-surface-600">
+            <button
+              v-for="t in ['Teams', 'Solo']"
+              :key="t"
+              @click="selectedEntryType = t"
+              class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+              :class="selectedEntryType === t
+                ? 'bg-primary-600 text-white'
+                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+            >{{ t }}</button>
+          </div>
+        </template>
       </div>
 
       <!-- Release Results toggle (admin/organiser only) -->
@@ -659,7 +714,7 @@ function transformForScore(data) {
               </thead>
               <tbody class="divide-y divide-surface-600/30">
                 <tr
-                  v-for="row in finalRows"
+                  v-for="row in pagedFinalRows"
                   :key="row.id"
                   class="bg-surface-800 even:bg-surface-700/40 hover:bg-primary-100/30 transition-colors duration-150"
                 >
@@ -721,6 +776,37 @@ function transformForScore(data) {
                 </tr>
               </tbody>
             </table>
+          </div>
+
+          <!-- Pagination bar -->
+          <div v-if="totalTablePages > 1" class="flex items-center justify-between mt-3 px-1">
+            <span class="text-xs text-content-muted">
+              {{ (tablePage - 1) * PAGE_SIZE + 1 }}–{{ Math.min(tablePage * PAGE_SIZE, finalRows.length) }}
+              of {{ finalRows.length }}
+            </span>
+            <div class="flex items-center gap-1">
+              <button
+                @click="tablePage--"
+                :disabled="tablePage === 1"
+                class="px-2.5 py-1.5 rounded-lg text-sm font-semibold border border-surface-600 bg-surface-800
+                       text-content-secondary hover:bg-surface-700 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              ><i class="pi pi-chevron-left text-xs"></i></button>
+              <button
+                v-for="p in totalTablePages"
+                :key="p"
+                @click="tablePage = p"
+                class="w-8 h-8 rounded-lg text-sm font-semibold border transition-all"
+                :class="tablePage === p
+                  ? 'bg-primary-600 text-white border-primary-600'
+                  : 'border-surface-600 bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              >{{ p }}</button>
+              <button
+                @click="tablePage++"
+                :disabled="tablePage === totalTablePages"
+                class="px-2.5 py-1.5 rounded-lg text-sm font-semibold border border-surface-600 bg-surface-800
+                       text-content-secondary hover:bg-surface-700 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              ><i class="pi pi-chevron-right text-xs"></i></button>
+            </div>
           </div>
         </template>
         <template v-else>

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -31,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.example.BES.dtos.battle.DeleteImageDto;
 import com.example.BES.dtos.battle.SetBattleModeDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
+import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
 import com.example.BES.dtos.battle.SetVoteDto;
@@ -248,5 +249,18 @@ public class BattleController {
         return ResponseEntity.ok(Map.of(
             "message", "List updated"
         ));
+    }
+
+    @GetMapping("/bracket")
+    public ResponseEntity<?> getBracketState(){
+        Object state = battleService.getBracketState();
+        if (state == null) return ResponseEntity.ok(Map.of());
+        return ResponseEntity.ok(state);
+    }
+
+    @PostMapping("/bracket")
+    public ResponseEntity<?> setBracketState(@RequestBody SetBracketStateDto dto){
+        battleService.setBracketStateService(dto);
+        return ResponseEntity.ok(Map.of("message", "Bracket state updated"));
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -31,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.example.BES.dtos.battle.DeleteImageDto;
 import com.example.BES.dtos.battle.SetBattleModeDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
+import com.example.BES.dtos.battle.SetBattlePhaseDto;
 import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
@@ -249,6 +250,17 @@ public class BattleController {
         return ResponseEntity.ok(Map.of(
             "message", "List updated"
         ));
+    }
+
+    @GetMapping("/phase")
+    public ResponseEntity<?> getBattlePhase(){
+        return ResponseEntity.ok(Map.of("phase", battleService.getBattlePhase()));
+    }
+
+    @PostMapping("/phase")
+    public ResponseEntity<?> setBattlePhase(@RequestBody SetBattlePhaseDto dto){
+        battleService.setBattlePhaseService(dto.getPhase());
+        return ResponseEntity.ok(Map.of("phase", battleService.getBattlePhase()));
     }
 
     @GetMapping("/bracket")

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -51,8 +51,11 @@ import com.example.BES.dtos.VerifyParticipantDto;
 import com.example.BES.models.EventGenreParticipant;
 import com.example.BES.models.EventParticipant;
 import com.example.BES.models.Participant;
+import com.example.BES.dtos.CreatePickupCrewDto;
+import com.example.BES.dtos.GetPickupCrewDto;
 import com.example.BES.services.AuditionFeedbackService;
 import com.example.BES.services.EventGenreParticpantService;
+import com.example.BES.services.PickupCrewService;
 import com.example.BES.services.ScoringCriteriaService;
 import com.example.BES.services.EventGenreService;
 import com.example.BES.services.EventParticpantService;
@@ -117,6 +120,9 @@ public class EventController {
 
     @Autowired
     ScoringCriteriaService scoringCriteriaService;
+
+    @Autowired
+    PickupCrewService pickupCrewService;
 
     private static final Gson gson = new Gson();
 
@@ -190,6 +196,21 @@ public class EventController {
     @GetMapping("/{eventName}/genres")
     public ResponseEntity<List<GetGenreDto>> getGenresByEvent(@PathVariable String eventName) {
         return new ResponseEntity<>(eventGenreService.getGenresByEventService(eventName), HttpStatus.OK);
+    }
+
+    @Operation(summary = "Update Event Genre Format", description = "Sets the battle format for a genre in a specific event (e.g. '2v2')")
+    @PostMapping("/{eventName}/genres/{genreName}/format")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> updateEventGenreFormat(
+            @PathVariable String eventName,
+            @PathVariable String genreName,
+            @RequestBody Map<String, String> body) {
+        try {
+            eventGenreService.updateEventGenreFormat(eventName, genreName, body.get("format"));
+            return ResponseEntity.ok().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
     }
 
     @Operation(summary = "Create Event", description = "Creates a new event")
@@ -572,6 +593,36 @@ public class EventController {
             @PathVariable String eventName,
             @RequestParam(required = false) String genre) {
         scoringCriteriaService.deleteAllCriteria(eventName, genre);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── Pickup Crew endpoints ──────────────────────────────────────────────────
+
+    @Operation(summary = "Get Pickup Crews", description = "Returns all pickup crews for a given event and genre")
+    @GetMapping("/crews/{eventName}/{genreName}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<List<GetPickupCrewDto>> getPickupCrews(
+            @PathVariable String eventName,
+            @PathVariable String genreName) {
+        return ResponseEntity.ok(pickupCrewService.getCrewsForEventGenre(eventName, genreName));
+    }
+
+    @Operation(summary = "Create Pickup Crew", description = "Forms a new pickup crew from solo participants")
+    @PostMapping("/crews")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> createPickupCrew(@RequestBody CreatePickupCrewDto dto) {
+        try {
+            return ResponseEntity.ok(pickupCrewService.createCrew(dto));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "Delete Pickup Crew", description = "Deletes a pickup crew by ID")
+    @DeleteMapping("/crews/{crewId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> deletePickupCrew(@PathVariable Long crewId) {
+        pickupCrewService.deleteCrew(crewId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -34,6 +34,7 @@ import com.example.BES.dtos.UpdateJudgingModeDto;
 import com.example.BES.dtos.UpdateAccessCodeDto;
 import com.example.BES.dtos.VerifyAccessCodeDto;
 // import com.example.BES.dtos.AddJudgesDto;
+import com.example.BES.dtos.AddJudgeDto;
 import com.example.BES.dtos.AddParticipantToEventDto;
 import com.example.BES.dtos.AddParticipantToEventGenreDto;
 import com.example.BES.dtos.AddWalkInDto;
@@ -250,6 +251,28 @@ public class EventController {
         } catch (Exception e) {
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
+    }
+
+    @Operation(summary = "Get Judges by Event", description = "Returns judges linked to a specific event")
+    @GetMapping("/{eventName}/judges")
+    public ResponseEntity<List<GetJudgeDto>> getJudgesByEvent(@PathVariable String eventName) {
+        return ResponseEntity.ok(judgeService.getJudgesByEvent(eventName));
+    }
+
+    @Operation(summary = "Add Judge to Event", description = "Creates a new judge and links them to an event")
+    @PostMapping("/{eventName}/judge")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<List<GetJudgeDto>> addJudgeToEvent(@PathVariable String eventName, @RequestBody AddJudgeDto dto) {
+        judgeService.addJudgeToEvent(eventName, dto.judgeName);
+        return ResponseEntity.ok(judgeService.getJudgesByEvent(eventName));
+    }
+
+    @Operation(summary = "Remove Judge from Event", description = "Removes a judge from an event")
+    @DeleteMapping("/{eventName}/judge/{judgeId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<List<GetJudgeDto>> removeJudgeFromEvent(@PathVariable String eventName, @PathVariable Long judgeId) {
+        judgeService.removeJudgeFromEvent(eventName, judgeId);
+        return ResponseEntity.ok(judgeService.getJudgesByEvent(eventName));
     }
 
     @Operation(summary = "Add Walk-in Participant", description = "Registers a new walk-in participant into an event")

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -236,7 +236,7 @@ public class EventController {
     public ResponseEntity<String> addWalkInToSystem(@RequestBody AddWalkInDto dto) {
         try {
             Participant p = participantService.addWalkInService(dto);
-            EventParticipant ep = eventParticipantService.addNewWalkInInEventService(p, dto.eventName, dto.genre);
+            EventParticipant ep = eventParticipantService.addNewWalkInInEventService(p, dto.eventName, dto.genre, dto.teamMembers, dto.teamName);
             EventGenreParticipant egp = eventGenreParticipantService.addWalkInToEventGenreParticipant(p, dto.genre, ep,
                     dto.judgeName);
             AddParticipantToEventGenreDto auditionDto = new AddParticipantToEventGenreDto();
@@ -414,6 +414,16 @@ public class EventController {
             @RequestBody UpdateEmailTemplateDto dto) {
         try {
             return new ResponseEntity<>(emailTemplateService.updateTemplate(eventName, dto), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Operation(summary = "Reset Email Template", description = "Regenerates the smart default email template based on current event genre formats")
+    @PostMapping("/{eventName}/email-template/reset")
+    public ResponseEntity<GetEmailTemplateDto> resetEmailTemplate(@PathVariable String eventName) {
+        try {
+            return new ResponseEntity<>(emailTemplateService.resetToSmartDefault(eventName), HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }

--- a/BES/src/main/java/com/example/BES/dtos/AddGenreToEventDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/AddGenreToEventDto.java
@@ -1,8 +1,10 @@
 package com.example.BES.dtos;
 
 import java.util.List;
+import java.util.Map;
 
 public class AddGenreToEventDto {
     public String eventName;
     public List<String> genreName;
+    public Map<String, String> genreFormats; // genreName → format (e.g. "2v2")
 }

--- a/BES/src/main/java/com/example/BES/dtos/AddParticipantDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/AddParticipantDto.java
@@ -1,6 +1,7 @@
 package com.example.BES.dtos;
 
 import java.util.List;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,4 +20,8 @@ public class AddParticipantDto {
     public List<String> genres;
     public Boolean paymentStatus;
     public String screenshotUrl;
+    public String stageName;
+    public String teamName;
+    public List<String> memberNames;
+    public Map<String, String> genreFormats;
 }

--- a/BES/src/main/java/com/example/BES/dtos/AddWalkInDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/AddWalkInDto.java
@@ -1,8 +1,12 @@
 package com.example.BES.dtos;
 
+import java.util.List;
+
 public class AddWalkInDto {
     public String name;
     public String genre;
     public String eventName;
     public String judgeName;
+    public List<String> teamMembers;
+    public String teamName;
 }

--- a/BES/src/main/java/com/example/BES/dtos/CreatePickupCrewDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/CreatePickupCrewDto.java
@@ -1,0 +1,10 @@
+package com.example.BES.dtos;
+
+import java.util.List;
+
+public class CreatePickupCrewDto {
+    public String eventName;
+    public String genreName;
+    public String crewName;
+    public List<Long> memberParticipantIds;
+}

--- a/BES/src/main/java/com/example/BES/dtos/GetEventGenreParticipantDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetEventGenreParticipantDto.java
@@ -15,4 +15,5 @@ public class GetEventGenreParticipantDto {
     public boolean emailSent;
     public String referenceCode;
     public List<String> memberNames; // non-null only for team-format EGPs
+    public String format;            // "2v2"/"3v3" for team entries; null for solo pickup
 }

--- a/BES/src/main/java/com/example/BES/dtos/GetEventGenreParticipantDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetEventGenreParticipantDto.java
@@ -1,5 +1,7 @@
 package com.example.BES.dtos;
 
+import java.util.List;
+
 public class GetEventGenreParticipantDto {
     public String eventName;
     public String participantName;
@@ -12,4 +14,5 @@ public class GetEventGenreParticipantDto {
     public Long genreId;
     public boolean emailSent;
     public String referenceCode;
+    public List<String> memberNames; // non-null only for team-format EGPs
 }

--- a/BES/src/main/java/com/example/BES/dtos/GetGenreDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetGenreDto.java
@@ -3,4 +3,5 @@ package com.example.BES.dtos;
 public class GetGenreDto {
     public Long id;
     public String genreName;
+    public String format;
 }

--- a/BES/src/main/java/com/example/BES/dtos/GetParticipatnScoreDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetParticipatnScoreDto.java
@@ -1,10 +1,12 @@
 package com.example.BES.dtos;
 
 public class GetParticipatnScoreDto {
+    public Long participantId;
     public String participantName;
     public String eventName;
     public String genreName;
     public String judgeName;
     public Double score;
     public String aspect;  // empty string for legacy single scores; criterion name for multi-criteria
+    public String format;  // "2v2"/"3v3" for team entries; null for solo pickup
 }

--- a/BES/src/main/java/com/example/BES/dtos/GetPickupCrewDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetPickupCrewDto.java
@@ -1,0 +1,16 @@
+package com.example.BES.dtos;
+
+import java.util.List;
+
+public class GetPickupCrewDto {
+    public Long id;
+    public String crewName;
+    public List<MemberDto> members;
+    public Double avgScore;
+    public Double leaderScore;  // avg score of the first (leader) member only
+
+    public static class MemberDto {
+        public Long participantId;
+        public String displayName;
+    }
+}

--- a/BES/src/main/java/com/example/BES/dtos/GetResultsDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetResultsDto.java
@@ -19,19 +19,22 @@ public class GetResultsDto {
 
     public static class GenreResult {
         private String genreName;
+        private String format;
         private Integer auditionNumber;
         private List<ScoreEntry> scores;
         private List<FeedbackEntry> feedback;
 
-        public GenreResult(String genreName, Integer auditionNumber,
+        public GenreResult(String genreName, String format, Integer auditionNumber,
                            List<ScoreEntry> scores, List<FeedbackEntry> feedback) {
             this.genreName = genreName;
+            this.format = format;
             this.auditionNumber = auditionNumber;
             this.scores = scores;
             this.feedback = feedback;
         }
 
         public String getGenreName() { return genreName; }
+        public String getFormat() { return format; }
         public Integer getAuditionNumber() { return auditionNumber; }
         public List<ScoreEntry> getScores() { return scores; }
         public List<FeedbackEntry> getFeedback() { return feedback; }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBattlePhaseDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBattlePhaseDto.java
@@ -1,0 +1,9 @@
+package com.example.BES.dtos.battle;
+
+public class SetBattlePhaseDto {
+    private String phase;
+
+    public String getPhase() {
+        return phase;
+    }
+}

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java
@@ -1,0 +1,19 @@
+package com.example.BES.dtos.battle;
+
+public class SetBracketStateDto {
+    private String topSize;
+    private Object rounds;
+
+    public String getTopSize() {
+        return topSize;
+    }
+    public void setTopSize(String topSize) {
+        this.topSize = topSize;
+    }
+    public Object getRounds() {
+        return rounds;
+    }
+    public void setRounds(Object rounds) {
+        this.rounds = rounds;
+    }
+}

--- a/BES/src/main/java/com/example/BES/enums/Genre.java
+++ b/BES/src/main/java/com/example/BES/enums/Genre.java
@@ -1,17 +1,37 @@
 package com.example.BES.enums;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public enum Genre {
     POPPING("popping"),
-    WAACKING("waacking"),
-    LOCKING("locking"),
-    BREAKING("breaking"),
-    HIPHOP("hip hop"),
+    WAACKING("waacking", "waack", "whacking"),
+    LOCKING("locking", "lock"),
+    BREAKING("breaking", "break", "bboy", "bgirl", "b-boy", "b-girl"),
+    HIPHOP("hip hop", "hiphop", "hip-hop"),
     OPEN("open"),
     AUDIENCE("audience"),
     ROOKIE("rookie"),
-    SMOKE("7 to smoke");
+    SMOKE("7 to smoke", "smoke", "seven to smoke", "7tosmoke");
 
     private final String label;
-    Genre(String label) { this.label = label; }
+    private final List<String> aliases;
+
+    Genre(String label, String... aliases) {
+        this.label = label;
+        this.aliases = Arrays.asList(aliases);
+    }
+
     public String getLabel() { return label; }
+
+    public List<String> getAliases() { return aliases; }
+
+    /** Returns the primary label followed by all aliases — every string that should match this genre. */
+    public List<String> getAllMatchStrings() {
+        List<String> all = new ArrayList<>();
+        all.add(label);
+        all.addAll(aliases);
+        return all;
+    }
 }

--- a/BES/src/main/java/com/example/BES/enums/SheetHeader.java
+++ b/BES/src/main/java/com/example/BES/enums/SheetHeader.java
@@ -7,4 +7,6 @@ public class SheetHeader {
     public static final String CATEGORIES = "categories";
     public static final String LOCAL_OVERSEAS = "local/overseas";
     public static final String SCREENSHOT = "screenshot";
+    public static final String STAGE_NAME = "stage name";
+    public static final String TEAM_NAME  = "team name";
 }

--- a/BES/src/main/java/com/example/BES/mapper/RegistrationDtoMapper.java
+++ b/BES/src/main/java/com/example/BES/mapper/RegistrationDtoMapper.java
@@ -15,17 +15,46 @@ public class RegistrationDtoMapper {
     public AddParticipantDto mapRow(List<String> row,
                                         Map<String,Integer> colIndexMap,
                                         List<Integer> categoriesCols,
-                                        List<String> genres){
+                                        List<String> genres,
+                                        List<Integer> memberCols) {
         AddParticipantDto dto = new AddParticipantDto();
 
         Integer nameIdx = colIndexMap.get(SheetHeader.NAME);
         Integer emailIdx = colIndexMap.get(SheetHeader.EMAIL);
+        Integer stageNameIdx = colIndexMap.get(SheetHeader.STAGE_NAME);
+        Integer teamNameIdx = colIndexMap.get(SheetHeader.TEAM_NAME);
+
+        // Fallback: if no primary name column, use team name as participant identity
+        if (nameIdx == null && teamNameIdx != null) {
+            nameIdx = teamNameIdx;
+        }
 
         if (nameIdx == null || emailIdx == null) return dto;
         if (row.size() <= nameIdx || row.size() <= emailIdx) return dto;
 
         dto.setParticipantName(row.get(nameIdx));
         dto.setParticipantEmail(row.get(emailIdx));
+
+        // Stage name: dedicated column if present, otherwise single name doubles as stage name
+        if (stageNameIdx != null && row.size() > stageNameIdx && !row.get(stageNameIdx).isBlank()) {
+            dto.setStageName(row.get(stageNameIdx));
+        } else {
+            dto.setStageName(row.get(nameIdx));
+        }
+
+        // Team name
+        if (teamNameIdx != null && row.size() > teamNameIdx && !row.get(teamNameIdx).isBlank()) {
+            dto.setTeamName(row.get(teamNameIdx));
+        }
+
+        // Member names (additional team members beyond the leader)
+        List<String> memberNames = new ArrayList<>();
+        for (Integer idx : memberCols) {
+            if (row.size() > idx && !row.get(idx).isBlank()) {
+                memberNames.add(row.get(idx));
+            }
+        }
+        dto.setMemberNames(memberNames);
 
         if (colIndexMap.containsKey(SheetHeader.LOCAL_OVERSEAS)) {
             int residencyIdx = colIndexMap.get(SheetHeader.LOCAL_OVERSEAS);
@@ -48,14 +77,17 @@ public class RegistrationDtoMapper {
             }
         }
 
-        List<String> categories = new ArrayList<>();
-        for (Integer i : categoriesCols){
-            if (row.size() > i) {
-                categories = GoogleSheetParser.normalizeGenre(row.get(i).toLowerCase(), genres);
-                if(!categories.isEmpty()) break;
+        // Genre formats: parse raw category cell into genre → format map
+        Map<String, String> genreFormats = new java.util.HashMap<>();
+        for (Integer i : categoriesCols) {
+            if (row.size() > i && !row.get(i).isBlank()) {
+                genreFormats = GoogleSheetParser.parseGenreFormats(row.get(i), genres);
+                if (!genreFormats.isEmpty()) break;
             }
         }
-        dto.setGenres(categories);
+        dto.setGenreFormats(genreFormats);
+        dto.setGenres(new ArrayList<>(genreFormats.keySet()));
+
         return dto;
     }
 }

--- a/BES/src/main/java/com/example/BES/models/EventGenre.java
+++ b/BES/src/main/java/com/example/BES/models/EventGenre.java
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Data
@@ -31,6 +32,10 @@ public class EventGenre {
     @JoinColumn(name = "genre_id")
     private Genre genre;
 
+    @Column(name = "format")
+    private String format;
+
+    @ToString.Exclude
     @OneToMany(mappedBy = "eventGenre")
-    private List<EventGenreParticipant> participants; 
+    private List<EventGenreParticipant> participants;
 }

--- a/BES/src/main/java/com/example/BES/models/EventGenreParticipant.java
+++ b/BES/src/main/java/com/example/BES/models/EventGenreParticipant.java
@@ -53,6 +53,9 @@ public class EventGenreParticipant {
     @Column(name = "display_name")
     private String displayName;
 
+    @Column(name = "format")
+    private String format;
+
     private Integer auditionNumber;
     @ManyToOne
     @JoinColumn(name = "judge_id", nullable = true)

--- a/BES/src/main/java/com/example/BES/models/EventParticipant.java
+++ b/BES/src/main/java/com/example/BES/models/EventParticipant.java
@@ -1,4 +1,5 @@
 package com.example.BES.models;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -6,24 +7,27 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class EventParticipant {
-    // @EmbeddedId
-    // private EventParticipantId id;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
     @ManyToOne
-    @JoinColumn(name = "event_id", nullable = false) 
+    @JoinColumn(name = "event_id", nullable = false)
     private Event event;
 
     @ManyToOne
@@ -41,5 +45,15 @@ public class EventParticipant {
 
     @Column(name = "display_name")
     private String displayName;
-}
 
+    @Column(name = "stage_name")
+    private String stageName;
+
+    @Column(name = "team_name")
+    private String teamName;
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @OneToMany(mappedBy = "eventParticipant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EventParticipantTeamMember> teamMembers = new ArrayList<>();
+}

--- a/BES/src/main/java/com/example/BES/models/EventParticipantTeamMember.java
+++ b/BES/src/main/java/com/example/BES/models/EventParticipantTeamMember.java
@@ -1,0 +1,36 @@
+package com.example.BES.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "event_participant_team_member")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventParticipantTeamMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "event_participant_id", nullable = false)
+    private EventParticipant eventParticipant;
+
+    @Column(name = "member_name", nullable = false)
+    private String memberName;
+
+    public EventParticipantTeamMember(EventParticipant eventParticipant, String memberName) {
+        this.eventParticipant = eventParticipant;
+        this.memberName = memberName;
+    }
+}

--- a/BES/src/main/java/com/example/BES/models/PickupCrew.java
+++ b/BES/src/main/java/com/example/BES/models/PickupCrew.java
@@ -1,0 +1,42 @@
+package com.example.BES.models;
+
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "pickup_crew")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PickupCrew {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne
+    @JoinColumn(name = "genre_id", nullable = false)
+    private Genre genre;
+
+    @Column(name = "crew_name", nullable = false)
+    private String crewName;
+
+    @OneToMany(mappedBy = "crew", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PickupCrewMember> members;
+}

--- a/BES/src/main/java/com/example/BES/models/PickupCrewMember.java
+++ b/BES/src/main/java/com/example/BES/models/PickupCrewMember.java
@@ -1,0 +1,31 @@
+package com.example.BES.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "pickup_crew_member")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PickupCrewMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "crew_id", nullable = false)
+    private PickupCrew crew;
+
+    @ManyToOne
+    @JoinColumn(name = "participant_id", nullable = false)
+    private Participant participant;
+}

--- a/BES/src/main/java/com/example/BES/parsers/GoogleSheetParser.java
+++ b/BES/src/main/java/com/example/BES/parsers/GoogleSheetParser.java
@@ -1,12 +1,20 @@
 package com.example.BES.parsers;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.google.api.services.sheets.v4.model.ValueRange;
 
 public class GoogleSheetParser {
+    private static final Pattern FORMAT_PATTERN = Pattern.compile("\\d+v\\d+");
+
     public static List<String> normalizeGenre(String event, List<String> genres) {
+        String eventLower = event.toLowerCase();
         return genres.stream()
-                     .filter(event::contains)
+                     .filter(eventLower::contains)
                      .toList();
     }
 
@@ -19,5 +27,36 @@ public class GoogleSheetParser {
         return firstRow.getValues().get(0).stream()
                        .map(Object::toString)
                        .toList();
+    }
+
+    /**
+     * Parses a raw category cell (e.g. "Popping 1v1, Open Styles 3v3") into a map of
+     * genre match-string → format string (e.g. "1v1", "3v3"). Format is null if not present.
+     *
+     * @param rawCellValue the raw comma-separated category string from the sheet
+     * @param genres       all known genre match strings (labels + aliases)
+     * @return map of genre label → format
+     */
+    public static Map<String, String> parseGenreFormats(String rawCellValue, List<String> genres) {
+        Map<String, String> result = new HashMap<>();
+        if (rawCellValue == null || rawCellValue.isBlank()) return result;
+
+        String[] segments = rawCellValue.split(",");
+        for (String segment : segments) {
+            String seg = segment.toLowerCase().trim();
+            if (seg.isBlank()) continue;
+
+            // Extract format (e.g. "3v3") from segment
+            Matcher m = FORMAT_PATTERN.matcher(seg);
+            String format = m.find() ? m.group() : null;
+
+            // Match against all known genre strings
+            for (String genre : genres) {
+                if (seg.contains(genre)) {
+                    result.putIfAbsent(genre, format);
+                }
+            }
+        }
+        return result;
     }
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventGenreParticpantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventGenreParticpantRepo.java
@@ -118,4 +118,18 @@ public interface EventGenreParticpantRepo extends JpaRepository<EventGenrePartic
     @Query("SELECT e.auditionNumber FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format = :format AND e.judge.name = :name AND e.auditionNumber IS NOT NULL")
     List<Integer> findAuditionNumberByEventAndGenreAndFormatAndJudge(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("format") String format, @Param("name") String name);
 
+    // ── Solo pool: treats format IS NULL and format = '1v1' as one unified pool ──
+
+    @Query("SELECT COUNT(e) FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND (e.format IS NULL OR LOWER(e.format) = '1v1')")
+    long countByEventIdAndGenreIdAndSolo(@Param("eventId") Long eventId, @Param("genreId") Long genreId);
+
+    @Query("SELECT e.auditionNumber FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND (e.format IS NULL OR LOWER(e.format) = '1v1') AND e.auditionNumber IS NOT NULL")
+    List<Integer> findAuditionNumberByEventAndGenreAndSolo(@Param("eventId") Long eventId, @Param("genreId") Long genreId);
+
+    @Query("SELECT COUNT(e) FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND (e.format IS NULL OR LOWER(e.format) = '1v1') AND e.judge.name = :name")
+    long countByEventIdAndGenreIdAndSoloAndJudge(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("name") String name);
+
+    @Query("SELECT e.auditionNumber FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND (e.format IS NULL OR LOWER(e.format) = '1v1') AND e.judge.name = :name AND e.auditionNumber IS NOT NULL")
+    List<Integer> findAuditionNumberByEventAndGenreAndSoloAndJudge(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("name") String name);
+
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventGenreParticpantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventGenreParticpantRepo.java
@@ -92,4 +92,30 @@ public interface EventGenreParticpantRepo extends JpaRepository<EventGenrePartic
         @Param("genreName") String genreName,
         @Param("auditionNumber") Integer auditionNumber);
 
+    // ── Format-scoped pool queries (for separate team / solo audition number pools) ──
+
+    @Query("SELECT COUNT(e) FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format IS NULL")
+    long countByEventIdAndGenreIdAndFormatIsNull(@Param("eventId") Long eventId, @Param("genreId") Long genreId);
+
+    @Query("SELECT COUNT(e) FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format = :format")
+    long countByEventIdAndGenreIdAndFormat(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("format") String format);
+
+    @Query("SELECT e.auditionNumber FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format IS NULL AND e.auditionNumber IS NOT NULL")
+    List<Integer> findAuditionNumberByEventAndGenreAndFormatIsNull(@Param("eventId") Long eventId, @Param("genreId") Long genreId);
+
+    @Query("SELECT e.auditionNumber FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format = :format AND e.auditionNumber IS NOT NULL")
+    List<Integer> findAuditionNumberByEventAndGenreAndFormat(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("format") String format);
+
+    @Query("SELECT COUNT(e) FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format IS NULL AND e.judge.name = :name")
+    long countByEventIdAndGenreIdAndFormatIsNullAndJudge(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("name") String name);
+
+    @Query("SELECT COUNT(e) FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format = :format AND e.judge.name = :name")
+    long countByEventIdAndGenreIdAndFormatAndJudge(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("format") String format, @Param("name") String name);
+
+    @Query("SELECT e.auditionNumber FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format IS NULL AND e.judge.name = :name AND e.auditionNumber IS NOT NULL")
+    List<Integer> findAuditionNumberByEventAndGenreAndFormatIsNullAndJudge(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("name") String name);
+
+    @Query("SELECT e.auditionNumber FROM EventGenreParticipant e WHERE e.event.eventId = :eventId AND e.genre.genreId = :genreId AND e.format = :format AND e.judge.name = :name AND e.auditionNumber IS NOT NULL")
+    List<Integer> findAuditionNumberByEventAndGenreAndFormatAndJudge(@Param("eventId") Long eventId, @Param("genreId") Long genreId, @Param("format") String format, @Param("name") String name);
+
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventParticipantTeamMemberRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventParticipantTeamMemberRepo.java
@@ -1,0 +1,12 @@
+package com.example.BES.respositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.EventParticipantTeamMember;
+
+@Repository
+public interface EventParticipantTeamMemberRepo extends JpaRepository<EventParticipantTeamMember, Long> {
+    void deleteByEventParticipant(EventParticipant eventParticipant);
+}

--- a/BES/src/main/java/com/example/BES/respositories/PickupCrewRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/PickupCrewRepo.java
@@ -1,0 +1,20 @@
+package com.example.BES.respositories;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.BES.models.Event;
+import com.example.BES.models.Genre;
+import com.example.BES.models.PickupCrew;
+
+@Repository
+public interface PickupCrewRepo extends JpaRepository<PickupCrew, Long> {
+    List<PickupCrew> findByEventAndGenre(Event event, Genre genre);
+
+    @Query("SELECT COUNT(m) FROM PickupCrewMember m WHERE m.crew.event = :event AND m.crew.genre = :genre AND m.participant.participantId = :participantId")
+    long countMemberInEventGenre(@Param("event") Event event, @Param("genre") Genre genre, @Param("participantId") Long participantId);
+}

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import com.example.BES.dtos.battle.SetBattleModeDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
+import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
 import com.example.BES.dtos.battle.SetVoteDto;
@@ -29,6 +30,7 @@ public class BattleService {
 
     // top 32, top 16 or 7ts
     private List<String> modes = Arrays.asList("Top32", "Top16", "7-to-Smoke");
+    private Object bracketState = null;
     private List<Battler> battlers = new ArrayList<>();
     public List<String> getModes() {
         return modes;
@@ -161,6 +163,18 @@ public class BattleService {
                 "judge", dto.getId()
             ));
         return code;
+    }
+
+    public Object getBracketState() {
+        return bracketState;
+    }
+
+    public void setBracketStateService(SetBracketStateDto dto) {
+        Map<String, Object> state = new java.util.HashMap<>();
+        state.put("topSize", dto.getTopSize());
+        state.put("rounds", dto.getRounds());
+        this.bracketState = state;
+        messagingTemplate.convertAndSend("/topic/battle/bracket", state);
     }
 
     public String getSelectedMode() {

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -32,6 +32,8 @@ public class BattleService {
     private List<String> modes = Arrays.asList("Top32", "Top16", "7-to-Smoke");
     private Object bracketState = null;
     private List<Battler> battlers = new ArrayList<>();
+    // IDLE | LOCKED | VOTING | REVEALED
+    private String battlePhase = "IDLE";
     public List<String> getModes() {
         return modes;
     }
@@ -78,6 +80,9 @@ public class BattleService {
                 "right", currentPair.getRightBattler().getName(),
                 "rightScore", currentPair.getRightBattler().getScore()
             ));
+        // Auto-transition to LOCKED when a new pair is set
+        battlePhase = "LOCKED";
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
     }
 
     public Integer setScoreService(){
@@ -107,6 +112,11 @@ public class BattleService {
                 "left", currentPair.getLeftBattler().getScore(),
                 "right", currentPair.getRightBattler().getScore()
             ));
+        // Auto-transition: winner → REVEALED, tie → stay VOTING
+        if (res == 0 || res == 1) {
+            battlePhase = "REVEALED";
+            messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        }
         return res;
     }
 
@@ -202,7 +212,18 @@ public class BattleService {
     public void setStatus(String status) {
         this.status = status;
     }
-    
+
+    public String getBattlePhase() {
+        return battlePhase;
+    }
+
+    public void setBattlePhaseService(String phase) {
+        // REVEALED is only set by the backend on score reveal, not manually
+        if ("REVEALED".equals(phase)) return;
+        battlePhase = phase;
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+    }
+
     public class BattleJudge {
         private Long id;
         private String name;

--- a/BES/src/main/java/com/example/BES/services/EmailTemplateService.java
+++ b/BES/src/main/java/com/example/BES/services/EmailTemplateService.java
@@ -1,5 +1,7 @@
 package com.example.BES.services;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -7,13 +9,25 @@ import com.example.BES.dtos.GetEmailTemplateDto;
 import com.example.BES.dtos.UpdateEmailTemplateDto;
 import com.example.BES.models.Event;
 import com.example.BES.models.EventEmailTemplate;
+import com.example.BES.models.EventGenre;
 import com.example.BES.respositories.EventEmailTemplateRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
 
 @Service
 public class EmailTemplateService {
 
     @Autowired
     private EventEmailTemplateRepo repo;
+
+    @Autowired
+    private EventGenreRepo eventGenreRepo;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    // Marker text present in the original generic default — used to detect un-customized templates
+    private static final String GENERIC_MARKER = "Please show this QR code during registration to get your audition number.";
 
     public void createDefaultTemplate(Event event) {
         EventEmailTemplate template = new EventEmailTemplate();
@@ -22,7 +36,7 @@ public class EmailTemplateService {
         template.setBody(
             "Hello {name},\n\n" +
             "Thanks for registering for " + event.getEventName() + ".\n" +
-            "Please show this QR code during registration to get your audition number.\n\n" +
+            GENERIC_MARKER + "\n\n" +
             "Thank you."
         );
         repo.save(template);
@@ -31,6 +45,16 @@ public class EmailTemplateService {
     public GetEmailTemplateDto getTemplateByEventName(String eventName) {
         EventEmailTemplate template = repo.findByEvent_EventName(eventName).orElse(null);
         if (template == null) return null;
+
+        // Auto-upgrade generic default to smart template on first open after genres are set
+        if (isGenericDefault(template.getBody())) {
+            String smart = buildSmartBody(eventName);
+            if (smart != null) {
+                template.setBody(smart);
+                repo.save(template);
+            }
+        }
+
         GetEmailTemplateDto dto = new GetEmailTemplateDto();
         dto.setSubject(template.getSubject());
         dto.setBody(template.getBody());
@@ -47,5 +71,89 @@ public class EmailTemplateService {
         result.setSubject(template.getSubject());
         result.setBody(template.getBody());
         return result;
+    }
+
+    /** Regenerates the smart default based on current genre formats and saves it. */
+    public GetEmailTemplateDto resetToSmartDefault(String eventName) {
+        EventEmailTemplate template = repo.findByEvent_EventName(eventName)
+            .orElseThrow(() -> new RuntimeException("No email template found for event: " + eventName));
+        String smart = buildSmartBody(eventName);
+        if (smart != null) {
+            template.setBody(smart);
+            repo.save(template);
+        }
+        GetEmailTemplateDto result = new GetEmailTemplateDto();
+        result.setSubject(template.getSubject());
+        result.setBody(template.getBody());
+        return result;
+    }
+
+    // ── private helpers ──────────────────────────────────────────────────────
+
+    private boolean isGenericDefault(String body) {
+        return body != null && body.contains(GENERIC_MARKER);
+    }
+
+    private boolean isTeamFormat(String format) {
+        return format != null && !format.equalsIgnoreCase("1v1");
+    }
+
+    /**
+     * Determines event type from its genres and returns the appropriate template body.
+     * Returns null if the event has no genres yet (can't determine type).
+     */
+    private String buildSmartBody(String eventName) {
+        Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
+        if (event == null) return null;
+
+        List<EventGenre> genres = eventGenreRepo.findByEvent(event);
+        if (genres.isEmpty()) return null;
+
+        boolean hasSolo = genres.stream().anyMatch(eg -> !isTeamFormat(eg.getFormat()));
+        boolean hasTeam = genres.stream().anyMatch(eg -> isTeamFormat(eg.getFormat()));
+
+        if (hasTeam && hasSolo) return buildMixedTemplate(event.getEventName());
+        if (hasTeam)            return buildTeamTemplate(event.getEventName());
+        return                         buildSoloTemplate(event.getEventName());
+    }
+
+    private String buildSoloTemplate(String eventName) {
+        return
+            "Hello {name},\n\n" +
+            "Thanks for registering for " + eventName + "!\n" +
+            "Please show this QR code during check-in to receive your audition number.\n\n" +
+            "Category: {soloCategories}\n\n" +
+            "Reference code: {refCode}\n\n" +
+            "Thank you and see you on the floor!";
+    }
+
+    private String buildTeamTemplate(String eventName) {
+        return
+            "Hello {teamName},\n\n" +
+            "Thanks for registering for " + eventName + "!\n" +
+            "Please show this QR code during check-in to receive your audition number.\n\n" +
+            "Team: {teamName}\n" +
+            "Members: {stageName}, {members}\n" +
+            "Category: {teamCategories}\n\n" +
+            "Reference code: {refCode}\n\n" +
+            "Thank you and see you on the floor!";
+    }
+
+    private String buildMixedTemplate(String eventName) {
+        return
+            "Hello {name},\n\n" +
+            "Thanks for registering for " + eventName + "!\n" +
+            "Please show this QR code during check-in to receive your audition number.\n\n" +
+            "{if:solo}" +
+            "Solo category: {soloCategories}\n" +
+            "Stage name: {stageName}\n" +
+            "{endif:solo}" +
+            "{if:team}" +
+            "Team: {teamName}\n" +
+            "Members: {stageName}, {members}\n" +
+            "Team category: {teamCategories}\n" +
+            "{endif:team}" +
+            "\nReference code: {refCode}\n\n" +
+            "Thank you and see you on the floor!";
     }
 }

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -21,6 +21,7 @@ import com.example.BES.dtos.GetEventGenreParticipantDto;
 import com.example.BES.dtos.ParticipantJudgeDto;
 import com.example.BES.dtos.UpdateParticipantJudgeDto;
 import com.example.BES.models.Event;
+import com.example.BES.models.EventGenre;
 import com.example.BES.models.EventGenreParticipant;
 import com.example.BES.models.EventGenreParticipantId;
 import com.example.BES.models.EventParticipant;
@@ -28,6 +29,7 @@ import com.example.BES.models.Genre;
 import com.example.BES.models.Judge;
 import com.example.BES.models.Participant;
 import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
 import com.example.BES.respositories.EventParticipantRepo;
 import com.example.BES.respositories.EventRepo;
 import com.example.BES.respositories.GenreRepo;
@@ -59,6 +61,9 @@ public class EventGenreParticpantService {
     @Autowired
     EventParticipantRepo eventParticipantRepo;
 
+    @Autowired
+    EventGenreRepo eventGenreRepo;
+
     public EventGenreParticipant addWalkInToEventGenreParticipant(Participant p, String genre, EventParticipant ep, String judge){
         
         Genre g = genreRepo.findByGenreName(genre).orElse(null);
@@ -73,6 +78,10 @@ public class EventGenreParticpantService {
             egp.setParticipant(p);
             egp.setGenre(g);
             egp.setDisplayName(ep.getDisplayName() != null ? ep.getDisplayName() : p.getParticipantName());
+            EventGenre eg = eventGenreRepo.findByEventAndGenre(ep.getEvent(), g).orElse(null);
+            if (eg != null) {
+                egp.setFormat(eg.getFormat());
+            }
         }
         return repo.save(egp);
     }

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -156,12 +156,26 @@ public class EventGenreParticpantService {
         }
         List<EventGenreParticipant> results = new ArrayList<>(seen.values());
 
-        // Build emailSent and referenceCode maps from EventParticipant records
+        // Build per-participant maps from EventParticipant records
         Map<Long, Boolean> emailSentMap = new java.util.HashMap<>();
         Map<Long, String> refCodeMap = new java.util.HashMap<>();
+        Map<Long, java.util.List<String>> memberNamesMap = new java.util.HashMap<>();
         for (EventParticipant ep : eventParticipantRepo.findByEvent(event)) {
-            emailSentMap.put(ep.getParticipant().getParticipantId(), ep.isEmailSent());
-            refCodeMap.put(ep.getParticipant().getParticipantId(), ep.getReferenceCode());
+            long pid = ep.getParticipant().getParticipantId();
+            emailSentMap.put(pid, ep.isEmailSent());
+            refCodeMap.put(pid, ep.getReferenceCode());
+            // Build full team roster: leader first, then additional members
+            List<String> allMembers = new ArrayList<>();
+            String leaderName = (ep.getStageName() != null && !ep.getStageName().isBlank())
+                ? ep.getStageName()
+                : ep.getParticipant().getParticipantName();
+            allMembers.add(leaderName);
+            if (ep.getTeamMembers() != null) {
+                ep.getTeamMembers().stream()
+                    .map(com.example.BES.models.EventParticipantTeamMember::getMemberName)
+                    .forEach(allMembers::add);
+            }
+            memberNamesMap.put(pid, allMembers);
         }
 
         List<GetEventGenreParticipantDto> dtos = new ArrayList<>();
@@ -172,14 +186,20 @@ public class EventGenreParticpantService {
             dto.genreName = res.getGenre().getGenreName();
             dto.auditionNumber = res.getAuditionNumber();
             dto.walkin = (res.getParticipant().getParticipantEmail() == null)? true : false;
-            dto.participantId = res.getParticipant().getParticipantId();
+            long pid = res.getParticipant().getParticipantId();
+            dto.participantId = pid;
             dto.eventId = res.getEvent().getEventId();
             dto.genreId = res.getGenre().getGenreId();
-            dto.emailSent = emailSentMap.getOrDefault(res.getParticipant().getParticipantId(), false);
-            dto.referenceCode = refCodeMap.get(res.getParticipant().getParticipantId());
+            dto.emailSent = emailSentMap.getOrDefault(pid, false);
+            dto.referenceCode = refCodeMap.get(pid);
             Judge j = res.getJudge();
             if(j != null){
                 dto.judgeName = j.getName();
+            }
+            // Only expose member names for team-format EGPs (format != "1v1")
+            String fmt = res.getFormat();
+            if (fmt != null && !fmt.equalsIgnoreCase("1v1")) {
+                dto.memberNames = memberNamesMap.get(pid);
             }
             dtos.add(dto);
         }

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -121,18 +121,21 @@ public class EventGenreParticpantService {
             List<Integer> takenNumbers;
 
             String entryFormat = participantInEventGenre.getFormat();
+            // null and "1v1" are both solo entries — pool them together to prevent
+            // duplicate audition numbers when format diverges between registration paths
+            boolean isSolo = entryFormat == null || "1v1".equalsIgnoreCase(entryFormat);
             if(j != null){
-                if (entryFormat == null) {
-                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormatIsNullAndJudge(dto.eventId, dto.genreId, j.getName());
-                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormatIsNullAndJudge(dto.eventId, dto.genreId, j.getName());
+                if (isSolo) {
+                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndSoloAndJudge(dto.eventId, dto.genreId, j.getName());
+                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndSoloAndJudge(dto.eventId, dto.genreId, j.getName());
                 } else {
                     totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormatAndJudge(dto.eventId, dto.genreId, entryFormat, j.getName());
                     takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormatAndJudge(dto.eventId, dto.genreId, entryFormat, j.getName());
                 }
             }else{
-                if (entryFormat == null) {
-                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormatIsNull(dto.eventId, dto.genreId);
-                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormatIsNull(dto.eventId, dto.genreId);
+                if (isSolo) {
+                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndSolo(dto.eventId, dto.genreId);
+                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndSolo(dto.eventId, dto.genreId);
                 } else {
                     totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormat(dto.eventId, dto.genreId, entryFormat);
                     takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormat(dto.eventId, dto.genreId, entryFormat);

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -80,7 +80,10 @@ public class EventGenreParticpantService {
             egp.setDisplayName(ep.getDisplayName() != null ? ep.getDisplayName() : p.getParticipantName());
             EventGenre eg = eventGenreRepo.findByEventAndGenre(ep.getEvent(), g).orElse(null);
             if (eg != null) {
-                egp.setFormat(eg.getFormat());
+                String genreFormat = eg.getFormat();
+                boolean isTeamEntry = (ep.getTeamName() != null && !ep.getTeamName().isBlank())
+                    || (ep.getTeamMembers() != null && !ep.getTeamMembers().isEmpty());
+                egp.setFormat(isTeamFormat(genreFormat) && !isTeamEntry ? null : genreFormat);
             }
         }
         return repo.save(egp);
@@ -117,12 +120,23 @@ public class EventGenreParticpantService {
             int totalInGenre;
             List<Integer> takenNumbers;
 
+            String entryFormat = participantInEventGenre.getFormat();
             if(j != null){
-                totalInGenre = (int) repo.countByEventIdAndGenreIdAndJudge(dto.eventId, dto.genreId, j.getName());
-                takenNumbers = repo.findAuditionNumberByEventAndGenreAndJudge(dto.eventId, dto.genreId, j.getName());
+                if (entryFormat == null) {
+                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormatIsNullAndJudge(dto.eventId, dto.genreId, j.getName());
+                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormatIsNullAndJudge(dto.eventId, dto.genreId, j.getName());
+                } else {
+                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormatAndJudge(dto.eventId, dto.genreId, entryFormat, j.getName());
+                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormatAndJudge(dto.eventId, dto.genreId, entryFormat, j.getName());
+                }
             }else{
-                totalInGenre = (int) repo.countByEventIdAndGenreId(dto.eventId, dto.genreId);
-                takenNumbers = repo.findAuditionNumberByEventAndGenre(dto.eventId, dto.genreId);
+                if (entryFormat == null) {
+                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormatIsNull(dto.eventId, dto.genreId);
+                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormatIsNull(dto.eventId, dto.genreId);
+                } else {
+                    totalInGenre = (int) repo.countByEventIdAndGenreIdAndFormat(dto.eventId, dto.genreId, entryFormat);
+                    takenNumbers = repo.findAuditionNumberByEventAndGenreAndFormat(dto.eventId, dto.genreId, entryFormat);
+                }
             }
 
             List<Integer> pool = IntStream.rangeClosed(1, totalInGenre)
@@ -133,17 +147,22 @@ public class EventGenreParticpantService {
             auditionNumber = pool.get(0);
             participantInEventGenre.setAuditionNumber(auditionNumber);
             repo.save(participantInEventGenre);
-            messagingTemplate.convertAndSend("/topic/audition/",
-                Map.of(
-                    "auditionNumber", auditionNumber,
-                    "genre", participantInEventGenre.getGenre().getGenreName(),
-                    "name", participantInEventGenre.getDisplayName(),
-                    "judge", j != null ? j.getName() : "",
-                    "eventName", participantInEventGenre.getEvent().getEventName(),
-                    "participantId", participantInEventGenre.getParticipant().getParticipantId(),
-                    "eventId", participantInEventGenre.getEvent().getEventId(),
-                    "genreId", participantInEventGenre.getGenre().getGenreId(),
-                    "walkin", participantInEventGenre.getParticipant().getParticipantEmail() == null));
+            EventParticipant ep = eventParticipantRepo.findByEventAndParticipant(
+                participantInEventGenre.getEvent(), participantInEventGenre.getParticipant()).orElse(null);
+            String refCode = ep != null ? ep.getReferenceCode() : null;
+            Map<String, Object> auditMsg = new java.util.HashMap<>();
+            auditMsg.put("auditionNumber", auditionNumber);
+            auditMsg.put("genre", participantInEventGenre.getGenre().getGenreName());
+            auditMsg.put("name", participantInEventGenre.getDisplayName());
+            auditMsg.put("judge", j != null ? j.getName() : "");
+            auditMsg.put("eventName", participantInEventGenre.getEvent().getEventName());
+            auditMsg.put("participantId", participantInEventGenre.getParticipant().getParticipantId());
+            auditMsg.put("eventId", participantInEventGenre.getEvent().getEventId());
+            auditMsg.put("genreId", participantInEventGenre.getGenre().getGenreId());
+            auditMsg.put("walkin", participantInEventGenre.getParticipant().getParticipantEmail() == null);
+            auditMsg.put("refCode", refCode != null ? refCode : "");
+            auditMsg.put("format", participantInEventGenre.getFormat() != null ? participantInEventGenre.getFormat() : "");
+            messagingTemplate.convertAndSend("/topic/audition/", auditMsg);
         }else{
             messagingTemplate.convertAndSend("/topic/error/",
                 Map.of(
@@ -210,6 +229,7 @@ public class EventGenreParticpantService {
             if (fmt != null && !fmt.equalsIgnoreCase("1v1")) {
                 dto.memberNames = memberNamesMap.get(pid);
             }
+            dto.format = fmt;
             dtos.add(dto);
         }
         return dtos;
@@ -293,6 +313,10 @@ public class EventGenreParticpantService {
                         "eventName", d.eventName));
             }
         }
+    }
+
+    private boolean isTeamFormat(String fmt) {
+        return fmt != null && !fmt.equalsIgnoreCase("1v1");
     }
 
 }

--- a/BES/src/main/java/com/example/BES/services/EventGenreService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreService.java
@@ -36,6 +36,7 @@ public class EventGenreService {
             GetGenreDto dto = new GetGenreDto();
             dto.id = eg.getGenre().getGenreId();
             dto.genreName = eg.getGenre().getGenreName();
+            dto.format = eg.getFormat();
             dtos.add(dto);
         }
         return dtos;

--- a/BES/src/main/java/com/example/BES/services/EventGenreService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreService.java
@@ -42,6 +42,16 @@ public class EventGenreService {
         return dtos;
     }
 
+    public void updateEventGenreFormat(String eventName, String genreName, String format) {
+        Event e = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
+        Genre g = genreRepo.findByGenreName(genreName.toLowerCase()).orElse(null);
+        if (e == null || g == null) throw new RuntimeException("Event or genre not found");
+        EventGenre eg = eventGenreRepo.findByEventAndGenre(e, g).orElse(null);
+        if (eg == null) throw new RuntimeException("Genre not linked to this event");
+        eg.setFormat(format == null || format.isBlank() ? null : format.trim());
+        eventGenreRepo.save(eg);
+    }
+
     public void addGenreToEventService(AddGenreToEventDto dto){
         Event e = eventRepo.findByEventName(dto.eventName).orElse(null);
         // Genre g = genreRepo.findByGenreName(dto.genreName.toLowerCase()).orElse(null);
@@ -57,6 +67,10 @@ public class EventGenreService {
             eventGenre.setEvent(e);
             eventGenre.setGenre(g);
             eventGenre.setId(new EventGenreId(e.getEventId(), g.getGenreId()));
+            if (dto.genreFormats != null) {
+                String fmt = dto.genreFormats.get(genre);
+                eventGenre.setFormat(fmt == null || fmt.isBlank() ? null : fmt.trim());
+            }
             eventGenreRepo.save(eventGenre);
         }
     }

--- a/BES/src/main/java/com/example/BES/services/EventParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventParticpantService.java
@@ -15,6 +15,7 @@ import com.example.BES.utils.ReferenceCodeUtil;
 import com.example.BES.models.Event;
 import com.example.BES.models.EventGenreParticipantId;
 import com.example.BES.models.EventParticipant;
+import com.example.BES.models.EventParticipantTeamMember;
 import com.example.BES.models.Genre;
 import com.example.BES.models.Participant;
 import com.example.BES.respositories.EventParticipantRepo;
@@ -81,7 +82,7 @@ public class EventParticpantService {
         return result;
     }
 
-    public EventParticipant addNewWalkInInEventService(Participant p, String eventName, String genre){
+    public EventParticipant addNewWalkInInEventService(Participant p, String eventName, String genre, List<String> teamMembers, String teamName){
         Event event = eventRepo.findByEventName(eventName).orElse(null);
         if(event == null){
             return null;
@@ -91,8 +92,23 @@ public class EventParticpantService {
             e = new EventParticipant();
             e.setEvent(event);
             e.setParticipant(p);
-            e.setDisplayName(p.getParticipantName());
+            e.setStageName(p.getParticipantName());
+            if (teamName != null && !teamName.isBlank()) {
+                e.setTeamName(teamName);
+                e.setDisplayName(teamName);
+            } else {
+                e.setDisplayName(p.getParticipantName());
+            }
             e.setReferenceCode(ReferenceCodeUtil.generate());
+            EventParticipant saved = eventParticipantRepo.save(e);
+            if (teamMembers != null) {
+                for (String memberName : teamMembers) {
+                    if (memberName != null && !memberName.isBlank()) {
+                        saved.getTeamMembers().add(new EventParticipantTeamMember(saved, memberName));
+                    }
+                }
+            }
+            return eventParticipantRepo.save(saved);
         }
         return eventParticipantRepo.save(e);
     }

--- a/BES/src/main/java/com/example/BES/services/EventParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventParticpantService.java
@@ -92,6 +92,7 @@ public class EventParticpantService {
             e = new EventParticipant();
             e.setEvent(event);
             e.setParticipant(p);
+            e.setPaymentVerified(true); // walk-ins pay on the day, no verification needed
             e.setStageName(p.getParticipantName());
             if (teamName != null && !teamName.isBlank()) {
                 e.setTeamName(teamName);

--- a/BES/src/main/java/com/example/BES/services/GoogleSheetService.java
+++ b/BES/src/main/java/com/example/BES/services/GoogleSheetService.java
@@ -28,12 +28,10 @@ import com.google.api.services.sheets.v4.model.ValueRange;
 
 @Service
 public class GoogleSheetService {
-    // if any new category just add here and update the constructor to map the function
-    // need to update dto as well
     private static final String CATEGORY_KEYWORD = "categor";
-    private final static List<String> PAYMENT_KEYWORDS = new ArrayList<>(Arrays.asList(SheetHeader.EMAIL,SheetHeader.NAME,SheetHeader.PAYMENT_STATUS,SheetHeader.CATEGORIES,SheetHeader.LOCAL_OVERSEAS));
-    private final static List<String> SCREENSHOT_KEYWORDS = new ArrayList<>(Arrays.asList("screenshot", "receipt", "proof"));
-    
+    private final static List<String> PAYMENT_KEYWORDS = new ArrayList<>(Arrays.asList(SheetHeader.EMAIL, SheetHeader.NAME, SheetHeader.PAYMENT_STATUS, SheetHeader.CATEGORIES, SheetHeader.LOCAL_OVERSEAS));
+    private final static List<String> SCREENSHOT_KEYWORDS = new ArrayList<>(Arrays.asList("screenshot", "receipt", "proof", "prove", "payment"));
+
     @Autowired
     private GoogleSheetClient sheetClient;
 
@@ -46,80 +44,94 @@ public class GoogleSheetService {
     Map<String, BiConsumer<GoogleSheetFileDto, List<String>>> actions;
     List<String> genres;
 
-    public GoogleSheetService(){
-        genres = new ArrayList<>(Arrays.asList(Genre.POPPING.getLabel(), Genre.WAACKING.getLabel(), 
-                                                Genre.LOCKING.getLabel(), Genre.BREAKING.getLabel(), 
-                                                Genre.HIPHOP.getLabel(), Genre.OPEN.getLabel(),
-                                                Genre.AUDIENCE.getLabel(), Genre.ROOKIE.getLabel(),
-                                                Genre.SMOKE.getLabel()));
+    public GoogleSheetService() {
+        genres = new ArrayList<>();
         actions = new HashMap<>();
-        actions.put(Genre.POPPING.getLabel(), (dto,list) -> dto.setPopping(categoriesCount(list, Genre.POPPING.getLabel())));
-        actions.put(Genre.WAACKING.getLabel(), (dto,list) -> dto.setWaacking(categoriesCount(list, Genre.WAACKING.getLabel())));
-        actions.put(Genre.LOCKING.getLabel(), (dto,list) -> dto.setLocking(categoriesCount(list, Genre.LOCKING.getLabel())));
-        actions.put(Genre.BREAKING.getLabel(), (dto,list) -> dto.setBreaking(categoriesCount(list, Genre.BREAKING.getLabel())));
-        actions.put(Genre.HIPHOP.getLabel(), (dto,list) -> dto.setHiphop(categoriesCount(list, Genre.HIPHOP.getLabel())));
-        actions.put(Genre.OPEN.getLabel(), (dto,list) -> dto.setOpen(categoriesCount(list, Genre.OPEN.getLabel())));
-        actions.put(Genre.AUDIENCE.getLabel(), (dto,list) -> dto.setAudience(categoriesCount(list, Genre.AUDIENCE.getLabel())));
-        actions.put(Genre.ROOKIE.getLabel(), (dto,list) -> dto.setRookie(categoriesCount(list, Genre.ROOKIE.getLabel())));
-        actions.put(Genre.SMOKE.getLabel(), (dto,list) -> dto.setSmoke(categoriesCount(list, Genre.SMOKE.getLabel())));
+
+        for (Genre g : Genre.values()) {
+            for (String matchString : g.getAllMatchStrings()) {
+                genres.add(matchString);
+                final String key = matchString;
+                switch (g) {
+                    case POPPING   -> actions.put(key, (dto, list) -> dto.setPopping(categoriesCount(list, key)));
+                    case WAACKING  -> actions.put(key, (dto, list) -> dto.setWaacking(categoriesCount(list, key)));
+                    case LOCKING   -> actions.put(key, (dto, list) -> dto.setLocking(categoriesCount(list, key)));
+                    case BREAKING  -> actions.put(key, (dto, list) -> dto.setBreaking(categoriesCount(list, key)));
+                    case HIPHOP    -> actions.put(key, (dto, list) -> dto.setHiphop(categoriesCount(list, key)));
+                    case OPEN      -> actions.put(key, (dto, list) -> dto.setOpen(categoriesCount(list, key)));
+                    case AUDIENCE  -> actions.put(key, (dto, list) -> dto.setAudience(categoriesCount(list, key)));
+                    case ROOKIE    -> actions.put(key, (dto, list) -> dto.setRookie(categoriesCount(list, key)));
+                    case SMOKE     -> actions.put(key, (dto, list) -> dto.setSmoke(categoriesCount(list, key)));
+                }
+            }
+        }
     }
 
-    /* Correct order should be: 
-     * 1. Search first row to identify the index of rows that has certain keyword eg. Category
-     * 2. Store the indices in list, and by going through the list transform index to alphabet and in H:H format
-     * 3. 
-    */
-    
-    // get numbers of participants of each genre
-    public GoogleSheetFileDto getParticipantsBreakDown(String fileId) throws IOException{
-        GoogleSheetFileDto dto = new GoogleSheetFileDto();  
-        List<String> matchingColumnAlphabet = new ArrayList<>();
+    public GoogleSheetFileDto getParticipantsBreakDown(String fileId) throws IOException {
+        GoogleSheetFileDto dto = new GoogleSheetFileDto();
         List<Integer> matchingCategoriesIndixes = getCategoriesColumns(fileId);
-        for(Integer index : matchingCategoriesIndixes){
+
+        if (matchingCategoriesIndixes.isEmpty()) {
+            return dto;
+        }
+
+        List<String> matchingColumnAlphabet = new ArrayList<>();
+        for (Integer index : matchingCategoriesIndixes) {
             String colLetter = colIndexToLetter(index + 1);
             matchingColumnAlphabet.add(colLetter + ":" + colLetter);
         }
-                            
-        // Get the value based on the columns identified
-        // usually there will be only two which are local and overseas 
+
         BatchGetValuesResponse response = sheetClient.batchGet(fileId, matchingColumnAlphabet);
         List<ValueRange> valueRanges = response.getValueRanges();
-        List<List<Object>> localGenre = valueRanges.get(0).getValues();
-        List<List<Object>> overseasGenre = new ArrayList<>();
-        if(valueRanges.size()>1){
-            overseasGenre = valueRanges.get(1).getValues();
-        }
-        
-        List<String> combined = new ArrayList<>();
-        for(int i = 1; i < localGenre.size(); i++){
-            if(localGenre.get(i).size() == 0){
-                combined.add(overseasGenre.get(i).get(0).toString());
-            }else{
-                combined.add(localGenre.get(i).get(0).toString());
+
+        int maxRows = 0;
+        for (ValueRange vr : valueRanges) {
+            List<List<Object>> vals = vr.getValues();
+            if (vals != null && vals.size() > maxRows) {
+                maxRows = vals.size();
             }
         }
+
+        List<String> combined = new ArrayList<>();
+        for (int i = 1; i < maxRows; i++) {
+            String value = "";
+            for (ValueRange vr : valueRanges) {
+                List<List<Object>> vals = vr.getValues();
+                if (vals != null && vals.size() > i) {
+                    List<Object> cell = vals.get(i);
+                    if (cell != null && !cell.isEmpty()) {
+                        value = cell.get(0).toString();
+                        break;
+                    }
+                }
+            }
+            combined.add(value);
+        }
+
         setDtoCategory(dto, combined);
         return dto;
     }
 
-    // When there is a new form, need to insert payment column for payment validation
-    public void insertPaymentColumn(String fileId) throws IOException{
+    public void insertPaymentColumn(String fileId) throws IOException {
         ValueRange headerRange = sheetClient.getRange(fileId, "1:1");
         List<String> headers = GoogleSheetParser.readHeaders(headerRange);
-        if(!GoogleSheetParser.columnExists(headers, SheetHeader.PAYMENT_STATUS)){
+        if (!GoogleSheetParser.columnExists(headers, SheetHeader.PAYMENT_STATUS)) {
             int rowSize = sheetClient.getSheetSize(fileId);
             sheetClient.insertPaymentCheckboxes(fileId, headers.size(), rowSize, sheetClient.getSheetId(fileId));
         }
     }
 
     public List<AddParticipantDto> getAllImportableParticipants(AddParticipantToEventDto dto)
-        throws IOException {
+            throws IOException {
         List<AddParticipantDto> importable = new ArrayList<>();
-        Map<String, Integer> colIndexMap = getColumnIndexMap(dto.fileId);
-        List<List<String>> resultString = getsheetAllRows(dto.fileId);
+        List<String> originalHeaders = getHeaders(dto.fileId);
+        Map<String, Integer> colIndexMap = getColumnIndexMap(dto.fileId, originalHeaders);
+        List<List<String>> resultString = getsheetAllRows(dto.fileId, originalHeaders);
         List<Integer> categoriesColumn = getCategoriesColumns(dto.fileId);
+        List<Integer> memberCols = getMemberNameColumns(originalHeaders);
+
         for (List<String> res : resultString) {
-            AddParticipantDto participant = mapper.mapRow(res, colIndexMap, categoriesColumn, genres);
+            AddParticipantDto participant = mapper.mapRow(res, colIndexMap, categoriesColumn, genres, memberCols);
             String name = participant.getParticipantName();
             String email = participant.getParticipantEmail();
             if (name != null && !name.isBlank() && email != null && !email.isBlank()) {
@@ -129,32 +141,36 @@ public class GoogleSheetService {
         return importable;
     }
 
-    public Integer getSheetSizeService(String fileId) throws IOException{
+    public Integer getSheetSizeService(String fileId) throws IOException {
         return sheetClient.getSheetSize(fileId) - 1;
     }
 
     /*
      * Helper functions region
      */
-    private Map<String,Integer> getColumnIndexMap(String fileId) throws IOException{
-        // email has no problem
-        // categories are handled differently
-        // local/overseas should be handled more nicely
-        // name may have multiple names for team
+    private Map<String, Integer> getColumnIndexMap(String fileId, List<String> headers) throws IOException {
         Map<String, Integer> colIndexMap = new HashMap<>();
-        List<String> headers = getHeaders(fileId);
-        // check how many contain name, if more than one, take team name
-        Integer nameCount = getNameHeaderCount(headers);
-        if(nameCount > 1){
-            headers = removeExtraName(headers);
+
+        // Pre-scan for stage name and team name before any header modification
+        for (int i = 0; i < headers.size(); i++) {
+            String h = headers.get(i).toLowerCase();
+            if (h.contains(SheetHeader.STAGE_NAME)) colIndexMap.putIfAbsent(SheetHeader.STAGE_NAME, i);
+            if (h.contains(SheetHeader.TEAM_NAME))  colIndexMap.putIfAbsent(SheetHeader.TEAM_NAME, i);
         }
-        for(Integer i = 0; i< headers.size(); i ++){
-            for(String keyword: PAYMENT_KEYWORDS){
-                if(headers.get(i).toLowerCase().contains(keyword.toLowerCase())){
-                    colIndexMap.put(keyword, i);
+
+        // Normalize headers: remove extra name columns (passing pre-scan map so special cols are skipped)
+        List<String> normalizedHeaders = headers;
+        if (getNameHeaderCount(headers) > 1) {
+            normalizedHeaders = removeExtraName(headers, colIndexMap);
+        }
+
+        for (int i = 0; i < normalizedHeaders.size(); i++) {
+            for (String keyword : PAYMENT_KEYWORDS) {
+                if (normalizedHeaders.get(i).toLowerCase().contains(keyword.toLowerCase())) {
+                    colIndexMap.putIfAbsent(keyword, i);
                 }
             }
-            String headerLower = headers.get(i).toLowerCase();
+            String headerLower = normalizedHeaders.get(i).toLowerCase();
             for (String screenshotKw : SCREENSHOT_KEYWORDS) {
                 if (headerLower.contains(screenshotKw) && !colIndexMap.containsKey(SheetHeader.SCREENSHOT)) {
                     colIndexMap.put(SheetHeader.SCREENSHOT, i);
@@ -165,100 +181,123 @@ public class GoogleSheetService {
         return colIndexMap;
     }
 
-    private Integer getNameHeaderCount(List<String> headers){
-        Integer count = 0;
-        for(String h : headers){
-            if(h.toLowerCase().contains("name")){
-                count += 1;
+    private Integer getNameHeaderCount(List<String> headers) {
+        int count = 0;
+        for (String h : headers) {
+            if (h.toLowerCase().contains("name")) {
+                count++;
             }
         }
         return count;
     }
 
-    // This is because Team battle form will consist of multiple name columns
-    // We only need to keep Team name
-    private List<String> removeExtraName(List<String> headers) {
+    /**
+     * Normalizes headers by marking extra name columns as "ignore".
+     * Stage name and team name columns (already pre-scanned) are marked as "ignore" so they
+     * don't compete with the primary participant name column. Member name columns are also
+     * marked as "ignore" since they are captured separately by getMemberNameColumns.
+     * The first remaining "name" column is kept as the primary participant name (NAME key).
+     */
+    private List<String> removeExtraName(List<String> headers, Map<String, Integer> preScanMap) {
         List<String> mutableHeaders = new ArrayList<>(headers);
-    
-        // Step 1: check if "team name" exists
-        boolean hasTeamName = headers.stream()
-            .anyMatch(h -> h.toLowerCase().contains("team name"));
-    
+
+        // Collect indices already captured as special columns
+        Set<Integer> specialIndices = new HashSet<>();
+        if (preScanMap.containsKey(SheetHeader.STAGE_NAME)) specialIndices.add(preScanMap.get(SheetHeader.STAGE_NAME));
+        if (preScanMap.containsKey(SheetHeader.TEAM_NAME))  specialIndices.add(preScanMap.get(SheetHeader.TEAM_NAME));
+
+        // Mark special columns as "ignore"
+        for (int idx : specialIndices) {
+            mutableHeaders.set(idx, "ignore");
+        }
+
+        // Mark member name columns as "ignore" (captured by getMemberNameColumns)
+        for (int i = 0; i < mutableHeaders.size(); i++) {
+            if (specialIndices.contains(i)) continue;
+            String lower = mutableHeaders.get(i).toLowerCase();
+            if (lower.contains("member") && lower.contains("name")) {
+                mutableHeaders.set(i, "ignore");
+            }
+        }
+
+        // Keep first remaining "name" column as NAME, mark rest as "ignore"
         boolean foundFirstName = false;
-    
-        // Step 2: iterate and mark extra "name" columns as "ignore"
         for (int i = 0; i < mutableHeaders.size(); i++) {
             String value = mutableHeaders.get(i).toLowerCase();
-    
+            if (value.equals("ignore")) continue;
             if (value.contains("name")) {
-                if (hasTeamName) {
-                    // Case A: "team name" exists → ignore all other "name" columns
-                    if (!value.contains("team name")) {
-                        mutableHeaders.set(i, "ignore");
-                    }
+                if (!foundFirstName) {
+                    foundFirstName = true;
                 } else {
-                    // Case B: no "team name" → keep first "name" only
-                    if (!foundFirstName) {
-                        foundFirstName = true; // keep this one
-                    } else {
-                        mutableHeaders.set(i, "ignore"); // ignore subsequent ones
-                    }
+                    mutableHeaders.set(i, "ignore");
                 }
             }
         }
         return mutableHeaders;
     }
 
-    private List<String> getHeaders(String fileId) throws IOException{
+    /**
+     * Returns column indices where the header contains both "member" and "name"
+     * (e.g. "Member 2 Name", "Member 3 Name").
+     */
+    private List<Integer> getMemberNameColumns(List<String> headers) {
+        List<Integer> indices = new ArrayList<>();
+        for (int i = 0; i < headers.size(); i++) {
+            String lower = headers.get(i).toLowerCase();
+            if (lower.contains("member") && lower.contains("name")) {
+                indices.add(i);
+            }
+        }
+        return indices;
+    }
+
+    private List<String> getHeaders(String fileId) throws IOException {
         ValueRange headerRange = sheetClient.getRange(fileId, "1:1");
         return GoogleSheetParser.readHeaders(headerRange);
-
     }
 
-    private List<List<String>> getsheetAllRows(String fileId) throws IOException{
-        List<String> headers = getHeaders(fileId);
-        String range = "A2:"+colIndexToLetter(headers.size());
-        ValueRange results = new ValueRange();
-        results = sheetClient.getRange(fileId, range);
-        return results.getValues().stream()
-                        .map(row -> row.stream()
-                            .map(Object::toString)   // convert each Object to String
-                            .collect(Collectors.toList()))
-                        .collect(Collectors.toList());       
+    private List<List<String>> getsheetAllRows(String fileId, List<String> headers) throws IOException {
+        String range = "A2:" + colIndexToLetter(headers.size());
+        ValueRange results = sheetClient.getRange(fileId, range);
+        List<List<Object>> values = results.getValues();
+        if (values == null) {
+            return new ArrayList<>();
+        }
+        return values.stream()
+                .map(row -> row.stream()
+                        .map(Object::toString)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
     }
 
-    // Get the count of the input category
-    private Integer categoriesCount(List<String> data, String Category){
-        return (int)data.stream()
-                .filter(s -> s.toLowerCase().contains(Category.toLowerCase()))
+    private Integer categoriesCount(List<String> data, String category) {
+        return (int) data.stream()
+                .filter(s -> s.toLowerCase().contains(category.toLowerCase()))
                 .count();
     }
 
-    // identify columns "Categories" from the sheet
-    private List<Integer> getCategoriesColumns(String fileId) throws IOException{
+    private List<Integer> getCategoriesColumns(String fileId) throws IOException {
         ValueRange headerRange = sheetClient.getRange(fileId, "1:1");
         List<String> headers = GoogleSheetParser.readHeaders(headerRange);
         List<Integer> matchingColumnIndices = new ArrayList<>();
-        for(int i = 0; i < headers.size(); i++){
-            if(headers.get(i).toLowerCase().contains(CATEGORY_KEYWORD.toLowerCase())){
+        for (int i = 0; i < headers.size(); i++) {
+            if (headers.get(i).toLowerCase().contains(CATEGORY_KEYWORD.toLowerCase())) {
                 matchingColumnIndices.add(i);
             }
-        }     
+        }
         return matchingColumnIndices;
     }
 
-    // This is to set the count of each genres
-    private void setDtoCategory(GoogleSheetFileDto dto, List<String> data){
-        Set<String> categories = new HashSet<String>(data);
-        for (String category: categories){
-            List<String> normalizeCategories = GoogleSheetParser.normalizeGenre(category.toLowerCase(), genres);
-            for(String normalizeCategory: normalizeCategories){
+    private void setDtoCategory(GoogleSheetFileDto dto, List<String> data) {
+        Set<String> categories = new HashSet<>(data);
+        for (String category : categories) {
+            List<String> normalizeCategories = GoogleSheetParser.normalizeGenre(category, genres);
+            for (String normalizeCategory : normalizeCategories) {
                 actions.get(normalizeCategory).accept(dto, data);
             }
         }
     }
 
-    // Map the index to Alphabet in Google Sheet eg. A == 1, B == 2
     private static String colIndexToLetter(int index) {
         StringBuilder result = new StringBuilder();
         while (index > 0) {

--- a/BES/src/main/java/com/example/BES/services/JudgeService.java
+++ b/BES/src/main/java/com/example/BES/services/JudgeService.java
@@ -5,18 +5,24 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.BES.dtos.AddJudgeDto;
 import com.example.BES.dtos.GetJudgeDto;
 import com.example.BES.dtos.admin.DeleteJudgeDto;
 import com.example.BES.dtos.admin.UpdateJudgeDto;
+import com.example.BES.models.Event;
 import com.example.BES.models.Judge;
+import com.example.BES.respositories.EventRepo;
 import com.example.BES.respositories.JudgeRepo;
 
 @Service
 public class JudgeService {
     @Autowired
     JudgeRepo judgeRepo;
+
+    @Autowired
+    EventRepo eventRepo;
 
     // public void addJudgesService(AddJudgesDto dto){
     //     for(String judge: dto.judges){
@@ -66,5 +72,42 @@ public class JudgeService {
 
     public Judge getJudgeById(Long id){
         return judgeRepo.findById(id).orElse(null);
+    }
+
+    @Transactional
+    public List<GetJudgeDto> getJudgesByEvent(String eventName) {
+        Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
+        if (event == null || event.getJudges() == null) return new ArrayList<>();
+        List<GetJudgeDto> dtos = new ArrayList<>();
+        for (Judge j : event.getJudges()) {
+            GetJudgeDto dto = new GetJudgeDto();
+            dto.judgeName = j.getName();
+            dto.judgeId = j.getJudgeId();
+            dtos.add(dto);
+        }
+        return dtos;
+    }
+
+    @Transactional
+    public Judge addJudgeToEvent(String eventName, String judgeName) {
+        Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
+        if (event == null) return null;
+        Judge j = new Judge();
+        j.setName(judgeName);
+        j = judgeRepo.save(j);
+        if (event.getJudges() == null) {
+            event.setJudges(new ArrayList<>());
+        }
+        event.getJudges().add(j);
+        eventRepo.save(event);
+        return j;
+    }
+
+    @Transactional
+    public void removeJudgeFromEvent(String eventName, Long judgeId) {
+        Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
+        if (event == null || event.getJudges() == null) return;
+        event.getJudges().removeIf(j -> j.getJudgeId().equals(judgeId));
+        eventRepo.save(event);
     }
 }

--- a/BES/src/main/java/com/example/BES/services/MailSenderService.java
+++ b/BES/src/main/java/com/example/BES/services/MailSenderService.java
@@ -2,6 +2,7 @@ package com.example.BES.services;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -10,7 +11,9 @@ import org.springframework.stereotype.Service;
 
 import com.example.BES.dtos.GetEmailTemplateDto;
 import com.example.BES.enums.Constant;
-import com.example.BES.models.EventGenreParticipantId;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.EventParticipantTeamMember;
 import com.example.BES.models.Participant;
 import com.google.zxing.WriterException;
 
@@ -34,40 +37,69 @@ public class MailSenderService {
     @Autowired
     private Environment env;
 
-
-    public void sendEmailWithAttachment(String eventName, Participant receiver, List<EventGenreParticipantId> ids, String referenceCode, String displayName) throws MessagingException, WriterException, IOException{
+    public void sendEmailWithAttachment(String eventName, Participant receiver,
+            EventParticipant ep, List<EventGenreParticipant> egps, String referenceCode)
+            throws MessagingException, WriterException, IOException {
         GetEmailTemplateDto template = emailTemplateService.getTemplateByEventName(eventName);
         if (template == null) {
             throw new RuntimeException("No email template found for event: " + eventName);
         }
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true);
-        EventGenreParticipantId first = ids.get(0);
+
+        // Use first EGP id for QR code link
+        EventGenreParticipant first = egps.get(0);
         String registerLink = String.format(
             "%s/api/v1/event/register-participant/%d/%d",
             env.getProperty("DOMAIN"),
-            first.getParticipantId(),
-            first.getEventId());
+            first.getId().getParticipantId(),
+            first.getId().getEventId());
         byte[] sourceBytes = qrService.generateQrCode(registerLink, 350, 350);
         DataSource dataSource = new ByteArrayDataSource(sourceBytes, "image/jpeg");
         messageHelper.addAttachment("audition-qr.jpg", dataSource);
-            // use with MimeBodyPart
+
         messageHelper.setFrom(Constant.SENDER_EMAIL.getLabel());
         messageHelper.setTo(receiver.getParticipantEmail());
+
+        String displayName = ep.getDisplayName() != null ? ep.getDisplayName() : receiver.getParticipantName();
+
         String body = template.getBody()
-            .replace("{name}", displayName != null ? displayName : receiver.getParticipantName())
-            .replace("{refCode}", referenceCode != null ? referenceCode : "");
+            .replace("{name}",            displayName)
+            .replace("{stageName}",       ep.getStageName()  != null ? ep.getStageName()  : "")
+            .replace("{teamName}",        ep.getTeamName()   != null ? ep.getTeamName()   : "")
+            .replace("{members}",         buildMemberString(ep.getTeamMembers()))
+            .replace("{soloCategories}",  buildCategoryString(egps, false))
+            .replace("{teamCategories}",  buildCategoryString(egps, true))
+            .replace("{refCode}",         referenceCode != null ? referenceCode : "");
+
         messageHelper.setText(body);
         messageHelper.setSubject(template.getSubject());
 
         mailSender.send(mimeMessage);
     }
 
+    private String buildMemberString(List<EventParticipantTeamMember> members) {
+        if (members == null || members.isEmpty()) return "";
+        return members.stream()
+            .map(EventParticipantTeamMember::getMemberName)
+            .collect(Collectors.joining(", "));
+    }
+
+    private String buildCategoryString(List<EventGenreParticipant> egps, boolean teamOnly) {
+        return egps.stream()
+            .filter(egp -> teamOnly ? isTeamFormat(egp.getFormat()) : !isTeamFormat(egp.getFormat()))
+            .map(egp -> egp.getGenre().getGenreName())
+            .collect(Collectors.joining(", "));
+    }
+
+    private boolean isTeamFormat(String format) {
+        return format != null && !format.equalsIgnoreCase("1v1");
+    }
+
     public static String normalizeKey(String key) {
         if (key == null) {
             return null;
         }
-        // Replace space and dot with underscore
         return key.replaceAll("[ .]", "_");
     }
 }

--- a/BES/src/main/java/com/example/BES/services/MailSenderService.java
+++ b/BES/src/main/java/com/example/BES/services/MailSenderService.java
@@ -2,6 +2,7 @@ package com.example.BES.services;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +64,15 @@ public class MailSenderService {
 
         String displayName = ep.getDisplayName() != null ? ep.getDisplayName() : receiver.getParticipantName();
 
-        String body = template.getBody()
+        boolean hasTeam = egps.stream().anyMatch(egp -> isTeamFormat(egp.getFormat()));
+        boolean hasSolo = egps.stream().anyMatch(egp -> !isTeamFormat(egp.getFormat()));
+
+        String body = template.getBody();
+        // Process conditional blocks before variable substitution
+        body = processConditionalBlock(body, "team", hasTeam);
+        body = processConditionalBlock(body, "solo", hasSolo);
+        // Variable substitution
+        body = body
             .replace("{name}",            displayName)
             .replace("{stageName}",       ep.getStageName()  != null ? ep.getStageName()  : "")
             .replace("{teamName}",        ep.getTeamName()   != null ? ep.getTeamName()   : "")
@@ -94,6 +103,21 @@ public class MailSenderService {
 
     private boolean isTeamFormat(String format) {
         return format != null && !format.equalsIgnoreCase("1v1");
+    }
+
+    /**
+     * If condition is true: strip the open/close tags and keep the content.
+     * If condition is false: remove the entire block including its content.
+     */
+    private String processConditionalBlock(String body, String tag, boolean condition) {
+        String openTag  = "\\{if:" + tag + "\\}";
+        String closeTag = "\\{endif:" + tag + "\\}";
+        if (condition) {
+            return body.replaceAll(openTag, "").replaceAll(closeTag, "");
+        } else {
+            return Pattern.compile(openTag + ".*?" + closeTag, Pattern.DOTALL)
+                          .matcher(body).replaceAll("");
+        }
     }
 
     public static String normalizeKey(String key) {

--- a/BES/src/main/java/com/example/BES/services/PickupCrewService.java
+++ b/BES/src/main/java/com/example/BES/services/PickupCrewService.java
@@ -1,0 +1,178 @@
+package com.example.BES.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.BES.dtos.CreatePickupCrewDto;
+import com.example.BES.dtos.GetPickupCrewDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenre;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventGenreParticipantId;
+import com.example.BES.models.Genre;
+import com.example.BES.models.Participant;
+import com.example.BES.models.PickupCrew;
+import com.example.BES.models.PickupCrewMember;
+import com.example.BES.models.Score;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.ParticipantRepo;
+import com.example.BES.respositories.PickupCrewRepo;
+import com.example.BES.respositories.ScoreRepo;
+
+@Service
+public class PickupCrewService {
+
+    @Autowired
+    PickupCrewRepo crewRepo;
+
+    @Autowired
+    EventRepo eventRepo;
+
+    @Autowired
+    GenreRepo genreRepo;
+
+    @Autowired
+    ParticipantRepo participantRepo;
+
+    @Autowired
+    EventGenreParticpantRepo egpRepo;
+
+    @Autowired
+    EventGenreRepo eventGenreRepo;
+
+    @Autowired
+    ScoreRepo scoreRepo;
+
+    public List<GetPickupCrewDto> getCrewsForEventGenre(String eventName, String genreName) {
+        Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
+        Genre genre = genreRepo.findByGenreName(genreName.toLowerCase()).orElse(null);
+        if (event == null || genre == null) return new ArrayList<>();
+
+        List<PickupCrew> crews = crewRepo.findByEventAndGenre(event, genre);
+        List<GetPickupCrewDto> result = new ArrayList<>();
+
+        for (PickupCrew crew : crews) {
+            GetPickupCrewDto dto = new GetPickupCrewDto();
+            dto.id = crew.getId();
+            dto.crewName = crew.getCrewName();
+            dto.members = new ArrayList<>();
+
+            double totalScore = 0;
+            int scoredMembers = 0;
+            boolean leaderScoreSet = false;
+
+            for (PickupCrewMember m : crew.getMembers()) {
+                GetPickupCrewDto.MemberDto memberDto = new GetPickupCrewDto.MemberDto();
+                memberDto.participantId = m.getParticipant().getParticipantId();
+
+                // Display name from EGP (solo pickup entry for this genre)
+                EventGenreParticipantId egpId = new EventGenreParticipantId(
+                    event.getEventId(), genre.getGenreId(), m.getParticipant().getParticipantId());
+                EventGenreParticipant egp = egpRepo.findById(egpId).orElse(null);
+                memberDto.displayName = egp != null ? egp.getDisplayName()
+                    : m.getParticipant().getParticipantName();
+                dto.members.add(memberDto);
+
+                // Aggregate score: sum all score rows for this participant+event+genre
+                if (egp != null) {
+                    List<Score> scores = scoreRepo.findByEventGenreParticipant(egp);
+                    if (!scores.isEmpty()) {
+                        double participantTotal = scores.stream()
+                            .mapToDouble(s -> s.getValue() != null ? s.getValue() : 0)
+                            .sum();
+                        totalScore += participantTotal;
+                        scoredMembers++;
+                        // First member in list is the leader
+                        if (!leaderScoreSet) {
+                            dto.leaderScore = Math.round((participantTotal / scores.size()) * 100.0) / 100.0;
+                            leaderScoreSet = true;
+                        }
+                    }
+                }
+            }
+
+            dto.avgScore = scoredMembers > 0 ? Math.round((totalScore / scoredMembers) * 100.0) / 100.0 : null;
+            result.add(dto);
+        }
+
+        return result;
+    }
+
+    @Transactional
+    public GetPickupCrewDto createCrew(CreatePickupCrewDto dto) {
+        Event event = eventRepo.findByEventNameIgnoreCase(dto.eventName).orElse(null);
+        Genre genre = genreRepo.findByGenreName(dto.genreName.toLowerCase()).orElse(null);
+        if (event == null || genre == null) throw new RuntimeException("Event or genre not found");
+
+        // Validate crew size matches genre format
+        EventGenre eventGenre = eventGenreRepo.findByEventAndGenre(event, genre).orElse(null);
+        if (eventGenre != null && eventGenre.getFormat() != null) {
+            java.util.regex.Matcher m = java.util.regex.Pattern.compile("^(\\d+)v\\d+$", java.util.regex.Pattern.CASE_INSENSITIVE)
+                .matcher(eventGenre.getFormat());
+            if (m.matches()) {
+                int required = Integer.parseInt(m.group(1));
+                if (dto.memberParticipantIds.size() != required) {
+                    throw new RuntimeException("Crew size must be " + required + " for " + eventGenre.getFormat() + " format");
+                }
+            }
+        }
+
+        // Validate all members are solo pickup entries (format=null) and not already in a crew
+        for (Long participantId : dto.memberParticipantIds) {
+            EventGenreParticipantId egpId = new EventGenreParticipantId(
+                event.getEventId(), genre.getGenreId(), participantId);
+            EventGenreParticipant egp = egpRepo.findById(egpId).orElse(null);
+            if (egp == null) throw new RuntimeException("Participant " + participantId + " is not registered in this genre");
+            if (egp.getFormat() != null) throw new RuntimeException("Participant " + participantId + " is a pre-formed team entry, not a solo pickup");
+            if (crewRepo.countMemberInEventGenre(event, genre, participantId) > 0) {
+                throw new RuntimeException("Participant " + participantId + " is already in a crew for this genre");
+            }
+        }
+
+        PickupCrew crew = new PickupCrew();
+        crew.setEvent(event);
+        crew.setGenre(genre);
+        crew.setCrewName(dto.crewName);
+        crew = crewRepo.save(crew);
+
+        List<PickupCrewMember> members = new ArrayList<>();
+        for (Long participantId : dto.memberParticipantIds) {
+            Participant participant = participantRepo.findById(participantId).orElseThrow();
+            PickupCrewMember member = new PickupCrewMember();
+            member.setCrew(crew);
+            member.setParticipant(participant);
+            members.add(member);
+        }
+        crew.setMembers(members);
+        crew = crewRepo.save(crew);
+
+        // Return as DTO
+        GetPickupCrewDto result = new GetPickupCrewDto();
+        result.id = crew.getId();
+        result.crewName = crew.getCrewName();
+        result.members = new ArrayList<>();
+        for (PickupCrewMember m : crew.getMembers()) {
+            GetPickupCrewDto.MemberDto memberDto = new GetPickupCrewDto.MemberDto();
+            memberDto.participantId = m.getParticipant().getParticipantId();
+            EventGenreParticipantId egpId = new EventGenreParticipantId(
+                event.getEventId(), genre.getGenreId(), m.getParticipant().getParticipantId());
+            EventGenreParticipant egp = egpRepo.findById(egpId).orElse(null);
+            memberDto.displayName = egp != null ? egp.getDisplayName() : m.getParticipant().getParticipantName();
+            result.members.add(memberDto);
+        }
+        result.avgScore = null;
+        return result;
+    }
+
+    @Transactional
+    public void deleteCrew(Long crewId) {
+        crewRepo.deleteById(crewId);
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/RegistrationService.java
+++ b/BES/src/main/java/com/example/BES/services/RegistrationService.java
@@ -15,6 +15,7 @@ import com.example.BES.dtos.AddParticipantToEventDto;
 import com.example.BES.dtos.GetUnverifiedParticipantDto;
 import com.example.BES.dtos.VerifyParticipantDto;
 import com.example.BES.models.Event;
+import com.example.BES.models.EventGenre;
 import com.example.BES.models.EventGenreParticipant;
 import com.example.BES.models.EventGenreParticipantId;
 import com.example.BES.models.EventParticipant;
@@ -23,6 +24,7 @@ import com.example.BES.models.Genre;
 import com.example.BES.models.Participant;
 import com.example.BES.utils.ReferenceCodeUtil;
 import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
 import com.example.BES.respositories.EventParticipantRepo;
 import com.example.BES.respositories.EventParticipantTeamMemberRepo;
 import com.example.BES.respositories.EventRepo;
@@ -62,6 +64,9 @@ public class RegistrationService {
 
     @Autowired
     GenreRepo genreRepo;
+
+    @Autowired
+    EventGenreRepo eventGenreRepo;
 
     public void addParticipantToEvent(AddParticipantToEventDto dto)
     throws IOException, MessagingException, WriterException {
@@ -126,13 +131,26 @@ public class RegistrationService {
                         egp.setGenre(genre);
                         egp.setParticipant(toAddParticipant);
 
-                        String format = participant.getGenreFormats() != null
+                        String rawFormat = participant.getGenreFormats() != null
                             ? participant.getGenreFormats().getOrDefault(genreName, null)
                             : null;
+                        boolean isTeamEntry = isTeamFormat(rawFormat)
+                            && ((participant.getTeamName() != null && !participant.getTeamName().isBlank())
+                                || (participant.getMemberNames() != null && !participant.getMemberNames().isEmpty()));
+                        String format = isTeamEntry ? rawFormat : (isTeamFormat(rawFormat) ? null : rawFormat);
                         egp.setFormat(format);
                         egp.setDisplayName(isTeamFormat(format)
                             ? orElse(participant.getTeamName(), participant.getParticipantName())
                             : orElse(participant.getStageName(), participant.getParticipantName()));
+
+                        // Backfill EventGenre.format from sheet data if not already set
+                        if (rawFormat != null && !rawFormat.isBlank()) {
+                            EventGenre eg = eventGenreRepo.findByEventAndGenre(event, genre).orElse(null);
+                            if (eg != null && eg.getFormat() == null) {
+                                eg.setFormat(rawFormat);
+                                eventGenreRepo.save(eg);
+                            }
+                        }
 
                         eventGenreParticipantRepo.save(egp);
                         egps.add(egp);

--- a/BES/src/main/java/com/example/BES/services/RegistrationService.java
+++ b/BES/src/main/java/com/example/BES/services/RegistrationService.java
@@ -131,26 +131,20 @@ public class RegistrationService {
                         egp.setGenre(genre);
                         egp.setParticipant(toAddParticipant);
 
-                        String rawFormat = participant.getGenreFormats() != null
-                            ? participant.getGenreFormats().getOrDefault(genreName, null)
-                            : null;
-                        boolean isTeamEntry = isTeamFormat(rawFormat)
+                        // Always use the format configured in the web portal (EventGenre.format)
+                        // — never rely on sheet cell format strings (e.g. "Hip Hop 1v1")
+                        // so all registration paths (sheet, walk-in, QR) share the same pool.
+                        EventGenre eg = eventGenreRepo.findByEventAndGenre(event, genre).orElse(null);
+                        String effectiveFormat = eg != null ? eg.getFormat() : null;
+
+                        boolean isTeamEntry = isTeamFormat(effectiveFormat)
                             && ((participant.getTeamName() != null && !participant.getTeamName().isBlank())
                                 || (participant.getMemberNames() != null && !participant.getMemberNames().isEmpty()));
-                        String format = isTeamEntry ? rawFormat : (isTeamFormat(rawFormat) ? null : rawFormat);
+                        String format = isTeamEntry ? effectiveFormat : (isTeamFormat(effectiveFormat) ? null : effectiveFormat);
                         egp.setFormat(format);
                         egp.setDisplayName(isTeamFormat(format)
                             ? orElse(participant.getTeamName(), participant.getParticipantName())
                             : orElse(participant.getStageName(), participant.getParticipantName()));
-
-                        // Backfill EventGenre.format from sheet data if not already set
-                        if (rawFormat != null && !rawFormat.isBlank()) {
-                            EventGenre eg = eventGenreRepo.findByEventAndGenre(event, genre).orElse(null);
-                            if (eg != null && eg.getFormat() == null) {
-                                eg.setFormat(rawFormat);
-                                eventGenreRepo.save(eg);
-                            }
-                        }
 
                         eventGenreParticipantRepo.save(egp);
                         egps.add(egp);

--- a/BES/src/main/java/com/example/BES/services/RegistrationService.java
+++ b/BES/src/main/java/com/example/BES/services/RegistrationService.java
@@ -18,11 +18,13 @@ import com.example.BES.models.Event;
 import com.example.BES.models.EventGenreParticipant;
 import com.example.BES.models.EventGenreParticipantId;
 import com.example.BES.models.EventParticipant;
+import com.example.BES.models.EventParticipantTeamMember;
 import com.example.BES.models.Genre;
 import com.example.BES.models.Participant;
 import com.example.BES.utils.ReferenceCodeUtil;
 import com.example.BES.respositories.EventGenreParticpantRepo;
 import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.EventParticipantTeamMemberRepo;
 import com.example.BES.respositories.EventRepo;
 import com.example.BES.respositories.GenreRepo;
 import com.example.BES.respositories.ParticipantRepo;
@@ -56,6 +58,9 @@ public class RegistrationService {
     EventGenreParticpantRepo eventGenreParticipantRepo;
 
     @Autowired
+    EventParticipantTeamMemberRepo teamMemberRepo;
+
+    @Autowired
     GenreRepo genreRepo;
 
     public void addParticipantToEvent(AddParticipantToEventDto dto)
@@ -75,8 +80,8 @@ public class RegistrationService {
                 if (!ep.isPaymentVerified()) continue; // Case C: waiting for manual verification
                 // Case B: payment verified but email not yet sent — retry
                 try {
-                    List<EventGenreParticipantId> ids = getIdsForParticipant(event.getEventId(), toAddParticipant.getParticipantId());
-                    mailService.sendEmailWithAttachment(dto.eventName, toAddParticipant, ids, ep.getReferenceCode(), ep.getDisplayName());
+                    List<EventGenreParticipant> egps = getEgpsForParticipant(event.getEventId(), toAddParticipant.getParticipantId());
+                    mailService.sendEmailWithAttachment(dto.eventName, toAddParticipant, ep, egps, ep.getReferenceCode());
                     ep.setEmailSent(true);
                     eventParticipantRepo.save(ep);
                 } catch (Exception e) {
@@ -87,7 +92,9 @@ public class RegistrationService {
                 ep = new EventParticipant();
                 ep.setParticipant(toAddParticipant);
                 ep.setEvent(event);
-                ep.setDisplayName(participant.getParticipantName());
+                ep.setStageName(participant.getStageName());
+                ep.setTeamName(participant.getTeamName());
+                ep.setDisplayName(resolveEmailDisplayName(participant));
                 ep.setResidency(participant.getResidency());
                 ep.setGenre(participant.getGenres() != null ? String.join(", ", participant.getGenres()) : "");
                 ep.setPaymentVerified(!event.isPaymentRequired());
@@ -95,37 +102,51 @@ public class RegistrationService {
                 ep.setScreenshotUrl(participant.getScreenshotUrl());
                 ep.setReferenceCode(ReferenceCodeUtil.generate());
 
-                // Save EP before sending email (DB state first)
+                // Save EP before saving team members (need EP id)
                 eventParticipantRepo.save(ep);
 
+                // Save team member records
+                if (participant.getMemberNames() != null && !participant.getMemberNames().isEmpty()) {
+                    for (String memberName : participant.getMemberNames()) {
+                        teamMemberRepo.save(new EventParticipantTeamMember(ep, memberName));
+                    }
+                }
+
                 // Save EGP entries
-                List<EventGenreParticipantId> ids = new ArrayList<>();
+                List<EventGenreParticipant> egps = new ArrayList<>();
                 if (participant.getGenres() != null) {
                     for (String genreName : participant.getGenres()) {
                         Genre genre = genreRepo.findByGenreName(genreName.toLowerCase()).orElse(null);
                         if (genre == null) continue;
                         EventGenreParticipantId id = new EventGenreParticipantId(
                             event.getEventId(), genre.getGenreId(), toAddParticipant.getParticipantId());
-                        ids.add(id);
                         EventGenreParticipant egp = new EventGenreParticipant();
                         egp.setId(id);
                         egp.setEvent(event);
                         egp.setGenre(genre);
                         egp.setParticipant(toAddParticipant);
-                        egp.setDisplayName(participant.getParticipantName());
+
+                        String format = participant.getGenreFormats() != null
+                            ? participant.getGenreFormats().getOrDefault(genreName, null)
+                            : null;
+                        egp.setFormat(format);
+                        egp.setDisplayName(isTeamFormat(format)
+                            ? orElse(participant.getTeamName(), participant.getParticipantName())
+                            : orElse(participant.getStageName(), participant.getParticipantName()));
+
                         eventGenreParticipantRepo.save(egp);
+                        egps.add(egp);
                     }
                 }
 
-                // Send email only if payment verified
-                if (ep.isPaymentVerified() && !ids.isEmpty()) {
+                // Send email only if payment verified and EGPs exist
+                if (ep.isPaymentVerified() && !egps.isEmpty()) {
                     try {
-                        mailService.sendEmailWithAttachment(dto.eventName, toAddParticipant, ids, ep.getReferenceCode(), ep.getDisplayName());
+                        mailService.sendEmailWithAttachment(dto.eventName, toAddParticipant, ep, egps, ep.getReferenceCode());
                         ep.setEmailSent(true);
                         eventParticipantRepo.save(ep);
                     } catch (Exception e) {
                         log.error("Failed to send email for {}", toAddParticipant.getParticipantEmail(), e);
-                        // emailSent stays false; will retry on next import run
                     }
                 }
             }
@@ -145,8 +166,8 @@ public class RegistrationService {
         ep.setPaymentVerified(true);
 
         if (!ep.isEmailSent()) {
-            List<EventGenreParticipantId> ids = getIdsForParticipant(eventId, participantId);
-            mailService.sendEmailWithAttachment(event.getEventName(), participant, ids, ep.getReferenceCode(), ep.getDisplayName());
+            List<EventGenreParticipant> egps = getEgpsForParticipant(eventId, participantId);
+            mailService.sendEmailWithAttachment(event.getEventName(), participant, ep, egps, ep.getReferenceCode());
             ep.setEmailSent(true);
         }
 
@@ -182,10 +203,25 @@ public class RegistrationService {
         return result;
     }
 
-    private List<EventGenreParticipantId> getIdsForParticipant(long eventId, long participantId) {
-        return eventGenreParticipantRepo.findByEventIdAndParticipantId(eventId, participantId)
-            .stream()
-            .map(EventGenreParticipant::getId)
-            .collect(Collectors.toList());
+    private List<EventGenreParticipant> getEgpsForParticipant(long eventId, long participantId) {
+        return eventGenreParticipantRepo.findByEventIdAndParticipantId(eventId, participantId);
+    }
+
+    /** A format is "team" if it is non-null and not "1v1". */
+    private boolean isTeamFormat(String format) {
+        return format != null && !format.equalsIgnoreCase("1v1");
+    }
+
+    /** Returns preferred if non-blank, otherwise fallback. */
+    private String orElse(String preferred, String fallback) {
+        return (preferred != null && !preferred.isBlank()) ? preferred : fallback;
+    }
+
+    /** Email display name: always the individual (stageName → participantName). */
+    private String resolveEmailDisplayName(AddParticipantDto dto) {
+        if (dto.getStageName() != null && !dto.getStageName().isBlank()) {
+            return dto.getStageName();
+        }
+        return dto.getParticipantName();
     }
 }

--- a/BES/src/main/java/com/example/BES/services/ResultsService.java
+++ b/BES/src/main/java/com/example/BES/services/ResultsService.java
@@ -69,6 +69,7 @@ public class ResultsService {
 
             genreResults.add(new GetResultsDto.GenreResult(
                 egp.getGenre().getGenreName(),
+                egp.getFormat(),
                 egp.getAuditionNumber(),
                 scoreEntries,
                 feedbackEntries

--- a/BES/src/main/java/com/example/BES/services/ScoreService.java
+++ b/BES/src/main/java/com/example/BES/services/ScoreService.java
@@ -36,12 +36,14 @@ public class ScoreService {
         for (Score s : scoreList) {
             if (s.getJudge() == null || s.getEventGenreParticipant() == null) continue;
             GetParticipatnScoreDto dto = new GetParticipatnScoreDto();
+            dto.participantId = s.getEventGenreParticipant().getId().getParticipantId();
             dto.eventName = s.getEventGenreParticipant().getEvent().getEventName();
             dto.genreName = s.getEventGenreParticipant().getGenre().getGenreName();
             dto.judgeName = s.getJudge().getName();
             dto.participantName = s.getEventGenreParticipant().getDisplayName();
             dto.score = s.getValue();
             dto.aspect = s.getAspect() != null ? s.getAspect() : "";
+            dto.format = s.getEventGenreParticipant().getFormat();
             scoreListDto.add(dto);
         }
         return scoreListDto;

--- a/BES/src/main/resources/db/migration/V14__add_stage_team_format_fields.sql
+++ b/BES/src/main/resources/db/migration/V14__add_stage_team_format_fields.sql
@@ -1,0 +1,15 @@
+-- Individual stage name (display name for 1v1 categories)
+ALTER TABLE event_participant ADD COLUMN stage_name VARCHAR(255);
+
+-- Team name (display name for team categories: 2v2, 3v3, 4v4, 5v5)
+ALTER TABLE event_participant ADD COLUMN team_name VARCHAR(255);
+
+-- Variable-size team member list (beyond the team leader)
+CREATE TABLE event_participant_team_member (
+    id                   BIGSERIAL PRIMARY KEY,
+    event_participant_id BIGINT NOT NULL REFERENCES event_participant(id) ON DELETE CASCADE,
+    member_name          VARCHAR(255) NOT NULL
+);
+
+-- Battle format per genre (e.g. "1v1", "2v2", "3v3", null = unspecified)
+ALTER TABLE event_genre_participant ADD COLUMN format VARCHAR(20);

--- a/BES/src/main/resources/db/migration/V15__add_format_to_event_genre.sql
+++ b/BES/src/main/resources/db/migration/V15__add_format_to_event_genre.sql
@@ -1,0 +1,15 @@
+-- Battle format at the event-genre level (e.g. "1v1", "2v2", "3v3")
+ALTER TABLE event_genre ADD COLUMN IF NOT EXISTS format VARCHAR(20);
+
+-- Backfill from existing event_genre_participant data (most common format per event-genre)
+UPDATE event_genre eg
+SET format = (
+    SELECT egp.format
+    FROM event_genre_participant egp
+    WHERE egp.event_id = eg.event_id
+      AND egp.genre_id = eg.genre_id
+      AND egp.format IS NOT NULL
+    GROUP BY egp.format
+    ORDER BY COUNT(*) DESC
+    LIMIT 1
+);

--- a/BES/src/main/resources/db/migration/V16__add_pickup_crew.sql
+++ b/BES/src/main/resources/db/migration/V16__add_pickup_crew.sql
@@ -1,0 +1,13 @@
+CREATE TABLE pickup_crew (
+    id          BIGSERIAL PRIMARY KEY,
+    event_id    BIGINT NOT NULL REFERENCES event(event_id),
+    genre_id    BIGINT NOT NULL REFERENCES genre(genre_id),
+    crew_name   VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE pickup_crew_member (
+    id             BIGSERIAL PRIMARY KEY,
+    crew_id        BIGINT NOT NULL REFERENCES pickup_crew(id) ON DELETE CASCADE,
+    participant_id BIGINT NOT NULL REFERENCES participant(participant_id),
+    UNIQUE (crew_id, participant_id)
+);

--- a/BES/src/test/java/com/example/BES/controllers/EventControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/EventControllerIntegrationTest.java
@@ -150,7 +150,7 @@ public class EventControllerIntegrationTest {
         egp.setParticipant(p);
 
         when(participantService.addWalkInService(any())).thenReturn(p);
-        when(eventParticipantService.addNewWalkInInEventService(any(), any(), any())).thenReturn(ep);
+        when(eventParticipantService.addNewWalkInInEventService(any(), any(), any(), any(), any())).thenReturn(ep);
         when(eventGenreParticipantService.addWalkInToEventGenreParticipant(any(), any(), any(), any())).thenReturn(egp);
 
         mockMvc.perform(post("/api/v1/event/walkins/")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,19 @@ Vue 3 frontend  →  Nginx (reverse proxy)  →  Spring Boot backend (port 5050)
 | `utils/useScrollReveal.js` | Scroll-reveal animation composable |
 | `router/index.js` | Client-side routes with RBAC guards |
 
+### Navigation Architecture
+
+**Navbar** (`App.vue`) uses a 3-column grid: Logo (left) · Primary nav (center) · Utilities (right).
+
+- **Primary nav** (center): Home · Events · Admin only — kept minimal
+- **Event chip** (right): Active event dropdown that doubles as section nav — contains Audition, Participants, Scoreboard, Battle links (role-filtered) + "Change Event". Do NOT add event-specific pages back as top-level nav items.
+- **Event switching**: `changeEvent()` always passes `?redirect=<currentPath>` so EventSelector returns the user to the same page after switching.
+
+**EventCard** (`components/EventCard.vue`):
+- Hover (desktop) or tap (mobile) reveals an absolute-positioned action panel that overlaps content below without affecting grid layout
+- `expandedId` state is lifted to `Events.vue` — only one card expands at a time. Cards emit `toggle`; parent manages which is open. Do not move this state back into the card.
+- Action buttons: Details → `/events/:name`, Audition/Participants/Score/Battle → calls `setActiveEvent()` then navigates directly
+
 ### Testing
 
 - **Backend**: JUnit 5 + Spring Boot Test + MockMvc; uses H2 in-memory DB via `@ActiveProfiles("test")`
@@ -215,6 +228,8 @@ Scoring only:
 | Pickup crew formation | `/event/crew-formation` | Form named crews from individual participants |
 | Access code | `EventDetails` | Per-event access code, visible to organiser |
 | Judging mode | `EventDetails` | Default (single score) or custom criteria mode |
+| Judge scoring card | `SwipeableCardsV2` | Minimal padding for mobile; `py-4` keypad buttons, `w-[97%]` card width, `p-2` card padding — do not increase these |
+| Event selector grid | `EventSelector` | ≤4 events → 1 col, 5+ events → 2-col grid; no scroll. Always passes `?redirect=` back to originating page |
 
 ## Frontend Design System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-**BES (Battle Event System)** — a full-stack web app for managing dance battle events (registration, judging, scoring, real-time battle control).
+**BES (Battle Event System)** — a full-stack web app for managing dance battle events (registration, judging, scoring, real-time battle control, results portal).
 
 ## Commands
 
@@ -31,7 +31,7 @@ npm run test:coverage # With coverage
 ### Docker (from root)
 
 ```bash
-docker-compose up --build   # Build and start all services
+docker-compose up --build --no-cache   # Build and start all services (always use --no-cache)
 # backend → port 5050, frontend → ports 80/443, postgres → port 5433
 ```
 
@@ -54,10 +54,10 @@ Vue 3 frontend  →  Nginx (reverse proxy)  →  Spring Boot backend (port 5050)
 
 | Package | Purpose |
 |---------|---------|
-| `controllers/` | 7 REST controllers under `/api/v1/` |
-| `services/` | 16 business logic services |
+| `controllers/` | 9 REST controllers under `/api/v1/` |
+| `services/` | 21 business logic services |
 | `respositories/` | Spring Data JPA repos |
-| `models/` | 11 JPA entities → PostgreSQL tables |
+| `models/` | 19 JPA entities → PostgreSQL tables |
 | `dtos/` | ~40 request/response DTOs |
 | `config/` | Security, CORS, WebSocket, Google API config |
 | `mapper/` | Entity ↔ DTO converters |
@@ -67,24 +67,46 @@ Vue 3 frontend  →  Nginx (reverse proxy)  →  Spring Boot backend (port 5050)
 | Controller | Base Path | Purpose |
 |-----------|-----------|---------|
 | `AuthController` | `/api/v1/auth` | Login, logout, session check |
-| `EventController` | `/api/v1/event` | CRUD events, participants, scores, genres |
-| `BattleController` | `/api/v1/battle` | Battle mode, voting, judges, images |
-| `AdminController` | `/api/v1/admin` | Admin CRUD for genres, judges, scores |
+| `EventController` | `/api/v1/event` | CRUD events, participants, scores, genres, scoring criteria, feedback, pickup crews |
+| `BattleController` | `/api/v1/battle` | Battle mode, voting, judges, images, battle phase state machine |
+| `AdminController` | `/api/v1/admin` | Admin CRUD for genres, judges, scores, feedback groups/tags |
+| `ResultsController` | `/api/v1/results` | Public results by reference code, QR access |
+| `SecurityController` | `/api/v1/security` | CSRF token endpoint |
 | `GoogleDriveFileController` | `/api/v1/files` | Google Drive file listing |
 | `GoogleDriveFolderController` | `/api/v1/folders` | Google Drive folder listing |
 | `GoogleSheetsController` | `/api/v1/sheets` | Google Sheets participant import |
+
+**Key Models:**
+
+| Model | Purpose |
+|-------|---------|
+| `Event` | Event with access code, payment flag, judging mode, results release toggle |
+| `EventParticipant` | Participant linked to event; supports walk-ins, stage name, team format, display name |
+| `EventParticipantTeamMember` | Individual member rows for team entries |
+| `EventGenre` | Genre linked to event with format field |
+| `EventGenreParticipant` | Participant-genre junction with audition number |
+| `Score` | Single overall score per judge/participant/genre |
+| `ScoringCriteria` | Named weighted criteria per event/genre (custom scoring mode) |
+| `AuditionFeedback` | Judge feedback per participant/genre with tags and note |
+| `FeedbackTag` / `FeedbackTagGroup` | Configurable tag taxonomy for feedback |
+| `PickupCrew` / `PickupCrewMember` | Ad-hoc crews formed from individual participants |
+| `EventEmailTemplate` | Customisable per-event email subject/body |
 
 ### Frontend Layout (`BES-frontend/src/`)
 
 | Path | Purpose |
 |------|---------|
-| `views/` | 14 page-level components (Login, MainMenu, BattleControl, etc.) |
-| `components/` | 18 reusable UI components |
-| `utils/api.js` | ~40 frontend→backend fetch functions |
-| `utils/adminApi.js` | ~10 admin-specific API functions |
-| `utils/websocket.js` | WebSocket/STOMP setup |
+| `views/` | 19 page-level components (see Routes section) |
+| `components/` | 22 reusable UI components |
+| `utils/api.js` | ~65 frontend→backend fetch functions |
+| `utils/adminApi.js` | ~14 admin-specific API functions |
+| `utils/auth.js` | Pinia auth store + active event helpers |
 | `utils/battleLogic.js` | Battle game logic |
-| `router/index.js` | Client-side routes |
+| `utils/websocket.js` | WebSocket/STOMP setup |
+| `utils/eventUtils.js` | Shared event/genre helpers |
+| `utils/dropdown.js` | Dropdown state utilities |
+| `utils/useScrollReveal.js` | Scroll-reveal animation composable |
+| `router/index.js` | Client-side routes with RBAC guards |
 
 ### Testing
 
@@ -105,11 +127,94 @@ Vue 3 frontend  →  Nginx (reverse proxy)  →  Spring Boot backend (port 5050)
 
 - File naming: `V{version}__{description}.sql` (double underscore, snake_case description)
 - Always add new migrations as new files — never edit existing ones
-- Next version after `V1__baseline.sql` would be `V2__...`
+- Latest migration: `V16__add_pickup_crew.sql` → next is `V17__...`
 
 ### Layer Modification Order
 
 **Always modify bottom-up**: DB migration → JPA entity → service → controller → DTO → frontend API call. Never change the frontend API contract without updating the backend first.
+
+## Routes & Access by Role
+
+Public routes (no authentication required):
+
+| Route | View | Purpose |
+|-------|------|---------|
+| `/login` | `Login` | Login page |
+| `/results` | `Results` | Public results portal (enter reference code) |
+| `/results-qr` | `ResultsQR` | Results via QR scan |
+| `/battle/overlay` | `BattleOverlay` | Stream overlay (OBS/broadcast display) |
+| `/battle/judge` | `BattleJudge` | Battle judge voting screen |
+| `/battle/chart` | `Chart` | 7-to-Smoke live chart |
+| `/battle/bracket` | `BracketVisualization` | Live bracket with winner animation + LED ticker |
+| `/event/select` | `EventSelector` | Select active event (redirected here if no event set) |
+
+Authenticated routes (role-gated):
+
+| Route | Roles | View | Purpose |
+|-------|-------|------|---------|
+| `/` | all | `MainMenu` | Role-filtered quick-action home |
+| `/events` | Admin, Organiser | `Events` | Event list with search |
+| `/events/:eventName` | Admin, Organiser | `EventDetails` | Event overview, genre accordion, Google Drive setup |
+| `/event/audition-number` | Admin, Organiser | `AuditionNumber` | Display audition number on screen |
+| `/event/update-event-details` | Admin, Organiser | `UpdateEventDetails` | Participant table, judge assignment, verification, payment |
+| `/event/audition-list` | Admin, Organiser, Emcee, Judge | `AuditionList` | Role-split view: Judge scores / Emcee timer+status |
+| `/event/score` | Admin, Organiser, Emcee | `Score` | Scoreboard with podium top-3 and by-judge breakdown |
+| `/event/crew-formation` | Admin, Organiser | `CrewFormation` | Form pickup crews from individual participants |
+| `/battle/control` | Admin, Organiser | `BattleControl` | Bracket seeding, battle phases, live match control |
+| `/admin` | Admin only | `AdminPage` | Genre/judge/image/feedback-tag CRUD |
+
+## Workflow by Role
+
+### Admin
+Full access to everything. Also manages global resources on `/admin`: genres, judges, images, and feedback tag groups/tags used across all events.
+
+### Organiser
+Event lifecycle end-to-end:
+1. Create event on `/events` (link Google Drive folder, add genres)
+2. Import participants from Google Sheets or add walk-ins on `EventDetails`
+3. Manage participants on `/event/update-event-details` — assign judges, verify & email, track payment, set stage names/team format
+4. Customise per-event email template
+5. Configure scoring criteria per genre (default single score or weighted multi-criteria)
+6. Run audition day: monitor `/event/audition-list`, check `/event/score` scoreboard
+7. Form pickup crews from individuals on `/event/crew-formation`
+8. Battle day: seed bracket on `/battle/control`, manage battle phases (IDLE → LOCKED → VOTING → REVEALED), watch `/battle/bracket` and `/battle/overlay` for stream
+9. Release results on `/event/score` → results become visible on public `/results` portal via reference code/QR
+
+### Emcee
+Event-day read/announce role:
+- `/event/audition-list` — timer, participant status (scored/unscored), swipe through rounds with `EmceeRoundView`
+- `/event/score` — live scoreboard to announce standings
+
+### Judge
+Scoring only:
+- `/event/audition-list` — `SwipeableCardsV2` score entry (whole + decimal keypads), per-aspect scoring if custom criteria are set, submit audition feedback tags + note via `FeedbackPopout`
+- `/battle/judge` — vote for a battler during VOTING phase; result revealed on REVEALED phase
+
+### Public (no login)
+- `/results` or `/results-qr` — participants look up their own results using a reference code (released by organiser)
+- `/battle/overlay` — OBS browser source for stream
+- `/battle/bracket` — projector/audience bracket display with live winner animation and LED ticker
+- `/battle/chart` — 7-to-Smoke cumulative battle chart
+
+## Feature Overview
+
+| Feature | Location | Notes |
+|---------|----------|-------|
+| Google Sheets import | `EventDetails`, `GoogleSheetsController` | Imports stage name, team format, member roster |
+| Walk-in registration | `EventDetails` → `addWalkinToSystem` | Supports team members, team name |
+| Participant verification + email | `UpdateEventDetails` | Verify individually or batch; uses `EventEmailTemplate` |
+| Payment tracking | `UpdateEventDetails` | Per-participant payment flag |
+| Custom scoring criteria | `ScoringCriteriaModal` / `ScoringCriteriaPanel` | Weighted criteria per event/genre; judge scores per aspect |
+| Audition feedback | `FeedbackPopout` | Tags (grouped taxonomy) + free-text note per judge/participant |
+| Results portal | `/results`, `/results-qr` | Reference code or QR; organiser controls release toggle |
+| Battle phase state machine | `BattleControl` | IDLE → LOCKED → VOTING → REVEALED via WebSocket |
+| Bracket seeding | `BattleControl` | By Rank (asc/desc), High↔Low pairing, Random; slot-picker UI |
+| Tie-breaker persistence | `Score` + localStorage | Tie-breaker selections survive page refresh, scoped per event/genre |
+| Live bracket visualization | `/battle/bracket` | Winner animations, LED ticker |
+| 7-to-Smoke format | `/battle/chart` | Cumulative smoke chart |
+| Pickup crew formation | `/event/crew-formation` | Form named crews from individual participants |
+| Access code | `EventDetails` | Per-event access code, visible to organiser |
+| Judging mode | `EventDetails` | Default (single score) or custom criteria mode |
 
 ## Frontend Design System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,42 +238,43 @@ All frontend work must follow this design system consistently across every compo
 ### Color Tokens (defined in `base.css` `@theme`)
 | Role | Token | Hex |
 |------|-------|-----|
-| Primary | `primary-500` | `#06b6d4` (cyan) |
-| Primary Dark | `primary-600/700` | `#0891b2 / #0e7490` |
-| Accent | `secondary-500` | `#f97316` (orange) |
-| Surface Dark | `surface-900` | `#0f172a` (deep navy) |
-| Surface Mid | `surface-700/800` | `#334155 / #1e293b` |
-| Surface Light | `surface-50/100` | `#f8fafc / #f1f5f9` |
-| Content | white | `#ffffff` |
+| Primary | `primary-500` | `#e53935` (red) |
+| Primary Dark | `primary-600/700` | `#c62828 / #b71c1c` |
+| Primary Text (dark mode) | `primary-400` | `#f87171` (light red) |
+| Accent | `accent-500` | `#f97316` (orange) |
+| Surface Dark | `surface-900` | `#111111` (near-black) |
+| Surface Card | `surface-800` | `#1a1a1a` |
+| Surface Border | `surface-600/700` | `#2c2c2c / #222222` |
+| Content | `content-primary` | `#f0f0f0` (off-white) |
 
 ### Typography
 | Use | Font | Class |
 |-----|------|-------|
 | Body / UI | Inter | `font-sans` |
 | Headings | Outfit | `font-heading` |
-| Numbers / Code | Source Code Pro | `font-source` |
+| Numbers / Code | JetBrains Mono | `font-source` |
 | Display titles | Anton SC | `font-anton` |
 
 ### Spacing & Shape
 - Border radius: `rounded-xl` (inputs, cards) · `rounded-2xl` (panels, modals) · `rounded-full` (badges, pills)
-- Card style: `bg-white rounded-2xl border border-surface-200/80 shadow-sm`
+- Card style: `bg-surface-800 rounded-2xl border border-surface-700`
 - Page container: `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8`
 - Navbar height offset: `h-16` (64px)
 
 ### Colour Usage Rules (60-30-10)
-- **60% Neutral** — `surface-*` for backgrounds, borders, text hierarchy
-- **30% Structure** — `surface-800/900` + white for nav, headers, dark surfaces
-- **10% Brand** — `primary-*` (cyan) for ALL interactive elements only
+- **60% Neutral** — `surface-*` for backgrounds, borders, text hierarchy (true neutral blacks/grays — no blue tinting)
+- **30% Structure** — `surface-800/900` + `content-primary` for nav, headers, dark surfaces
+- **10% Brand** — `primary-*` (red) for ALL interactive elements only
 - **Semantic** — emerald=success, amber=warning, red=error — functional use only, never decorative
 - **Orange `accent-*`** — medals/rankings ONLY; never buttons, nav, or role badges
-- **Button secondary** → `bg-surface-800 text-white` (dark navy, not orange)
-- **Role badges** → all use `bg-surface-100 text-surface-600 border-surface-200` (label is differentiator)
+- **Button secondary** → `bg-surface-600 text-content-primary` (neutral dark, not orange)
+- **Role badges** → all use `bg-surface-700 text-content-secondary border-surface-600` (label is differentiator)
 
 ### Interaction States
-- Active nav item: `bg-primary-500 text-white` (filled cyan pill)
+- Active nav item: `bg-primary-500 text-white` (filled red pill)
 - Button active: `active:scale-95`
 - Focus ring: `focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500`
-- Row hover: `hover:bg-primary-50` or `hover:bg-surface-50`
+- Row hover: `hover:bg-primary-50` or `hover:bg-surface-700`
 
 ### Target Audience UX Rules
 - **Judges**: Large touch targets (min 48px), very large font for scores/numbers, minimal steps to complete a score

--- a/Product_roadmapv2.md
+++ b/Product_roadmapv2.md
@@ -1,0 +1,264 @@
+# Documentation Task: Write Plans
+
+---
+
+## File 1: FEATURE_5_BRACKET_VISUALIZATION.md
+
+### Content to write:
+
+```markdown
+# Feature 5: Bracket Visualization — Implementation Plan
+
+## Context
+BattleControl.vue manages the full bracket lifecycle (seeding, match progression,
+winner advancement) but state only lives in the organiser's browser localStorage.
+Spectators, participants, and emcees have no way to see the bracket. This adds a
+live public view at /battle/bracket that mirrors BattleControl in real time via WebSocket.
+
+## Architecture
+BattleControl.vue → POST /api/v1/battle/bracket → BattleService (in-memory)
+                                                         ↓ broadcast
+                                              /topic/battle/bracket
+                                                         ↓
+                                          BracketVisualization.vue (public, no login)
+
+## Backend Changes
+1. New DTO: dtos/battle/SetBracketStateDto.java — fields: topSize (String), rounds (Object)
+2. BattleService — add bracketState field, getBracketState(), setBracketStateService(dto)
+   broadcasts to /topic/battle/bracket
+3. BattleController — GET /api/v1/battle/bracket (for page refresh) + POST (stores + broadcasts)
+
+## Frontend Changes
+4. api.js — add setBracketState(rounds, topSize), getBracketState()
+5. BattleControl.vue — add broadcastBracket() helper; call after:
+   - setWinner()
+   - clearWinner()
+   - updateMatch()
+   - applyToFirstRound()
+   - clearLocalStorage()
+6. router/index.js — add public route /battle/bracket → BracketVisualization.vue
+7. BracketVisualization.vue (NEW) — public page, subscribes to:
+   - /topic/battle/bracket       → re-render full bracket
+   - /topic/battle/battle-pair   → highlight active match (cyan glow)
+   - /topic/battle/score         → trigger winner animation
+
+## BracketVisualization UI Design
+- Dark background: bg-surface-900
+- Horizontal tree: Top{N} → Top{N/2} → ... → Top2 (Final), left to right
+- Each column = one round; each card: [left] vs [right]
+- Active match: border-primary-500 shadow-lg shadow-primary-500/20 (cyan glow)
+- Winner name: text-primary-500 font-bold | Loser: text-surface-500 line-through
+- Winner animation: scale-up burst on name → 800ms → winner slides into next slot
+  (Vue <Transition name="slide-in"> on new slot entry)
+- Connector lines: thin SVG/CSS lines between rounds (border-surface-600)
+- Smoke mode (topSize=7): queue list view with scores, not tree
+- On load: call getBracketState() REST as fallback before WS message
+
+## Verification
+1. Seed bracket in BattleControl → open /battle/bracket in another tab → names visible
+2. Click "Initiate Battle" → bracket page highlights that match in cyan
+3. Get Score → winner animates, advances to next round; highlight shifts on "Next Pair"
+4. Open on separate phone → same live state
+5. Refresh /battle/bracket → loads via REST fallback
+6. Smoke mode → queue view shown
+```
+
+---
+
+## File 2: FEATURE_6_BATTLE_FEEDBACK.md
+
+### Content to write:
+
+```markdown
+# Feature 6: Battle Feedback — Implementation Plan
+
+## Context
+BattleJudge.vue handles voting only. After a winner is announced, judges have
+no structured way to leave feedback for either battler. This adds a popup feedback
+panel triggered by the winner announcement, reusing the FeedbackTag system.
+
+## Problem
+- BattleJudge.vue cannot see the current pair (no /topic/battle/battle-pair subscription)
+- No post-battle feedback mechanism exists
+- Feedback model (AuditionFeedback) exists but is tied to EventGenreParticipant (audition context)
+- Battles are in-memory (battler names, no EGP FK) — need a separate BattleFeedback entity
+
+## Proposed UX
+When /topic/battle/score fires with winner (0 or 1):
+1. BattleJudge.vue shows a full-screen feedback popup
+2. Popup has two sections: Winner (green border) + Loser (neutral border)
+3. Each section: battler name + FeedbackTag chips grouped by FeedbackTagGroup
+4. Judge taps 1–3 tags per section (optional)
+5. Optional free-text note per section
+6. "Submit Feedback" → POST both sections; popup closes
+7. "Skip" → popup closes, nothing saved; score/vote already persisted
+
+## Current Pair Visibility Fix (prerequisite)
+- BattleJudge.vue must subscribe to /topic/battle/battle-pair on mount
+- Store leftName / rightName in state
+- Display subtly in header: "NOW: [Left] vs [Right]"
+
+## Data Model: BattleFeedback (new entity)
+BattleFeedback:
+  id            Long (PK, auto)
+  judge         Judge (FK → judge)
+  battlerName   String   ← store name string (in-memory battles have no EGP FK)
+  battleResult  String   ← "winner" or "loser"
+  tags          Set<FeedbackTag> (ManyToMany → battle_feedback_tag join table)
+  note          String (nullable)
+  createdAt     LocalDateTime
+
+DB Migration (V{next}__add_battle_feedback.sql):
+  CREATE TABLE battle_feedback (
+    id            BIGSERIAL PRIMARY KEY,
+    judge_id      BIGINT NOT NULL REFERENCES judge(judge_id),
+    battler_name  VARCHAR(255) NOT NULL,
+    battle_result VARCHAR(50),
+    note          TEXT,
+    created_at    TIMESTAMP
+  );
+  CREATE TABLE battle_feedback_tag (
+    feedback_id BIGINT REFERENCES battle_feedback(id),
+    tag_id      BIGINT REFERENCES feedback_tag(id),
+    PRIMARY KEY (feedback_id, tag_id)
+  );
+
+## Backend Changes
+1. New model: BattleFeedback.java
+2. New repo: BattleFeedbackRepo.java
+3. New DTOs: SubmitBattleFeedbackDto (judgeId, battlerName, battleResult, tagIds[], note)
+             GetBattleFeedbackDto
+4. New service: BattleFeedbackService.java — submitFeedback(dto), getFeedbackByBattler(name)
+5. BattleController — add POST /api/v1/battle/feedback, GET /api/v1/battle/feedback?battler={name}
+
+## Frontend Changes
+6. api.js — add submitBattleFeedback(dto), reuse existing endpoint for FeedbackTagGroups
+7. BattleJudge.vue:
+   - Subscribe to /topic/battle/battle-pair → store leftName / rightName
+   - Subscribe to /topic/battle/score → when winner 0 or 1 → show feedback popup
+   - Render FeedbackTagGroup chips in popup
+   - On submit → POST /api/v1/battle/feedback for both battlers
+   - On skip → dismiss popup
+
+## Verification
+1. BattleControl announces winner → BattleJudge popup appears immediately
+2. Popup shows winner (green border) + loser with correct names
+3. FeedbackTagGroup chips render; multiple selectable
+4. Submit → rows in battle_feedback + battle_feedback_tag tables
+5. Skip → popup closes, no rows inserted
+6. Battler name pair visible in BattleJudge header during battle
+```
+
+---
+
+## File 3: BATTLE_FLOW_ROBUSTNESS.md
+
+### Content to write:
+
+```markdown
+# Battle Flow Robustness — Implementation Plan
+
+## Context
+The current battle flow (BattleControl → judge votes in BattleJudge → reveal score)
+works if handled with care but has no guardrails. Problems:
+- Judges have no signal for when voting is open — can accidentally vote early or late
+- BattleJudge voting buttons are always active (no phase-gating)
+- "Get Score" and "Reset Bracket" can be accidentally pressed
+- No clear phase display for Emcee / anyone watching the control interface
+- After a tie the re-initiation is not clearly communicated to judges
+
+## Goal
+Add a battle phase state machine that gates every interface. The organiser (BattleControl)
+controls phase transitions explicitly. Each interface (BattleJudge, BattleOverlay) reacts
+to phase changes automatically — zero coordination needed by voice.
+
+## Phase State Machine
+
+LOCKED → VOTING → REVEALED → LOCKED (next pair)
+   ↑                              |
+   └──────── Reset Bracket ───────┘ (→ IDLE)
+
+| Phase    | Who sees what |
+|----------|---------------|
+| IDLE     | Setup/bracket building phase. All voting locked |
+| LOCKED   | Pair announced. Overlay shows battler names. Judges see "NEXT UP: A vs B" but cannot vote |
+| VOTING   | Organiser opened voting. Judges can vote. BattleControl shows per-judge vote status |
+| REVEALED | Score revealed. Winner shown. Judges locked. Organiser sees "Next Pair" button only |
+
+## Phase Transitions (all triggered from BattleControl)
+- "Start Match" (initiateBattlePair) → automatically sets phase to LOCKED
+- New "Open Voting" button → sets phase to VOTING (replaces current always-available voting)
+- "Get Score" → available only in VOTING; on success → auto-sets phase to REVEALED
+- "Next Pair" → available only in REVEALED; on click → sets phase to LOCKED for next pair
+- Tie result → phase stays VOTING (judge re-votes; "Rematch" is just re-opening voting)
+- "Reset Bracket" → requires confirmation dialog → sets phase to IDLE
+
+## Backend Changes
+1. BattleService — add battlePhase field (String: "IDLE"/"LOCKED"/"VOTING"/"REVEALED")
+   Default: "IDLE"
+   Auto-transitions:
+     - setBattlerPair() called → force phase to "LOCKED" + broadcast
+     - setScoreService() returns winner (0 or 1) → force phase to "REVEALED" + broadcast
+     - setScoreService() returns -1 (tie) → keep VOTING, broadcast special tie message
+2. New endpoint: POST /api/v1/battle/phase { phase: "VOTING" | "LOCKED" | "IDLE" }
+   (REVEALED is only set by the backend on score reveal — not manually settable)
+3. GET /api/v1/battle/phase → returns current phase (for reconnect)
+4. All phase changes broadcast to /topic/battle/phase
+
+## Frontend Changes — BattleControl.vue
+5. Subscribe to /topic/battle/phase on mount; store in battlePhase ref
+6. On mount: GET /api/v1/battle/phase to hydrate on refresh
+7. Button visibility rules:
+   - "Open Voting" button: visible only when battlePhase === 'LOCKED'
+     → calls POST /api/v1/battle/phase { phase: 'VOTING' }
+   - "Get Score" button: visible only when battlePhase === 'VOTING'
+   - "Next Pair" button: visible only when battlePhase === 'REVEALED'
+   - "Previous" button: visible only when battlePhase === 'REVEALED' (allows backing up)
+   - "Start Round" (initiateBattlePair): always available when not in VOTING/REVEALED
+8. "Reset Bracket" → requires confirmation modal before proceeding; sets phase to IDLE
+9. Phase status badge in "Live Match" card header (colored pill: LOCKED/VOTING/REVEALED)
+
+## Frontend Changes — BattleJudge.vue
+10. Subscribe to /topic/battle/phase on mount; store in battlePhase ref
+11. Subscribe to /topic/battle/battle-pair on mount; store leftName/rightName
+12. On mount: GET /api/v1/battle/phase + GET /api/v1/battle/battle-pair for reconnect
+13. Phase-gated UI:
+    - IDLE: Full-screen overlay "Waiting for battle setup..."
+      (dark, centered text, no voting buttons visible)
+    - LOCKED: Show battler names prominently ("NEXT UP: A vs B")
+      Buttons visible but disabled with lock icon + "Waiting for voting to open"
+    - VOTING: Full interaction. Buttons active. Pulse animation on buttons.
+      Shows "VOTING OPEN" status chip. Current pair names shown.
+    - REVEALED: Buttons disabled. Winner shown ("A WINS" banner).
+      If this judge's vote matched winner → "✓ Correct call" indicator.
+14. Tie handling: phase stays VOTING, overlay shows "TIE — revote"
+
+## Frontend Changes — BattleOverlay.vue (stream display)
+15. Subscribe to /topic/battle/phase
+16. LOCKED: Show battler intro animation ("NEXT UP" card)
+17. VOTING: Show the normal judge panel (slide down as it does now)
+18. REVEALED: Show winner + score; hide judge vote indicators after 3s
+
+## Recoverable Actions
+- Organiser accidentally clicks "Get Score" before judges voted:
+  Backend check: if any judge vote === -3 (default) → return -3, phase stays VOTING
+- Organiser needs to undo a winner: "clearWinner" available in bracket view (already exists)
+- Organiser needs to re-open voting: only possible if phase === LOCKED
+  (can re-initiate same pair to go back to LOCKED, then Open Voting again)
+- Wrong pair started: while in LOCKED phase, operator can still click a different
+  "Start Round" to reset to a new pair → goes back to LOCKED with new names
+
+## New WebSocket Topic
+/topic/battle/phase → { phase: "IDLE" | "LOCKED" | "VOTING" | "REVEALED" }
+
+## Verification
+1. Open BattleControl + BattleJudge side by side
+2. Click "Start Round" → BattleJudge shows names + "Waiting for voting to open"
+   (buttons visible but disabled)
+3. Click "Open Voting" → BattleJudge buttons activate with pulse; VOTING chip shown
+4. Judge votes in BattleJudge → vote status visible in BattleControl
+5. Click "Get Score" → winner revealed; BattleJudge locks; BattleControl shows "Next Pair"
+6. Tie: BattleJudge shows "TIE — revote"; buttons stay active; no "Next Pair" visible
+7. Click "Reset Bracket" → confirmation modal appears; cancelling does nothing
+8. Refresh BattleJudge mid-battle → phase and pair names restored via REST
+```

--- a/SHEET_SERVICE_REVIEW.md
+++ b/SHEET_SERVICE_REVIEW.md
@@ -1,0 +1,116 @@
+# Google Sheet Service — Stability Review
+
+## What It Currently Does
+
+The sheet import pipeline works as follows:
+1. Reads the first row to detect column headers by keyword matching
+2. Identifies "name" columns — if more than one, applies team-name resolution logic
+3. Builds a `colIndexMap` (keyword → column index) for the critical fields
+4. Fetches all data rows and maps each row via `RegistrationDtoMapper`
+5. Genre columns are detected separately via `getCategoriesColumns` and resolved against the known genre list
+
+---
+
+## Findings
+
+### 1. NullPointerException on Empty Sheet Data
+
+**File:** `GoogleSheetService.java:223`, `GoogleSheetService.java:87`
+
+`results.getValues()` and `valueRanges.get(0).getValues()` from the Google Sheets API return `null` (not an empty list) when the range contains no data. Neither `getsheetAllRows` nor `getParticipantsBreakDown` null-checks before calling `.stream()` or `.size()`.
+
+- `getsheetAllRows`: if the sheet has only a header row and no participants, `getValues()` is null → NPE.
+- `getParticipantsBreakDown`: if a category column is entirely empty, `getValues()` is null → NPE.
+
+**What happens when an event folder has no sheet?**
+
+The expected folder structure is: root folder → event folder → one sheet per event. If an event folder contains no sheet, the frontend sheet selector would receive an empty list from `GoogleDriveFileService` and show nothing to select. The user simply cannot proceed past the sheet selection step, so no backend import call would be made — this path is implicitly safe.
+
+However, if a `fileId` is somehow passed to the backend without a valid sheet (e.g., a folder ID mistakenly passed as a file ID, or a sheet that was deleted after selection), `sheetClient.getRange()` would throw a Google API `IOException`. This is currently unhandled and would bubble up as a 500. A dedicated error message would be more helpful here.
+
+---
+
+### 2. Name Detection: Group Names Beyond "team name" Not Handled
+
+**File:** `GoogleSheetService.java:184–185`
+
+`removeExtraName` only recognises `"team name"` as the authoritative multi-person name column. If an organiser labels the column `"crew name"`, `"group name"`, or `"squad name"`, the logic falls into Case B (keep first "name" encountered) instead, which may return a member's individual name rather than the collective name.
+
+**Recommended approach:**
+1. If only one "name" column exists → use it as the individual display name.
+2. If multiple "name" columns exist → scan for any column containing group-hint keywords: `"team"`, `"crew"`, `"group"`, `"squad"`. If found, use that as the display name.
+3. If no group hint is found → fall back to the first "name" column (current Case B behaviour).
+
+**On the email / team name concern:**
+
+When a team registers, the display name will be the team/crew name, but the email will be whichever individual filled out the form. This is the correct behaviour — the email is the contact point for QR and communication, not the "owner" of the display name. There is no conflict here: `participantEmail` stays as the representative's email; `participantName` becomes the crew name. Both are stored independently on the `Participant` entity.
+
+---
+
+### 3. `colIndexMap` Silently Overwrites on Duplicate Keyword Matches
+
+**File:** `GoogleSheetService.java:151–156`
+
+The loop that builds `colIndexMap` does `put(keyword, i)` with no guard against overwriting. If two headers both contain the same keyword, the map keeps the **last** matching column.
+
+In practice, duplicate columns for `email`, `payment status`, or `local/overseas` are uncommon. The name column is already protected by `removeExtraName`. A first-match-wins guard should still be added as a safety net for unexpected form layouts.
+
+---
+
+### 4. `getParticipantsBreakDown` Crashes When There Is Only One Category Column
+
+**File:** `GoogleSheetService.java:87–100`
+
+The method was originally built around a local + overseas category column split. Since local/overseas is no longer tracked, a sheet will typically have just **one** category column. However, the loop still tries to access `overseasGenre.get(i)` whenever a local row cell is empty, which throws `IndexOutOfBoundsException` on a blank signup.
+
+The fix is to simplify this method: iterate over however many category columns exist and combine all non-empty values, without assuming two columns or a local/overseas split.
+
+---
+
+### 5. Genre Matching: Complex Labels Need Alias Support
+
+**File:** `GoogleSheetParser.java:7–11`
+
+`normalizeGenre` checks `event::contains` — i.e., the cell value must contain the genre label as a substring. This works for most genres but breaks for `SMOKE`, whose label is `"7 to smoke"`:
+
+- `"Seven to Smoke"`, `"Smoke Battle"`, `"7toSmoke"` → no match → participant imported with no genre.
+
+Any genre with a long or stylised label has this fragility. The solution is to support **aliases** per genre — a primary label plus a list of alternative strings that should all resolve to the same genre. For example, SMOKE could also match `"smoke"`, `"7 to smoke"`, `"seven to smoke"`.
+
+`normalizeGenre` also has an invisible caller contract: callers must lowercase the input before calling since the method does not normalise internally. This should be moved inside the method.
+
+---
+
+### 6. `getsheetAllRows` Truncates Rows Wider Than the Header
+
+**File:** `GoogleSheetService.java:220`
+
+The data range is `A2:<lastHeaderCol>`, where the end column is derived from `headers.size()`. If any data row has more columns than the header row (e.g., Google Forms appending a timestamp or hidden column beyond the declared headers), those extra cells are silently excluded. This is harmless for current fields but worth knowing.
+
+---
+
+## Summary Table
+
+| # | Issue | Severity | Breaks? | Action |
+|---|-------|----------|---------|--------|
+| 1 | NPE on empty data / null `getValues()` | High | Yes — hard crash | Fix |
+| 1b | Invalid `fileId` returns generic 500 | Low | No crash, bad UX | Nice to have |
+| 2 | `crew/group/squad name` not handled; Case B only | Medium | Silent wrong data | Fix |
+| 3 | `colIndexMap` overwrites on duplicate keywords | Low | Unlikely in practice | Add guard |
+| 4 | `getParticipantsBreakDown` crashes with one category column | High | Yes — crash on blank cell | Fix |
+| 5 | Genre alias support missing (`"7 to smoke"` variants) | Medium | Silent missing genre | Fix |
+| 6 | Rows truncated at header width | Low | Rare, silent drop | Informational |
+
+---
+
+## Proposed Solutions
+
+1. **Null-guard all `getValues()` calls.** Treat a null return as an empty list. Both `getsheetAllRows` and `getParticipantsBreakDown` need this.
+
+2. **Extend group-name detection in `removeExtraName`.** Check for `"team"`, `"crew"`, `"group"`, `"squad"` as group-hint keywords. If any name column contains a group hint, use it as the display name and ignore the rest. If none found, keep first-match behaviour.
+
+3. **First-match wins for `colIndexMap`.** Use `putIfAbsent` instead of `put` so the first matching column for each keyword wins. Document this as intentional.
+
+4. **Simplify `getParticipantsBreakDown` to be column-count agnostic.** Iterate over all detected category columns, collect all non-empty values into a single combined list, then pass to `setDtoCategory`. Remove the hardcoded index-0/index-1 assumption entirely.
+
+5. **Add genre alias support.** Extend the `Genre` enum (or a companion map) with a list of aliases per entry. `normalizeGenre` checks both the primary label and all aliases. Example aliases for SMOKE: `"smoke"`, `"seven to smoke"`, `"7tosmoke"`. Also move the `toLowerCase()` call inside `normalizeGenre` so it is not caller-dependent.


### PR DESCRIPTION
## Summary

- **Design system rebrand**: Migrated primary color from cyan to red (`#e53935`) across all components; updated `base.css` color tokens, buttons, nav active states, focus rings, and badges to the new Tesla-inspired neutral-black + red palette
- **Navigation overhaul**: 3-column grid navbar (logo · primary nav · utilities), active event chip with role-filtered section links (Audition, Participants, Scoreboard, Battle), `?redirect=` support on event switching
- **Per-event judge management**: Judges now assigned per event in `EventDetails` tab layout; reactive active event propagation across views
- **New views & components**: `BattleControl`, `BattleJudge`, `BattleOverlay`, `BracketVisualization`, `Chart`, `CrewFormation`, `EventDetails`, `EventSelector`, `AdminPage`, `Results`, `ResultsQR`, `Login`, `Score` (major rewrites); new components: `EventCard`, `EmceeRoundView`, `SwipeableCardsV2`, `FeedbackPopout`, `ScoringCriteriaModal`, `ScoringCriteriaPanel`, `PairScoreCards`
- **Battle phase state machine**: IDLE → LOCKED → VOTING → REVEALED via WebSocket
- **Full-stack features added**: Audition feedback system, custom weighted scoring criteria, results portal (reference codes + QR), pickup crew formation, bracket seeding strategies, walk-in team support, email templates, participant verification/payment tracking

## Test plan
- [ ] Login and verify role-based nav renders correctly for Admin / Organiser / Emcee / Judge
- [ ] Switch active event and confirm `?redirect=` returns to correct page
- [ ] Create an event, add genres, import participants from Google Sheets
- [ ] Assign judges per event and verify scoring on `/event/audition-list`
- [ ] Run through battle phase transitions: IDLE → LOCKED → VOTING → REVEALED
- [ ] Check `/battle/bracket` and `/battle/overlay` update in real time
- [ ] Verify results portal (`/results`) only shows data after release toggle is enabled
- [ ] Confirm design tokens (red primary, neutral surfaces) render correctly in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)