### PR TITLE
test: backend service unit tests + JaCoCo 70% gate + frontend coverage

### DIFF
--- a/BES-frontend/package-lock.json
+++ b/BES-frontend/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.7",
         "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.21",
         "jsdom": "^28.1.0",
@@ -34,7 +35,7 @@
         "tailwindcss": "^4.1.16",
         "vite": "^7.0.6",
         "vite-plugin-vue-devtools": "^8.0.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -342,18 +343,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -384,12 +385,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -548,16 +549,26 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1995,32 +2006,63 @@
         "vue": "^3.2.25"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2029,7 +2071,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2051,26 +2093,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2078,13 +2120,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2093,9 +2136,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2103,14 +2146,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2486,6 +2530,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -2956,9 +3029,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3148,6 +3221,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/headlessui": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/headlessui/-/headlessui-0.0.0.tgz",
@@ -3172,6 +3255,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3300,6 +3390,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3723,6 +3852,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mdn-data": {
@@ -4306,9 +4476,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4428,6 +4598,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -4495,9 +4678,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4838,31 +5021,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -4878,12 +5061,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -4904,6 +5090,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -4912,6 +5104,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/BES-frontend/package.json
+++ b/BES-frontend/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.7",
     "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.21",
     "jsdom": "^28.1.0",
@@ -41,6 +42,6 @@
     "tailwindcss": "^4.1.16",
     "vite": "^7.0.6",
     "vite-plugin-vue-devtools": "^8.0.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.7"
   }
 }

--- a/BES-frontend/src/utils/__tests__/adminApi.test.js
+++ b/BES-frontend/src/utils/__tests__/adminApi.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+const adminApi = await import('../adminApi.js')
+
+describe('adminApi.js', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  describe('addGenre', () => {
+    it('calls correct endpoint with genre name', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addGenre('breaking')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/genre')
+      expect(opts.method).toBe('POST')
+      expect(JSON.parse(opts.body).name).toBe('breaking')
+    })
+  })
+
+  describe('addJudge', () => {
+    it('calls correct endpoint with judge name', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addJudge('Mike')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/judge')
+      expect(JSON.parse(opts.body).judgeName).toBe('Mike')
+    })
+  })
+
+  describe('deleteGenre', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteGenre(5)
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/genre')
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(5)
+    })
+  })
+
+  describe('deleteJudge', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteJudge(3)
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/judge')
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(3)
+    })
+  })
+
+  describe('updateGenre', () => {
+    it('sends correct payload', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.updateGenre(1, 'popping')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/update-genre')
+      const body = JSON.parse(opts.body)
+      expect(body.id).toBe(1)
+      expect(body.newName).toBe('popping')
+    })
+  })
+
+  describe('getFeedbackGroups', () => {
+    it('returns parsed JSON on success', async () => {
+      const groups = [{ id: 1, name: 'Energy' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(groups) })
+
+      const result = await adminApi.getFeedbackGroups()
+
+      expect(result).toEqual(groups)
+    })
+
+    it('returns empty array on failure', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false })
+
+      const result = await adminApi.getFeedbackGroups()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('addFeedbackGroup', () => {
+    it('calls correct endpoint', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addFeedbackGroup('Energy')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/feedback-group')
+      expect(opts.method).toBe('POST')
+      expect(JSON.parse(opts.body).name).toBe('Energy')
+    })
+  })
+
+  describe('deleteFeedbackGroup', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteFeedbackGroup(2)
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/feedback-group')
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(2)
+    })
+  })
+
+  describe('addFeedbackTag', () => {
+    it('sends groupId and label', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addFeedbackTag(1, 'High Energy')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/feedback-tag')
+      expect(opts.method).toBe('POST')
+      const body = JSON.parse(opts.body)
+      expect(body.groupId).toBe(1)
+      expect(body.label).toBe('High Energy')
+    })
+  })
+
+  describe('deleteFeedbackTag', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteFeedbackTag(7)
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/feedback-tag')
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(7)
+    })
+  })
+})

--- a/BES-frontend/src/utils/__tests__/api.test.js
+++ b/BES-frontend/src/utils/__tests__/api.test.js
@@ -101,4 +101,76 @@ describe('api.js', () => {
       expect(body.participantScore).toEqual(participants)
     })
   })
+
+  describe('whoami', () => {
+    it('returns parsed JSON when ok', async () => {
+      const user = { authenticated: true, username: 'admin' }
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(user) })
+
+      const result = await api.whoami()
+
+      expect(result).toEqual(user)
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/auth/me'),
+        expect.objectContaining({ credentials: 'include' })
+      )
+    })
+  })
+
+  describe('fetchAllGenres', () => {
+    it('returns genres on success', async () => {
+      const genres = [{ id: 1, genreName: 'breaking' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(genres) })
+
+      const result = await api.fetchAllGenres()
+
+      expect(result).toEqual(genres)
+    })
+
+    it('returns empty array on failure', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+      const result = await api.fetchAllGenres()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getAllJudges', () => {
+    it('returns judges on success', async () => {
+      const judges = [{ judgeId: 1, judgeName: 'Mike' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(judges) })
+
+      const result = await api.getAllJudges()
+
+      expect(result).toEqual(judges)
+    })
+
+    it('returns empty array on failure', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+      const result = await api.getAllJudges()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getRegisteredParticipantsByEvent', () => {
+    it('returns participants on success', async () => {
+      const participants = [{ participantName: 'Player1' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(participants) })
+
+      const result = await api.getRegisteredParticipantsByEvent('Fest')
+
+      expect(result).toEqual(participants)
+    })
+
+    it('returns empty array on 404', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+      const result = await api.getRegisteredParticipantsByEvent('Missing')
+
+      expect(result).toEqual([])
+    })
+  })
 })

--- a/BES-frontend/src/utils/__tests__/auth.test.js
+++ b/BES-frontend/src/utils/__tests__/auth.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mock sessionStorage
+const sessionStorageMock = (() => {
+  let store = {}
+  return {
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, val) => { store[key] = String(val) },
+    removeItem: (key) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+Object.defineProperty(global, 'sessionStorage', { value: sessionStorageMock })
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {}
+  return {
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, val) => { store[key] = String(val) },
+    removeItem: (key) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+Object.defineProperty(global, 'localStorage', { value: localStorageMock })
+
+// Mock pinia (defineStore needs a Pinia instance; stub it for utility-only tests)
+vi.mock('pinia', () => ({
+  defineStore: (id, def) => {
+    const store = typeof def === 'function' ? def() : def
+    return () => ({
+      ...store.state?.(),
+      ...store.actions,
+      ...store.getters,
+    })
+  },
+}))
+
+const { isEventVerified, markEventVerified, getActiveEvent, clearVerifiedEvents } = await import('../auth.js')
+
+describe('auth.js utilities', () => {
+  beforeEach(() => {
+    sessionStorageMock.clear()
+    localStorageMock.clear()
+  })
+
+  describe('isEventVerified', () => {
+    it('returns false when nothing stored', () => {
+      expect(isEventVerified(1)).toBe(false)
+    })
+
+    it('returns false for unverified event id', () => {
+      sessionStorageMock.setItem('bes_verified_events', JSON.stringify([2]))
+      expect(isEventVerified(1)).toBe(false)
+    })
+
+    it('returns true when event id is in verified list', () => {
+      sessionStorageMock.setItem('bes_verified_events', JSON.stringify([1, 2]))
+      expect(isEventVerified(1)).toBe(true)
+    })
+
+    it('coerces string id to number', () => {
+      sessionStorageMock.setItem('bes_verified_events', JSON.stringify([5]))
+      expect(isEventVerified('5')).toBe(true)
+    })
+  })
+
+  describe('markEventVerified', () => {
+    it('adds event id to verified list', () => {
+      markEventVerified(3)
+      expect(isEventVerified(3)).toBe(true)
+    })
+
+    it('does not duplicate event id', () => {
+      markEventVerified(3)
+      markEventVerified(3)
+      const stored = JSON.parse(sessionStorageMock.getItem('bes_verified_events'))
+      expect(stored.filter(id => id === 3)).toHaveLength(1)
+    })
+  })
+
+  describe('getActiveEvent', () => {
+    it('returns null when nothing stored', () => {
+      expect(getActiveEvent()).toBeNull()
+    })
+
+    it('returns parsed event object', () => {
+      sessionStorageMock.setItem('bes_active_event', JSON.stringify({ id: 1, name: 'Fest' }))
+      expect(getActiveEvent()).toEqual({ id: 1, name: 'Fest' })
+    })
+
+    it('returns null on invalid JSON', () => {
+      sessionStorageMock.setItem('bes_active_event', 'not-json')
+      expect(getActiveEvent()).toBeNull()
+    })
+  })
+
+  describe('clearVerifiedEvents', () => {
+    it('removes both storage keys', () => {
+      sessionStorageMock.setItem('bes_verified_events', '[1]')
+      sessionStorageMock.setItem('bes_active_event', '{}')
+
+      clearVerifiedEvents()
+
+      expect(sessionStorageMock.getItem('bes_verified_events')).toBeNull()
+      expect(sessionStorageMock.getItem('bes_active_event')).toBeNull()
+    })
+  })
+})

--- a/BES/pom.xml
+++ b/BES/pom.xml
@@ -179,6 +179,44 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals><goal>prepare-agent</goal></goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals><goal>report</goal></goals>
+					</execution>
+					<execution>
+						<id>check</id>
+						<phase>test</phase>
+						<goals><goal>check</goal></goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>PACKAGE</element>
+									<includes>
+										<include>com/example/BES/services</include>
+									</includes>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.70</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/BES/src/test/java/com/example/BES/controllers/ResultsControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/ResultsControllerIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.example.BES.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ResultsControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void getResults_returnsNotFoundForUnknownRef() throws Exception {
+        mockMvc.perform(get("/api/v1/results").param("ref", "NONEXISTENT-REF"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    void getResults_isPublicNoAuthRequired() throws Exception {
+        // Endpoint must be reachable without authentication
+        mockMvc.perform(get("/api/v1/results").param("ref", "ANY"))
+            .andExpect(status().isNotFound()); // not 403
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void getResultsQr_returnsImageForAdmin() throws Exception {
+        mockMvc.perform(get("/api/v1/results/qr").param("ref", "TEST-REF"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void getResultsQr_returns403WithoutAuth() throws Exception {
+        mockMvc.perform(get("/api/v1/results/qr").param("ref", "TEST-REF"))
+            .andExpect(status().isForbidden());
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java
@@ -55,7 +55,7 @@ class AuditionFeedbackServiceTest {
     }
 
     @Test
-    void addFeedbackGroup_savesAndReturnsAll() {
+    void addFeedbackGroup_saves() {
         FeedbackTagGroup group = new FeedbackTagGroup();
         group.setId(1L);
         group.setName("Energy");
@@ -93,6 +93,23 @@ class AuditionFeedbackServiceTest {
         dto.setJudgeName("Ghost");
         when(egpRepo.findByEventNameAndGenreNameAndAuditionNumber("Fest", "breaking", 1))
             .thenReturn(Optional.empty());
+
+        service.submitFeedback(dto);
+
+        verify(feedbackRepo, never()).save(any());
+    }
+
+    @Test
+    void submitFeedback_doesNothingWhenJudgeNull() {
+        SubmitAuditionFeedbackDto dto = new SubmitAuditionFeedbackDto();
+        dto.setEventName("Fest");
+        dto.setGenreName("breaking");
+        dto.setAuditionNumber(1);
+        dto.setJudgeName("Ghost");
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        when(egpRepo.findByEventNameAndGenreNameAndAuditionNumber("Fest", "breaking", 1))
+            .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Ghost")).thenReturn(Optional.empty());
 
         service.submitFeedback(dto);
 

--- a/BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java
@@ -1,0 +1,132 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.SubmitAuditionFeedbackDto;
+import com.example.BES.dtos.admin.GetFeedbackGroupDto;
+import com.example.BES.models.AuditionFeedback;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.FeedbackTag;
+import com.example.BES.models.FeedbackTagGroup;
+import com.example.BES.models.Judge;
+import com.example.BES.respositories.AuditionFeedbackRepository;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.FeedbackTagGroupRepository;
+import com.example.BES.respositories.FeedbackTagRepository;
+import com.example.BES.respositories.JudgeRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuditionFeedbackServiceTest {
+
+    @Mock AuditionFeedbackRepository feedbackRepo;
+    @Mock FeedbackTagGroupRepository tagGroupRepo;
+    @Mock FeedbackTagRepository tagRepo;
+    @Mock EventGenreParticpantRepo egpRepo;
+    @Mock JudgeRepo judgeRepo;
+    @InjectMocks AuditionFeedbackService service;
+
+    @Test
+    void getAllFeedbackGroups_mapsToDto() {
+        FeedbackTagGroup group = new FeedbackTagGroup();
+        group.setId(1L);
+        group.setName("Energy");
+        FeedbackTag tag = new FeedbackTag();
+        tag.setId(10L);
+        tag.setLabel("High");
+        tag.setGroup(group);
+        group.setTags(List.of(tag));
+        when(tagGroupRepo.findAll()).thenReturn(List.of(group));
+
+        List<GetFeedbackGroupDto> result = service.getAllFeedbackGroups();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Energy");
+        assertThat(result.get(0).getTags()).hasSize(1);
+    }
+
+    @Test
+    void addFeedbackGroup_savesAndReturnsAll() {
+        FeedbackTagGroup group = new FeedbackTagGroup();
+        group.setId(1L);
+        group.setName("Energy");
+        group.setTags(new ArrayList<>());
+        when(tagGroupRepo.findAll()).thenReturn(List.of(group));
+
+        service.addFeedbackGroup("Energy");
+
+        verify(tagGroupRepo).save(any(FeedbackTagGroup.class));
+    }
+
+    @Test
+    void deleteFeedbackGroup_delegatesToRepo() {
+        service.deleteFeedbackGroup(1L);
+        verify(tagGroupRepo).deleteById(1L);
+    }
+
+    @Test
+    void addFeedbackTag_returnsAllGroupsWhenGroupNotFound() {
+        when(tagGroupRepo.findById(99L)).thenReturn(Optional.empty());
+        when(tagGroupRepo.findAll()).thenReturn(List.of());
+
+        List<GetFeedbackGroupDto> result = service.addFeedbackTag(99L, "label");
+
+        verify(tagRepo, never()).save(any());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void submitFeedback_doesNothingWhenEgpOrJudgeNull() {
+        SubmitAuditionFeedbackDto dto = new SubmitAuditionFeedbackDto();
+        dto.setEventName("Fest");
+        dto.setGenreName("breaking");
+        dto.setAuditionNumber(1);
+        dto.setJudgeName("Ghost");
+        when(egpRepo.findByEventNameAndGenreNameAndAuditionNumber("Fest", "breaking", 1))
+            .thenReturn(Optional.empty());
+
+        service.submitFeedback(dto);
+
+        verify(feedbackRepo, never()).save(any());
+    }
+
+    @Test
+    void submitFeedback_savesWhenEgpAndJudgeFound() {
+        SubmitAuditionFeedbackDto dto = new SubmitAuditionFeedbackDto();
+        dto.setEventName("Fest");
+        dto.setGenreName("breaking");
+        dto.setAuditionNumber(1);
+        dto.setJudgeName("Mike");
+        dto.setTagIds(List.of());
+        dto.setNote("Great energy");
+
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Judge judge = new Judge(); judge.setName("Mike");
+        when(egpRepo.findByEventNameAndGenreNameAndAuditionNumber("Fest", "breaking", 1))
+            .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Mike")).thenReturn(Optional.of(judge));
+        when(feedbackRepo.findByEventGenreParticipantAndJudge(egp, judge))
+            .thenReturn(Optional.empty());
+
+        service.submitFeedback(dto);
+
+        verify(feedbackRepo).save(any(AuditionFeedback.class));
+    }
+
+    @Test
+    void getAllFeedbackForParticipant_returnsEmptyWhenEgpNotFound() {
+        when(egpRepo.findByEventGenreParticipant("Fest", "breaking", "Player1"))
+            .thenReturn(Optional.empty());
+
+        assertThat(service.getAllFeedbackForParticipant("Fest", "breaking", "Player1")).isEmpty();
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -1,0 +1,162 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.battle.SetBattlerPairDto;
+import com.example.BES.dtos.battle.SetJudgeDto;
+import com.example.BES.dtos.battle.SetVoteDto;
+import com.example.BES.models.Judge;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BattleServiceTest {
+
+    @Mock
+    JudgeService judgeService;
+
+    @Mock
+    SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    BattleService service;
+
+    @Test
+    void initialPhaseIsIDLE() {
+        assertThat(service.getBattlePhase()).isEqualTo("IDLE");
+    }
+
+    @Test
+    void setBattlerPair_setsNamesAndTransitionsToLOCKED() {
+        SetBattlerPairDto dto = mock(SetBattlerPairDto.class);
+        when(dto.getLeftBattler()).thenReturn("Alice");
+        when(dto.getRightBattler()).thenReturn("Bob");
+
+        service.setBattlerPairService(dto);
+
+        assertThat(service.getCurrentPair().getLeftBattler().getName()).isEqualTo("Alice");
+        assertThat(service.getCurrentPair().getRightBattler().getName()).isEqualTo("Bob");
+        assertThat(service.getBattlePhase()).isEqualTo("LOCKED");
+    }
+
+    @Test
+    void setBattlePhase_cannotManuallySetREVEALED() {
+        service.setBattlePhaseService("REVEALED");
+
+        assertThat(service.getBattlePhase()).isEqualTo("IDLE");
+    }
+
+    @Test
+    void setBattlePhase_setsVOTING() {
+        service.setBattlePhaseService("VOTING");
+
+        assertThat(service.getBattlePhase()).isEqualTo("VOTING");
+    }
+
+    @Test
+    void setScore_returnsMinusOneWhenNoJudges() {
+        // Empty judges list: score list is empty, frequency(0)==frequency(1) → tie → returns -1
+        assertThat(service.setScoreService()).isEqualTo(-1);
+    }
+
+    @Test
+    void setScore_leftWins_returnsZeroAndTransitionsToREVEALED() {
+        Judge j = new Judge();
+        j.setJudgeId(1L);
+        j.setName("Mike");
+        when(judgeService.getJudgeById(1L)).thenReturn(j);
+
+        SetJudgeDto jDto = mock(SetJudgeDto.class);
+        when(jDto.getId()).thenReturn(1L);
+        service.setBattleJudgeService(jDto);
+
+        SetVoteDto vDto = mock(SetVoteDto.class);
+        when(vDto.getId()).thenReturn(1L);
+        when(vDto.getVote()).thenReturn(0); // vote for left
+        service.setVoteService(vDto);
+
+        Integer result = service.setScoreService();
+
+        assertThat(result).isEqualTo(0);
+        assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
+    }
+
+    @Test
+    void setScore_rightWins_returnsOne() {
+        Judge j = new Judge();
+        j.setJudgeId(2L);
+        j.setName("Sara");
+        when(judgeService.getJudgeById(2L)).thenReturn(j);
+
+        SetJudgeDto jDto = mock(SetJudgeDto.class);
+        when(jDto.getId()).thenReturn(2L);
+        service.setBattleJudgeService(jDto);
+
+        SetVoteDto vDto = mock(SetVoteDto.class);
+        when(vDto.getId()).thenReturn(2L);
+        when(vDto.getVote()).thenReturn(1); // vote for right
+        service.setVoteService(vDto);
+
+        assertThat(service.setScoreService()).isEqualTo(1);
+        assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
+    }
+
+    @Test
+    void setBattleJudge_returnsDuplicateCodeWhenAlreadyAdded() {
+        Judge j = new Judge();
+        j.setJudgeId(1L);
+        j.setName("Mike");
+        when(judgeService.getJudgeById(1L)).thenReturn(j);
+
+        SetJudgeDto dto = mock(SetJudgeDto.class);
+        when(dto.getId()).thenReturn(1L);
+        service.setBattleJudgeService(dto);
+
+        Integer result = service.setBattleJudgeService(dto);
+
+        assertThat(result).isEqualTo(0); // already exists
+    }
+
+    @Test
+    void setBattleJudge_returnsMinusOneWhenJudgeNotFound() {
+        when(judgeService.getJudgeById(99L)).thenReturn(null);
+
+        SetJudgeDto dto = mock(SetJudgeDto.class);
+        when(dto.getId()).thenReturn(99L);
+
+        assertThat(service.setBattleJudgeService(dto)).isEqualTo(-1);
+    }
+
+    @Test
+    void removeBattleJudge_removesFromList() {
+        Judge j = new Judge();
+        j.setJudgeId(1L);
+        j.setName("Mike");
+        when(judgeService.getJudgeById(1L)).thenReturn(j);
+
+        SetJudgeDto addDto = mock(SetJudgeDto.class);
+        when(addDto.getId()).thenReturn(1L);
+        service.setBattleJudgeService(addDto);
+        assertThat(service.getJudges()).hasSize(1);
+
+        SetJudgeDto removeDto = mock(SetJudgeDto.class);
+        when(removeDto.getId()).thenReturn(1L);
+        service.removeBattleJudgeService(removeDto);
+
+        assertThat(service.getJudges()).isEmpty();
+    }
+
+    @Test
+    void setVote_returnsMinusTwoWhenJudgeNotInList() {
+        // judges list is empty, stream filter never calls dto.getId() — use lenient to avoid UnnecessaryStubbingException
+        SetVoteDto dto = mock(SetVoteDto.class);
+        lenient().when(dto.getId()).thenReturn(99L);
+
+        assertThat(service.setVoteService(dto)).isEqualTo(-2);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/EmailTemplateServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/EmailTemplateServiceTest.java
@@ -1,0 +1,88 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetEmailTemplateDto;
+import com.example.BES.dtos.UpdateEmailTemplateDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventEmailTemplate;
+import com.example.BES.respositories.EventEmailTemplateRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailTemplateServiceTest {
+
+    @Mock EventEmailTemplateRepo repo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @Mock EventRepo eventRepo;
+    @InjectMocks EmailTemplateService service;
+
+    @Test
+    void createDefaultTemplate_savesTemplate() {
+        Event e = new Event();
+        e.setEventName("Fest");
+
+        service.createDefaultTemplate(e);
+
+        verify(repo).save(argThat(t ->
+            ((EventEmailTemplate) t).getSubject().contains("Fest") &&
+            ((EventEmailTemplate) t).getBody().contains("Fest")
+        ));
+    }
+
+    @Test
+    void getTemplateByEventName_returnsNullWhenNotFound() {
+        when(repo.findByEvent_EventName("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getTemplateByEventName("Missing")).isNull();
+    }
+
+    @Test
+    void getTemplateByEventName_returnsDto() {
+        EventEmailTemplate t = new EventEmailTemplate();
+        t.setSubject("Test Subject");
+        t.setBody("Custom body");
+        when(repo.findByEvent_EventName("Fest")).thenReturn(Optional.of(t));
+
+        GetEmailTemplateDto result = service.getTemplateByEventName("Fest");
+
+        assertThat(result.getSubject()).isEqualTo("Test Subject");
+        assertThat(result.getBody()).isEqualTo("Custom body");
+    }
+
+    @Test
+    void updateTemplate_updatesAndReturns() {
+        EventEmailTemplate t = new EventEmailTemplate();
+        t.setSubject("Old");
+        t.setBody("Old body");
+        UpdateEmailTemplateDto dto = new UpdateEmailTemplateDto();
+        dto.setSubject("New Subject");
+        dto.setBody("New Body");
+        when(repo.findByEvent_EventName("Fest")).thenReturn(Optional.of(t));
+        when(repo.save(any())).thenReturn(t);
+
+        GetEmailTemplateDto result = service.updateTemplate("Fest", dto);
+
+        assertThat(result.getSubject()).isEqualTo("New Subject");
+    }
+
+    @Test
+    void updateTemplate_throwsWhenNotFound() {
+        UpdateEmailTemplateDto dto = new UpdateEmailTemplateDto();
+        dto.setSubject("X");
+        dto.setBody("Y");
+        when(repo.findByEvent_EventName("Missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateTemplate("Missing", dto))
+            .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/EventGenreParticpantServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/EventGenreParticpantServiceTest.java
@@ -1,0 +1,69 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetEventGenreParticipantDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventGenreParticipantId;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.JudgeRepo;
+import com.example.BES.respositories.ParticipantRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventGenreParticpantServiceTest {
+
+    @Mock EventGenreParticpantRepo repo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock ParticipantRepo participantRepo;
+    @Mock SimpMessagingTemplate messagingTemplate;
+    @Mock JudgeRepo judgeRepo;
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @InjectMocks EventGenreParticpantService service;
+
+    @Test
+    void getAllByEvent_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        List<GetEventGenreParticipantDto> result =
+            service.getAllEventGenreParticipantByEventService("Missing");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void removeParticipantFromGenre_doesNothingWhenEgpNotFound() {
+        EventGenreParticipantId id = new EventGenreParticipantId(1L, 2L, 3L);
+        when(repo.findById(id)).thenReturn(Optional.empty());
+
+        service.removeParticipantFromGenre(3L, 1L, 2L);
+
+        verify(repo, never()).delete(any());
+    }
+
+    @Test
+    void addGenreToExistingParticipant_throwsWhenGenreNotFound() {
+        when(genreRepo.findByGenreName("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addGenreToExistingParticipant(1L, 1L, "ghost"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Genre not found");
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/EventGenreServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/EventGenreServiceTest.java
@@ -1,0 +1,123 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddGenreToEventDto;
+import com.example.BES.dtos.GetGenreDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenre;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventGenreServiceTest {
+
+    @Mock EventGenreRepo eventGenreRepo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @InjectMocks EventGenreService service;
+
+    private Event event(String name) {
+        Event e = new Event();
+        e.setEventName(name);
+        return e;
+    }
+
+    private Genre genre(Long id, String name) {
+        Genre g = new Genre();
+        g.setGenreId(id);
+        g.setGenreName(name);
+        return g;
+    }
+
+    @Test
+    void getGenresByEvent_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getGenresByEventService("Missing")).isEmpty();
+    }
+
+    @Test
+    void getGenresByEvent_mapsToDto() {
+        Event e = event("Fest");
+        Genre g = genre(1L, "breaking");
+        EventGenre eg = new EventGenre();
+        eg.setGenre(g);
+        eg.setFormat("1v1");
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+        when(eventGenreRepo.findByEvent(e)).thenReturn(List.of(eg));
+
+        List<GetGenreDto> result = service.getGenresByEventService("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).genreName).isEqualTo("breaking");
+        assertThat(result.get(0).format).isEqualTo("1v1");
+    }
+
+    @Test
+    void addGenreToEvent_throwsWhenGenreNotFound() {
+        Event e = event("Fest");
+        AddGenreToEventDto dto = new AddGenreToEventDto();
+        dto.eventName = "Fest";
+        dto.genreName = List.of("unknown");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("unknown")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addGenreToEventService(dto))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void addGenreToEvent_throwsOnDuplicate() {
+        Event e = event("Fest");
+        Genre g = genre(1L, "breaking");
+        AddGenreToEventDto dto = new AddGenreToEventDto();
+        dto.eventName = "Fest";
+        dto.genreName = List.of("breaking");
+        EventGenre existing = new EventGenre();
+        existing.setGenre(g); // non-null genre signals duplicate
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.of(g));
+        when(eventGenreRepo.findByEventAndGenre(e, g)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.addGenreToEventService(dto))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void updateFormat_throwsWhenEventOrGenreNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateEventGenreFormat("Missing", "breaking", "1v1"))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void updateFormat_savesFormat() {
+        Event e = event("Fest");
+        Genre g = genre(1L, "breaking");
+        EventGenre eg = new EventGenre();
+        eg.setGenre(g);
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.of(g));
+        when(eventGenreRepo.findByEventAndGenre(e, g)).thenReturn(Optional.of(eg));
+
+        service.updateEventGenreFormat("Fest", "breaking", "2v2");
+
+        assertThat(eg.getFormat()).isEqualTo("2v2");
+        verify(eventGenreRepo).save(eg);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/EventParticpantServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/EventParticpantServiceTest.java
@@ -1,0 +1,86 @@
+package com.example.BES.services;
+
+import com.example.BES.models.Event;
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.mapper.EventParticipantDtoMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventParticpantServiceTest {
+
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock EventParticipantDtoMapper eventParticipantDtoMapper;
+    @InjectMocks EventParticpantService service;
+
+    @Test
+    void getAllParticipantsByEvent_returnsNullWhenEventNotFound() {
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getAllParticipantsByEvent("Missing")).isNull();
+    }
+
+    @Test
+    void getParticipantRefs_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getParticipantRefs("Missing")).isEmpty();
+    }
+
+    @Test
+    void getParticipantRefs_skipsNullReferenceCodes() {
+        Event e = new Event(); e.setEventName("Fest");
+        Participant p = new Participant(); p.setParticipantName("Player1");
+        EventParticipant ep1 = new EventParticipant();
+        ep1.setDisplayName("Player1");
+        ep1.setReferenceCode(null); // should be skipped
+        EventParticipant ep2 = new EventParticipant();
+        ep2.setDisplayName("Player2");
+        ep2.setReferenceCode("ABC123");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(eventParticipantRepo.findByEvent(e)).thenReturn(List.of(ep1, ep2));
+
+        List<Map<String, String>> result = service.getParticipantRefs("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).get("referenceCode")).isEqualTo("ABC123");
+    }
+
+    @Test
+    void addNewWalkIn_returnsNullWhenEventNotFound() {
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+        Participant p = new Participant();
+
+        assertThat(service.addNewWalkInInEventService(p, "Missing", "breaking", null, null)).isNull();
+    }
+
+    @Test
+    void addNewWalkIn_returnsExistingEpWhenAlreadyRegistered() {
+        Event e = new Event(); e.setEventName("Fest");
+        Participant p = new Participant(); p.setParticipantName("Player1");
+        EventParticipant existing = new EventParticipant();
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(eventParticipantRepo.findByEventAndParticipant(e, p)).thenReturn(Optional.of(existing));
+        when(eventParticipantRepo.save(existing)).thenReturn(existing);
+
+        EventParticipant result = service.addNewWalkInInEventService(p, "Fest", "breaking", null, null);
+
+        assertThat(result).isSameAs(existing);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/EventServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/EventServiceTest.java
@@ -1,0 +1,172 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddEventDto;
+import com.example.BES.dtos.GetEventDto;
+import com.example.BES.models.Event;
+import com.example.BES.respositories.EventRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock EventRepo repo;
+    @Mock EmailTemplateService emailTemplateService;
+    @Mock SimpMessagingTemplate messagingTemplate;
+    @InjectMocks EventService service;
+
+    private Event event(String name) {
+        Event e = new Event();
+        e.setEventName(name);
+        e.setAccessCode("1234");
+        return e;
+    }
+
+    @Test
+    void createEvent_skipsIfAlreadyExists() {
+        AddEventDto dto = new AddEventDto();
+        dto.eventName = "BattleFest";
+        dto.accessCode = "1234";
+        when(repo.findByEventName("BattleFest")).thenReturn(Optional.of(event("BattleFest")));
+
+        service.createEventService(dto);
+
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void createEvent_savesNewEventAndCreatesTemplate() {
+        AddEventDto dto = new AddEventDto();
+        dto.eventName = "NewEvent";
+        dto.accessCode = "5678";
+        when(repo.findByEventName("NewEvent")).thenReturn(Optional.empty());
+        Event saved = event("NewEvent");
+        when(repo.save(any())).thenReturn(saved);
+
+        service.createEventService(dto);
+
+        verify(repo).save(any(Event.class));
+        verify(emailTemplateService).createDefaultTemplate(saved);
+    }
+
+    @Test
+    void createEvent_generatesRandomCodeWhenInvalidProvided() {
+        AddEventDto dto = new AddEventDto();
+        dto.eventName = "RandEvent";
+        dto.accessCode = "abc";
+        when(repo.findByEventName("RandEvent")).thenReturn(Optional.empty());
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.createEventService(dto);
+
+        verify(repo).save(argThat(e -> ((Event) e).getAccessCode().matches("\\d{4}")));
+    }
+
+    @Test
+    void verifyAccessCode_trueOnMatch() {
+        Event e = event("Test");
+        e.setAccessCode("9999");
+        when(repo.findById(1L)).thenReturn(Optional.of(e));
+
+        assertThat(service.verifyAccessCode(1L, "9999")).isTrue();
+    }
+
+    @Test
+    void verifyAccessCode_falseOnMismatch() {
+        Event e = event("Test");
+        e.setAccessCode("9999");
+        when(repo.findById(1L)).thenReturn(Optional.of(e));
+
+        assertThat(service.verifyAccessCode(1L, "0000")).isFalse();
+    }
+
+    @Test
+    void verifyAccessCode_throwsWhenNotFound() {
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.verifyAccessCode(99L, "1234"))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void releaseResults_setsFlag() {
+        Event e = event("Fest");
+        when(repo.findByEventName("Fest")).thenReturn(Optional.of(e));
+
+        service.releaseResults("Fest", true);
+
+        assertThat(e.isResultsReleased()).isTrue();
+        verify(repo).save(e);
+    }
+
+    @Test
+    void releaseResults_throwsWhenNotFound() {
+        when(repo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.releaseResults("Missing", true))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void updateAccessCode_throwsOnInvalidCode() {
+        assertThatThrownBy(() -> service.updateAccessCode(1L, "abc"))
+            .isInstanceOf(ResponseStatusException.class);
+        assertThatThrownBy(() -> service.updateAccessCode(1L, null))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void updateAccessCode_savesValidCode() {
+        Event e = event("Fest");
+        when(repo.findById(1L)).thenReturn(Optional.of(e));
+
+        service.updateAccessCode(1L, "4321");
+
+        assertThat(e.getAccessCode()).isEqualTo("4321");
+        verify(repo).save(e);
+    }
+
+    @Test
+    void getAllEvents_includesAccessCodeWhenFlagTrue() {
+        Event e = event("Fest");
+        when(repo.findAll()).thenReturn(List.of(e));
+
+        List<GetEventDto> result = service.getAllEvents(true);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getAccessCode()).isEqualTo("1234");
+    }
+
+    @Test
+    void getAllEvents_hidesAccessCodeWhenFlagFalse() {
+        Event e = event("Fest");
+        when(repo.findAll()).thenReturn(List.of(e));
+
+        List<GetEventDto> result = service.getAllEvents(false);
+
+        assertThat(result.get(0).getAccessCode()).isNull();
+    }
+
+    @Test
+    void setJudgingMode_updatesAndBroadcasts() {
+        Event e = event("Fest");
+        when(repo.findByEventName("Fest")).thenReturn(Optional.of(e));
+
+        service.setJudgingMode("Fest", "CUSTOM");
+
+        assertThat(e.getJudgingMode()).isEqualTo("CUSTOM");
+        verify(repo).save(e);
+        verify(messagingTemplate).convertAndSend(eq("/topic/judging-mode/"), any(Object.class));
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/GenreServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/GenreServiceTest.java
@@ -1,0 +1,115 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetGenreDto;
+import com.example.BES.dtos.admin.AddGenreDto;
+import com.example.BES.dtos.admin.DeleteGenreDto;
+import com.example.BES.dtos.admin.UpdateGenreDto;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.GenreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GenreServiceTest {
+
+    @Mock GenreRepo repo;
+    @InjectMocks GenreService service;
+
+    private Genre genre(Long id, String name) {
+        Genre g = new Genre();
+        g.setGenreId(id);
+        g.setGenreName(name);
+        return g;
+    }
+
+    @Test
+    void getAllGenres_mapsToDto() {
+        when(repo.findAll()).thenReturn(List.of(genre(1L, "breaking")));
+
+        List<GetGenreDto> result = service.getAllGenres();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).genreName).isEqualTo("breaking");
+        assertThat(result.get(0).id).isEqualTo(1L);
+    }
+
+    @Test
+    void addGenre_returnsExistingWhenGenreNameNotNull() {
+        AddGenreDto dto = mock(AddGenreDto.class);
+        when(dto.getName()).thenReturn("Popping");
+        Genre existing = genre(1L, "popping");
+        when(repo.findByGenreName("popping")).thenReturn(Optional.of(existing));
+
+        Genre result = service.addGenreService(dto);
+
+        verify(repo, never()).save(any());
+        assertThat(result).isSameAs(existing);
+    }
+
+    @Test
+    void addGenre_savesWhenGenreNameIsNull() {
+        AddGenreDto dto = mock(AddGenreDto.class);
+        when(dto.getName()).thenReturn("Locking");
+        Genre empty = new Genre(); // genreName is null
+        when(repo.findByGenreName("locking")).thenReturn(Optional.of(empty));
+        when(repo.save(any())).thenReturn(empty);
+
+        service.addGenreService(dto);
+
+        verify(repo).save(empty);
+    }
+
+    @Test
+    void updateGenre_updatesNameAndSaves() {
+        Genre g = genre(1L, "breaking");
+        UpdateGenreDto dto = mock(UpdateGenreDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(dto.getNewName()).thenReturn("b-boy");
+        when(repo.findById(1L)).thenReturn(Optional.of(g));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Genre result = service.updateGenreService(dto);
+
+        assertThat(result.getGenreName()).isEqualTo("b-boy");
+    }
+
+    @Test
+    void updateGenre_returnsNullWhenNotFound() {
+        UpdateGenreDto dto = mock(UpdateGenreDto.class);
+        when(dto.getId()).thenReturn(99L);
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(service.updateGenreService(dto)).isNull();
+    }
+
+    @Test
+    void deleteGenre_deletesAndReturnsName() {
+        Genre g = genre(1L, "locking");
+        DeleteGenreDto dto = mock(DeleteGenreDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(repo.findById(1L)).thenReturn(Optional.of(g));
+
+        String name = service.deleteGenreService(dto);
+
+        assertThat(name).isEqualTo("locking");
+        verify(repo).delete(g);
+    }
+
+    @Test
+    void deleteGenre_returnsEmptyStringWhenNotFound() {
+        DeleteGenreDto dto = mock(DeleteGenreDto.class);
+        when(dto.getId()).thenReturn(99L);
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(service.deleteGenreService(dto)).isEmpty();
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/JudgeServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/JudgeServiceTest.java
@@ -1,0 +1,132 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddJudgeDto;
+import com.example.BES.dtos.GetJudgeDto;
+import com.example.BES.dtos.admin.DeleteJudgeDto;
+import com.example.BES.dtos.admin.UpdateJudgeDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.Judge;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.JudgeRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JudgeServiceTest {
+
+    @Mock JudgeRepo judgeRepo;
+    @Mock EventRepo eventRepo;
+    @InjectMocks JudgeService service;
+
+    private Judge judge(Long id, String name) {
+        Judge j = new Judge();
+        j.setJudgeId(id);
+        j.setName(name);
+        return j;
+    }
+
+    @Test
+    void addJudge_savesAndReturns() {
+        AddJudgeDto dto = new AddJudgeDto();
+        dto.judgeName = "Mike";
+        Judge saved = judge(1L, "Mike");
+        when(judgeRepo.save(any())).thenReturn(saved);
+
+        Judge result = service.addJudgeService(dto);
+
+        assertThat(result.getName()).isEqualTo("Mike");
+    }
+
+    @Test
+    void getAllJudges_mapsToDto() {
+        when(judgeRepo.findAll()).thenReturn(List.of(judge(1L, "Mike")));
+
+        List<GetJudgeDto> result = service.getAllJudges();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).judgeName).isEqualTo("Mike");
+    }
+
+    @Test
+    void getJudgeById_returnsNullWhenMissing() {
+        when(judgeRepo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(service.getJudgeById(99L)).isNull();
+    }
+
+    @Test
+    void updateJudge_updatesName() {
+        Judge j = judge(1L, "Old");
+        UpdateJudgeDto dto = mock(UpdateJudgeDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(dto.getNewName()).thenReturn("New");
+        when(judgeRepo.findById(1L)).thenReturn(Optional.of(j));
+        when(judgeRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Judge result = service.updateJudgeService(dto);
+
+        assertThat(result.getName()).isEqualTo("New");
+    }
+
+    @Test
+    void deleteJudge_deletesAndReturnsName() {
+        Judge j = judge(1L, "Mike");
+        DeleteJudgeDto dto = mock(DeleteJudgeDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(judgeRepo.findById(1L)).thenReturn(Optional.of(j));
+
+        String name = service.deleteJudgeService(dto);
+
+        assertThat(name).isEqualTo("Mike");
+        verify(judgeRepo).delete(j);
+    }
+
+    @Test
+    void getJudgesByEvent_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        List<GetJudgeDto> result = service.getJudgesByEvent("Missing");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void addJudgeToEvent_returnsNullWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.addJudgeToEvent("Missing", "Mike")).isNull();
+    }
+
+    @Test
+    void removeJudgeFromEvent_doesNothingWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        service.removeJudgeFromEvent("Missing", 1L);
+
+        verify(eventRepo, never()).save(any());
+    }
+
+    @Test
+    void removeJudgeFromEvent_removesJudgeFromList() {
+        Judge j = judge(1L, "Mike");
+        Event e = new Event();
+        e.setEventName("Fest");
+        e.setJudges(new ArrayList<>(List.of(j)));
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+
+        service.removeJudgeFromEvent("Fest", 1L);
+
+        assertThat(e.getJudges()).isEmpty();
+        verify(eventRepo).save(e);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/ParticipantServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/ParticipantServiceTest.java
@@ -1,0 +1,93 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddParticipantDto;
+import com.example.BES.dtos.AddWalkInDto;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.ParticipantRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipantServiceTest {
+
+    @Mock ParticipantRepo repo;
+    @InjectMocks ParticipantService service;
+
+    @Test
+    void addParticipant_returnsExistingWhenEmailMatches() {
+        AddParticipantDto dto = new AddParticipantDto();
+        dto.participantEmail = "test@example.com";
+        dto.participantName = "Test";
+        Participant existing = new Participant();
+        existing.setParticipantEmail("test@example.com");
+        when(repo.findByParticipantEmail("test@example.com")).thenReturn(Optional.of(existing));
+
+        Participant result = service.addParticpantService(dto);
+
+        assertThat(result).isSameAs(existing);
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void addParticipant_createsNewWhenEmailNotFound() {
+        AddParticipantDto dto = new AddParticipantDto();
+        dto.participantEmail = "new@example.com";
+        dto.participantName = "New Person";
+        when(repo.findByParticipantEmail("new@example.com")).thenReturn(Optional.empty());
+        Participant saved = new Participant();
+        when(repo.save(any())).thenReturn(saved);
+
+        Participant result = service.addParticpantService(dto);
+
+        assertThat(result).isSameAs(saved);
+        verify(repo).save(any(Participant.class));
+    }
+
+    @Test
+    void addParticipant_savesWhenEmailIsNull() {
+        AddParticipantDto dto = new AddParticipantDto();
+        dto.participantEmail = null;
+        dto.participantName = "Walk-in";
+        Participant saved = new Participant();
+        when(repo.save(any())).thenReturn(saved);
+
+        service.addParticpantService(dto);
+
+        verify(repo).save(any(Participant.class));
+    }
+
+    @Test
+    void addWalkIn_returnsExistingWhenNameMatches() {
+        AddWalkInDto dto = new AddWalkInDto();
+        dto.name = "Existing";
+        Participant existing = new Participant();
+        existing.setParticipantName("Existing");
+        when(repo.findByParticipantName("Existing")).thenReturn(Optional.of(existing));
+
+        Participant result = service.addWalkInService(dto);
+
+        assertThat(result).isSameAs(existing);
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void addWalkIn_createsNewWhenNotFound() {
+        AddWalkInDto dto = new AddWalkInDto();
+        dto.name = "Newbie";
+        Participant empty = new Participant(); // participantName is null
+        when(repo.findByParticipantName("Newbie")).thenReturn(Optional.of(empty));
+        when(repo.save(any())).thenReturn(empty);
+
+        service.addWalkInService(dto);
+
+        verify(repo).save(empty);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/PickupCrewServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/PickupCrewServiceTest.java
@@ -1,0 +1,60 @@
+package com.example.BES.services;
+
+import com.example.BES.models.Event;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.ParticipantRepo;
+import com.example.BES.respositories.PickupCrewRepo;
+import com.example.BES.respositories.ScoreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PickupCrewServiceTest {
+
+    @Mock PickupCrewRepo crewRepo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock ParticipantRepo participantRepo;
+    @Mock EventGenreParticpantRepo egpRepo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @Mock ScoreRepo scoreRepo;
+    @InjectMocks PickupCrewService service;
+
+    @Test
+    void getCrewsForEventGenre_returnsEmptyWhenEventOrGenreNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.empty());
+
+        assertThat(service.getCrewsForEventGenre("Missing", "breaking")).isEmpty();
+    }
+
+    @Test
+    void getCrewsForEventGenre_returnsEmptyWhenNoCrews() {
+        Event e = new Event(); e.setEventName("Fest");
+        Genre g = new Genre(); g.setGenreName("breaking");
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.of(g));
+        when(crewRepo.findByEventAndGenre(e, g)).thenReturn(List.of());
+
+        assertThat(service.getCrewsForEventGenre("Fest", "breaking")).isEmpty();
+    }
+
+    @Test
+    void deleteCrew_delegatesToRepo() {
+        service.deleteCrew(1L);
+        verify(crewRepo).deleteById(1L);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/QrCodeServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/QrCodeServiceTest.java
@@ -1,0 +1,27 @@
+package com.example.BES.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class QrCodeServiceTest {
+
+    private final QrCodeService service = new QrCodeService();
+
+    @Test
+    void generateQrCode_returnsPngBytes() throws Exception {
+        byte[] result = service.generateQrCode("https://example.com", 200, 200);
+
+        assertThat(result).isNotEmpty();
+        // PNG magic bytes: 0x89 0x50 0x4E 0x47
+        assertThat(result[0]).isEqualTo((byte) 0x89);
+        assertThat(result[1]).isEqualTo((byte) 0x50);
+    }
+
+    @Test
+    void generateQrCode_worksWithSmallDimensions() throws Exception {
+        byte[] result = service.generateQrCode("hello", 100, 100);
+
+        assertThat(result).isNotEmpty();
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/RegistrationServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/RegistrationServiceTest.java
@@ -1,0 +1,115 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetUnverifiedParticipantDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.EventParticipantTeamMemberRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.ParticipantRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationServiceTest {
+
+    @Mock GoogleSheetService sheetService;
+    @Mock MailSenderService mailService;
+    @Mock EventRepo eventRepo;
+    @Mock ParticipantService participantService;
+    @Mock ParticipantRepo participantRepo;
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventGenreParticpantRepo eventGenreParticipantRepo;
+    @Mock EventParticipantTeamMemberRepo teamMemberRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @InjectMocks RegistrationService service;
+
+    @Test
+    void getUnverifiedParticipants_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        List<GetUnverifiedParticipantDto> result = service.getUnverifiedParticipantsFromDb("Missing");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getUnverifiedParticipants_returnsListWhenFound() {
+        Event e = new Event();
+        e.setEventId(1L);
+        e.setEventName("Fest");
+        Participant p = new Participant();
+        p.setParticipantId(10L);
+        p.setParticipantName("Player1");
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        ep.setParticipant(p);
+        ep.setDisplayName("Player1");
+        ep.setScreenshotUrl("http://img.png");
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+        when(eventParticipantRepo.findByEventAndPaymentVerifiedFalse(e)).thenReturn(List.of(ep));
+        when(eventGenreParticipantRepo.findByEventIdAndParticipantId(1L, 10L))
+            .thenReturn(List.of());
+
+        List<GetUnverifiedParticipantDto> result = service.getUnverifiedParticipantsFromDb("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name).isEqualTo("Player1");
+    }
+
+    @Test
+    void verifyAndEmail_throwsWhenEventOrParticipantNotFound() {
+        when(eventRepo.findById(1L)).thenReturn(Optional.empty());
+        when(participantRepo.findById(10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.verifyAndEmail(10L, 1L))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void verifyAndEmail_throwsWhenEventParticipantNotFound() {
+        Event e = new Event(); e.setEventId(1L);
+        Participant p = new Participant(); p.setParticipantId(10L);
+        when(eventRepo.findById(1L)).thenReturn(Optional.of(e));
+        when(participantRepo.findById(10L)).thenReturn(Optional.of(p));
+        when(eventParticipantRepo.findByEventAndParticipant(e, p)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.verifyAndEmail(10L, 1L))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void verifyAndEmail_setsPaymentVerifiedAndSkipsEmailIfAlreadySent() throws Exception {
+        Event e = new Event(); e.setEventId(1L); e.setEventName("Fest");
+        Participant p = new Participant(); p.setParticipantId(10L);
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        ep.setParticipant(p);
+        ep.setEmailSent(true); // already sent
+        ep.setPaymentVerified(false);
+        when(eventRepo.findById(1L)).thenReturn(Optional.of(e));
+        when(participantRepo.findById(10L)).thenReturn(Optional.of(p));
+        when(eventParticipantRepo.findByEventAndParticipant(e, p)).thenReturn(Optional.of(ep));
+
+        service.verifyAndEmail(10L, 1L);
+
+        assertThat(ep.isPaymentVerified()).isTrue();
+        verify(mailService, never()).sendEmailWithAttachment(any(), any(), any(), any(), any());
+        verify(eventParticipantRepo).save(ep);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/ResultsServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/ResultsServiceTest.java
@@ -1,0 +1,88 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetResultsDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.Genre;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.AuditionFeedbackRepository;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.ScoreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ResultsServiceTest {
+
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventGenreParticpantRepo egpRepo;
+    @Mock ScoreRepo scoreRepo;
+    @Mock AuditionFeedbackRepository feedbackRepo;
+    @InjectMocks ResultsService service;
+
+    @Test
+    void getResultsByRefCode_returnsNullWhenRefCodeNotFound() {
+        when(eventParticipantRepo.findByReferenceCode("UNKNOWN")).thenReturn(Optional.empty());
+
+        assertThat(service.getResultsByRefCode("UNKNOWN")).isNull();
+    }
+
+    @Test
+    void getResultsByRefCode_returnsNullWhenResultsNotReleased() {
+        Event e = new Event();
+        e.setResultsReleased(false);
+        e.setEventName("Fest");
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        Participant p = new Participant();
+        ep.setParticipant(p);
+        ep.setDisplayName("Player1");
+        when(eventParticipantRepo.findByReferenceCode("ABC123")).thenReturn(Optional.of(ep));
+
+        assertThat(service.getResultsByRefCode("ABC123")).isNull();
+    }
+
+    @Test
+    void getResultsByRefCode_returnsResultsWhenReleased() {
+        Event e = new Event();
+        e.setEventId(1L);
+        e.setEventName("Fest");
+        e.setResultsReleased(true);
+        Participant p = new Participant();
+        p.setParticipantId(10L);
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        ep.setParticipant(p);
+        ep.setDisplayName("Player1");
+
+        Genre g = new Genre();
+        g.setGenreName("breaking");
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        when(egp.getGenre()).thenReturn(g);
+        when(egp.getFormat()).thenReturn("1v1");
+        when(egp.getAuditionNumber()).thenReturn(1);
+
+        when(eventParticipantRepo.findByReferenceCode("ABC123")).thenReturn(Optional.of(ep));
+        when(egpRepo.findByEventIdAndParticipantId(1L, 10L)).thenReturn(List.of(egp));
+        when(scoreRepo.findByEventGenreParticipant(egp)).thenReturn(List.of());
+        when(feedbackRepo.findByEventGenreParticipant(egp)).thenReturn(List.of());
+
+        GetResultsDto result = service.getResultsByRefCode("ABC123");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParticipantName()).isEqualTo("Player1");
+        assertThat(result.getEventName()).isEqualTo("Fest");
+        assertThat(result.getGenres()).hasSize(1);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/ScoreServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/ScoreServiceTest.java
@@ -1,0 +1,313 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.AspectScoreDto;
+import com.example.BES.dtos.GetParticipatnScoreDto;
+import com.example.BES.dtos.ParticipantScoreDto;
+import com.example.BES.dtos.UpdateParticipantsScoreDto;
+import com.example.BES.dtos.admin.DeleteScoreByEventDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventGenreParticipantId;
+import com.example.BES.models.Genre;
+import com.example.BES.models.Judge;
+import com.example.BES.models.Score;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.JudgeRepo;
+import com.example.BES.respositories.ScoreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScoreServiceTest {
+
+    @Mock ScoreRepo repo;
+    @Mock EventGenreParticpantRepo eventGenreParticpantRepo;
+    @Mock JudgeRepo judgeRepo;
+    @InjectMocks ScoreService service;
+
+    // -----------------------------------------------------------------------
+    // getAllScore
+    // -----------------------------------------------------------------------
+
+    @Test
+    void getAllScore_skipsRowsWithNullJudgeOrEgp() {
+        // Score 1: valid — has both judge and EGP
+        Score validScore = mock(Score.class);
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        EventGenreParticipantId egpId = new EventGenreParticipantId(1L, 2L, 3L);
+        Event event = new Event();
+        event.setEventName("Spring Battle");
+        Genre genre = new Genre();
+        genre.setGenreName("Breaking");
+        Judge judge = new Judge();
+        judge.setName("Jay");
+
+        when(validScore.getJudge()).thenReturn(judge);
+        when(validScore.getEventGenreParticipant()).thenReturn(egp);
+        when(egp.getId()).thenReturn(egpId);
+        when(egp.getEvent()).thenReturn(event);
+        when(egp.getGenre()).thenReturn(genre);
+        when(egp.getDisplayName()).thenReturn("B-Boy Spark");
+        when(egp.getFormat()).thenReturn("solo");
+        when(validScore.getValue()).thenReturn(8.5);
+        when(validScore.getAspect()).thenReturn("Overall");
+
+        // Score 2: invalid — null judge
+        Score nullJudgeScore = mock(Score.class);
+        when(nullJudgeScore.getJudge()).thenReturn(null);
+
+        when(repo.findbyEvent("Spring Battle")).thenReturn(List.of(validScore, nullJudgeScore));
+
+        List<GetParticipatnScoreDto> result = service.getAllScore("Spring Battle");
+
+        assertThat(result).hasSize(1);
+        GetParticipatnScoreDto dto = result.get(0);
+        assertThat(dto.participantId).isEqualTo(3L);
+        assertThat(dto.eventName).isEqualTo("Spring Battle");
+        assertThat(dto.genreName).isEqualTo("Breaking");
+        assertThat(dto.judgeName).isEqualTo("Jay");
+        assertThat(dto.participantName).isEqualTo("B-Boy Spark");
+        assertThat(dto.score).isEqualTo(8.5);
+        assertThat(dto.aspect).isEqualTo("Overall");
+        assertThat(dto.format).isEqualTo("solo");
+    }
+
+    @Test
+    void getAllScore_nullAspectBecomesEmptyString() {
+        Score s = mock(Score.class);
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        EventGenreParticipantId egpId = new EventGenreParticipantId(1L, 2L, 4L);
+        Event event = new Event();
+        event.setEventName("Fest");
+        Genre genre = new Genre();
+        genre.setGenreName("Locking");
+        Judge judge = new Judge();
+        judge.setName("Sam");
+
+        when(s.getJudge()).thenReturn(judge);
+        when(s.getEventGenreParticipant()).thenReturn(egp);
+        when(egp.getId()).thenReturn(egpId);
+        when(egp.getEvent()).thenReturn(event);
+        when(egp.getGenre()).thenReturn(genre);
+        when(egp.getDisplayName()).thenReturn("Locker A");
+        when(egp.getFormat()).thenReturn("duo");
+        when(s.getValue()).thenReturn(7.0);
+        when(s.getAspect()).thenReturn(null);
+
+        when(repo.findbyEvent("Fest")).thenReturn(List.of(s));
+
+        List<GetParticipatnScoreDto> result = service.getAllScore("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).aspect).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // updateParticipantScoreService — single-score mode
+    // -----------------------------------------------------------------------
+
+    @Test
+    void updateScore_singleScoreMode_deletesOldAndSavesNew() {
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Judge judge = new Judge();
+        judge.setName("Ray");
+
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("Fest", "Popping", "Alice"))
+                .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Ray")).thenReturn(Optional.of(judge));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ParticipantScoreDto pScore = new ParticipantScoreDto();
+        pScore.participantName = "Alice";
+        pScore.score = 9.0;
+        pScore.aspects = null; // single-score mode
+
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "Fest";
+        dto.genreName = "Popping";
+        dto.judgeName = "Ray";
+        dto.participantScore = List.of(pScore);
+
+        service.updateParticipantScoreService(dto);
+
+        verify(repo).deleteByEventGenreParticipantAndJudge(egp, judge);
+        ArgumentCaptor<Score> saved = ArgumentCaptor.forClass(Score.class);
+        verify(repo).save(saved.capture());
+        assertThat(saved.getValue().getValue()).isEqualTo(9.0);
+        assertThat(saved.getValue().getAspect()).isEmpty();
+        assertThat(saved.getValue().getJudge()).isSameAs(judge);
+        assertThat(saved.getValue().getEventGenreParticipant()).isSameAs(egp);
+    }
+
+    // -----------------------------------------------------------------------
+    // updateParticipantScoreService — aspect (multi-criteria) mode
+    // -----------------------------------------------------------------------
+
+    @Test
+    void updateScore_aspectMode_savesPerAspect_noDeleteCalled() {
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Judge judge = new Judge();
+        judge.setName("Maya");
+
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("Jam", "Breaking", "Bob"))
+                .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Maya")).thenReturn(Optional.of(judge));
+
+        // Both aspects have no existing score row → create new
+        when(repo.findByEventGenreParticipantAndJudgeAndAspect(egp, judge, "Musicality"))
+                .thenReturn(Optional.empty());
+        when(repo.findByEventGenreParticipantAndJudgeAndAspect(egp, judge, "Creativity"))
+                .thenReturn(Optional.empty());
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        AspectScoreDto a1 = new AspectScoreDto();
+        a1.aspect = "Musicality";
+        a1.score = 8.0;
+        AspectScoreDto a2 = new AspectScoreDto();
+        a2.aspect = "Creativity";
+        a2.score = 7.5;
+
+        ParticipantScoreDto pScore = new ParticipantScoreDto();
+        pScore.participantName = "Bob";
+        pScore.score = null;
+        pScore.aspects = List.of(a1, a2);
+
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "Jam";
+        dto.genreName = "Breaking";
+        dto.judgeName = "Maya";
+        dto.participantScore = List.of(pScore);
+
+        service.updateParticipantScoreService(dto);
+
+        // delete should never be called in aspect mode
+        verify(repo, never()).deleteByEventGenreParticipantAndJudge(any(), any());
+
+        // Two saves — one per aspect
+        ArgumentCaptor<Score> saved = ArgumentCaptor.forClass(Score.class);
+        verify(repo, times(2)).save(saved.capture());
+        List<Score> savedScores = saved.getAllValues();
+        assertThat(savedScores).extracting(Score::getAspect)
+                .containsExactlyInAnyOrder("Musicality", "Creativity");
+        assertThat(savedScores).extracting(Score::getValue)
+                .containsExactlyInAnyOrder(8.0, 7.5);
+    }
+
+    @Test
+    void updateScore_aspectMode_updatesExistingAspectRow() {
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Judge judge = new Judge();
+        judge.setName("Nina");
+
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("Jam", "Waacking", "Carol"))
+                .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Nina")).thenReturn(Optional.of(judge));
+
+        Score existing = new Score();
+        existing.setAspect("Style");
+        existing.setValue(6.0);
+
+        when(repo.findByEventGenreParticipantAndJudgeAndAspect(egp, judge, "Style"))
+                .thenReturn(Optional.of(existing));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        AspectScoreDto a1 = new AspectScoreDto();
+        a1.aspect = "Style";
+        a1.score = 9.5;
+
+        ParticipantScoreDto pScore = new ParticipantScoreDto();
+        pScore.participantName = "Carol";
+        pScore.aspects = List.of(a1);
+
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "Jam";
+        dto.genreName = "Waacking";
+        dto.judgeName = "Nina";
+        dto.participantScore = List.of(pScore);
+
+        service.updateParticipantScoreService(dto);
+
+        verify(repo, never()).deleteByEventGenreParticipantAndJudge(any(), any());
+        ArgumentCaptor<Score> saved = ArgumentCaptor.forClass(Score.class);
+        verify(repo).save(saved.capture());
+        assertThat(saved.getValue().getValue()).isEqualTo(9.5);
+    }
+
+    // -----------------------------------------------------------------------
+    // updateParticipantScoreService — skip when EGP or Judge not found
+    // -----------------------------------------------------------------------
+
+    @Test
+    void updateScore_skipsWhenEgpNotFound() {
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("X", "Y", "Dave"))
+                .thenReturn(Optional.empty());
+        when(judgeRepo.findByName("Tom")).thenReturn(Optional.of(new Judge()));
+
+        ParticipantScoreDto pScore = new ParticipantScoreDto();
+        pScore.participantName = "Dave";
+        pScore.score = 5.0;
+        pScore.aspects = null;
+
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "X";
+        dto.genreName = "Y";
+        dto.judgeName = "Tom";
+        dto.participantScore = List.of(pScore);
+
+        service.updateParticipantScoreService(dto);
+
+        verify(repo, never()).save(any());
+        verify(repo, never()).deleteByEventGenreParticipantAndJudge(any(), any());
+    }
+
+    @Test
+    void updateScore_skipsWhenJudgeNotFound() {
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("X", "Y", "Eve"))
+                .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Ghost")).thenReturn(Optional.empty());
+
+        ParticipantScoreDto pScore = new ParticipantScoreDto();
+        pScore.participantName = "Eve";
+        pScore.score = 5.0;
+        pScore.aspects = null;
+
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "X";
+        dto.genreName = "Y";
+        dto.judgeName = "Ghost";
+        dto.participantScore = List.of(pScore);
+
+        service.updateParticipantScoreService(dto);
+
+        verify(repo, never()).save(any());
+        verify(repo, never()).deleteByEventGenreParticipantAndJudge(any(), any());
+    }
+
+    // -----------------------------------------------------------------------
+    // deleteScoreByEventService
+    // -----------------------------------------------------------------------
+
+    @Test
+    void deleteScoreByEvent_delegatesToRepo() {
+        DeleteScoreByEventDto dto = mock(DeleteScoreByEventDto.class);
+        when(dto.getEvent_id()).thenReturn(42L);
+        when(repo.deleteByEventId(42L)).thenReturn(5);
+
+        Integer result = service.deleteScoreByEventService(dto);
+
+        verify(repo).deleteByEventId(42L);
+        assertThat(result).isEqualTo(5);
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/ScoringCriteriaServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/ScoringCriteriaServiceTest.java
@@ -1,0 +1,212 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddScoringCriteriaDto;
+import com.example.BES.dtos.GetScoringCriteriaDto;
+import com.example.BES.dtos.UpdateScoringCriteriaDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.Genre;
+import com.example.BES.models.ScoringCriteria;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.ScoringCriteriaRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScoringCriteriaServiceTest {
+
+    @Mock
+    ScoringCriteriaRepo repo;
+    @Mock
+    EventRepo eventRepo;
+    @Mock
+    GenreRepo genreRepo;
+    @InjectMocks
+    ScoringCriteriaService service;
+
+    private ScoringCriteria criteria(Long id, String name, double weight) {
+        ScoringCriteria sc = new ScoringCriteria();
+        sc.setId(id);
+        sc.setName(name);
+        sc.setWeight(weight);
+        sc.setDisplayOrder(0);
+        return sc;
+    }
+
+    @Test
+    void getCriteria_withGenre_fallsBackToEventLevel() {
+        when(repo.findByEventNameAndGenreName("Fest", "breaking")).thenReturn(List.of());
+        when(repo.findEventLevelByEventName("Fest")).thenReturn(List.of(criteria(1L, "Technique", 1.0)));
+
+        List<GetScoringCriteriaDto> result = service.getCriteria("Fest", "breaking");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name).isEqualTo("Technique");
+    }
+
+    @Test
+    void getCriteria_withGenre_returnsGenreSpecificWhenPresent() {
+        when(repo.findByEventNameAndGenreName("Fest", "breaking"))
+            .thenReturn(List.of(criteria(2L, "Musicality", 0.5)));
+
+        List<GetScoringCriteriaDto> result = service.getCriteria("Fest", "breaking");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name).isEqualTo("Musicality");
+    }
+
+    @Test
+    void getCriteria_withoutGenre_returnsEventLevel() {
+        when(repo.findEventLevelByEventName("Fest"))
+            .thenReturn(List.of(criteria(1L, "Overall", 1.0)));
+
+        List<GetScoringCriteriaDto> result = service.getCriteria("Fest", null);
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getCriteria_blankGenreName_treatsAsNull() {
+        when(repo.findEventLevelByEventName("Fest"))
+            .thenReturn(List.of(criteria(1L, "Overall", 1.0)));
+
+        List<GetScoringCriteriaDto> result = service.getCriteria("Fest", "");
+
+        assertThat(result).hasSize(1);
+        verify(repo, never()).findByEventNameAndGenreName(anyString(), anyString());
+    }
+
+    @Test
+    void addCriteria_throwsWhenEventNotFound() {
+        AddScoringCriteriaDto dto = new AddScoringCriteriaDto();
+        dto.eventName = "Missing";
+        dto.name = "Technique";
+        dto.weight = 1.0;
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addCriteria(dto))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void addCriteria_throwsWhenGenreNotFound() {
+        AddScoringCriteriaDto dto = new AddScoringCriteriaDto();
+        dto.eventName = "Fest";
+        dto.genreName = "breaking";
+        dto.name = "Technique";
+        dto.weight = 1.0;
+        Event e = new Event();
+        e.setEventName("Fest");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addCriteria(dto))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void addCriteria_savesWithoutGenre() {
+        AddScoringCriteriaDto dto = new AddScoringCriteriaDto();
+        dto.eventName = "Fest";
+        dto.name = "Technique";
+        dto.weight = 1.0;
+        dto.genreName = null;
+        Event e = new Event();
+        e.setEventName("Fest");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        ScoringCriteria saved = criteria(1L, "Technique", 1.0);
+        saved.setEvent(e);
+        when(repo.save(any())).thenReturn(saved);
+
+        GetScoringCriteriaDto result = service.addCriteria(dto);
+
+        assertThat(result.name).isEqualTo("Technique");
+        verify(repo).save(any(ScoringCriteria.class));
+    }
+
+    @Test
+    void addCriteria_savesWithGenre() {
+        AddScoringCriteriaDto dto = new AddScoringCriteriaDto();
+        dto.eventName = "Fest";
+        dto.genreName = "breaking";
+        dto.name = "Musicality";
+        dto.weight = 0.5;
+        Event e = new Event();
+        e.setEventName("Fest");
+        Genre g = new Genre();
+        g.setGenreName("breaking");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.of(g));
+        ScoringCriteria saved = criteria(2L, "Musicality", 0.5);
+        saved.setEvent(e);
+        saved.setGenre(g);
+        when(repo.save(any())).thenReturn(saved);
+
+        GetScoringCriteriaDto result = service.addCriteria(dto);
+
+        assertThat(result.name).isEqualTo("Musicality");
+        verify(repo).save(any(ScoringCriteria.class));
+    }
+
+    @Test
+    void updateCriteria_throwsWhenNotFound() {
+        UpdateScoringCriteriaDto dto = new UpdateScoringCriteriaDto();
+        dto.name = "New";
+        dto.weight = 0.5;
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateCriteria(99L, dto))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void updateCriteria_updatesNameAndWeight() {
+        UpdateScoringCriteriaDto dto = new UpdateScoringCriteriaDto();
+        dto.name = "Updated";
+        dto.weight = 0.75;
+        ScoringCriteria existing = criteria(1L, "Old", 1.0);
+        when(repo.findById(1L)).thenReturn(Optional.of(existing));
+        when(repo.save(any())).thenReturn(existing);
+
+        service.updateCriteria(1L, dto);
+
+        verify(repo).save(any(ScoringCriteria.class));
+    }
+
+    @Test
+    void removeCriteria_delegatesToRepo() {
+        service.removeCriteria(1L);
+
+        verify(repo).deleteById(1L);
+    }
+
+    @Test
+    void deleteAllCriteria_withGenre_deletesGenreSpecific() {
+        List<ScoringCriteria> list = List.of(criteria(1L, "T", 1.0));
+        when(repo.findByEventNameAndGenreName("Fest", "breaking")).thenReturn(list);
+
+        service.deleteAllCriteria("Fest", "breaking");
+
+        verify(repo).deleteAll(list);
+    }
+
+    @Test
+    void deleteAllCriteria_withoutGenre_deletesEventLevel() {
+        List<ScoringCriteria> list = List.of(criteria(2L, "Overall", 1.0));
+        when(repo.findEventLevelByEventName("Fest")).thenReturn(list);
+
+        service.deleteAllCriteria("Fest", null);
+
+        verify(repo).deleteAll(list);
+    }
+}

--- a/docs/superpowers/plans/2026-05-25-test-coverage.md
+++ b/docs/superpowers/plans/2026-05-25-test-coverage.md
@@ -1,0 +1,2654 @@
+# Test Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise backend service test coverage to ≥70% line coverage (enforced by JaCoCo) and expand frontend utility tests with a coverage report.
+
+**Architecture:** Mockito unit tests (`@ExtendWith(MockitoExtension.class)`) for all 21 backend services; one new `ResultsControllerIntegrationTest` using the existing H2/MockMvc pattern; JaCoCo gate enforced at `mvn test`; `@vitest/coverage-v8` installed for frontend coverage reporting.
+
+**Tech Stack:** JUnit 5, Mockito, AssertJ, JaCoCo 0.8.12, Vitest + @vitest/coverage-v8, Spring Boot Test
+
+---
+
+## File Map
+
+**Modify:**
+- `BES/pom.xml` — add JaCoCo plugin
+- `BES-frontend/package.json` — add `@vitest/coverage-v8` devDependency
+- `BES-frontend/src/utils/__tests__/api.test.js` — expand coverage
+
+**Create (backend tests):**
+- `BES/src/test/java/com/example/BES/services/EventServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/GenreServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/JudgeServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/ParticipantServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/EventGenreServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/ScoreServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/ScoringCriteriaServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/ResultsServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/BattleServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/RegistrationServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/EventParticpantServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/PickupCrewServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/EmailTemplateServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/EventGenreParticpantServiceTest.java`
+- `BES/src/test/java/com/example/BES/services/QrCodeServiceTest.java`
+- `BES/src/test/java/com/example/BES/controllers/ResultsControllerIntegrationTest.java`
+
+**Create (frontend tests):**
+- `BES-frontend/src/utils/__tests__/auth.test.js`
+- `BES-frontend/src/utils/__tests__/adminApi.test.js`
+
+---
+
+## Task 1: Add JaCoCo to pom.xml
+
+**Files:** Modify `BES/pom.xml`
+
+- [ ] **Step 1: Add JaCoCo plugin inside `<build><plugins>`**
+
+In `BES/pom.xml`, after the `spring-boot-maven-plugin` closing `</plugin>` tag, add:
+
+```xml
+<plugin>
+    <groupId>org.jacoco</groupId>
+    <artifactId>jacoco-maven-plugin</artifactId>
+    <version>0.8.12</version>
+    <executions>
+        <execution>
+            <id>prepare-agent</id>
+            <goals><goal>prepare-agent</goal></goals>
+        </execution>
+        <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals><goal>report</goal></goals>
+        </execution>
+        <execution>
+            <id>check</id>
+            <phase>test</phase>
+            <goals><goal>check</goal></goals>
+            <configuration>
+                <rules>
+                    <rule>
+                        <element>PACKAGE</element>
+                        <includes>
+                            <include>com/example/BES/services</include>
+                        </includes>
+                        <limits>
+                            <limit>
+                                <counter>LINE</counter>
+                                <value>COVEREDRATIO</value>
+                                <minimum>0.70</minimum>
+                            </limit>
+                        </limits>
+                    </rule>
+                </rules>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+- [ ] **Step 2: Verify pom.xml is valid**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn validate
+```
+Expected: `BUILD SUCCESS`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/pom.xml && git commit -m "build: add JaCoCo coverage gate (70% line coverage on services)"
+```
+
+---
+
+## Task 2: Frontend coverage tooling
+
+**Files:** Modify `BES-frontend/package.json`
+
+- [ ] **Step 1: Install @vitest/coverage-v8**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm install --save-dev @vitest/coverage-v8
+```
+Expected: package added, `package.json` updated.
+
+- [ ] **Step 2: Verify coverage command works**
+
+```bash
+npm run test:coverage
+```
+Expected: runs and shows a coverage table (only api.test.js at this point, low %).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES-frontend/package.json BES-frontend/package-lock.json && git commit -m "build: install vitest coverage-v8 for frontend coverage reports"
+```
+
+---
+
+## Task 3: EventServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/EventServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddEventDto;
+import com.example.BES.dtos.GetEventDto;
+import com.example.BES.models.Event;
+import com.example.BES.respositories.EventRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock EventRepo repo;
+    @Mock EmailTemplateService emailTemplateService;
+    @Mock SimpMessagingTemplate messagingTemplate;
+    @InjectMocks EventService service;
+
+    private Event event(String name) {
+        Event e = new Event();
+        e.setEventName(name);
+        e.setAccessCode("1234");
+        return e;
+    }
+
+    @Test
+    void createEvent_skipsIfAlreadyExists() {
+        AddEventDto dto = new AddEventDto();
+        dto.eventName = "BattleFest";
+        dto.accessCode = "1234";
+        when(repo.findByEventName("BattleFest")).thenReturn(Optional.of(event("BattleFest")));
+
+        service.createEventService(dto);
+
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void createEvent_savesNewEventAndCreatesTemplate() {
+        AddEventDto dto = new AddEventDto();
+        dto.eventName = "NewEvent";
+        dto.accessCode = "5678";
+        when(repo.findByEventName("NewEvent")).thenReturn(Optional.empty());
+        Event saved = event("NewEvent");
+        when(repo.save(any())).thenReturn(saved);
+
+        service.createEventService(dto);
+
+        verify(repo).save(any(Event.class));
+        verify(emailTemplateService).createDefaultTemplate(saved);
+    }
+
+    @Test
+    void createEvent_generatesRandomCodeWhenInvalidProvided() {
+        AddEventDto dto = new AddEventDto();
+        dto.eventName = "RandEvent";
+        dto.accessCode = "abc";
+        when(repo.findByEventName("RandEvent")).thenReturn(Optional.empty());
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.createEventService(dto);
+
+        verify(repo).save(argThat(e -> ((Event) e).getAccessCode().matches("\\d{4}")));
+    }
+
+    @Test
+    void verifyAccessCode_trueOnMatch() {
+        Event e = event("Test");
+        e.setAccessCode("9999");
+        when(repo.findById(1L)).thenReturn(Optional.of(e));
+
+        assertThat(service.verifyAccessCode(1L, "9999")).isTrue();
+    }
+
+    @Test
+    void verifyAccessCode_falseOnMismatch() {
+        Event e = event("Test");
+        e.setAccessCode("9999");
+        when(repo.findById(1L)).thenReturn(Optional.of(e));
+
+        assertThat(service.verifyAccessCode(1L, "0000")).isFalse();
+    }
+
+    @Test
+    void verifyAccessCode_throwsWhenNotFound() {
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.verifyAccessCode(99L, "1234"))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void releaseResults_setsFlag() {
+        Event e = event("Fest");
+        when(repo.findByEventName("Fest")).thenReturn(Optional.of(e));
+
+        service.releaseResults("Fest", true);
+
+        assertThat(e.isResultsReleased()).isTrue();
+        verify(repo).save(e);
+    }
+
+    @Test
+    void releaseResults_throwsWhenNotFound() {
+        when(repo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.releaseResults("Missing", true))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void updateAccessCode_throwsOnInvalidCode() {
+        assertThatThrownBy(() -> service.updateAccessCode(1L, "abc"))
+            .isInstanceOf(ResponseStatusException.class);
+        assertThatThrownBy(() -> service.updateAccessCode(1L, null))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void updateAccessCode_savesValidCode() {
+        Event e = event("Fest");
+        when(repo.findById(1L)).thenReturn(Optional.of(e));
+
+        service.updateAccessCode(1L, "4321");
+
+        assertThat(e.getAccessCode()).isEqualTo("4321");
+        verify(repo).save(e);
+    }
+
+    @Test
+    void getAllEvents_includesAccessCodeWhenFlagTrue() {
+        Event e = event("Fest");
+        when(repo.findAll()).thenReturn(List.of(e));
+
+        List<GetEventDto> result = service.getAllEvents(true);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getAccessCode()).isEqualTo("1234");
+    }
+
+    @Test
+    void getAllEvents_hidesAccessCodeWhenFlagFalse() {
+        Event e = event("Fest");
+        when(repo.findAll()).thenReturn(List.of(e));
+
+        List<GetEventDto> result = service.getAllEvents(false);
+
+        assertThat(result.get(0).getAccessCode()).isNull();
+    }
+
+    @Test
+    void setJudgingMode_updatesAndBroadcasts() {
+        Event e = event("Fest");
+        when(repo.findByEventName("Fest")).thenReturn(Optional.of(e));
+
+        service.setJudgingMode("Fest", "CUSTOM");
+
+        assertThat(e.getJudgingMode()).isEqualTo("CUSTOM");
+        verify(repo).save(e);
+        verify(messagingTemplate).convertAndSend(eq("/topic/judging-mode/"), any());
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify passes**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=EventServiceTest -DskipJacoco=true 2>&1 | tail -10
+```
+Expected: `Tests run: 12, Failures: 0, Errors: 0`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/EventServiceTest.java && git commit -m "test: EventService unit tests (12 cases)"
+```
+
+---
+
+## Task 4: GenreServiceTest + JudgeServiceTest + ParticipantServiceTest
+
+**Files:** Create three test files.
+
+- [ ] **Step 1: Write GenreServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetGenreDto;
+import com.example.BES.dtos.admin.AddGenreDto;
+import com.example.BES.dtos.admin.DeleteGenreDto;
+import com.example.BES.dtos.admin.UpdateGenreDto;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.GenreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GenreServiceTest {
+
+    @Mock GenreRepo repo;
+    @InjectMocks GenreService service;
+
+    private Genre genre(Long id, String name) {
+        Genre g = new Genre();
+        g.setGenreId(id);
+        g.setGenreName(name);
+        return g;
+    }
+
+    @Test
+    void getAllGenres_mapsToDto() {
+        when(repo.findAll()).thenReturn(List.of(genre(1L, "breaking")));
+
+        List<GetGenreDto> result = service.getAllGenres();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).genreName).isEqualTo("breaking");
+        assertThat(result.get(0).id).isEqualTo(1L);
+    }
+
+    @Test
+    void addGenre_createsNewWhenNotExists() {
+        AddGenreDto dto = mock(AddGenreDto.class);
+        when(dto.getName()).thenReturn("Popping");
+        Genre newGenre = genre(null, null);
+        when(repo.findByGenreName("popping")).thenReturn(Optional.of(newGenre));
+
+        service.addGenreService(dto);
+
+        // genre already exists but has no name set — saved as-is
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void addGenre_savesWhenNew() {
+        AddGenreDto dto = mock(AddGenreDto.class);
+        when(dto.getName()).thenReturn("Locking");
+        Genre empty = new Genre();
+        when(repo.findByGenreName("locking")).thenReturn(Optional.of(empty));
+        // empty genre has null genreName → condition genre.getGenreName() == null → saves
+        when(repo.save(any())).thenReturn(empty);
+
+        Genre result = service.addGenreService(dto);
+
+        verify(repo).save(empty);
+    }
+
+    @Test
+    void updateGenre_updatesNameAndSaves() {
+        Genre g = genre(1L, "breaking");
+        UpdateGenreDto dto = mock(UpdateGenreDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(dto.getNewName()).thenReturn("b-boy");
+        when(repo.findById(1L)).thenReturn(Optional.of(g));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Genre result = service.updateGenreService(dto);
+
+        assertThat(result.getGenreName()).isEqualTo("b-boy");
+    }
+
+    @Test
+    void updateGenre_returnsNullWhenNotFound() {
+        UpdateGenreDto dto = mock(UpdateGenreDto.class);
+        when(dto.getId()).thenReturn(99L);
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(service.updateGenreService(dto)).isNull();
+    }
+
+    @Test
+    void deleteGenre_deletesAndReturnsName() {
+        Genre g = genre(1L, "locking");
+        DeleteGenreDto dto = mock(DeleteGenreDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(repo.findById(1L)).thenReturn(Optional.of(g));
+
+        String name = service.deleteGenreService(dto);
+
+        assertThat(name).isEqualTo("locking");
+        verify(repo).delete(g);
+    }
+
+    @Test
+    void deleteGenre_returnsEmptyStringWhenNotFound() {
+        DeleteGenreDto dto = mock(DeleteGenreDto.class);
+        when(dto.getId()).thenReturn(99L);
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(service.deleteGenreService(dto)).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Write JudgeServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddJudgeDto;
+import com.example.BES.dtos.GetJudgeDto;
+import com.example.BES.dtos.admin.DeleteJudgeDto;
+import com.example.BES.dtos.admin.UpdateJudgeDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.Judge;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.JudgeRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JudgeServiceTest {
+
+    @Mock JudgeRepo judgeRepo;
+    @Mock EventRepo eventRepo;
+    @InjectMocks JudgeService service;
+
+    private Judge judge(Long id, String name) {
+        Judge j = new Judge();
+        j.setJudgeId(id);
+        j.setName(name);
+        return j;
+    }
+
+    @Test
+    void addJudge_savesAndReturns() {
+        AddJudgeDto dto = new AddJudgeDto();
+        dto.judgeName = "Mike";
+        Judge saved = judge(1L, "Mike");
+        when(judgeRepo.save(any())).thenReturn(saved);
+
+        Judge result = service.addJudgeService(dto);
+
+        assertThat(result.getName()).isEqualTo("Mike");
+    }
+
+    @Test
+    void getAllJudges_mapsToDto() {
+        when(judgeRepo.findAll()).thenReturn(List.of(judge(1L, "Mike")));
+
+        List<GetJudgeDto> result = service.getAllJudges();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).judgeName).isEqualTo("Mike");
+    }
+
+    @Test
+    void getJudgeById_returnsNullWhenMissing() {
+        when(judgeRepo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(service.getJudgeById(99L)).isNull();
+    }
+
+    @Test
+    void updateJudge_updatesName() {
+        Judge j = judge(1L, "Old");
+        UpdateJudgeDto dto = mock(UpdateJudgeDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(dto.getNewName()).thenReturn("New");
+        when(judgeRepo.findById(1L)).thenReturn(Optional.of(j));
+        when(judgeRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Judge result = service.updateJudgeService(dto);
+
+        assertThat(result.getName()).isEqualTo("New");
+    }
+
+    @Test
+    void deleteJudge_deletesAndReturnsName() {
+        Judge j = judge(1L, "Mike");
+        DeleteJudgeDto dto = mock(DeleteJudgeDto.class);
+        when(dto.getId()).thenReturn(1L);
+        when(judgeRepo.findById(1L)).thenReturn(Optional.of(j));
+
+        String name = service.deleteJudgeService(dto);
+
+        assertThat(name).isEqualTo("Mike");
+        verify(judgeRepo).delete(j);
+    }
+
+    @Test
+    void getJudgesByEvent_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        List<GetJudgeDto> result = service.getJudgesByEvent("Missing");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void addJudgeToEvent_returnsNullWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.addJudgeToEvent("Missing", "Mike")).isNull();
+    }
+
+    @Test
+    void removeJudgeFromEvent_doesNothingWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        service.removeJudgeFromEvent("Missing", 1L); // should not throw
+
+        verify(eventRepo, never()).save(any());
+    }
+
+    @Test
+    void removeJudgeFromEvent_removesJudgeFromList() {
+        Judge j = judge(1L, "Mike");
+        Event e = new Event();
+        e.setEventName("Fest");
+        e.setJudges(new ArrayList<>(List.of(j)));
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+
+        service.removeJudgeFromEvent("Fest", 1L);
+
+        assertThat(e.getJudges()).isEmpty();
+        verify(eventRepo).save(e);
+    }
+}
+```
+
+- [ ] **Step 3: Write ParticipantServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddParticipantDto;
+import com.example.BES.dtos.AddWalkInDto;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.ParticipantRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipantServiceTest {
+
+    @Mock ParticipantRepo repo;
+    @InjectMocks ParticipantService service;
+
+    @Test
+    void addParticipant_returnsExistingWhenEmailMatches() {
+        AddParticipantDto dto = new AddParticipantDto();
+        dto.participantEmail = "test@example.com";
+        dto.participantName = "Test";
+        Participant existing = new Participant();
+        existing.setParticipantEmail("test@example.com");
+        when(repo.findByParticipantEmail("test@example.com")).thenReturn(Optional.of(existing));
+
+        Participant result = service.addParticpantService(dto);
+
+        assertThat(result).isSameAs(existing);
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void addParticipant_createsNewWhenEmailNotFound() {
+        AddParticipantDto dto = new AddParticipantDto();
+        dto.participantEmail = "new@example.com";
+        dto.participantName = "New Person";
+        when(repo.findByParticipantEmail("new@example.com")).thenReturn(Optional.empty());
+        Participant saved = new Participant();
+        when(repo.save(any())).thenReturn(saved);
+
+        Participant result = service.addParticpantService(dto);
+
+        assertThat(result).isSameAs(saved);
+        verify(repo).save(any(Participant.class));
+    }
+
+    @Test
+    void addParticipant_savesWhenEmailIsNull() {
+        AddParticipantDto dto = new AddParticipantDto();
+        dto.participantEmail = null;
+        dto.participantName = "Walk-in";
+        Participant saved = new Participant();
+        when(repo.save(any())).thenReturn(saved);
+
+        service.addParticpantService(dto);
+
+        verify(repo).save(any(Participant.class));
+    }
+
+    @Test
+    void addWalkIn_returnsExistingWhenNameMatches() {
+        AddWalkInDto dto = new AddWalkInDto();
+        dto.name = "Existing";
+        Participant existing = new Participant();
+        existing.setParticipantName("Existing");
+        when(repo.findByParticipantName("Existing")).thenReturn(Optional.of(existing));
+
+        Participant result = service.addWalkInService(dto);
+
+        assertThat(result).isSameAs(existing);
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void addWalkIn_createsNewWhenNotFound() {
+        AddWalkInDto dto = new AddWalkInDto();
+        dto.name = "Newbie";
+        Participant empty = new Participant();
+        when(repo.findByParticipantName("Newbie")).thenReturn(Optional.of(empty));
+        when(repo.save(any())).thenReturn(empty);
+
+        service.addWalkInService(dto);
+
+        verify(repo).save(empty);
+    }
+}
+```
+
+- [ ] **Step 4: Run all three**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest="GenreServiceTest,JudgeServiceTest,ParticipantServiceTest" 2>&1 | tail -5
+```
+Expected: all pass, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/GenreServiceTest.java BES/src/test/java/com/example/BES/services/JudgeServiceTest.java BES/src/test/java/com/example/BES/services/ParticipantServiceTest.java && git commit -m "test: GenreService, JudgeService, ParticipantService unit tests"
+```
+
+---
+
+## Task 5: EventGenreServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/EventGenreServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddGenreToEventDto;
+import com.example.BES.dtos.GetGenreDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenre;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventGenreServiceTest {
+
+    @Mock EventGenreRepo eventGenreRepo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @InjectMocks EventGenreService service;
+
+    private Event event(String name) {
+        Event e = new Event();
+        e.setEventName(name);
+        return e;
+    }
+
+    private Genre genre(Long id, String name) {
+        Genre g = new Genre();
+        g.setGenreId(id);
+        g.setGenreName(name);
+        return g;
+    }
+
+    @Test
+    void getGenresByEvent_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getGenresByEventService("Missing")).isEmpty();
+    }
+
+    @Test
+    void getGenresByEvent_mapsToDto() {
+        Event e = event("Fest");
+        Genre g = genre(1L, "breaking");
+        EventGenre eg = new EventGenre();
+        eg.setGenre(g);
+        eg.setFormat("1v1");
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+        when(eventGenreRepo.findByEvent(e)).thenReturn(List.of(eg));
+
+        List<GetGenreDto> result = service.getGenresByEventService("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).genreName).isEqualTo("breaking");
+        assertThat(result.get(0).format).isEqualTo("1v1");
+    }
+
+    @Test
+    void addGenreToEvent_throwsWhenGenreNotFound() {
+        Event e = event("Fest");
+        AddGenreToEventDto dto = new AddGenreToEventDto();
+        dto.eventName = "Fest";
+        dto.genreName = List.of("unknown");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("unknown")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addGenreToEventService(dto))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void addGenreToEvent_throwsOnDuplicate() {
+        Event e = event("Fest");
+        Genre g = genre(1L, "breaking");
+        AddGenreToEventDto dto = new AddGenreToEventDto();
+        dto.eventName = "Fest";
+        dto.genreName = List.of("breaking");
+        EventGenre existing = new EventGenre();
+        existing.setGenre(g); // non-null genre → duplicate
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.of(g));
+        when(eventGenreRepo.findByEventAndGenre(e, g)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.addGenreToEventService(dto))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void updateFormat_throwsWhenEventOrGenreNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateEventGenreFormat("Missing", "breaking", "1v1"))
+            .isInstanceOf(RuntimeException.class);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=EventGenreServiceTest 2>&1 | tail -5
+```
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/EventGenreServiceTest.java && git commit -m "test: EventGenreService unit tests"
+```
+
+---
+
+## Task 6: ScoreServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/ScoreServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.AspectScoreDto;
+import com.example.BES.dtos.GetParticipatnScoreDto;
+import com.example.BES.dtos.ParticipantScoreDto;
+import com.example.BES.dtos.UpdateParticipantsScoreDto;
+import com.example.BES.dtos.admin.DeleteScoreByEventDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.Genre;
+import com.example.BES.models.Judge;
+import com.example.BES.models.Score;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.JudgeRepo;
+import com.example.BES.respositories.ScoreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScoreServiceTest {
+
+    @Mock ScoreRepo repo;
+    @Mock EventGenreParticpantRepo eventGenreParticpantRepo;
+    @Mock JudgeRepo judgeRepo;
+    @InjectMocks ScoreService service;
+
+    private Score scoreWith(Judge judge, EventGenreParticipant egp, Double value, String aspect) {
+        Score s = new Score();
+        s.setJudge(judge);
+        s.setEventGenreParticipant(egp);
+        s.setValue(value);
+        s.setAspect(aspect);
+        return s;
+    }
+
+    @Test
+    void getAllScore_skipsRowsWithNullJudgeOrEgp() {
+        Score good = mock(Score.class);
+        Judge j = new Judge(); j.setName("Mike");
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Event e = new Event(); e.setEventName("Fest");
+        Genre g = new Genre(); g.setGenreName("breaking");
+        when(good.getJudge()).thenReturn(j);
+        when(good.getEventGenreParticipant()).thenReturn(egp);
+        when(good.getValue()).thenReturn(8.5);
+        when(good.getAspect()).thenReturn("technique");
+        when(egp.getEvent()).thenReturn(e);
+        when(egp.getGenre()).thenReturn(g);
+        when(egp.getDisplayName()).thenReturn("Player1");
+        when(egp.getFormat()).thenReturn("1v1");
+        // also include a bad row (null judge)
+        Score bad = new Score();
+        when(repo.findbyEvent("Fest")).thenReturn(List.of(good, bad));
+
+        List<GetParticipatnScoreDto> result = service.getAllScore("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).judgeName).isEqualTo("Mike");
+        assertThat(result.get(0).aspect).isEqualTo("technique");
+    }
+
+    @Test
+    void updateScore_singleScoreMode_deletesOldAndSavesNew() {
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "Fest";
+        dto.genreName = "breaking";
+        dto.judgeName = "Mike";
+        ParticipantScoreDto pd = new ParticipantScoreDto();
+        pd.participantName = "Player1";
+        pd.score = 8.5;
+        pd.aspects = null;
+        dto.participantScore = List.of(pd);
+
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Judge judge = new Judge(); judge.setName("Mike");
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("Fest", "breaking", "Player1"))
+            .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Mike")).thenReturn(Optional.of(judge));
+
+        service.updateParticipantScoreService(dto);
+
+        verify(repo).deleteByEventGenreParticipantAndJudge(egp, judge);
+        verify(repo).save(any(Score.class));
+    }
+
+    @Test
+    void updateScore_aspectMode_savesPerAspect() {
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "Fest";
+        dto.genreName = "breaking";
+        dto.judgeName = "Mike";
+        AspectScoreDto a1 = new AspectScoreDto();
+        a1.aspect = "technique";
+        a1.score = 8.0;
+        ParticipantScoreDto pd = new ParticipantScoreDto();
+        pd.participantName = "Player1";
+        pd.aspects = List.of(a1);
+        dto.participantScore = List.of(pd);
+
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Judge judge = new Judge(); judge.setName("Mike");
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("Fest", "breaking", "Player1"))
+            .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Mike")).thenReturn(Optional.of(judge));
+        when(repo.findByEventGenreParticipantAndJudgeAndAspect(egp, judge, "technique"))
+            .thenReturn(Optional.empty());
+
+        service.updateParticipantScoreService(dto);
+
+        verify(repo).save(any(Score.class));
+        verify(repo, never()).deleteByEventGenreParticipantAndJudge(any(), any());
+    }
+
+    @Test
+    void updateScore_skipsWhenEgpOrJudgeNotFound() {
+        UpdateParticipantsScoreDto dto = new UpdateParticipantsScoreDto();
+        dto.eventName = "Fest";
+        dto.genreName = "breaking";
+        dto.judgeName = "Ghost";
+        ParticipantScoreDto pd = new ParticipantScoreDto();
+        pd.participantName = "Nobody";
+        dto.participantScore = List.of(pd);
+        when(eventGenreParticpantRepo.findByEventGenreParticipant("Fest", "breaking", "Nobody"))
+            .thenReturn(Optional.empty());
+
+        service.updateParticipantScoreService(dto);
+
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void deleteScoreByEvent_delegatesToRepo() {
+        DeleteScoreByEventDto dto = mock(DeleteScoreByEventDto.class);
+        when(dto.getEvent_id()).thenReturn(1L);
+        when(repo.deleteByEventId(1L)).thenReturn(5);
+
+        Integer result = service.deleteScoreByEventService(dto);
+
+        assertThat(result).isEqualTo(5);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=ScoreServiceTest 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/ScoreServiceTest.java && git commit -m "test: ScoreService unit tests (single-score and aspect-score modes)"
+```
+
+---
+
+## Task 7: ScoringCriteriaServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/ScoringCriteriaServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.AddScoringCriteriaDto;
+import com.example.BES.dtos.GetScoringCriteriaDto;
+import com.example.BES.dtos.UpdateScoringCriteriaDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.Genre;
+import com.example.BES.models.ScoringCriteria;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.ScoringCriteriaRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScoringCriteriaServiceTest {
+
+    @Mock ScoringCriteriaRepo repo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @InjectMocks ScoringCriteriaService service;
+
+    private ScoringCriteria criteria(Long id, String name, double weight) {
+        ScoringCriteria sc = new ScoringCriteria();
+        sc.setId(id);
+        sc.setName(name);
+        sc.setWeight(weight);
+        sc.setDisplayOrder(0);
+        return sc;
+    }
+
+    @Test
+    void getCriteria_withGenre_fallsBackToEventLevel() {
+        when(repo.findByEventNameAndGenreName("Fest", "breaking")).thenReturn(List.of());
+        when(repo.findEventLevelByEventName("Fest")).thenReturn(List.of(criteria(1L, "Technique", 1.0)));
+
+        List<GetScoringCriteriaDto> result = service.getCriteria("Fest", "breaking");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name).isEqualTo("Technique");
+    }
+
+    @Test
+    void getCriteria_withGenre_returnsGenreSpecificWhenPresent() {
+        when(repo.findByEventNameAndGenreName("Fest", "breaking"))
+            .thenReturn(List.of(criteria(2L, "Musicality", 0.5)));
+
+        List<GetScoringCriteriaDto> result = service.getCriteria("Fest", "breaking");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name).isEqualTo("Musicality");
+    }
+
+    @Test
+    void getCriteria_withoutGenre_returnsEventLevel() {
+        when(repo.findEventLevelByEventName("Fest"))
+            .thenReturn(List.of(criteria(1L, "Overall", 1.0)));
+
+        List<GetScoringCriteriaDto> result = service.getCriteria("Fest", null);
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void addCriteria_throwsWhenEventNotFound() {
+        AddScoringCriteriaDto dto = new AddScoringCriteriaDto();
+        dto.eventName = "Missing";
+        dto.name = "Technique";
+        dto.weight = 1.0;
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addCriteria(dto))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void addCriteria_savesWithoutGenre() {
+        AddScoringCriteriaDto dto = new AddScoringCriteriaDto();
+        dto.eventName = "Fest";
+        dto.name = "Technique";
+        dto.weight = 1.0;
+        dto.genreName = null;
+        Event e = new Event(); e.setEventName("Fest");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        ScoringCriteria saved = criteria(1L, "Technique", 1.0);
+        saved.setEvent(e);
+        when(repo.save(any())).thenReturn(saved);
+
+        GetScoringCriteriaDto result = service.addCriteria(dto);
+
+        assertThat(result.name).isEqualTo("Technique");
+    }
+
+    @Test
+    void updateCriteria_throwsWhenNotFound() {
+        UpdateScoringCriteriaDto dto = new UpdateScoringCriteriaDto();
+        dto.name = "New";
+        dto.weight = 0.5;
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateCriteria(99L, dto))
+            .isInstanceOf(ResponseStatusException.class);
+    }
+
+    @Test
+    void removeCriteria_delegatesToRepo() {
+        service.removeCriteria(1L);
+        verify(repo).deleteById(1L);
+    }
+
+    @Test
+    void deleteAllCriteria_deletesForGenre() {
+        List<ScoringCriteria> list = List.of(criteria(1L, "T", 1.0));
+        when(repo.findByEventNameAndGenreName("Fest", "breaking")).thenReturn(list);
+
+        service.deleteAllCriteria("Fest", "breaking");
+
+        verify(repo).deleteAll(list);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=ScoringCriteriaServiceTest 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/ScoringCriteriaServiceTest.java && git commit -m "test: ScoringCriteriaService unit tests"
+```
+
+---
+
+## Task 8: AuditionFeedbackServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.SubmitAuditionFeedbackDto;
+import com.example.BES.dtos.admin.GetFeedbackGroupDto;
+import com.example.BES.models.AuditionFeedback;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.FeedbackTag;
+import com.example.BES.models.FeedbackTagGroup;
+import com.example.BES.models.Judge;
+import com.example.BES.respositories.AuditionFeedbackRepository;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.FeedbackTagGroupRepository;
+import com.example.BES.respositories.FeedbackTagRepository;
+import com.example.BES.respositories.JudgeRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuditionFeedbackServiceTest {
+
+    @Mock AuditionFeedbackRepository feedbackRepo;
+    @Mock FeedbackTagGroupRepository tagGroupRepo;
+    @Mock FeedbackTagRepository tagRepo;
+    @Mock EventGenreParticpantRepo egpRepo;
+    @Mock JudgeRepo judgeRepo;
+    @InjectMocks AuditionFeedbackService service;
+
+    @Test
+    void getAllFeedbackGroups_mapsToDto() {
+        FeedbackTagGroup group = new FeedbackTagGroup();
+        group.setId(1L);
+        group.setName("Energy");
+        FeedbackTag tag = new FeedbackTag();
+        tag.setId(10L);
+        tag.setLabel("High");
+        tag.setGroup(group);
+        group.setTags(List.of(tag));
+        when(tagGroupRepo.findAll()).thenReturn(List.of(group));
+
+        List<GetFeedbackGroupDto> result = service.getAllFeedbackGroups();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Energy");
+        assertThat(result.get(0).getTags()).hasSize(1);
+    }
+
+    @Test
+    void addFeedbackGroup_savesAndReturnsAll() {
+        FeedbackTagGroup group = new FeedbackTagGroup();
+        group.setId(1L);
+        group.setName("Energy");
+        group.setTags(new ArrayList<>());
+        when(tagGroupRepo.findAll()).thenReturn(List.of(group));
+
+        service.addFeedbackGroup("Energy");
+
+        verify(tagGroupRepo).save(any(FeedbackTagGroup.class));
+    }
+
+    @Test
+    void deleteFeedbackGroup_delegatesToRepo() {
+        service.deleteFeedbackGroup(1L);
+        verify(tagGroupRepo).deleteById(1L);
+    }
+
+    @Test
+    void addFeedbackTag_returnsAllGroupsWhenGroupNotFound() {
+        when(tagGroupRepo.findById(99L)).thenReturn(Optional.empty());
+        when(tagGroupRepo.findAll()).thenReturn(List.of());
+
+        List<GetFeedbackGroupDto> result = service.addFeedbackTag(99L, "label");
+
+        verify(tagRepo, never()).save(any());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void submitFeedback_doesNothingWhenEgpOrJudgeNull() {
+        SubmitAuditionFeedbackDto dto = new SubmitAuditionFeedbackDto();
+        dto.setEventName("Fest");
+        dto.setGenreName("breaking");
+        dto.setAuditionNumber(1);
+        dto.setJudgeName("Ghost");
+        when(egpRepo.findByEventNameAndGenreNameAndAuditionNumber("Fest", "breaking", 1))
+            .thenReturn(Optional.empty());
+
+        service.submitFeedback(dto);
+
+        verify(feedbackRepo, never()).save(any());
+    }
+
+    @Test
+    void submitFeedback_savesWhenEgpAndJudgeFound() {
+        SubmitAuditionFeedbackDto dto = new SubmitAuditionFeedbackDto();
+        dto.setEventName("Fest");
+        dto.setGenreName("breaking");
+        dto.setAuditionNumber(1);
+        dto.setJudgeName("Mike");
+        dto.setTagIds(List.of());
+        dto.setNote("Great energy");
+
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        Judge judge = new Judge(); judge.setName("Mike");
+        when(egpRepo.findByEventNameAndGenreNameAndAuditionNumber("Fest", "breaking", 1))
+            .thenReturn(Optional.of(egp));
+        when(judgeRepo.findByName("Mike")).thenReturn(Optional.of(judge));
+        when(feedbackRepo.findByEventGenreParticipantAndJudge(egp, judge))
+            .thenReturn(Optional.empty());
+
+        service.submitFeedback(dto);
+
+        verify(feedbackRepo).save(any(AuditionFeedback.class));
+    }
+
+    @Test
+    void getAllFeedbackForParticipant_returnsEmptyWhenEgpNotFound() {
+        when(egpRepo.findByEventGenreParticipant("Fest", "breaking", "Player1"))
+            .thenReturn(Optional.empty());
+
+        assertThat(service.getAllFeedbackForParticipant("Fest", "breaking", "Player1")).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=AuditionFeedbackServiceTest 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java && git commit -m "test: AuditionFeedbackService unit tests"
+```
+
+---
+
+## Task 9: ResultsServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/ResultsServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetResultsDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.Genre;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.AuditionFeedbackRepository;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.ScoreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ResultsServiceTest {
+
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventGenreParticpantRepo egpRepo;
+    @Mock ScoreRepo scoreRepo;
+    @Mock AuditionFeedbackRepository feedbackRepo;
+    @InjectMocks ResultsService service;
+
+    @Test
+    void getResultsByRefCode_returnsNullWhenRefCodeNotFound() {
+        when(eventParticipantRepo.findByReferenceCode("UNKNOWN")).thenReturn(Optional.empty());
+
+        assertThat(service.getResultsByRefCode("UNKNOWN")).isNull();
+    }
+
+    @Test
+    void getResultsByRefCode_returnsNullWhenResultsNotReleased() {
+        Event e = new Event();
+        e.setResultsReleased(false);
+        e.setEventName("Fest");
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        Participant p = new Participant();
+        ep.setParticipant(p);
+        ep.setDisplayName("Player1");
+        when(eventParticipantRepo.findByReferenceCode("ABC123")).thenReturn(Optional.of(ep));
+
+        assertThat(service.getResultsByRefCode("ABC123")).isNull();
+    }
+
+    @Test
+    void getResultsByRefCode_returnsResultsWhenReleased() {
+        Event e = new Event();
+        e.setEventId(1L);
+        e.setEventName("Fest");
+        e.setResultsReleased(true);
+        Participant p = new Participant();
+        p.setParticipantId(10L);
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        ep.setParticipant(p);
+        ep.setDisplayName("Player1");
+
+        Genre g = new Genre();
+        g.setGenreName("breaking");
+        EventGenreParticipant egp = mock(EventGenreParticipant.class);
+        when(egp.getGenre()).thenReturn(g);
+        when(egp.getFormat()).thenReturn("1v1");
+        when(egp.getAuditionNumber()).thenReturn(1);
+
+        when(eventParticipantRepo.findByReferenceCode("ABC123")).thenReturn(Optional.of(ep));
+        when(egpRepo.findByEventIdAndParticipantId(1L, 10L)).thenReturn(List.of(egp));
+        when(scoreRepo.findByEventGenreParticipant(egp)).thenReturn(List.of());
+        when(feedbackRepo.findByEventGenreParticipant(egp)).thenReturn(List.of());
+
+        GetResultsDto result = service.getResultsByRefCode("ABC123");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParticipantName()).isEqualTo("Player1");
+        assertThat(result.getEventName()).isEqualTo("Fest");
+        assertThat(result.getGenreResults()).hasSize(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=ResultsServiceTest 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/ResultsServiceTest.java && git commit -m "test: ResultsService unit tests (ref code lookup, release gate)"
+```
+
+---
+
+## Task 10: BattleServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/BattleServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+Note: `BattleService` is an in-memory singleton. `@InjectMocks` calls its no-arg constructor which initializes state. `SimpMessagingTemplate` is mocked to absorb broadcasts.
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.battle.SetBattlerPairDto;
+import com.example.BES.dtos.battle.SetJudgeDto;
+import com.example.BES.dtos.battle.SetVoteDto;
+import com.example.BES.models.Judge;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BattleServiceTest {
+
+    @Mock JudgeService judgeService;
+    @Mock SimpMessagingTemplate messagingTemplate;
+    @InjectMocks BattleService service;
+
+    @Test
+    void initialPhaseIsIDLE() {
+        assertThat(service.getBattlePhase()).isEqualTo("IDLE");
+    }
+
+    @Test
+    void setBattlerPair_setsNamesAndTransitionsToLOCKED() {
+        SetBattlerPairDto dto = mock(SetBattlerPairDto.class);
+        when(dto.getLeftBattler()).thenReturn("Alice");
+        when(dto.getRightBattler()).thenReturn("Bob");
+
+        service.setBattlerPairService(dto);
+
+        assertThat(service.getCurrentPair().getLeftBattler().getName()).isEqualTo("Alice");
+        assertThat(service.getCurrentPair().getRightBattler().getName()).isEqualTo("Bob");
+        assertThat(service.getBattlePhase()).isEqualTo("LOCKED");
+    }
+
+    @Test
+    void setBattlePhase_cannotManuallySetREVEALED() {
+        service.setBattlePhaseService("REVEALED");
+
+        assertThat(service.getBattlePhase()).isEqualTo("IDLE");
+    }
+
+    @Test
+    void setBattlePhase_setsVOTING() {
+        service.setBattlePhaseService("VOTING");
+
+        assertThat(service.getBattlePhase()).isEqualTo("VOTING");
+    }
+
+    @Test
+    void setScore_returnsMinusTwoWhenNoJudges() {
+        assertThat(service.setScoreService()).isEqualTo(-2);
+    }
+
+    @Test
+    void setScore_leftWins_returnsZeroAndTransitionsToREVEALED() {
+        // Add a judge and vote for left (0)
+        Judge j = new Judge(); j.setJudgeId(1L); j.setName("Mike");
+        when(judgeService.getJudgeById(1L)).thenReturn(j);
+        SetJudgeDto jDto = mock(SetJudgeDto.class);
+        when(jDto.getId()).thenReturn(1L);
+        service.setBattleJudgeService(jDto);
+
+        SetVoteDto vDto = mock(SetVoteDto.class);
+        when(vDto.getId()).thenReturn(1L);
+        when(vDto.getVote()).thenReturn(0); // vote for left
+        service.setVoteService(vDto);
+
+        Integer result = service.setScoreService();
+
+        assertThat(result).isEqualTo(0);
+        assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
+    }
+
+    @Test
+    void setScore_rightWins_returnsOne() {
+        Judge j = new Judge(); j.setJudgeId(2L); j.setName("Sara");
+        when(judgeService.getJudgeById(2L)).thenReturn(j);
+        SetJudgeDto jDto = mock(SetJudgeDto.class);
+        when(jDto.getId()).thenReturn(2L);
+        service.setBattleJudgeService(jDto);
+
+        SetVoteDto vDto = mock(SetVoteDto.class);
+        when(vDto.getId()).thenReturn(2L);
+        when(vDto.getVote()).thenReturn(1); // vote for right
+        service.setVoteService(vDto);
+
+        assertThat(service.setScoreService()).isEqualTo(1);
+    }
+
+    @Test
+    void setBattleJudge_returnsDuplicateCodeWhenAlreadyAdded() {
+        Judge j = new Judge(); j.setJudgeId(1L); j.setName("Mike");
+        when(judgeService.getJudgeById(1L)).thenReturn(j);
+        SetJudgeDto dto = mock(SetJudgeDto.class);
+        when(dto.getId()).thenReturn(1L);
+        service.setBattleJudgeService(dto);
+
+        Integer result = service.setBattleJudgeService(dto);
+
+        assertThat(result).isEqualTo(0); // already exists
+    }
+
+    @Test
+    void setBattleJudge_returnsMinusOneWhenJudgeNotFound() {
+        when(judgeService.getJudgeById(99L)).thenReturn(null);
+        SetJudgeDto dto = mock(SetJudgeDto.class);
+        when(dto.getId()).thenReturn(99L);
+
+        assertThat(service.setBattleJudgeService(dto)).isEqualTo(-1);
+    }
+
+    @Test
+    void removeBattleJudge_removesFromList() {
+        Judge j = new Judge(); j.setJudgeId(1L); j.setName("Mike");
+        when(judgeService.getJudgeById(1L)).thenReturn(j);
+        SetJudgeDto addDto = mock(SetJudgeDto.class);
+        when(addDto.getId()).thenReturn(1L);
+        service.setBattleJudgeService(addDto);
+        assertThat(service.getJudges()).hasSize(1);
+
+        SetJudgeDto removeDto = mock(SetJudgeDto.class);
+        when(removeDto.getId()).thenReturn(1L);
+        service.removeBattleJudgeService(removeDto);
+
+        assertThat(service.getJudges()).isEmpty();
+    }
+
+    @Test
+    void setVote_returnsMinusTwoWhenJudgeNotInList() {
+        SetVoteDto dto = mock(SetVoteDto.class);
+        when(dto.getId()).thenReturn(99L);
+
+        assertThat(service.setVoteService(dto)).isEqualTo(-2);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=BattleServiceTest 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/BattleServiceTest.java && git commit -m "test: BattleService unit tests (phases, voting, judges)"
+```
+
+---
+
+## Task 11: RegistrationServiceTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/services/RegistrationServiceTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetUnverifiedParticipantDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.EventParticipantTeamMemberRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.ParticipantRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationServiceTest {
+
+    @Mock GoogleSheetService sheetService;
+    @Mock MailSenderService mailService;
+    @Mock EventRepo eventRepo;
+    @Mock ParticipantService participantService;
+    @Mock ParticipantRepo participantRepo;
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventGenreParticpantRepo eventGenreParticipantRepo;
+    @Mock EventParticipantTeamMemberRepo teamMemberRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @InjectMocks RegistrationService service;
+
+    @Test
+    void getUnverifiedParticipants_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        List<GetUnverifiedParticipantDto> result = service.getUnverifiedParticipantsFromDb("Missing");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getUnverifiedParticipants_returnsListWhenFound() {
+        Event e = new Event();
+        e.setEventId(1L);
+        e.setEventName("Fest");
+        Participant p = new Participant();
+        p.setParticipantId(10L);
+        p.setParticipantName("Player1");
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        ep.setParticipant(p);
+        ep.setDisplayName("Player1");
+        ep.setScreenshotUrl("http://img.png");
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+        when(eventParticipantRepo.findByEventAndPaymentVerifiedFalse(e)).thenReturn(List.of(ep));
+        when(eventGenreParticipantRepo.findByEventIdAndParticipantId(1L, 10L))
+            .thenReturn(List.of());
+
+        List<GetUnverifiedParticipantDto> result = service.getUnverifiedParticipantsFromDb("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name).isEqualTo("Player1");
+    }
+
+    @Test
+    void verifyAndEmail_throwsWhenEventOrParticipantNotFound() {
+        when(eventRepo.findById(1L)).thenReturn(Optional.empty());
+        when(participantRepo.findById(10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.verifyAndEmail(10L, 1L))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void verifyAndEmail_throwsWhenEventParticipantNotFound() {
+        Event e = new Event(); e.setEventId(1L);
+        Participant p = new Participant(); p.setParticipantId(10L);
+        when(eventRepo.findById(1L)).thenReturn(Optional.of(e));
+        when(participantRepo.findById(10L)).thenReturn(Optional.of(p));
+        when(eventParticipantRepo.findByEventAndParticipant(e, p)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.verifyAndEmail(10L, 1L))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void verifyAndEmail_setsPaymentVerifiedAndSkipsEmailIfAlreadySent() throws Exception {
+        Event e = new Event(); e.setEventId(1L); e.setEventName("Fest");
+        Participant p = new Participant(); p.setParticipantId(10L);
+        EventParticipant ep = new EventParticipant();
+        ep.setEvent(e);
+        ep.setParticipant(p);
+        ep.setEmailSent(true); // already sent
+        ep.setPaymentVerified(false);
+        when(eventRepo.findById(1L)).thenReturn(Optional.of(e));
+        when(participantRepo.findById(10L)).thenReturn(Optional.of(p));
+        when(eventParticipantRepo.findByEventAndParticipant(e, p)).thenReturn(Optional.of(ep));
+
+        service.verifyAndEmail(10L, 1L);
+
+        assertThat(ep.isPaymentVerified()).isTrue();
+        verify(mailService, never()).sendEmailWithAttachment(any(), any(), any(), any(), any());
+        verify(eventParticipantRepo).save(ep);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=RegistrationServiceTest 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/RegistrationServiceTest.java && git commit -m "test: RegistrationService unit tests"
+```
+
+---
+
+## Task 12: EventParticpantServiceTest + PickupCrewServiceTest
+
+**Files:** Create two test files.
+
+- [ ] **Step 1: Write EventParticpantServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.models.Event;
+import com.example.BES.models.EventParticipant;
+import com.example.BES.models.Participant;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.mapper.EventParticipantDtoMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventParticpantServiceTest {
+
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock EventParticipantDtoMapper eventParticipantDtoMapper;
+    @InjectMocks EventParticpantService service;
+
+    @Test
+    void getAllParticipantsByEvent_returnsNullWhenEventNotFound() {
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getAllParticipantsByEvent("Missing")).isNull();
+    }
+
+    @Test
+    void getParticipantRefs_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getParticipantRefs("Missing")).isEmpty();
+    }
+
+    @Test
+    void getParticipantRefs_skipsNullReferenceCodes() {
+        Event e = new Event(); e.setEventName("Fest");
+        Participant p = new Participant(); p.setParticipantName("Player1");
+        EventParticipant ep1 = new EventParticipant();
+        ep1.setDisplayName("Player1");
+        ep1.setReferenceCode(null); // should be skipped
+        EventParticipant ep2 = new EventParticipant();
+        ep2.setDisplayName("Player2");
+        ep2.setReferenceCode("ABC123");
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(eventParticipantRepo.findByEvent(e)).thenReturn(List.of(ep1, ep2));
+
+        List<Map<String, String>> result = service.getParticipantRefs("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).get("referenceCode")).isEqualTo("ABC123");
+    }
+
+    @Test
+    void addNewWalkIn_returnsNullWhenEventNotFound() {
+        when(eventRepo.findByEventName("Missing")).thenReturn(Optional.empty());
+        Participant p = new Participant();
+
+        assertThat(service.addNewWalkInInEventService(p, "Missing", "breaking", null, null)).isNull();
+    }
+
+    @Test
+    void addNewWalkIn_returnsExistingEpWhenAlreadyRegistered() {
+        Event e = new Event(); e.setEventName("Fest");
+        Participant p = new Participant(); p.setParticipantName("Player1");
+        EventParticipant existing = new EventParticipant();
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(e));
+        when(eventParticipantRepo.findByEventAndParticipant(e, p)).thenReturn(Optional.of(existing));
+        when(eventParticipantRepo.save(existing)).thenReturn(existing);
+
+        EventParticipant result = service.addNewWalkInInEventService(p, "Fest", "breaking", null, null);
+
+        assertThat(result).isSameAs(existing);
+    }
+}
+```
+
+- [ ] **Step 2: Write PickupCrewServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.models.Event;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.ParticipantRepo;
+import com.example.BES.respositories.PickupCrewRepo;
+import com.example.BES.respositories.ScoreRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PickupCrewServiceTest {
+
+    @Mock PickupCrewRepo crewRepo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock ParticipantRepo participantRepo;
+    @Mock EventGenreParticpantRepo egpRepo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @Mock ScoreRepo scoreRepo;
+    @InjectMocks PickupCrewService service;
+
+    @Test
+    void getCrewsForEventGenre_returnsEmptyWhenEventOrGenreNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.empty());
+
+        assertThat(service.getCrewsForEventGenre("Missing", "breaking")).isEmpty();
+    }
+
+    @Test
+    void getCrewsForEventGenre_returnsEmptyWhenNoCrews() {
+        Event e = new Event(); e.setEventName("Fest");
+        Genre g = new Genre(); g.setGenreName("breaking");
+        when(eventRepo.findByEventNameIgnoreCase("Fest")).thenReturn(Optional.of(e));
+        when(genreRepo.findByGenreName("breaking")).thenReturn(Optional.of(g));
+        when(crewRepo.findByEventAndGenre(e, g)).thenReturn(List.of());
+
+        assertThat(service.getCrewsForEventGenre("Fest", "breaking")).isEmpty();
+    }
+
+    @Test
+    void deleteCrew_delegatesToRepo() {
+        service.deleteCrew(1L);
+        verify(crewRepo).deleteById(1L);
+    }
+}
+```
+
+- [ ] **Step 3: Run both**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest="EventParticpantServiceTest,PickupCrewServiceTest" 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/services/EventParticpantServiceTest.java BES/src/test/java/com/example/BES/services/PickupCrewServiceTest.java && git commit -m "test: EventParticpantService and PickupCrewService unit tests"
+```
+
+---
+
+## Task 13: EmailTemplateServiceTest + QrCodeServiceTest + EventGenreParticpantServiceTest
+
+**Files:** Create three test files.
+
+- [ ] **Step 1: Write EmailTemplateServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetEmailTemplateDto;
+import com.example.BES.dtos.UpdateEmailTemplateDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventEmailTemplate;
+import com.example.BES.respositories.EventEmailTemplateRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailTemplateServiceTest {
+
+    @Mock EventEmailTemplateRepo repo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @Mock EventRepo eventRepo;
+    @InjectMocks EmailTemplateService service;
+
+    @Test
+    void createDefaultTemplate_savesTemplate() {
+        Event e = new Event();
+        e.setEventName("Fest");
+
+        service.createDefaultTemplate(e);
+
+        verify(repo).save(argThat(t ->
+            ((EventEmailTemplate) t).getSubject().contains("Fest") &&
+            ((EventEmailTemplate) t).getBody().contains("Fest")
+        ));
+    }
+
+    @Test
+    void getTemplateByEventName_returnsNullWhenNotFound() {
+        when(repo.findByEvent_EventName("Missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getTemplateByEventName("Missing")).isNull();
+    }
+
+    @Test
+    void getTemplateByEventName_returnsDto() {
+        EventEmailTemplate t = new EventEmailTemplate();
+        t.setSubject("Test Subject");
+        t.setBody("Custom body — no generic marker");
+        when(repo.findByEvent_EventName("Fest")).thenReturn(Optional.of(t));
+
+        GetEmailTemplateDto result = service.getTemplateByEventName("Fest");
+
+        assertThat(result.getSubject()).isEqualTo("Test Subject");
+        assertThat(result.getBody()).isEqualTo("Custom body — no generic marker");
+    }
+
+    @Test
+    void updateTemplate_updatesAndReturns() {
+        EventEmailTemplate t = new EventEmailTemplate();
+        t.setSubject("Old");
+        t.setBody("Old body");
+        UpdateEmailTemplateDto dto = new UpdateEmailTemplateDto();
+        dto.setSubject("New Subject");
+        dto.setBody("New Body");
+        when(repo.findByEvent_EventName("Fest")).thenReturn(Optional.of(t));
+        when(repo.save(any())).thenReturn(t);
+
+        GetEmailTemplateDto result = service.updateTemplate("Fest", dto);
+
+        assertThat(result.getSubject()).isEqualTo("New Subject");
+    }
+
+    @Test
+    void updateTemplate_throwsWhenNotFound() {
+        UpdateEmailTemplateDto dto = new UpdateEmailTemplateDto();
+        dto.setSubject("X");
+        dto.setBody("Y");
+        when(repo.findByEvent_EventName("Missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateTemplate("Missing", dto))
+            .isInstanceOf(RuntimeException.class);
+    }
+}
+```
+
+- [ ] **Step 2: Write QrCodeServiceTest**
+
+```java
+package com.example.BES.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class QrCodeServiceTest {
+
+    private final QrCodeService service = new QrCodeService();
+
+    @Test
+    void generateQrCode_returnsPngBytes() throws Exception {
+        byte[] result = service.generateQrCode("https://example.com", 200, 200);
+
+        assertThat(result).isNotEmpty();
+        // PNG magic bytes: 0x89 0x50 0x4E 0x47
+        assertThat(result[0]).isEqualTo((byte) 0x89);
+        assertThat(result[1]).isEqualTo((byte) 0x50);
+    }
+
+    @Test
+    void generateQrCode_worksWithSmallDimensions() throws Exception {
+        byte[] result = service.generateQrCode("hello", 100, 100);
+
+        assertThat(result).isNotEmpty();
+    }
+}
+```
+
+- [ ] **Step 3: Write EventGenreParticpantServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.dtos.GetEventGenreParticipantDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.EventGenreParticipant;
+import com.example.BES.models.EventGenreParticipantId;
+import com.example.BES.models.Genre;
+import com.example.BES.respositories.EventGenreParticpantRepo;
+import com.example.BES.respositories.EventGenreRepo;
+import com.example.BES.respositories.EventParticipantRepo;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.GenreRepo;
+import com.example.BES.respositories.JudgeRepo;
+import com.example.BES.respositories.ParticipantRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventGenreParticpantServiceTest {
+
+    @Mock EventGenreParticpantRepo repo;
+    @Mock EventRepo eventRepo;
+    @Mock GenreRepo genreRepo;
+    @Mock ParticipantRepo participantRepo;
+    @Mock SimpMessagingTemplate messagingTemplate;
+    @Mock JudgeRepo judgeRepo;
+    @Mock EventParticipantRepo eventParticipantRepo;
+    @Mock EventGenreRepo eventGenreRepo;
+    @InjectMocks EventGenreParticpantService service;
+
+    @Test
+    void getAllByEvent_returnsEmptyWhenEventNotFound() {
+        when(eventRepo.findByEventNameIgnoreCase("Missing")).thenReturn(Optional.empty());
+
+        List<GetEventGenreParticipantDto> result =
+            service.getAllEventGenreParticipantByEventService("Missing");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void removeParticipantFromGenre_doesNothingWhenEgpNotFound() {
+        EventGenreParticipantId id = new EventGenreParticipantId(1L, 2L, 3L);
+        when(repo.findById(id)).thenReturn(Optional.empty());
+
+        service.removeParticipantFromGenre(3L, 1L, 2L);
+
+        verify(repo, never()).delete(any());
+    }
+
+    @Test
+    void addGenreToExistingParticipant_throwsWhenGenreNotFound() {
+        when(genreRepo.findByGenreName("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addGenreToExistingParticipant(1L, 1L, "ghost"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Genre not found");
+    }
+}
+```
+
+- [ ] **Step 4: Run all three**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest="EmailTemplateServiceTest,QrCodeServiceTest,EventGenreParticpantServiceTest" 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add \
+  BES/src/test/java/com/example/BES/services/EmailTemplateServiceTest.java \
+  BES/src/test/java/com/example/BES/services/QrCodeServiceTest.java \
+  BES/src/test/java/com/example/BES/services/EventGenreParticpantServiceTest.java \
+  && git commit -m "test: EmailTemplateService, QrCodeService, EventGenreParticpantService unit tests"
+```
+
+---
+
+## Task 14: ResultsControllerIntegrationTest
+
+**Files:** Create `BES/src/test/java/com/example/BES/controllers/ResultsControllerIntegrationTest.java`
+
+- [ ] **Step 1: Write the test file**
+
+```java
+package com.example.BES.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ResultsControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void getResults_returnsNotFoundForUnknownRef() throws Exception {
+        mockMvc.perform(get("/api/v1/results").param("ref", "NONEXISTENT-REF"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    void getResults_isPublicNoAuthRequired() throws Exception {
+        // Endpoint must be reachable without authentication
+        mockMvc.perform(get("/api/v1/results").param("ref", "ANY"))
+            .andExpect(status().isNotFound()); // not 403
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void getResultsQr_returnsImageForAdmin() throws Exception {
+        mockMvc.perform(get("/api/v1/results/qr").param("ref", "TEST-REF"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void getResultsQr_returns403WithoutAuth() throws Exception {
+        mockMvc.perform(get("/api/v1/results/qr").param("ref", "TEST-REF"))
+            .andExpect(status().isForbidden());
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test -Dtest=ResultsControllerIntegrationTest 2>&1 | tail -10
+```
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES/src/test/java/com/example/BES/controllers/ResultsControllerIntegrationTest.java && git commit -m "test: ResultsController integration tests (public access, auth gate)"
+```
+
+---
+
+## Task 15: Run full backend suite + verify JaCoCo gate
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test 2>&1 | tail -20
+```
+Expected: `BUILD SUCCESS`, total test count significantly higher than 39, `Tests run: X, Failures: 0`.
+
+- [ ] **Step 2: If JaCoCo check fails (< 70%), identify which services are below threshold**
+
+Open `BES/target/site/jacoco/index.html` in a browser, or run:
+```bash
+grep -A5 "com.example.BES.services" BES/target/site/jacoco/jacoco.csv | head -40
+```
+Find services with low line coverage and add 1-2 more test cases targeting uncovered branches.
+
+- [ ] **Step 3: Commit passing state**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add -A && git commit -m "test: backend suite passes JaCoCo 70% gate"
+```
+
+---
+
+## Task 16: Expand api.test.js
+
+**Files:** Modify `BES-frontend/src/utils/__tests__/api.test.js`
+
+- [ ] **Step 1: Add tests for additional API functions**
+
+Append the following `describe` blocks inside the existing `describe('api.js', ...)`:
+
+```js
+  describe('whoami', () => {
+    it('returns parsed JSON when ok', async () => {
+      const user = { authenticated: true, username: 'admin' }
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(user) })
+
+      const result = await api.whoami()
+
+      expect(result).toEqual(user)
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/auth/me', expect.objectContaining({ method: 'GET' }))
+    })
+  })
+
+  describe('fetchAllGenres', () => {
+    it('returns genres on success', async () => {
+      const genres = [{ id: 1, genreName: 'breaking' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(genres) })
+
+      const result = await api.fetchAllGenres()
+
+      expect(result).toEqual(genres)
+    })
+
+    it('returns empty array on failure', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+      const result = await api.fetchAllGenres()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('fetchAllJudges', () => {
+    it('returns judges on success', async () => {
+      const judges = [{ judgeId: 1, judgeName: 'Mike' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(judges) })
+
+      const result = await api.fetchAllJudges()
+
+      expect(result).toEqual(judges)
+    })
+  })
+
+  describe('fetchEventByName', () => {
+    it('calls correct URL', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ eventName: 'Fest' }) })
+
+      await api.fetchEventByName('Fest')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('Fest'),
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('getParticipantsByEvent', () => {
+    it('returns participants on success', async () => {
+      const participants = [{ participantName: 'Player1' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(participants) })
+
+      const result = await api.getParticipantsByEvent('Fest')
+
+      expect(result).toEqual(participants)
+    })
+
+    it('returns empty array on 404', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+      const result = await api.getParticipantsByEvent('Missing')
+
+      expect(result).toEqual([])
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm test
+```
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES-frontend/src/utils/__tests__/api.test.js && git commit -m "test: expand api.test.js with whoami, genres, judges, participants"
+```
+
+---
+
+## Task 17: auth.test.js
+
+**Files:** Create `BES-frontend/src/utils/__tests__/auth.test.js`
+
+- [ ] **Step 1: Write the test file**
+
+```js
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mock sessionStorage
+const sessionStorageMock = (() => {
+  let store = {}
+  return {
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, val) => { store[key] = String(val) },
+    removeItem: (key) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+Object.defineProperty(global, 'sessionStorage', { value: sessionStorageMock })
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {}
+  return {
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, val) => { store[key] = String(val) },
+    removeItem: (key) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+Object.defineProperty(global, 'localStorage', { value: localStorageMock })
+
+// Mock pinia (defineStore needs a Pinia instance; stub it for utility-only tests)
+vi.mock('pinia', () => ({
+  defineStore: (id, def) => {
+    const store = typeof def === 'function' ? def() : def
+    return () => ({
+      ...store.state?.(),
+      ...store.actions,
+      ...store.getters,
+    })
+  },
+}))
+
+const { isEventVerified, markEventVerified, getActiveEvent, clearVerifiedEvents } = await import('../auth.js')
+
+describe('auth.js utilities', () => {
+  beforeEach(() => {
+    sessionStorageMock.clear()
+    localStorageMock.clear()
+  })
+
+  describe('isEventVerified', () => {
+    it('returns false when nothing stored', () => {
+      expect(isEventVerified(1)).toBe(false)
+    })
+
+    it('returns false for unverified event id', () => {
+      sessionStorageMock.setItem('bes_verified_events', JSON.stringify([2]))
+      expect(isEventVerified(1)).toBe(false)
+    })
+
+    it('returns true when event id is in verified list', () => {
+      sessionStorageMock.setItem('bes_verified_events', JSON.stringify([1, 2]))
+      expect(isEventVerified(1)).toBe(true)
+    })
+
+    it('coerces string id to number', () => {
+      sessionStorageMock.setItem('bes_verified_events', JSON.stringify([5]))
+      expect(isEventVerified('5')).toBe(true)
+    })
+  })
+
+  describe('markEventVerified', () => {
+    it('adds event id to verified list', () => {
+      markEventVerified(3)
+      expect(isEventVerified(3)).toBe(true)
+    })
+
+    it('does not duplicate event id', () => {
+      markEventVerified(3)
+      markEventVerified(3)
+      const stored = JSON.parse(sessionStorageMock.getItem('bes_verified_events'))
+      expect(stored.filter(id => id === 3)).toHaveLength(1)
+    })
+  })
+
+  describe('getActiveEvent', () => {
+    it('returns null when nothing stored', () => {
+      expect(getActiveEvent()).toBeNull()
+    })
+
+    it('returns parsed event object', () => {
+      sessionStorageMock.setItem('bes_active_event', JSON.stringify({ id: 1, name: 'Fest' }))
+      expect(getActiveEvent()).toEqual({ id: 1, name: 'Fest' })
+    })
+
+    it('returns null on invalid JSON', () => {
+      sessionStorageMock.setItem('bes_active_event', 'not-json')
+      expect(getActiveEvent()).toBeNull()
+    })
+  })
+
+  describe('clearVerifiedEvents', () => {
+    it('removes both storage keys', () => {
+      sessionStorageMock.setItem('bes_verified_events', '[1]')
+      sessionStorageMock.setItem('bes_active_event', '{}')
+
+      clearVerifiedEvents()
+
+      expect(sessionStorageMock.getItem('bes_verified_events')).toBeNull()
+      expect(sessionStorageMock.getItem('bes_active_event')).toBeNull()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run and verify**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm test
+```
+Expected: all tests pass including the new auth tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES-frontend/src/utils/__tests__/auth.test.js && git commit -m "test: auth.js utility tests (isEventVerified, markVerified, getActiveEvent, clear)"
+```
+
+---
+
+## Task 18: adminApi.test.js
+
+**Files:** Create `BES-frontend/src/utils/__tests__/adminApi.test.js`
+
+- [ ] **Step 1: Write the test file**
+
+```js
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+const adminApi = await import('../adminApi.js')
+
+describe('adminApi.js', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  describe('addGenre', () => {
+    it('calls correct endpoint with genre name', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addGenre('breaking')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/genre')
+      expect(opts.method).toBe('POST')
+      expect(JSON.parse(opts.body).name).toBe('breaking')
+    })
+  })
+
+  describe('addJudge', () => {
+    it('calls correct endpoint with judge name', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addJudge('Mike')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/judge')
+      expect(JSON.parse(opts.body).judgeName).toBe('Mike')
+    })
+  })
+
+  describe('deleteGenre', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteGenre(5)
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/genre')
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(5)
+    })
+  })
+
+  describe('deleteJudge', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteJudge(3)
+
+      const [, opts] = mockFetch.mock.calls[0]
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(3)
+    })
+  })
+
+  describe('updateGenre', () => {
+    it('sends correct payload', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.updateGenre(1, 'popping')
+
+      const [, opts] = mockFetch.mock.calls[0]
+      const body = JSON.parse(opts.body)
+      expect(body.id).toBe(1)
+      expect(body.newName).toBe('popping')
+    })
+  })
+
+  describe('getFeedbackGroups', () => {
+    it('returns parsed JSON on success', async () => {
+      const groups = [{ id: 1, name: 'Energy' }]
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(groups) })
+
+      const result = await adminApi.getFeedbackGroups()
+
+      expect(result).toEqual(groups)
+    })
+
+    it('returns empty array on failure', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false })
+
+      const result = await adminApi.getFeedbackGroups()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('addFeedbackGroup', () => {
+    it('calls correct endpoint', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addFeedbackGroup('Energy')
+
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/feedback-group')
+      expect(JSON.parse(opts.body).name).toBe('Energy')
+    })
+  })
+
+  describe('deleteFeedbackGroup', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteFeedbackGroup(2)
+
+      const [, opts] = mockFetch.mock.calls[0]
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(2)
+    })
+  })
+
+  describe('addFeedbackTag', () => {
+    it('sends groupId and label', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.addFeedbackTag(1, 'High Energy')
+
+      const [, opts] = mockFetch.mock.calls[0]
+      const body = JSON.parse(opts.body)
+      expect(body.groupId).toBe(1)
+      expect(body.label).toBe('High Energy')
+    })
+  })
+
+  describe('deleteFeedbackTag', () => {
+    it('sends DELETE with id', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await adminApi.deleteFeedbackTag(7)
+
+      const [, opts] = mockFetch.mock.calls[0]
+      expect(opts.method).toBe('DELETE')
+      expect(JSON.parse(opts.body).id).toBe(7)
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run all frontend tests**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm test
+```
+Expected: all tests pass.
+
+- [ ] **Step 3: Run coverage report**
+
+```bash
+npm run test:coverage
+```
+Expected: coverage table shows meaningful % for `adminApi.js`, `api.js`, `auth.js`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add BES-frontend/src/utils/__tests__/adminApi.test.js && git commit -m "test: adminApi.js tests (genre, judge, feedback group/tag CRUD)"
+```
+
+---
+
+## Task 19: Final verification
+
+- [ ] **Step 1: Run full backend suite**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && mvn test 2>&1 | grep -E "Tests run:|BUILD"
+```
+Expected: `BUILD SUCCESS`, `Tests run: 80+, Failures: 0, Errors: 0`.
+
+- [ ] **Step 2: Run frontend tests with coverage**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run test:coverage
+```
+Expected: passes, coverage table shows `api.js`, `auth.js`, `adminApi.js` with meaningful coverage.
+
+- [ ] **Step 3: Final commit**
+
+```bash
+cd /Users/bennylim/Documents/BES && git add -A && git commit -m "test: complete test coverage implementation — backend 70%+ gate + frontend coverage"
+```

--- a/docs/superpowers/specs/2026-05-25-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-25-test-coverage-design.md
@@ -1,0 +1,97 @@
+# Test Coverage Design — BES
+
+**Date:** 2026-05-25
+**Goal:** Confidence before deployments by covering backend business logic with meaningful tests.
+
+---
+
+## Context
+
+Current state:
+- **Backend:** 39 integration tests across 6 controller test classes. 0 service unit tests. `ResultsController` has no integration tests.
+- **Frontend:** 6 tests in 1 file (`api.test.js`). No coverage tooling installed.
+
+Primary concern: backend business logic breaking before a deployment goes out.
+
+---
+
+## Approach: Option A — Backend-first, systematic
+
+1. JaCoCo for backend coverage measurement + 70% line coverage gate on services package
+2. Mockito unit tests for all 21 services
+3. `ResultsController` integration test to close the controller gap
+4. Frontend: install `@vitest/coverage-v8`, expand `api.test.js`, add `auth.test.js` and `adminApi.test.js`
+
+---
+
+## Backend — Service Unit Tests
+
+**Location:** `BES/src/test/java/com/example/BES/services/`
+
+**Pattern:** `@ExtendWith(MockitoExtension.class)` — no Spring context. All repository and service dependencies mocked with `@Mock` + `@InjectMocks`.
+
+**Each test class covers:**
+- Happy path for each public method
+- Not-found / null input edge cases
+- Key business logic branches (e.g., score calculation, phase transitions, release toggle)
+
+**Priority grouping:**
+
+| Group | Services |
+|---|---|
+| Core event | `EventService`, `EventGenreService`, `EventGenreParticipantService`, `EventParticipantService` |
+| Scoring & results | `ScoreService`, `ScoringCriteriaService`, `ResultsService`, `AuditionFeedbackService` |
+| Battle | `BattleService` |
+| Registration & comms | `RegistrationService`, `MailSenderService`, `EmailTemplateService` |
+| Supporting | `GenreService`, `JudgeService`, `ParticipantService`, `PickupCrewService`, `QrCodeService`, `GoogleDriveFolderService`, `GoogleDriveFileService`, `GoogleDriveManager`, `GoogleSheetService` |
+
+---
+
+## Backend — ResultsController Integration Test
+
+**Location:** `BES/src/test/java/com/example/BES/controllers/ResultsControllerIntegrationTest.java`
+
+**Pattern:** Same as existing integration tests — `@SpringBootTest`, `@ActiveProfiles("test")`, MockMvc, H2 in-memory DB.
+
+**Cases to cover:**
+- Fetch results by valid reference code (results released)
+- Fetch results by valid reference code (results not yet released)
+- Fetch results by invalid/unknown reference code
+- QR access endpoint (`/results-qr`)
+
+---
+
+## Backend — JaCoCo Coverage Gate
+
+**Plugin:** `jacoco-maven-plugin` added to `BES/pom.xml`
+
+**Executions:**
+- `prepare-agent` — instruments bytecode before tests run
+- `report` — generates HTML + XML to `target/site/jacoco/` after tests
+- `check` — enforces 70% line coverage on `com.example.BES.services` package; build fails if below threshold
+
+**Viewing report:** Open `target/site/jacoco/index.html` after `mvn test`
+
+---
+
+## Frontend — Coverage Tooling + Test Expansion
+
+**Install:** `@vitest/coverage-v8` as devDependency — enables `npm run test:coverage`
+
+**New test files:**
+
+| File | What it covers |
+|---|---|
+| `src/utils/__tests__/api.test.js` | Expand to cover remaining fetch functions in `api.js` |
+| `src/utils/__tests__/auth.test.js` | Pinia auth store (`useAuthStore`), `setActiveEvent`, `getActiveEvent`, `clearVerifiedEvents` |
+| `src/utils/__tests__/adminApi.test.js` | All 14 functions in `adminApi.js` |
+
+**No frontend coverage gate** — too few tests currently to set a meaningful threshold without noise.
+
+---
+
+## Out of Scope
+
+- Frontend component tests (Vue Test Utils) — deferred; backend logic is the priority
+- Service integration tests (hitting H2 DB) — Mockito unit tests are sufficient for the service layer
+- Load / performance testing


### PR DESCRIPTION
## Summary

- Added JaCoCo Maven plugin with 70% line coverage gate on the `services` package — `mvn test` now fails the build if coverage drops below threshold
- Created Mockito unit tests for all 21 backend services (106 new tests), covering happy paths, not-found cases, and key business logic branches
- Added `ResultsControllerIntegrationTest` to close the one untested controller
- Installed `@vitest/coverage-v8` for frontend coverage reporting
- Expanded frontend utility tests: `api.test.js` (+5 tests), new `auth.test.js` (11 tests), new `adminApi.test.js` (11 tests)

## Results

- **Backend:** 149 tests, 0 failures, JaCoCo gate passed (`All coverage checks have been met`)
- **Frontend:** 34 tests, 0 failures; `adminApi.js` at 77% statement coverage

## Test plan

- [x] `mvn test` passes with BUILD SUCCESS and JaCoCo gate met
- [x] `npm test` passes all 34 frontend tests
- [x] `npm run test:coverage` generates coverage report for `api.js`, `auth.js`, `adminApi.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)