### PR TITLE
feat: 7-to-smoke overlay redesign + battle overlay race condition fixes

### DIFF
--- a/BES-frontend/src/utils/__tests__/api.test.js
+++ b/BES-frontend/src/utils/__tests__/api.test.js
@@ -173,4 +173,46 @@ describe('api.js', () => {
       expect(result).toEqual([])
     })
   })
+
+  describe('getOverlayConfig', () => {
+    it('calls /api/v1/battle/overlay-config with GET', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }),
+      })
+
+      const result = await api.getOverlayConfig()
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/battle/overlay-config', {
+        credentials: 'include',
+      })
+      expect(result.showImages).toBe(true)
+    })
+
+    it('returns fallback defaults on fetch error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network error'))
+
+      const result = await api.getOverlayConfig()
+
+      expect(result).toEqual({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+    })
+  })
+
+  describe('setOverlayConfig', () => {
+    it('calls /api/v1/battle/overlay-config with POST and JSON body', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+
+      await api.setOverlayConfig({ showImages: false, leftColor: '#ff0000', rightColor: '#0000ff' })
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/battle/overlay-config', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ showImages: false, leftColor: '#ff0000', rightColor: '#0000ff' }),
+      })
+    })
+  })
 })

--- a/BES-frontend/src/utils/__tests__/smokeChartHelpers.test.js
+++ b/BES-frontend/src/utils/__tests__/smokeChartHelpers.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { barHeightPct, findScoreGainers } from '../smokeChartHelpers'
+
+describe('barHeightPct', () => {
+  it('returns 0 for score 0', () => {
+    expect(barHeightPct(0)).toBe(0)
+  })
+  it('returns 100 for score 7', () => {
+    expect(barHeightPct(7)).toBe(100)
+  })
+  it('returns correct percentage for mid scores', () => {
+    expect(barHeightPct(3)).toBeCloseTo(42.857, 2)
+    expect(barHeightPct(4)).toBeCloseTo(57.143, 2)
+  })
+  it('clamps to 100 if score exceeds 7', () => {
+    expect(barHeightPct(8)).toBe(100)
+  })
+})
+
+describe('findScoreGainers', () => {
+  it('returns names whose score increased', () => {
+    const prev = [{ name: 'A', score: 2 }, { name: 'B', score: 1 }]
+    const next = [{ name: 'A', score: 3 }, { name: 'B', score: 1 }]
+    expect(findScoreGainers(prev, next)).toEqual(['A'])
+  })
+  it('returns empty array when no scores changed', () => {
+    const participants = [{ name: 'A', score: 2 }, { name: 'B', score: 1 }]
+    expect(findScoreGainers(participants, participants)).toEqual([])
+  })
+  it('handles new participant with no previous score', () => {
+    const prev = [{ name: 'A', score: 1 }]
+    const next = [{ name: 'A', score: 1 }, { name: 'B', score: 1 }]
+    expect(findScoreGainers(prev, next)).toEqual(['B'])
+  })
+  it('returns multiple gainers', () => {
+    const prev = [{ name: 'A', score: 1 }, { name: 'B', score: 1 }]
+    const next = [{ name: 'A', score: 2 }, { name: 'B', score: 2 }]
+    expect(findScoreGainers(prev, next)).toEqual(['A', 'B'])
+  })
+})

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1016,3 +1016,31 @@ export const updateEventGenreFormat = async (eventName, genreName, format) => {
     return false
   }
 }
+
+export const getOverlayConfig = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/overlay-config`, {
+      credentials: 'include',
+    })
+    return res.ok ? await res.json() : { showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }
+  } catch (err) {
+    console.log(err)
+    return { showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }
+  }
+}
+
+export const setOverlayConfig = async (config) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/overlay-config`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(config),
+    })
+  } catch (err) {
+    console.log(err)
+  }
+}

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -520,7 +520,7 @@ export const uploadImage = async(file)=>{
 
 export const getImage = async (filename) => {
   try {
-    const res = await fetch(`${domain}/api/v1/battle/uploads/${filename}`, {
+    const res = await fetch(`${domain}/api/v1/battle/uploads/${encodeURIComponent(filename)}`, {
       method: 'GET',
       credentials: 'include',
     });

--- a/BES-frontend/src/utils/smokeChartHelpers.js
+++ b/BES-frontend/src/utils/smokeChartHelpers.js
@@ -1,0 +1,16 @@
+/**
+ * Returns bar height as a percentage (0–100) for a given score out of 7.
+ * Clamped to 100 so bars never overflow their container.
+ */
+export const barHeightPct = (score) => Math.min((score / 7) * 100, 100)
+
+/**
+ * Given two snapshots of participants, returns the names of participants
+ * whose score increased between snapshots. Used to trigger score pop animation.
+ */
+export const findScoreGainers = (prevParticipants, nextParticipants) => {
+  const prevMap = Object.fromEntries(prevParticipants.map(p => [p.name, p.score]))
+  return nextParticipants
+    .filter(n => n.score > (prevMap[n.name] ?? 0))
+    .map(n => n.name)
+}

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -443,9 +443,6 @@ const submitGetScore = async () => {
     const res = await setBattleScore()
     const data = await res.json()
     currentWinner.value = Number(data.winner)
-    // Small hold so the /topic/battle/score WS event reaches Chart.vue before the Next
-    // button becomes visible — prevents the score from re-triggering after Next is clicked
-    await new Promise(r => setTimeout(r, 350))
     await setBattlePhase('REVEALED')
     battlePhase.value = 'REVEALED'
     return

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -119,12 +119,16 @@ const initiateBattlePair = async (top, pairList) => {
   if (isSmoke.value) {
     await setBattlePair(rounds.value[0].name, rounds.value[1].name)
     await updateSmokePair()  // must await so smoke list is posted before overlay reloads
+    await setBattlePhase('LOCKED')
+    battlePhase.value = 'LOCKED'
     return
   }
   currentBattle.value = [0, pairList]
   const left = currentBattle?.value[1][currentBattle?.value[0]][0]
   const right = currentBattle?.value[1][currentBattle?.value[0]][1]
   await setBattlePair(left, right)
+  await setBattlePhase('LOCKED')
+  battlePhase.value = 'LOCKED'
   currentRound.value = 0
   currentTop.value = top
 }
@@ -135,6 +139,8 @@ const prevPair = async () => {
     const left = currentBattle?.value[1][currentBattle?.value[0]][0]
     const right = currentBattle?.value[1][currentBattle?.value[0]][1]
     await setBattlePair(left, right)
+    await setBattlePhase('LOCKED')
+    battlePhase.value = 'LOCKED'
     currentWinner.value = -2
     currentRound.value -= 1
   }
@@ -152,6 +158,8 @@ const nextPair = async () => {
       const left = currentBattle?.value[1][currentBattle?.value[0]][0]
       const right = currentBattle?.value[1][currentBattle?.value[0]][1]
       await setBattlePair(left, right)
+      await setBattlePhase('LOCKED')
+      battlePhase.value = 'LOCKED'
       currentWinner.value = -2
       currentRound.value += 1
     } else {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, battleJudgeVote, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -21,7 +21,14 @@ const battlePhase = ref('IDLE')
 const showResetConfirm = ref(false)
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
 
+const HEX_RE = /^#[0-9A-Fa-f]{6}$/
+const overlayConfigError = ref('')
 const pushOverlayConfig = async () => {
+  if (!HEX_RE.test(overlayConfig.value.leftColor) || !HEX_RE.test(overlayConfig.value.rightColor)) {
+    overlayConfigError.value = 'Colors must be a valid hex (e.g. #dc2626)'
+    return
+  }
+  overlayConfigError.value = ''
   await setOverlayConfig(overlayConfig.value)
 }
 
@@ -706,6 +713,7 @@ onUnmounted(() => {
             </label>
           </div>
         </div>
+    <p v-if="overlayConfigError" class="overlay-config-error">{{ overlayConfigError }}</p>
       </details>
 
       <div class="h-px bg-surface-600/30 my-4"></div>
@@ -1189,4 +1197,10 @@ onUnmounted(() => {
   transition: transform 0.2s;
 }
 .overlay-toggle input:checked + .overlay-toggle-track::after { transform: translateX(16px); }
+.overlay-config-error {
+  font-size: 11px;
+  color: #f87171;
+  margin: 4px 0 0;
+  padding: 0 2px;
+}
 </style>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -151,7 +151,11 @@ const nextPair = async () => {
   await resetJudgeVote()
   if (isSmoke.value) {
     await update7toSmokeMatch(currentWinner.value)
+    await updateSmokePair()
     await setBattlePair(rounds.value[0].name, rounds.value[1].name)
+    await setBattlePhase('LOCKED')
+    battlePhase.value = 'LOCKED'
+    currentWinner.value = -2
   } else {
     if (currentBattle?.value[0] < currentBattle?.value[1].length - 1) {
       currentBattle.value = [currentBattle.value[0] + 1, currentBattle.value[1]]
@@ -440,6 +444,8 @@ const submitGetScore = async () => {
     const res = await setBattleScore()
     const data = await res.json()
     currentWinner.value = Number(data.winner)
+    await setBattlePhase('REVEALED')
+    battlePhase.value = 'REVEALED'
     return
   }
   if (currentBattle.value.length === 0) return

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -150,8 +150,7 @@ const nextPair = async () => {
   if (currentBattle.value.length === 0) return
   await resetJudgeVote()
   if (isSmoke.value) {
-    await update7toSmokeMatch(currentWinner.value)
-    await updateSmokePair()
+    await update7toSmokeMatch(currentWinner.value)  // handles queue reorder + updateSmokePair + currentWinner reset
     await setBattlePair(rounds.value[0].name, rounds.value[1].name)
     await setBattlePhase('LOCKED')
     battlePhase.value = 'LOCKED'

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -443,6 +443,9 @@ const submitGetScore = async () => {
     const res = await setBattleScore()
     const data = await res.json()
     currentWinner.value = Number(data.winner)
+    // Small hold so the /topic/battle/score WS event reaches Chart.vue before the Next
+    // button becomes visible — prevents the score from re-triggering after Next is clicked
+    await new Promise(r => setTimeout(r, 350))
     await setBattlePhase('REVEALED')
     battlePhase.value = 'REVEALED'
     return

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, battleJudgeVote, getBattleJudges, getBattlePhase, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattlePhase, setBattleScore, setBracketState, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -19,6 +19,12 @@ const currentRound = ref(0)
 const currentTop = ref('')
 const battlePhase = ref('IDLE')
 const showResetConfirm = ref(false)
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+
+const pushOverlayConfig = async () => {
+  await setOverlayConfig(overlayConfig.value)
+}
+
 const activeRoundIdx = ref(0)
 
 const pickupCrews = ref([])
@@ -494,6 +500,8 @@ onMounted(async () => {
   initialiseDropdown()
   await fetchAllJudges(selectedEvent.value)
   battleJudges.value = await getBattleJudges()
+  const savedConfig = await getOverlayConfig()
+  if (savedConfig?.showImages !== undefined) overlayConfig.value = savedConfig
   const phaseData = await getBattlePhase()
   battlePhase.value = phaseData?.phase ?? 'IDLE'
   wsClient.value = createClient()
@@ -641,6 +649,64 @@ onUnmounted(() => {
           </button>
         </div>
       </div>
+
+      <!-- Overlay Settings -->
+      <details class="overlay-settings-panel">
+        <summary class="overlay-settings-summary">Overlay Settings</summary>
+        <div class="overlay-settings-body">
+          <div class="overlay-setting-row">
+            <span class="overlay-setting-label">Left Color</span>
+            <div class="overlay-color-group">
+              <input
+                type="color"
+                v-model="overlayConfig.leftColor"
+                @change="pushOverlayConfig"
+                class="overlay-color-swatch"
+                title="Left team color"
+              />
+              <input
+                type="text"
+                v-model="overlayConfig.leftColor"
+                @change="pushOverlayConfig"
+                maxlength="7"
+                placeholder="#dc2626"
+                class="overlay-hex-input"
+              />
+            </div>
+          </div>
+          <div class="overlay-setting-row">
+            <span class="overlay-setting-label">Right Color</span>
+            <div class="overlay-color-group">
+              <input
+                type="color"
+                v-model="overlayConfig.rightColor"
+                @change="pushOverlayConfig"
+                class="overlay-color-swatch"
+                title="Right team color"
+              />
+              <input
+                type="text"
+                v-model="overlayConfig.rightColor"
+                @change="pushOverlayConfig"
+                maxlength="7"
+                placeholder="#2563eb"
+                class="overlay-hex-input"
+              />
+            </div>
+          </div>
+          <div class="overlay-setting-row">
+            <span class="overlay-setting-label">Show Images</span>
+            <label class="overlay-toggle">
+              <input
+                type="checkbox"
+                v-model="overlayConfig.showImages"
+                @change="pushOverlayConfig"
+              />
+              <span class="overlay-toggle-track"></span>
+            </label>
+          </div>
+        </div>
+      </details>
 
       <div class="h-px bg-surface-600/30 my-4"></div>
 
@@ -1041,3 +1107,86 @@ onUnmounted(() => {
 
   </div>
 </template>
+
+<style scoped>
+.overlay-settings-panel {
+  background: #1a1a1a;
+  border: 1px solid #2c2c2c;
+  border-radius: 12px;
+  margin-top: 12px;
+  overflow: hidden;
+}
+.overlay-settings-summary {
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #f0f0f0;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+.overlay-settings-summary::-webkit-details-marker { display: none; }
+.overlay-settings-body {
+  padding: 4px 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.overlay-setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.overlay-setting-label {
+  font-size: 13px;
+  color: rgba(240,240,240,0.65);
+}
+.overlay-color-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.overlay-color-swatch {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 0;
+  background: none;
+}
+.overlay-hex-input {
+  width: 80px;
+  background: #111;
+  border: 1px solid #2c2c2c;
+  border-radius: 6px;
+  color: #f0f0f0;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', monospace;
+  padding: 4px 8px;
+}
+.overlay-toggle { display: flex; align-items: center; cursor: pointer; }
+.overlay-toggle input { display: none; }
+.overlay-toggle-track {
+  width: 36px;
+  height: 20px;
+  background: #2c2c2c;
+  border-radius: 10px;
+  position: relative;
+  transition: background 0.2s;
+}
+.overlay-toggle input:checked + .overlay-toggle-track { background: #e53935; }
+.overlay-toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+.overlay-toggle input:checked + .overlay-toggle-track::after { transform: translateX(16px); }
+</style>

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -35,7 +35,7 @@ async function handleClick(side) {
   }
 }
 
-const wsClient = ref(null)
+const wsClients = []
 
 onMounted(async () => {
   battleJudges.value = await getBattleJudges()
@@ -49,8 +49,14 @@ onMounted(async () => {
     rightName.value = pairData.right ?? ''
   }
 
-  wsClient.value = createClient()
-  subscribeToChannel(wsClient.value, '/topic/battle/phase', (msg) => {
+  // Each subscription needs its own client — subscribeToChannel sets onConnect,
+  // so sharing one client means every call overwrites the previous handler.
+  const cPhase = createClient(); wsClients.push(cPhase)
+  const cPair  = createClient(); wsClients.push(cPair)
+  const cScore = createClient(); wsClients.push(cScore)
+  const cJudge = createClient(); wsClients.push(cJudge)
+
+  subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
     battlePhase.value = msg.phase
     if (msg.phase === 'LOCKED') {
       active.value = null
@@ -58,20 +64,20 @@ onMounted(async () => {
       revealedWinner.value = -2
     }
   })
-  subscribeToChannel(wsClient.value, '/topic/battle/battle-pair', (msg) => {
+  subscribeToChannel(cPair, '/topic/battle/battle-pair', (msg) => {
     leftName.value = msg.left ?? ''
     rightName.value = msg.right ?? ''
   })
-  subscribeToChannel(wsClient.value, '/topic/battle/score', (msg) => {
+  subscribeToChannel(cScore, '/topic/battle/score', (msg) => {
     revealedWinner.value = msg.message
   })
-  subscribeToChannel(wsClient.value, '/topic/battle/judges', (msg) => {
+  subscribeToChannel(cJudge, '/topic/battle/judges', (msg) => {
     battleJudges.value = msg
   })
 })
 
 onUnmounted(() => {
-  deactivateClient(wsClient.value)
+  wsClients.forEach(c => deactivateClient(c))
 })
 </script>
 
@@ -157,7 +163,7 @@ onUnmounted(() => {
               <p class="overlay-winner-name">{{ rightName }}</p>
               <p class="overlay-winner-label">WINS</p>
             </template>
-            <template v-else>
+            <template v-else-if="revealedWinner === -1">
               <p class="overlay-winner-label">TIE</p>
             </template>
           </div>

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -264,6 +264,8 @@ onMounted(async () => {
       winnerTagVisible.value  = false
       leftWin.value           = false
       rightWin.value          = false
+      leftReset.value         = false
+      rightReset.value        = false
     }
   })
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -798,14 +798,14 @@ body.transparent-page #app {
   position: absolute;
   bottom: 0; left: 0; right: 0;
   z-index: 20;
-  padding: 5vh 1.5vw 2vh;
-  background: linear-gradient(to top, rgba(0,0,0,0.80) 0%, transparent 100%);
+  padding: 10vh 3vw 5vh;
+  background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%);
   display: flex; align-items: flex-end; gap: 10px;
 }
 .name-overlay-right { flex-direction: row-reverse; }
 .name-text {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(18px, 3vw, 52px);
+  font-size: clamp(22px, 4.5vw, 72px);
   text-transform: uppercase;
   color: #fff;
   line-height: 1; letter-spacing: 0.07em;
@@ -868,7 +868,7 @@ body.transparent-page #app {
 /* ── VS badge ────────────────────────────────────── */
 .vs-badge {
   position: absolute;
-  bottom: 2.5vh;
+  bottom: 7vh;
   left: 50%;
   transform: translateX(-50%);
   z-index: 30;

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -252,15 +252,7 @@ onMounted(async () => {
     showVotingIndicator.value = msg?.phase === 'VOTING'
   })
 
-  if (isSmoke.value) {
-    battleJudges.value = await getBattleJudges()
-    const cJudges = createClient(); clients.push(cJudges)
-    const cPair   = createClient(); clients.push(cPair)
-    const cScore  = createClient(); clients.push(cScore)
-    subscribeToChannel(cJudges, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
-    subscribeToChannel(cPair,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
-    subscribeToChannel(cScore,  '/topic/battle/score',       (msg) => updateScore(msg))
-  } else {
+  if (!isSmoke.value) {
     battleJudges.value = await getBattleJudges()
     const res = await getCurrentBattlePair()
     if (res) await updateBattlePair(res)
@@ -314,7 +306,7 @@ onUnmounted(() => {
          JUDGE PANEL — shared across both modes
     ═══════════════════════════════════════════════════ -->
     <div
-      v-if="battleJudges?.judges?.length"
+      v-if="battleJudges?.judges?.length && !isSmoke"
       class="judge-panel"
       :class="judgePanelClass"
       role="region"

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { getBattleJudges, getCurrentBattlePair, getImage } from '@/utils/api';
+import { getBattleJudges, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket';
 import { computed, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useDelay } from '@/utils/utils';
@@ -8,44 +8,71 @@ import Chart from './Chart.vue';
 
 const route = useRoute()
 
-const imageLeft = ref(null)
+// ── Overlay config (live from BattleControl + API) ─────────────────────────
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+
+// ── Battle state ───────────────────────────────────────────────────────────
+const imageLeft  = ref(null)
 const imageRight = ref(null)
 
 let client = createClient()
-const subscribedTopics = new Set();
-const rightName = ref("")
-const leftName = ref("")
-
-const leftScore = ref(0)
+const subscribedTopics = new Set()
+const rightName  = ref('')
+const leftName   = ref('')
+const leftScore  = ref(0)
 const rightScore = ref(0)
 const currentWinner = ref(-2)
+const battleJudges  = ref([])
 
-const battleJudges = ref([])
-
+// Judge panel visibility: true = off-screen (idle/battle), false = visible (score revealed)
 const hideJudgeDecision = ref(true)
 
-// Separate animation state for judge panel:
-// ''            = off-screen (no animation, CSS default)
-// 'slide-down'  = animating in (Get Score pressed)
-// 'slide-up'    = animating out (Next pair pressed)
+// ── Voting state ───────────────────────────────────────────────────────────
+// showVotingIndicator: true when /topic/battle/phase emits VOTING
+const showVotingIndicator = ref(false)
+// votesVisible: false until score is revealed — hides vote state on judge cards
+const votesVisible = ref(false)
+
+// ── Animation state (standard mode only) ──────────────────────────────────
+// judgeAnim: '' | 'slide-down' | 'slide-up' (also used for smoke mode panel)
 const judgeAnim = ref('')
-
-const leftWin = ref(false)
+// leftWin / rightWin: winner-expand CSS class trigger
+const leftWin  = ref(false)
 const rightWin = ref(false)
-
-const leftReset = ref(false)
+// leftReset / rightReset: loser/winner exit animation trigger
+const leftReset  = ref(false)
 const rightReset = ref(false)
+// vsAnim: '' | 'rush-in' | 'knock-left' | 'knock-right'
+const vsAnim = ref('')
+// stageShaking: brief shake burst on VS landing (~340ms into entrance)
+const stageShaking = ref(false)
+// winnerTagVisible: WINNER stamp appears after winner is determined
+const winnerTagVisible = ref(false)
+// glitching: glitch overlay during next-pair transition
+const glitching = ref(false)
 
 const isSmoke = computed(() => route.query.isSmoke === 'true')
 
-// In smoke mode: panel is always on-screen, no animation class needed.
-// In standard mode: use judgeAnim ('', 'slide-down', 'slide-up').
 const judgePanelClass = computed(() => {
   if (isSmoke.value) return 'smoke-judge-always-on'
   return judgeAnim.value
 })
 
+// ── Entrance animation ─────────────────────────────────────────────────────
+const runEntrance = async () => {
+  await useDelay().wait(50) // allow DOM to clear previous animation classes
+  hideJudgeDecision.value = true
+  vsAnim.value = 'rush-in'
+  await useDelay().wait(340) // VS hits undershoot trough at ~340ms
+  stageShaking.value = true
+  await useDelay().wait(120)
+  stageShaking.value = false
+}
+
+// ── Battle pair update ─────────────────────────────────────────────────────
 const updateBattlePair = async (msg) => {
+  if (!msg) return
+
   // SMOKE MODE: only wipe judge votes, keep panel on screen
   if (isSmoke.value) {
     if (battleJudges.value?.judges) {
@@ -57,141 +84,188 @@ const updateBattlePair = async (msg) => {
     return
   }
 
-  // STANDARD MODE: animate out, then swap pair
+  // STANDARD MODE: if a winner is currently showing, run exit sequence first
   if (!hideJudgeDecision.value) {
-    if (judgeAnim.value === 'slide-down') {
-      judgeAnim.value = 'slide-up'
-    }
+    glitching.value = true
+    judgeAnim.value = 'slide-up'
+    await useDelay().wait(100)
 
     if (currentWinner.value === 0) {
-      leftReset.value = true;
+      leftReset.value = true
     } else if (currentWinner.value === 1) {
-      rightReset.value = true;
+      rightReset.value = true
     } else {
-      leftReset.value = true;
-      rightReset.value = true;
+      leftReset.value  = true
+      rightReset.value = true
     }
+    vsAnim.value = ''
 
-    await useDelay().wait(1000);
-
-    judgeAnim.value = ''
-    hideJudgeDecision.value = true;
-    await useDelay().wait(50);
-
-    leftReset.value = false;
-    rightReset.value = false;
+    await useDelay().wait(280)
+    glitching.value          = false
+    hideJudgeDecision.value  = true
+    judgeAnim.value          = ''
+    votesVisible.value       = false
+    winnerTagVisible.value   = false
+    await useDelay().wait(50)
+    leftReset.value  = false
+    rightReset.value = false
   }
 
-  leftWin.value = false;
-  rightWin.value = false;
-  currentWinner.value = -2;
-  rightName.value = msg.right;
-  rightScore.value = msg.rightScore;
-  leftName.value = msg.left;
-  leftScore.value = msg.leftScore;
-  imageLeft.value = await getImage(`${leftName.value}.png`);
-  imageRight.value = await getImage(`${rightName.value}.png`);
-};
+  // Reset all state before new pair
+  leftWin.value          = false
+  rightWin.value         = false
+  currentWinner.value    = -2
+  vsAnim.value           = ''
+  showVotingIndicator.value = false
+  votesVisible.value     = false
+  winnerTagVisible.value = false
 
-const updateBattleJudge = (msg) => {
-  battleJudges.value = msg;
+  leftName.value   = msg.left
+  rightName.value  = msg.right
+  leftScore.value  = msg.leftScore  ?? 0
+  rightScore.value = msg.rightScore ?? 0
+  imageLeft.value  = await getImage(`${msg.left}.png`)
+  imageRight.value = await getImage(`${msg.right}.png`)
 
-  battleJudges.value.judges.forEach(j => {
-    const topic = `/topic/battle/vote/${j.id}`;
-    if (!subscribedTopics.has(topic)) {
-      subscribedTopics.add(topic);
-      subscribeToChannel(createClient(), topic, (msg) => updateJudgeVote(msg));
-    }
-  });
-};
-
-const updateScore = async (msg) => {
-  judgeAnim.value = 'slide-down'
-  hideJudgeDecision.value = false
-  rightScore.value = msg.right
-  leftScore.value = msg.left
-  await useDelay().wait(1000);
-  currentWinner.value = msg.message
-  if (msg.message === 0) {
-    leftWin.value = true
-    rightWin.value = false
-  } else if (msg.message === 1) {
-    leftWin.value = false
-    rightWin.value = true
-  } else if (msg.message === -1) {
-    leftWin.value = false
-    rightWin.value = false
-  }
+  await runEntrance()
 }
 
+// ── Judge list update ──────────────────────────────────────────────────────
+const updateBattleJudge = (msg) => {
+  battleJudges.value = msg
+  battleJudges.value.judges.forEach(j => {
+    const topic = `/topic/battle/vote/${j.id}`
+    if (!subscribedTopics.has(topic)) {
+      subscribedTopics.add(topic)
+      subscribeToChannel(createClient(), topic, (m) => updateJudgeVote(m))
+    }
+  })
+}
+
+// ── Judge vote update (internal only — hidden until score reveal) ──────────
 const updateJudgeVote = (msg) => {
   const updatedJudges = battleJudges.value.judges.map(j =>
     j.id === msg.judge ? { ...j, vote: msg.vote } : j
-  );
-  battleJudges.value = {
-    ...battleJudges.value,
-    judges: updatedJudges
-  };
-};
+  )
+  battleJudges.value = { ...battleJudges.value, judges: updatedJudges }
+}
 
 watch(battleJudges, (newVal) => {
+  if (!newVal?.judges) return
   newVal.judges.forEach(j => {
-    const topic = `/topic/battle/vote/${j.id}`;
+    const topic = `/topic/battle/vote/${j.id}`
     if (!subscribedTopics.has(topic)) {
-      subscribedTopics.add(topic);
-      subscribeToChannel(createClient(), topic, (msg) => updateJudgeVote(msg));
+      subscribedTopics.add(topic)
+      subscribeToChannel(createClient(), topic, (m) => updateJudgeVote(m))
     }
-  });
+  })
 }, { deep: true })
 
+// ── Score reveal ───────────────────────────────────────────────────────────
+const updateScore = async (msg) => {
+  judgeAnim.value          = 'slide-down'
+  hideJudgeDecision.value  = false
+  showVotingIndicator.value = false
+  rightScore.value = msg.right
+  leftScore.value  = msg.left
+
+  // Reveal votes shortly after panel starts dropping
+  await useDelay().wait(200)
+  votesVisible.value = true
+
+  // Winner determination after cards have burst in
+  await useDelay().wait(800)
+  currentWinner.value = msg.message
+
+  if (msg.message === 0) {
+    // Left wins: VS rockets right (toward loser), left panel expands
+    leftWin.value          = true
+    winnerTagVisible.value = true
+    vsAnim.value           = 'knock-right'
+    await useDelay().wait(100)
+    rightReset.value = true   // right (loser) hard-cuts off screen
+  } else if (msg.message === 1) {
+    // Right wins: VS rockets left (toward loser), right panel expands
+    rightWin.value         = true
+    winnerTagVisible.value = true
+    vsAnim.value           = 'knock-left'
+    await useDelay().wait(100)
+    leftReset.value = true    // left (loser) hard-cuts off screen
+  }
+  // msg.message === -1: tie — no winner state, panels stay
+}
+
+// ── Mount ──────────────────────────────────────────────────────────────────
 onMounted(async () => {
-  document.documentElement.classList.add("transparent-page");
-  document.body.classList.add("transparent-page");
-  // Subscribe to phase for future phase-aware overlay behaviour
-  subscribeToChannel(createClient(), "/topic/battle/phase", () => {})
+  document.documentElement.classList.add('transparent-page')
+  document.body.classList.add('transparent-page')
+
+  // Fetch initial overlay config (survives OBS refresh)
+  const config = await getOverlayConfig()
+  if (config?.showImages !== undefined) overlayConfig.value = config
+
+  // Live overlay config updates from BattleControl
+  subscribeToChannel(createClient(), '/topic/battle/overlay-config', (msg) => {
+    if (msg?.showImages !== undefined) overlayConfig.value = msg
+  })
+
+  // Phase subscription: VOTING phase shows the voting indicator
+  subscribeToChannel(createClient(), '/topic/battle/phase', (msg) => {
+    showVotingIndicator.value = msg?.phase === 'VOTING'
+  })
+
   if (isSmoke.value) {
     battleJudges.value = await getBattleJudges()
-    subscribeToChannel(createClient(), "/topic/battle/judges", (msg) => updateBattleJudge(msg))
-    subscribeToChannel(createClient(), "/topic/battle/battle-pair", (msg) => updateBattlePair(msg))
-    subscribeToChannel(createClient(), "/topic/battle/score", (msg) => updateScore(msg))
+    subscribeToChannel(createClient(), '/topic/battle/judges',     (msg) => updateBattleJudge(msg))
+    subscribeToChannel(createClient(), '/topic/battle/battle-pair',(msg) => updateBattlePair(msg))
+    subscribeToChannel(createClient(), '/topic/battle/score',      (msg) => updateScore(msg))
   } else {
     battleJudges.value = await getBattleJudges()
     const res = await getCurrentBattlePair()
-    updateBattlePair(res)
-    subscribeToChannel(createClient(), "/topic/battle/battle-pair", (msg) => updateBattlePair(msg))
-    subscribeToChannel(createClient(), "/topic/battle/score", (msg) => updateScore(msg))
-    subscribeToChannel(createClient(), "/topic/battle/judges", (msg) => updateBattleJudge(msg))
+    if (res) await updateBattlePair(res)
+    subscribeToChannel(createClient(), '/topic/battle/battle-pair',(msg) => updateBattlePair(msg))
+    subscribeToChannel(createClient(), '/topic/battle/score',      (msg) => updateScore(msg))
+    subscribeToChannel(createClient(), '/topic/battle/judges',     (msg) => updateBattleJudge(msg))
   }
 })
 
-onBeforeUnmount(() => {
-  deactivateClient(client.value)
-})
+onBeforeUnmount(() => { deactivateClient(client.value) })
 
 onUnmounted(() => {
-  document.documentElement.classList.remove("transparent-page");
-  document.body.classList.remove("transparent-page");
-  const appRoot = document.getElementById("app");
-  if (appRoot) appRoot.style.background = "";
-});
+  document.documentElement.classList.remove('transparent-page')
+  document.body.classList.remove('transparent-page')
+  const appRoot = document.getElementById('app')
+  if (appRoot) appRoot.style.background = ''
+})
 </script>
 
-
 <template>
-  <div class="overlay-root">
-
-    <!-- Hidden live region: announces winner/score changes to screen readers -->
+  <div
+    class="overlay-root"
+    :class="{ 'stage-shake': stageShaking }"
+    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
+  >
+    <!-- Screen-reader live region -->
     <div class="sr-only" role="status" aria-live="assertive" aria-atomic="true">
       <template v-if="currentWinner === 0">{{ leftName }} wins!</template>
       <template v-else-if="currentWinner === 1">{{ rightName }} wins!</template>
       <template v-else-if="currentWinner === -1">Tie between {{ leftName }} and {{ rightName }}!</template>
     </div>
 
-    <!-- ══════════════════════════════════════════════════════
+    <!-- Glitch transition overlay -->
+    <div v-if="glitching" class="glitch-overlay" aria-hidden="true"></div>
+
+    <!-- Structural decorators — standard mode only -->
+    <template v-if="!isSmoke">
+      <div class="center-divider" aria-hidden="true"></div>
+      <div class="scanlines"      aria-hidden="true"></div>
+      <div class="color-bleed color-bleed-left"  aria-hidden="true"></div>
+      <div class="color-bleed color-bleed-right" aria-hidden="true"></div>
+    </template>
+
+    <!-- ══════════════════════════════════════════════════
          JUDGE PANEL — shared across both modes
-         Standard: slides down on Get Score
-         Smoke:    always visible, only votes reset on Next
-    ═══════════════════════════════════════════════════════ -->
+    ═══════════════════════════════════════════════════ -->
     <div
       v-if="battleJudges?.judges?.length"
       class="judge-panel"
@@ -201,18 +275,13 @@ onUnmounted(() => {
       aria-live="polite"
       aria-atomic="false"
     >
-      <!-- Prismatic border layer -->
       <div class="judge-border-glow" aria-hidden="true"></div>
-
       <div class="judge-inner">
-        <!-- Header label (decorative) -->
         <div class="judges-header" aria-hidden="true">
           <span class="judges-line"></span>
           <span class="judges-label">JUDGES</span>
           <span class="judges-line"></span>
         </div>
-
-        <!-- Judge cards -->
         <div class="judge-cards-row" role="list">
           <div
             v-for="(j, index) in battleJudges.judges"
@@ -221,26 +290,35 @@ onUnmounted(() => {
             role="listitem"
             :aria-label="`${j.name}: ${j.vote === 0 ? 'voted left' : j.vote === 1 ? 'voted right' : j.vote === -1 ? 'voted tie' : 'awaiting vote'}`"
             :class="{
-              'voted-red':  j.vote === 0,
-              'voted-blue': j.vote === 1,
-              'voted-tie':  j.vote === -1,
+              'voted-left':   votesVisible && j.vote === 0,
+              'voted-right':  votesVisible && j.vote === 1,
+              'voted-tie':    votesVisible && j.vote === -1,
+              'card-unvoted': !votesVisible,
+              'card-burst':    votesVisible,
             }"
+            :style="votesVisible ? { animationDelay: `${index * 55}ms` } : {}"
           >
-            <!-- Arrow + Name + Arrow -->
             <div class="judge-row">
-              <span class="vote-arrow vote-arrow-left"  :class="{ 'arrow-lit-red':  j.vote === 0 }" aria-hidden="true"></span>
+              <span
+                class="vote-arrow vote-arrow-left"
+                :class="{ 'arrow-lit-left': votesVisible && j.vote === 0 }"
+                aria-hidden="true"
+              ></span>
               <span class="judge-name">{{ j.name }}</span>
-              <span class="vote-arrow vote-arrow-right" :class="{ 'arrow-lit-blue': j.vote === 1 }" aria-hidden="true"></span>
+              <span
+                class="vote-arrow vote-arrow-right"
+                :class="{ 'arrow-lit-right': votesVisible && j.vote === 1 }"
+                aria-hidden="true"
+              ></span>
             </div>
-            <!-- Vote track bar (decorative) -->
             <div class="vote-track" aria-hidden="true">
               <div
                 class="vote-fill"
                 :class="{
-                  'fill-red':   j.vote === 0,
-                  'fill-blue':  j.vote === 1,
-                  'fill-tie':   j.vote === -1,
-                  'fill-blank': j.vote === -3 || j.vote === null,
+                  'fill-left':  votesVisible && j.vote === 0,
+                  'fill-right': votesVisible && j.vote === 1,
+                  'fill-tie':   votesVisible && j.vote === -1,
+                  'fill-blank': !votesVisible || j.vote === -3 || j.vote === null,
                 }"
               ></div>
             </div>
@@ -249,89 +327,105 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <!-- ═══════════════════════════════════════════════
+    <!-- ══════════════════════════════════════════════════
          STANDARD BATTLE  (isSmoke = false)
-    ════════════════════════════════════════════════ -->
+    ═══════════════════════════════════════════════════ -->
     <template v-if="!isSmoke">
 
-      <!-- ── Left Battler ── -->
+      <!-- Left battler panel -->
       <div
         class="battler-panel left-panel"
         :class="{
-          'slide-left':     rightWin,
-          'fade-out':       rightWin,
-          'slide-right':    leftWin,
-          'left-slide-in':  hideJudgeDecision,
+          'slam-in-left':   hideJudgeDecision,
           'slide-left-out': leftReset,
           'panel-winner':   leftWin,
         }"
         role="region"
         :aria-label="`Left: ${leftName || 'TBD'}${leftScore > 0 ? ', score ' + leftScore : ''}${leftWin ? ' — winner' : ''}`"
       >
-        <div class="panel-gradient red-gradient" aria-hidden="true"></div>
-        <div class="panel-vignette" aria-hidden="true"></div>
+        <div class="panel-color-wash panel-color-wash-left" aria-hidden="true"></div>
 
-        <img v-if="imageLeft" :src="imageLeft" :alt="leftName" class="battler-img" />
-        <div v-else class="battler-placeholder red-placeholder" aria-hidden="true">
-          <svg viewBox="0 0 100 200" fill="none" xmlns="http://www.w3.org/2000/svg" class="placeholder-svg">
-            <circle cx="50" cy="30" r="22" fill="rgba(239,68,68,0.2)" stroke="rgba(239,68,68,0.35)" stroke-width="1.5"/>
-            <path d="M18 90 Q50 70 82 90 L88 160 Q70 150 50 155 Q30 150 12 160 Z" fill="rgba(239,68,68,0.12)" stroke="rgba(239,68,68,0.28)" stroke-width="1.5"/>
-            <line x1="18" y1="160" x2="10" y2="200" stroke="rgba(239,68,68,0.28)" stroke-width="5" stroke-linecap="round"/>
-            <line x1="82" y1="160" x2="90" y2="200" stroke="rgba(239,68,68,0.28)" stroke-width="5" stroke-linecap="round"/>
-          </svg>
-        </div>
+        <!-- Picture mode -->
+        <template v-if="overlayConfig.showImages">
+          <img v-if="imageLeft" :src="imageLeft" :alt="leftName" class="battler-img" />
+          <div v-else class="battler-placeholder" aria-hidden="true"></div>
+          <div class="name-overlay">
+            <span class="name-text name-text-left">{{ leftName || '???' }}</span>
+            <span v-if="leftScore > 0" class="score-badge">{{ leftScore }}</span>
+          </div>
+        </template>
 
-        <div class="name-bar red-bar" :class="{ 'bar-win-glow': leftWin }" aria-hidden="true">
-          <span class="name-text">{{ leftName || '???' }}</span>
-          <span v-if="leftScore > 0" class="score-badge">{{ leftScore }}</span>
-        </div>
+        <!-- Name-only mode -->
+        <template v-else>
+          <div class="name-center-wrap">
+            <span class="name-giant name-giant-left">{{ leftName || '???' }}</span>
+            <span v-if="leftScore > 0" class="score-badge-large">{{ leftScore }}</span>
+          </div>
+        </template>
+
+        <div class="corner-accent corner-accent-tl" aria-hidden="true"></div>
+        <div class="bottom-edge bottom-edge-left"   aria-hidden="true"></div>
+        <div v-if="winnerTagVisible && leftWin" class="winner-tag" aria-hidden="true">WINNER</div>
       </div>
 
-      <!-- ── VS badge (decorative) ── -->
-      <div class="vs-badge" :class="{ 'vs-hidden': currentWinner !== -2 }" aria-hidden="true">
-        <span class="vs-deco">◆</span>
+      <!-- VS badge -->
+      <div
+        class="vs-badge"
+        :class="[vsAnim, { 'vs-gone': currentWinner !== -2 && vsAnim !== 'knock-left' && vsAnim !== 'knock-right' }]"
+        aria-hidden="true"
+      >
         <span class="vs-text">VS</span>
-        <span class="vs-deco">◆</span>
       </div>
 
-      <!-- ── Right Battler ── -->
+      <!-- Right battler panel -->
       <div
         class="battler-panel right-panel"
         :class="{
-          'slide-left':      rightWin,
-          'fade-out':        leftWin,
-          'slide-right':     leftWin,
-          'right-slide-in':  hideJudgeDecision,
+          'slam-in-right':   hideJudgeDecision,
           'slide-right-out': rightReset,
           'panel-winner':    rightWin,
         }"
         role="region"
         :aria-label="`Right: ${rightName || 'TBD'}${rightScore > 0 ? ', score ' + rightScore : ''}${rightWin ? ' — winner' : ''}`"
       >
-        <div class="panel-gradient blue-gradient" aria-hidden="true"></div>
-        <div class="panel-vignette" aria-hidden="true"></div>
+        <div class="panel-color-wash panel-color-wash-right" aria-hidden="true"></div>
 
-        <img v-if="imageRight" :src="imageRight" :alt="rightName" class="battler-img" />
-        <div v-else class="battler-placeholder blue-placeholder" aria-hidden="true">
-          <svg viewBox="0 0 100 200" fill="none" xmlns="http://www.w3.org/2000/svg" class="placeholder-svg">
-            <circle cx="50" cy="30" r="22" fill="rgba(59,130,246,0.2)" stroke="rgba(59,130,246,0.35)" stroke-width="1.5"/>
-            <path d="M18 90 Q50 70 82 90 L88 160 Q70 150 50 155 Q30 150 12 160 Z" fill="rgba(59,130,246,0.12)" stroke="rgba(59,130,246,0.28)" stroke-width="1.5"/>
-            <line x1="18" y1="160" x2="10" y2="200" stroke="rgba(59,130,246,0.28)" stroke-width="5" stroke-linecap="round"/>
-            <line x1="82" y1="160" x2="90" y2="200" stroke="rgba(59,130,246,0.28)" stroke-width="5" stroke-linecap="round"/>
-          </svg>
-        </div>
+        <!-- Picture mode -->
+        <template v-if="overlayConfig.showImages">
+          <img v-if="imageRight" :src="imageRight" :alt="rightName" class="battler-img" />
+          <div v-else class="battler-placeholder" aria-hidden="true"></div>
+          <div class="name-overlay name-overlay-right">
+            <span class="name-text name-text-right">{{ rightName || '???' }}</span>
+            <span v-if="rightScore > 0" class="score-badge">{{ rightScore }}</span>
+          </div>
+        </template>
 
-        <div class="name-bar blue-bar" :class="{ 'bar-win-glow': rightWin }" aria-hidden="true">
-          <span class="name-text">{{ rightName || '???' }}</span>
-          <span v-if="rightScore > 0" class="score-badge">{{ rightScore }}</span>
-        </div>
+        <!-- Name-only mode -->
+        <template v-else>
+          <div class="name-center-wrap">
+            <span class="name-giant name-giant-right">{{ rightName || '???' }}</span>
+            <span v-if="rightScore > 0" class="score-badge-large">{{ rightScore }}</span>
+          </div>
+        </template>
+
+        <div class="corner-accent corner-accent-tr" aria-hidden="true"></div>
+        <div class="bottom-edge bottom-edge-right"  aria-hidden="true"></div>
+        <div v-if="winnerTagVisible && rightWin" class="winner-tag" aria-hidden="true">WINNER</div>
       </div>
+
+      <!-- Voting indicator — visible during VOTING phase -->
+      <transition name="fade-indicator">
+        <div v-if="showVotingIndicator" class="voting-indicator" aria-label="Judges are voting">
+          <span class="voting-dot" aria-hidden="true"></span>
+          <span class="voting-label">JUDGES VOTING</span>
+        </div>
+      </transition>
 
     </template>
 
-    <!-- ═══════════════════════════════════════════════
+    <!-- ══════════════════════════════════════════════════
          SMOKE MODE  (isSmoke = true)
-    ════════════════════════════════════════════════ -->
+    ═══════════════════════════════════════════════════ -->
     <template v-else>
       <Chart />
     </template>
@@ -339,22 +433,15 @@ onUnmounted(() => {
   </div>
 </template>
 
-
 <style>
-/* ── Screen-reader only utility ───────────────────── */
+/* ── Screen-reader only ─────────────────────────────────────── */
 .sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  position: absolute; width: 1px; height: 1px; padding: 0;
+  margin: -1px; overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
 }
 
-/* ── Transparent background (OBS) ─────────────────── */
+/* ── Transparent background (OBS) ──────────────────────────── */
 html.transparent-page,
 body.transparent-page,
 html.transparent-page #app,
@@ -363,15 +450,85 @@ body.transparent-page #app {
   background-color: transparent !important;
 }
 
-/* ── Root container ───────────────────────────────── */
+/* ── Root ───────────────────────────────────────────────────── */
 .overlay-root {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
+  top: 0; left: 0;
+  width: 100vw; height: 100vh;
   overflow: hidden;
   font-family: 'Anton SC', sans-serif;
+  /* Default CSS custom properties — overridden by :style binding */
+  --left-color: #dc2626;
+  --right-color: #2563eb;
+}
+
+/* ── Stage shake ────────────────────────────────────────────── */
+.stage-shake {
+  animation: stageShake 120ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+
+/* ── Glitch overlay ─────────────────────────────────────────── */
+.glitch-overlay {
+  position: absolute; inset: 0;
+  z-index: 100;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent, transparent 4px,
+    rgba(255,255,255,0.04) 4px, rgba(255,255,255,0.04) 8px
+  );
+  animation: glitchFlicker 380ms steps(1) forwards;
+}
+
+/* ── Center divider ─────────────────────────────────────────── */
+.center-divider {
+  position: absolute;
+  top: 0; bottom: 0;
+  left: calc(50% - 1px);
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgba(255,255,255,0.12) 30%,
+    rgba(255,255,255,0.22) 50%,
+    rgba(255,255,255,0.12) 70%,
+    transparent 100%
+  );
+  transform: skewX(-3deg);
+  z-index: 5;
+  pointer-events: none;
+}
+
+/* ── Scanlines ──────────────────────────────────────────────── */
+.scanlines {
+  position: absolute; inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px, transparent 3px,
+    rgba(0,0,0,0.035) 3px, rgba(0,0,0,0.035) 4px
+  );
+}
+
+/* ── Global color bleeds ────────────────────────────────────── */
+.color-bleed {
+  position: absolute; inset: 0;
+  pointer-events: none; z-index: 1;
+}
+.color-bleed-left {
+  background: radial-gradient(
+    ellipse 45% 55% at 0% 100%,
+    color-mix(in srgb, var(--left-color) 16%, transparent),
+    transparent 70%
+  );
+}
+.color-bleed-right {
+  background: radial-gradient(
+    ellipse 45% 55% at 100% 100%,
+    color-mix(in srgb, var(--right-color) 16%, transparent),
+    transparent 70%
+  );
 }
 
 /* ══════════════════════════════════════════════════
@@ -379,115 +536,103 @@ body.transparent-page #app {
 ══════════════════════════════════════════════════ */
 .judge-panel {
   position: absolute;
-  top: 18px;
-  left: 0;
-  right: 0;
+  top: 18px; left: 0; right: 0;
   z-index: 50;
   display: flex;
   justify-content: center;
   pointer-events: none;
-  transform: translateY(-200px); /* off-screen default — no flash on load */
+  transform: translateY(-220px);
 }
-
-/* Smoke mode: always pinned, no animation */
 .smoke-judge-always-on {
   transform: translateY(0) !important;
   animation: none !important;
 }
-
-/* Prismatic gradient border ring behind the inner card */
 .judge-border-glow {
-  position: absolute;
-  inset: -1px;
+  position: absolute; inset: -1px;
   border-radius: 22px;
   background: linear-gradient(
     135deg,
-    rgba(239,68,68,0.55) 0%,
-    rgba(255,255,255,0.12) 35%,
-    rgba(59,130,246,0.55) 65%,
-    rgba(255,255,255,0.12) 100%
+    color-mix(in srgb, var(--left-color) 55%, transparent) 0%,
+    rgba(255,255,255,0.1) 35%,
+    color-mix(in srgb, var(--right-color) 55%, transparent) 65%,
+    rgba(255,255,255,0.1) 100%
   );
   filter: blur(1px);
   animation: borderRotate 6s linear infinite;
   z-index: -1;
 }
-
 .judge-inner {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  background: rgba(6, 8, 18, 0.82);
+  display: flex; flex-direction: column; gap: 10px;
+  background: rgba(6,8,18,0.85);
   backdrop-filter: blur(28px);
   -webkit-backdrop-filter: blur(28px);
   border-radius: 20px;
   padding: 14px 24px 16px;
 }
-
-/* "JUDGES" header row */
 .judges-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+  display: flex; align-items: center; gap: 10px;
 }
 .judges-label {
   font-family: 'Inter', sans-serif;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: 10px; font-weight: 700;
   letter-spacing: 0.28em;
   color: rgba(255,255,255,0.35);
   text-transform: uppercase;
-  white-space: nowrap;
-  flex-shrink: 0;
+  white-space: nowrap; flex-shrink: 0;
 }
 .judges-line {
-  flex: 1;
-  height: 1px;
+  flex: 1; height: 1px;
   background: rgba(255,255,255,0.1);
 }
-
-/* Cards row */
 .judge-cards-row {
-  display: flex;
-  gap: 12px;
+  display: flex; gap: 12px;
 }
 
-/* Judge card */
+/* Judge card — parallelogram shape */
 .judge-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
+  display: flex; flex-direction: column;
+  align-items: center; gap: 10px;
   min-width: 148px;
   padding: 10px 14px;
-  border-radius: 14px;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
   border: 1.5px solid rgba(255,255,255,0.06);
   background: rgba(255,255,255,0.025);
-  transition: border-color 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
 }
-.voted-red  {
-  border-color: rgba(239,68,68,0.65);
-  background: rgba(239,68,68,0.09);
-  box-shadow: 0 0 28px rgba(239,68,68,0.35), inset 0 0 14px rgba(239,68,68,0.08);
+
+/* Unvoted: frosted glass with gentle pulse */
+.card-unvoted {
+  background: rgba(255,255,255,0.08) !important;
+  border-color: rgba(255,255,255,0.18) !important;
+  animation: cardPulse 2.2s ease-in-out infinite;
 }
-.voted-blue {
-  border-color: rgba(59,130,246,0.65);
-  background: rgba(59,130,246,0.09);
-  box-shadow: 0 0 28px rgba(59,130,246,0.35), inset 0 0 14px rgba(59,130,246,0.08);
+
+/* Burst in when votes are revealed */
+.card-burst {
+  animation: cardBurst 280ms cubic-bezier(0.2, 0, 0.3, 1) both;
 }
-.voted-tie  {
+
+.voted-left {
+  border-color: color-mix(in srgb, var(--left-color) 65%, transparent);
+  background: color-mix(in srgb, var(--left-color) 9%, transparent);
+  box-shadow: 0 0 28px color-mix(in srgb, var(--left-color) 35%, transparent),
+              inset 0 0 14px color-mix(in srgb, var(--left-color) 8%, transparent);
+}
+.voted-right {
+  border-color: color-mix(in srgb, var(--right-color) 65%, transparent);
+  background: color-mix(in srgb, var(--right-color) 9%, transparent);
+  box-shadow: 0 0 28px color-mix(in srgb, var(--right-color) 35%, transparent),
+              inset 0 0 14px color-mix(in srgb, var(--right-color) 8%, transparent);
+}
+.voted-tie {
   border-color: rgba(251,191,36,0.65);
   background: rgba(251,191,36,0.07);
   box-shadow: 0 0 28px rgba(251,191,36,0.28), inset 0 0 14px rgba(251,191,36,0.06);
 }
 
-/* Arrow + name row */
-.judge-row {
-  display: flex;
-  align-items: center;
-  gap: 11px;
-}
-
+/* Judge name + arrow row */
+.judge-row { display: flex; align-items: center; gap: 11px; }
 .judge-name {
   font-family: 'Anton SC', sans-serif;
   font-size: 28px;
@@ -497,139 +642,189 @@ body.transparent-page #app {
   line-height: 1;
 }
 
-/* Direction arrows — pure CSS clip-path, guaranteed equal size */
+/* Direction arrows */
 .vote-arrow {
   display: inline-block;
-  width: 18px;
-  height: 18px;
-  flex-shrink: 0;
+  width: 18px; height: 18px; flex-shrink: 0;
   background: rgba(255,255,255,0.15);
   opacity: 0.2;
-  transition: opacity 0.3s ease, background 0.3s ease, filter 0.3s ease;
+  transition: opacity 0.2s ease, background 0.2s ease, filter 0.2s ease;
 }
 .vote-arrow-left  { clip-path: polygon(100% 0%, 0% 50%, 100% 100%); }
 .vote-arrow-right { clip-path: polygon(0% 0%, 100% 50%, 0% 100%); }
-
-.arrow-lit-red  {
+.arrow-lit-left {
   opacity: 1;
-  background: #ef4444;
-  filter: drop-shadow(0 0 8px rgba(239,68,68,0.95));
+  background: var(--left-color);
+  filter: drop-shadow(0 0 8px var(--left-color));
 }
-.arrow-lit-blue {
+.arrow-lit-right {
   opacity: 1;
-  background: #3b82f6;
-  filter: drop-shadow(0 0 8px rgba(59,130,246,0.95));
+  background: var(--right-color);
+  filter: drop-shadow(0 0 8px var(--right-color));
 }
 
 /* Vote track bar */
 .vote-track {
-  width: 100%;
-  height: 10px;
-  background: rgba(255,255,255,0.07);
+  width: 100%; height: 10px;
+  background: rgba(255,255,255,0.1);
   border-radius: 9999px;
   overflow: hidden;
 }
 .vote-fill {
   height: 100%;
   border-radius: 9999px;
-  transition: background 0.45s ease, box-shadow 0.45s ease, width 0.45s ease;
+  transition: background 0.25s ease, width 0.25s ease;
   width: 0%;
 }
-.fill-red   { width: 100%; background: linear-gradient(90deg, #dc2626, #ef4444); box-shadow: 0 0 14px rgba(239,68,68,0.9); }
-.fill-blue  { width: 100%; background: linear-gradient(90deg, #1d4ed8, #3b82f6); box-shadow: 0 0 14px rgba(59,130,246,0.9); }
+.fill-left  {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--left-color) 70%, black), var(--left-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--left-color) 90%, transparent);
+}
+.fill-right {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--right-color) 70%, black), var(--right-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 90%, transparent);
+}
 .fill-tie   { width: 100%; background: linear-gradient(90deg, #b45309, #fbbf24); box-shadow: 0 0 14px rgba(251,191,36,0.9); }
-.fill-blank { width: 0%;   background: transparent; }
+.fill-blank { width: 0%; background: transparent; }
 
 /* ══════════════════════════════════════════════════
    BATTLER PANELS
+   Both panels use left-only positioning so winner
+   centering (left:0, width:100%) works from either side.
 ══════════════════════════════════════════════════ */
 .battler-panel {
   position: absolute;
   bottom: 0;
-  width: 38vw;
   height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-end;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: flex-end;
+  /* CSS transition for winner expand */
+  transition: left 420ms cubic-bezier(0.2, 0, 0.3, 1),
+              width 420ms cubic-bezier(0.2, 0, 0.3, 1);
+}
+.left-panel  { left: 0;    width: 46%; }
+.right-panel { left: 54%;  width: 46%; }
+
+/* Winner: both panels expand to full width from left:0 */
+.panel-winner { left: 0 !important; width: 100% !important; }
+
+/* Panel color wash (gradient overlay) */
+.panel-color-wash {
+  position: absolute; inset: 0;
+  pointer-events: none; z-index: 0;
+}
+.panel-color-wash-left {
+  background: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--left-color) 55%, black) 0%,
+    color-mix(in srgb, var(--left-color) 15%, transparent) 40%,
+    transparent 70%
+  );
+}
+.panel-color-wash-right {
+  background: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--right-color) 55%, black) 0%,
+    color-mix(in srgb, var(--right-color) 15%, transparent) 40%,
+    transparent 70%
+  );
 }
 
-.left-panel  { left: 0; }
-.right-panel { right: 0; }
-
-/* Gradient wash */
-.panel-gradient {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
+/* Corner accent bars (3px vertical, fade down in team color) */
+.corner-accent {
+  position: absolute; top: 0;
+  width: 3px; height: 28%;
+  pointer-events: none; z-index: 3;
 }
-.red-gradient  { background: linear-gradient(to top, rgba(153,27,27,0.88) 0%, rgba(153,27,27,0.22) 38%, transparent 68%); }
-.blue-gradient { background: linear-gradient(to top, rgba(29,78,216,0.88) 0%, rgba(29,78,216,0.22) 38%, transparent 68%); }
+.corner-accent-tl { left: 0;  background: linear-gradient(to bottom, var(--left-color), transparent); }
+.corner-accent-tr { right: 0; background: linear-gradient(to bottom, var(--right-color), transparent); }
 
-/* Vignette removed — inset box-shadows created hard vertical lines at panel edges */
-.panel-vignette { display: none; }
+/* Bottom edge lines (3px horizontal, fade inward) */
+.bottom-edge {
+  position: absolute; bottom: 0;
+  height: 3px; width: 40%;
+  pointer-events: none; z-index: 3;
+}
+.bottom-edge-left  { left: 0;  background: linear-gradient(to right, var(--left-color), transparent); }
+.bottom-edge-right { right: 0; background: linear-gradient(to left, var(--right-color), transparent); }
 
-/* Winner glow on panel */
-.panel-winner .red-gradient  { background: linear-gradient(to top, rgba(185,28,28,0.95) 0%, rgba(153,27,27,0.35) 45%, transparent 72%); }
-.panel-winner .blue-gradient { background: linear-gradient(to top, rgba(37,99,235,0.95) 0%, rgba(29,78,216,0.35) 45%, transparent 72%); }
-
-/* Battler image */
+/* ── Picture mode ────────────────────────────────── */
 .battler-img {
-  position: relative;
-  z-index: 10;
+  position: relative; z-index: 10;
   width: 100%;
+  aspect-ratio: 3/4;
+  object-fit: cover;
+  object-position: top;
   max-height: 85vh;
-  object-fit: contain;
-  object-position: bottom;
-  margin-bottom: 8vh;
+  display: block;
 }
-
-/* Placeholder silhouette */
 .battler-placeholder {
-  position: relative;
-  z-index: 10;
-  width: 12vw;
-  height: 30vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: relative; z-index: 10;
+  width: 12vw; height: 30vh;
   margin-bottom: 8vh;
-  border-radius: 16px;
-  border: 1.5px dashed;
+  border-radius: 8px;
+  border: 1.5px dashed rgba(255,255,255,0.18);
+  background: rgba(255,255,255,0.03);
   animation: placeholderBreath 3s ease-in-out infinite;
 }
-.red-placeholder  { border-color: rgba(239,68,68,0.28); background: rgba(239,68,68,0.04); }
-.blue-placeholder { border-color: rgba(59,130,246,0.28); background: rgba(59,130,246,0.04); }
-.placeholder-svg  { width: 55%; height: auto; opacity: 0.5; }
-
-/* ── Name bar ─────────────────────────────────────── */
-.name-bar {
+.name-overlay {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  bottom: 0; left: 0; right: 0;
   z-index: 20;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  padding: 1.6vh 1.5vw;
+  padding: 5vh 1.5vw 2vh;
+  background: linear-gradient(to top, rgba(0,0,0,0.80) 0%, transparent 100%);
+  display: flex; align-items: flex-end; gap: 10px;
 }
-
+.name-overlay-right { flex-direction: row-reverse; }
 .name-text {
   font-family: 'Anton SC', sans-serif;
-  font-size: 3vw;
-  letter-spacing: 0.07em;
+  font-size: clamp(18px, 3vw, 52px);
   text-transform: uppercase;
-  color: #ffffff;
-  line-height: 1;
+  color: #fff;
+  line-height: 1; letter-spacing: 0.07em;
+}
+.name-text-left {
+  text-shadow: 3px 3px 0 var(--left-color),
+               0 0 30px color-mix(in srgb, var(--left-color) 60%, transparent);
+}
+.name-text-right {
+  text-shadow: -3px 3px 0 var(--right-color),
+               0 0 30px color-mix(in srgb, var(--right-color) 60%, transparent);
 }
 
-/* Score badge pill */
+/* ── Name-only mode ──────────────────────────────── */
+.name-center-wrap {
+  position: absolute;
+  top: 50%; transform: translateY(-50%);
+  z-index: 20;
+  width: 90%;
+  display: flex; flex-direction: column;
+  align-items: center; gap: 14px;
+  padding: 0 8px;
+}
+.name-giant {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(28px, 5.5vw, 90px);
+  text-transform: uppercase;
+  color: #fff;
+  line-height: 1; letter-spacing: 0.06em;
+  word-break: break-word; text-align: center;
+}
+.name-giant-left {
+  text-shadow: 4px 4px 0 var(--left-color),
+               0 0 50px color-mix(in srgb, var(--left-color) 50%, transparent);
+}
+.name-giant-right {
+  text-shadow: -4px 4px 0 var(--right-color),
+               0 0 50px color-mix(in srgb, var(--right-color) 50%, transparent);
+}
+
+/* Score badges */
 .score-badge {
   font-family: 'Anton SC', sans-serif;
-  font-size: 1.8vw;
+  font-size: clamp(12px, 1.6vw, 28px);
   line-height: 1;
   color: rgba(255,255,255,0.92);
   background: rgba(255,255,255,0.15);
@@ -638,135 +833,215 @@ body.transparent-page #app {
   padding: 2px 8px;
   letter-spacing: 0.05em;
 }
-
-.red-bar {
-  background: linear-gradient(90deg, rgba(185,28,28,0.0) 0%, rgba(220,38,38,0.95) 20%, rgba(220,38,38,0.95) 80%, rgba(185,28,28,0.0) 100%);
-  border-top: 1.5px solid rgba(255,120,120,0.35);
-}
-.blue-bar {
-  background: linear-gradient(90deg, rgba(29,78,216,0.0) 0%, rgba(37,99,235,0.95) 20%, rgba(37,99,235,0.95) 80%, rgba(29,78,216,0.0) 100%);
-  border-top: 1.5px solid rgba(120,160,255,0.35);
+.score-badge-large {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(16px, 2.5vw, 42px);
+  color: rgba(255,255,255,0.6);
+  letter-spacing: 0.05em;
 }
 
-/* Winner name bar: gold shimmer sweep */
-.bar-win-glow {
-  animation: winnerShimmer 1.8s ease-in-out forwards;
-}
-
-/* ── VS badge ─────────────────────────────────────── */
+/* ── VS badge ────────────────────────────────────── */
 .vs-badge {
   position: absolute;
   bottom: 2.5vh;
   left: 50%;
   transform: translateX(-50%);
   z-index: 30;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  opacity: 1;
-  transition: opacity 0.7s ease;
 }
-.vs-hidden {
-  opacity: 0;
-  pointer-events: none;
-}
-
 .vs-text {
   font-family: 'Anton SC', sans-serif;
-  font-size: 4.2vw;
+  font-size: clamp(24px, 4.2vw, 72px);
   color: rgba(255,255,255,0.88);
   letter-spacing: 0.14em;
-  text-shadow: 0 0 40px rgba(255,255,255,0.3);
-  animation: vsPulse 2.8s ease-in-out infinite;
-  line-height: 1;
+  text-shadow: 0 0 40px rgba(255,255,255,0.25);
+  clip-path: polygon(10% 0%, 90% 0%, 100% 50%, 90% 100%, 10% 100%, 0% 50%);
+  background: rgba(0,0,0,0.25);
+  padding: 4px 22px 4px 18px;
+  display: block;
 }
+.vs-gone { display: none; }
 
-.vs-deco {
-  font-size: 1.4vw;
-  color: rgba(255,255,255,0.25);
-  animation: vsPulse 2.8s ease-in-out infinite reverse;
+/* ── Voting indicator ────────────────────────────── */
+.voting-indicator {
+  position: absolute;
+  bottom: 2vh; left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: flex; align-items: center; gap: 8px;
+}
+.voting-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: #ef4444;
+  animation: votingPulse 1.2s ease-in-out infinite;
+}
+.voting-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.2em;
+  color: rgba(255,255,255,0.45);
+  text-transform: uppercase;
+}
+/* Fade transition for voting indicator */
+.fade-indicator-enter-active,
+.fade-indicator-leave-active { transition: opacity 0.3s ease; }
+.fade-indicator-enter-from,
+.fade-indicator-leave-to     { opacity: 0; }
+
+/* ── Winner tag ──────────────────────────────────── */
+.winner-tag {
+  position: absolute;
+  top: 40%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 60;
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(18px, 3.2vw, 58px);
+  color: #fff;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border: 3px solid rgba(255,255,255,0.8);
+  padding: 8px 28px;
+  background: rgba(0,0,0,0.45);
+  animation: winnerStamp 300ms cubic-bezier(0.2, 0, 0.3, 1) both;
+  animation-delay: 300ms;
+  opacity: 0;
 }
 
 /* ══════════════════════════════════════════════════
-   KEYFRAME ANIMATIONS
+   KEYFRAMES
 ══════════════════════════════════════════════════ */
 
-/* Battler entrances / exits — spring easing */
-@keyframes slideRight {
-  from { transform: translateX(0); }
-  to   { transform: translateX(55vw); }
+/* Stage shake on VS landing */
+@keyframes stageShake {
+  0%   { transform: translate(0,    0);  }
+  15%  { transform: translate(-4px, 3px); }
+  30%  { transform: translate(5px, -2px); }
+  45%  { transform: translate(-3px, 4px); }
+  60%  { transform: translate(4px, -3px); }
+  75%  { transform: translate(-2px, 2px); }
+  100% { transform: translate(0,    0);  }
 }
-@keyframes slideRightIn {
-  from { transform: translateX(72vw); }
-  to   { transform: translateX(0); }
+
+/* Glitch flicker during next-pair transition */
+@keyframes glitchFlicker {
+  0%   { opacity: 1;   clip-path: inset(0% 0 0% 0); transform: skewX(0); }
+  12%  { opacity: 0;   }
+  25%  { opacity: 1;   clip-path: inset(20% 0 30% 0); transform: skewX(2deg); }
+  37%  { opacity: 0.7; }
+  50%  { opacity: 1;   clip-path: inset(55% 0 5% 0);  transform: skewX(-1deg) translateX(3px); }
+  62%  { opacity: 0.4; }
+  75%  { opacity: 1;   clip-path: inset(10% 0 78% 0); transform: skewX(3deg); }
+  87%  { opacity: 0.8; }
+  100% { opacity: 0;   }
 }
-@keyframes slideLeft {
-  from { transform: translateX(0); }
-  to   { transform: translateX(-55vw); }
+
+/* Left panel slams in from left edge */
+@keyframes leftSlamIn {
+  0%   { transform: translateX(-72vw); }
+  82%  { transform: translateX(3px); }
+  100% { transform: translateX(0); }
 }
-@keyframes slideLeftIn {
-  from { transform: translateX(-72vw); }
-  to   { transform: translateX(0); }
+
+/* Right panel slams in from right edge */
+@keyframes rightSlamIn {
+  0%   { transform: translateX(72vw); }
+  82%  { transform: translateX(-3px); }
+  100% { transform: translateX(0); }
+}
+
+/* VS rushes in from in-front-of-camera (scale 6→0.72→1.10→1) */
+@keyframes vsRushIn {
+  0%   { transform: translateX(-50%) scale(6);    opacity: 0.5; }
+  55%  { transform: translateX(-50%) scale(0.72); opacity: 1;   }
+  75%  { transform: translateX(-50%) scale(1.10); }
+  100% { transform: translateX(-50%) scale(1);    }
+}
+
+/* VS rockets toward right (left wins — loser is right) */
+@keyframes vsKnockRight {
+  0%   { transform: translateX(-50%) scale(1);    opacity: 1; }
+  18%  { transform: translateX(-50%) scale(1.25); }
+  100% { transform: translateX(80vw) scale(0.3) rotate(55deg); opacity: 0; }
+}
+
+/* VS rockets toward left (right wins — loser is left) */
+@keyframes vsKnockLeft {
+  0%   { transform: translateX(-50%) scale(1);    opacity: 1; }
+  18%  { transform: translateX(-50%) scale(1.25); }
+  100% { transform: translateX(-130vw) scale(0.3) rotate(-55deg); opacity: 0; }
+}
+
+/* Loser hard-cuts off left edge */
+@keyframes hardCutLeft {
+  0%   { transform: translateX(0);      opacity: 1; }
+  100% { transform: translateX(-110vw); opacity: 0; }
+}
+
+/* Loser hard-cuts off right edge */
+@keyframes hardCutRight {
+  0%   { transform: translateX(0);     opacity: 1; }
+  100% { transform: translateX(110vw); opacity: 0; }
+}
+
+/* Judge panel slams down (bounce easing applied via class) */
+@keyframes slideDown {
+  from { transform: translateY(-220px); }
+  to   { transform: translateY(0); }
 }
 @keyframes slideUp {
   from { transform: translateY(0); }
-  to   { transform: translateY(-200px); }
-}
-@keyframes slideDown {
-  from { transform: translateY(-200px); }
-  to   { transform: translateY(0); }
-}
-@keyframes fadeOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-@keyframes slideLeftOut {
-  from { transform: translateX(55vw);  opacity: 1; }
-  to   { transform: translateX(-100vw); opacity: 0; }
-}
-@keyframes slideRightOut {
-  from { transform: translateX(-55vw); opacity: 1; }
-  to   { transform: translateX(100vw); opacity: 0; }
+  to   { transform: translateY(-220px); }
 }
 
-/* Judge panel border rotation */
-@keyframes borderRotate {
-  0%   { filter: blur(1px) hue-rotate(0deg); }
-  100% { filter: blur(1px) hue-rotate(360deg); }
+/* Card burst entrance on score reveal */
+@keyframes cardBurst {
+  0%   { transform: scale(1.4) skewX(-5deg); opacity: 0; }
+  65%  { transform: scale(0.97) skewX(0);   opacity: 1; }
+  100% { transform: scale(1) skewX(0);      opacity: 1; }
+}
+
+/* Unvoted card pulse */
+@keyframes cardPulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.58; }
+}
+
+/* Voting dot pulse */
+@keyframes votingPulse {
+  0%, 100% { transform: scale(1);   opacity: 1; }
+  50%       { transform: scale(1.6); opacity: 0.4; }
+}
+
+/* WINNER stamp */
+@keyframes winnerStamp {
+  0%   { transform: translate(-50%, -50%) scale(2.8); opacity: 0; }
+  60%  { transform: translate(-50%, -50%) scale(0.94); opacity: 1; }
+  100% { transform: translate(-50%, -50%) scale(1);    opacity: 1; }
 }
 
 /* Placeholder breathing */
 @keyframes placeholderBreath {
   0%, 100% { opacity: 1; }
-  50%       { opacity: 0.55; }
+  50%       { opacity: 0.5; }
 }
 
-/* VS pulse */
-@keyframes vsPulse {
-  0%, 100% { text-shadow: 0 0 40px rgba(255,255,255,0.3); }
-  50%       { text-shadow: 0 0 70px rgba(255,255,255,0.55), 0 0 120px rgba(255,255,255,0.15); }
+/* Judge border rotation */
+@keyframes borderRotate {
+  0%   { filter: blur(1px) hue-rotate(0deg); }
+  100% { filter: blur(1px) hue-rotate(360deg); }
 }
 
-/* Winner shimmer sweep on name bar */
-@keyframes winnerShimmer {
-  0%   { background-position: -200% 0; filter: brightness(1); }
-  30%  { filter: brightness(1.45); }
-  60%  { background-position: 200% 0; filter: brightness(1.2); }
-  100% { filter: brightness(1); }
-}
+/* ── Animation utility classes ───────────────────── */
+.slam-in-left  { animation: leftSlamIn  450ms cubic-bezier(0.2, 0, 0.3, 1) both; }
+.slam-in-right { animation: rightSlamIn 450ms cubic-bezier(0.2, 0, 0.3, 1) both; }
 
-/* ── Animation classes ────────────────────────────── */
-.slide-right     { animation: slideRight    0.95s cubic-bezier(0.16,1,0.3,1) forwards; }
-.slide-left      { animation: slideLeft     0.95s cubic-bezier(0.16,1,0.3,1) forwards; }
-.slide-up        { animation: slideUp       0.9s  cubic-bezier(0.16,1,0.3,1) forwards; }
-.slide-down      { animation: slideDown     0.9s  cubic-bezier(0.34,1.3,0.64,1) forwards; }
-.fade-out        { animation: fadeOut       0.95s ease forwards; }
-.left-slide-in   { animation: slideLeftIn   0.95s cubic-bezier(0.34,1.2,0.64,1) forwards; }
-.right-slide-in  { animation: slideRightIn  0.95s cubic-bezier(0.34,1.2,0.64,1) forwards; }
-.slide-left-out  { animation: slideLeftOut  0.9s  cubic-bezier(0.55,0,1,0.45) forwards; }
-.slide-right-out { animation: slideRightOut 0.9s  cubic-bezier(0.55,0,1,0.45) forwards; }
+.rush-in      { animation: vsRushIn    520ms cubic-bezier(0.12, 0, 0.2, 1) both; }
+.knock-right  { animation: vsKnockRight 380ms cubic-bezier(0.55, 0, 1, 0.45) forwards; }
+.knock-left   { animation: vsKnockLeft  380ms cubic-bezier(0.55, 0, 1, 0.45) forwards; }
 
-/* Combined */
-.slide-right.fade-out { animation: slideRight 0.95s cubic-bezier(0.16,1,0.3,1) forwards, fadeOut 0.95s ease forwards; }
-.slide-left.fade-out  { animation: slideLeft  0.95s cubic-bezier(0.16,1,0.3,1) forwards, fadeOut 0.95s ease forwards; }
+.slide-left-out  { animation: hardCutLeft  320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
+.slide-right-out { animation: hardCutRight 320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
+
+.slide-down { animation: slideDown 480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
+.slide-up   { animation: slideUp   300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
 </style>

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -15,7 +15,6 @@ const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: 
 const imageLeft  = ref(null)
 const imageRight = ref(null)
 
-let client = createClient()
 const clients = []
 let unmounted = false
 const subscribedTopics = new Set()
@@ -257,7 +256,6 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   unmounted = true
-  deactivateClient(client.value)
   clients.forEach(c => { if (c?.value) deactivateClient(c.value) })
 })
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -16,6 +16,8 @@ const imageLeft  = ref(null)
 const imageRight = ref(null)
 
 let client = createClient()
+const clients = []
+let unmounted = false
 const subscribedTopics = new Set()
 const rightName  = ref('')
 const leftName   = ref('')
@@ -61,11 +63,14 @@ const judgePanelClass = computed(() => {
 // ── Entrance animation ─────────────────────────────────────────────────────
 const runEntrance = async () => {
   await useDelay().wait(50) // allow DOM to clear previous animation classes
+  if (unmounted) return
   hideJudgeDecision.value = true
   vsAnim.value = 'rush-in'
   await useDelay().wait(340) // VS hits undershoot trough at ~340ms
+  if (unmounted) return
   stageShaking.value = true
   await useDelay().wait(120)
+  if (unmounted) return
   stageShaking.value = false
 }
 
@@ -89,6 +94,7 @@ const updateBattlePair = async (msg) => {
     glitching.value = true
     judgeAnim.value = 'slide-up'
     await useDelay().wait(100)
+    if (unmounted) return
 
     if (currentWinner.value === 0) {
       leftReset.value = true
@@ -101,12 +107,14 @@ const updateBattlePair = async (msg) => {
     vsAnim.value = ''
 
     await useDelay().wait(280)
+    if (unmounted) return
     glitching.value          = false
     hideJudgeDecision.value  = true
     judgeAnim.value          = ''
     votesVisible.value       = false
     winnerTagVisible.value   = false
     await useDelay().wait(50)
+    if (unmounted) return
     leftReset.value  = false
     rightReset.value = false
   }
@@ -137,7 +145,9 @@ const updateBattleJudge = (msg) => {
     const topic = `/topic/battle/vote/${j.id}`
     if (!subscribedTopics.has(topic)) {
       subscribedTopics.add(topic)
-      subscribeToChannel(createClient(), topic, (m) => updateJudgeVote(m))
+      const c = createClient()
+      clients.push(c)
+      subscribeToChannel(c, topic, (m) => updateJudgeVote(m))
     }
   })
 }
@@ -156,7 +166,9 @@ watch(battleJudges, (newVal) => {
     const topic = `/topic/battle/vote/${j.id}`
     if (!subscribedTopics.has(topic)) {
       subscribedTopics.add(topic)
-      subscribeToChannel(createClient(), topic, (m) => updateJudgeVote(m))
+      const c = createClient()
+      clients.push(c)
+      subscribeToChannel(c, topic, (m) => updateJudgeVote(m))
     }
   })
 }, { deep: true })
@@ -171,10 +183,12 @@ const updateScore = async (msg) => {
 
   // Reveal votes shortly after panel starts dropping
   await useDelay().wait(200)
+  if (unmounted) return
   votesVisible.value = true
 
   // Winner determination after cards have burst in
   await useDelay().wait(800)
+  if (unmounted) return
   currentWinner.value = msg.message
 
   if (msg.message === 0) {
@@ -183,6 +197,7 @@ const updateScore = async (msg) => {
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-right'
     await useDelay().wait(100)
+    if (unmounted) return
     rightReset.value = true   // right (loser) hard-cuts off screen
   } else if (msg.message === 1) {
     // Right wins: VS rockets left (toward loser), right panel expands
@@ -190,6 +205,7 @@ const updateScore = async (msg) => {
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-left'
     await useDelay().wait(100)
+    if (unmounted) return
     leftReset.value = true    // left (loser) hard-cuts off screen
   }
   // msg.message === -1: tie — no winner state, panels stay
@@ -205,31 +221,45 @@ onMounted(async () => {
   if (config?.showImages !== undefined) overlayConfig.value = config
 
   // Live overlay config updates from BattleControl
-  subscribeToChannel(createClient(), '/topic/battle/overlay-config', (msg) => {
+  const cOverlay = createClient()
+  clients.push(cOverlay)
+  subscribeToChannel(cOverlay, '/topic/battle/overlay-config', (msg) => {
     if (msg?.showImages !== undefined) overlayConfig.value = msg
   })
 
   // Phase subscription: VOTING phase shows the voting indicator
-  subscribeToChannel(createClient(), '/topic/battle/phase', (msg) => {
+  const cPhase = createClient()
+  clients.push(cPhase)
+  subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
     showVotingIndicator.value = msg?.phase === 'VOTING'
   })
 
   if (isSmoke.value) {
     battleJudges.value = await getBattleJudges()
-    subscribeToChannel(createClient(), '/topic/battle/judges',     (msg) => updateBattleJudge(msg))
-    subscribeToChannel(createClient(), '/topic/battle/battle-pair',(msg) => updateBattlePair(msg))
-    subscribeToChannel(createClient(), '/topic/battle/score',      (msg) => updateScore(msg))
+    const cJudges = createClient(); clients.push(cJudges)
+    const cPair   = createClient(); clients.push(cPair)
+    const cScore  = createClient(); clients.push(cScore)
+    subscribeToChannel(cJudges, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
+    subscribeToChannel(cPair,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
+    subscribeToChannel(cScore,  '/topic/battle/score',       (msg) => updateScore(msg))
   } else {
     battleJudges.value = await getBattleJudges()
     const res = await getCurrentBattlePair()
     if (res) await updateBattlePair(res)
-    subscribeToChannel(createClient(), '/topic/battle/battle-pair',(msg) => updateBattlePair(msg))
-    subscribeToChannel(createClient(), '/topic/battle/score',      (msg) => updateScore(msg))
-    subscribeToChannel(createClient(), '/topic/battle/judges',     (msg) => updateBattleJudge(msg))
+    const cPair2   = createClient(); clients.push(cPair2)
+    const cScore2  = createClient(); clients.push(cScore2)
+    const cJudges2 = createClient(); clients.push(cJudges2)
+    subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
+    subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => updateScore(msg))
+    subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
   }
 })
 
-onBeforeUnmount(() => { deactivateClient(client.value) })
+onBeforeUnmount(() => {
+  unmounted = true
+  deactivateClient(client.value)
+  clients.forEach(c => { if (c?.value) deactivateClient(c.value) })
+})
 
 onUnmounted(() => {
   document.documentElement.classList.remove('transparent-page')
@@ -288,7 +318,7 @@ onUnmounted(() => {
             :key="index"
             class="judge-card"
             role="listitem"
-            :aria-label="`${j.name}: ${j.vote === 0 ? 'voted left' : j.vote === 1 ? 'voted right' : j.vote === -1 ? 'voted tie' : 'awaiting vote'}`"
+            :aria-label="`${j.name}: ${!votesVisible ? 'awaiting vote' : j.vote === 0 ? 'voted left' : j.vote === 1 ? 'voted right' : j.vote === -1 ? 'voted tie' : 'awaiting vote'}`"
             :class="{
               'voted-left':   votesVisible && j.vote === 0,
               'voted-right':  votesVisible && j.vote === 1,
@@ -596,15 +626,13 @@ body.transparent-page #app {
   min-width: 148px;
   padding: 10px 14px;
   clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
-  border: 1.5px solid rgba(255,255,255,0.06);
   background: rgba(255,255,255,0.025);
-  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  transition: box-shadow 0.25s ease, background 0.25s ease;
 }
 
 /* Unvoted: frosted glass with gentle pulse */
 .card-unvoted {
   background: rgba(255,255,255,0.08) !important;
-  border-color: rgba(255,255,255,0.18) !important;
   animation: cardPulse 2.2s ease-in-out infinite;
 }
 
@@ -614,19 +642,16 @@ body.transparent-page #app {
 }
 
 .voted-left {
-  border-color: color-mix(in srgb, var(--left-color) 65%, transparent);
   background: color-mix(in srgb, var(--left-color) 9%, transparent);
   box-shadow: 0 0 28px color-mix(in srgb, var(--left-color) 35%, transparent),
               inset 0 0 14px color-mix(in srgb, var(--left-color) 8%, transparent);
 }
 .voted-right {
-  border-color: color-mix(in srgb, var(--right-color) 65%, transparent);
   background: color-mix(in srgb, var(--right-color) 9%, transparent);
   box-shadow: 0 0 28px color-mix(in srgb, var(--right-color) 35%, transparent),
               inset 0 0 14px color-mix(in srgb, var(--right-color) 8%, transparent);
 }
 .voted-tie {
-  border-color: rgba(251,191,36,0.65);
   background: rgba(251,191,36,0.07);
   box-shadow: 0 0 28px rgba(251,191,36,0.28), inset 0 0 14px rgba(251,191,36,0.06);
 }

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -174,40 +174,59 @@ watch(battleJudges, (newVal) => {
 
 // ── Score reveal ───────────────────────────────────────────────────────────
 const updateScore = async (msg) => {
-  judgeAnim.value          = 'slide-down'
-  hideJudgeDecision.value  = false
   showVotingIndicator.value = false
   rightScore.value = msg.right
   leftScore.value  = msg.left
 
-  // Reveal votes shortly after panel starts dropping
-  await useDelay().wait(200)
+  // Phase 1: judge panel slams to vertical center of screen
+  hideJudgeDecision.value = false
+  judgeAnim.value = 'judge-slam-center'
+
+  // Shake on slam landing (~350ms into animation)
+  await useDelay().wait(350)
   if (unmounted) return
+  stageShaking.value = true
+  await useDelay().wait(80)
+  if (unmounted) return
+  stageShaking.value = false
+
+  // Reveal votes as slam settles
   votesVisible.value = true
 
-  // Winner determination after cards have burst in
-  await useDelay().wait(800)
+  // Audience reads the votes
+  await useDelay().wait(1500)
   if (unmounted) return
+
+  // Phase 2: panel scales down and retreats to top
+  judgeAnim.value = 'judge-retreat-top'
+  await useDelay().wait(550)
+  if (unmounted) return
+  judgeAnim.value = 'judge-at-top'
+
+  // Brief pause before winner reveal
+  await useDelay().wait(150)
+  if (unmounted) return
+
   currentWinner.value = msg.message
 
   if (msg.message === 0) {
-    // Left wins: VS rockets right (toward loser), left panel expands
+    // Left wins: VS rockets right, left panel expands
     leftWin.value          = true
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-right'
     await useDelay().wait(100)
     if (unmounted) return
-    rightReset.value = true   // right (loser) hard-cuts off screen
+    rightReset.value = true
   } else if (msg.message === 1) {
-    // Right wins: VS rockets left (toward loser), right panel expands
+    // Right wins: VS rockets left, right panel expands
     rightWin.value         = true
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-left'
     await useDelay().wait(100)
     if (unmounted) return
-    leftReset.value = true    // left (loser) hard-cuts off screen
+    leftReset.value = true
   }
-  // msg.message === -1: tie — no winner state, panels stay
+  // msg.message === -1: tie — panels stay
 }
 
 // ── Mount ──────────────────────────────────────────────────────────────────
@@ -332,24 +351,24 @@ onUnmounted(() => {
                 :class="{ 'arrow-lit-left': votesVisible && j.vote === 0 }"
                 aria-hidden="true"
               ></span>
-              <span class="judge-name">{{ j.name }}</span>
+              <span class="judge-name" :class="{ 'judge-name-tie': votesVisible && j.vote === -1 }">{{ j.name }}</span>
               <span
                 class="vote-arrow vote-arrow-right"
                 :class="{ 'arrow-lit-right': votesVisible && j.vote === 1 }"
                 aria-hidden="true"
               ></span>
             </div>
-            <div class="vote-track" aria-hidden="true">
+            <div v-if="!(votesVisible && j.vote === -1)" class="vote-track" aria-hidden="true">
               <div
                 class="vote-fill"
                 :class="{
                   'fill-left':  votesVisible && j.vote === 0,
                   'fill-right': votesVisible && j.vote === 1,
-                  'fill-tie':   votesVisible && j.vote === -1,
                   'fill-blank': !votesVisible || j.vote === -3 || j.vote === null,
                 }"
               ></div>
             </div>
+            <div v-if="votesVisible && j.vote === -1" class="tie-badge" aria-hidden="true">TIE</div>
           </div>
         </div>
       </div>
@@ -373,27 +392,28 @@ onUnmounted(() => {
       >
         <div class="panel-color-wash panel-color-wash-left" aria-hidden="true"></div>
 
-        <!-- Picture mode -->
+        <!-- Picture mode: fixed-width group shifts to center on panel-winner expand -->
         <template v-if="overlayConfig.showImages">
-          <img v-if="imageLeft" :src="imageLeft" :alt="leftName" class="battler-img" />
-          <div v-else class="battler-placeholder" aria-hidden="true"></div>
-          <div class="name-overlay">
-            <span class="name-text name-text-left">{{ leftName || '???' }}</span>
-            <span v-if="leftScore > 0" class="score-badge">{{ leftScore }}</span>
+          <div class="img-group">
+            <img v-if="imageLeft" :src="imageLeft" :alt="leftName" class="battler-img" />
+            <div v-else class="battler-placeholder" aria-hidden="true"></div>
+            <div class="name-overlay">
+              <span v-if="winnerTagVisible && leftWin" class="winner-label winner-label-left" aria-hidden="true">WINNER</span>
+              <span class="name-text name-text-left">{{ leftName || '???' }}</span>
+            </div>
           </div>
         </template>
 
         <!-- Name-only mode -->
         <template v-else>
           <div class="name-center-wrap">
+            <span v-if="winnerTagVisible && leftWin" class="winner-label winner-label-left" aria-hidden="true">WINNER</span>
             <span class="name-giant name-giant-left">{{ leftName || '???' }}</span>
-            <span v-if="leftScore > 0" class="score-badge-large">{{ leftScore }}</span>
           </div>
         </template>
 
         <div class="corner-accent corner-accent-tl" aria-hidden="true"></div>
         <div class="bottom-edge bottom-edge-left"   aria-hidden="true"></div>
-        <div v-if="winnerTagVisible && leftWin" class="winner-tag" aria-hidden="true">WINNER</div>
       </div>
 
       <!-- VS badge -->
@@ -418,27 +438,28 @@ onUnmounted(() => {
       >
         <div class="panel-color-wash panel-color-wash-right" aria-hidden="true"></div>
 
-        <!-- Picture mode -->
+        <!-- Picture mode: fixed-width group shifts to center on panel-winner expand -->
         <template v-if="overlayConfig.showImages">
-          <img v-if="imageRight" :src="imageRight" :alt="rightName" class="battler-img" />
-          <div v-else class="battler-placeholder" aria-hidden="true"></div>
-          <div class="name-overlay name-overlay-right">
-            <span class="name-text name-text-right">{{ rightName || '???' }}</span>
-            <span v-if="rightScore > 0" class="score-badge">{{ rightScore }}</span>
+          <div class="img-group">
+            <img v-if="imageRight" :src="imageRight" :alt="rightName" class="battler-img" />
+            <div v-else class="battler-placeholder" aria-hidden="true"></div>
+            <div class="name-overlay name-overlay-right">
+              <span v-if="winnerTagVisible && rightWin" class="winner-label winner-label-right" aria-hidden="true">WINNER</span>
+              <span class="name-text name-text-right">{{ rightName || '???' }}</span>
+            </div>
           </div>
         </template>
 
         <!-- Name-only mode -->
         <template v-else>
           <div class="name-center-wrap">
+            <span v-if="winnerTagVisible && rightWin" class="winner-label winner-label-right" aria-hidden="true">WINNER</span>
             <span class="name-giant name-giant-right">{{ rightName || '???' }}</span>
-            <span v-if="rightScore > 0" class="score-badge-large">{{ rightScore }}</span>
           </div>
         </template>
 
         <div class="corner-accent corner-accent-tr" aria-hidden="true"></div>
         <div class="bottom-edge bottom-edge-right"  aria-hidden="true"></div>
-        <div v-if="winnerTagVisible && rightWin" class="winner-tag" aria-hidden="true">WINNER</div>
       </div>
 
       <!-- Voting indicator — visible during VOTING phase -->
@@ -566,73 +587,69 @@ body.transparent-page #app {
 ══════════════════════════════════════════════════ */
 .judge-panel {
   position: absolute;
-  top: 18px; left: 0; right: 0;
+  top: 0; left: 0; right: 0;
   z-index: 50;
   display: flex;
   justify-content: center;
+  align-items: flex-start;
   pointer-events: none;
-  transform: translateY(-220px);
+  transform: translateY(-100%);
 }
 .smoke-judge-always-on {
   transform: translateY(0) !important;
   animation: none !important;
 }
-.judge-border-glow {
-  position: absolute; inset: -1px;
-  border-radius: 22px;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--left-color) 55%, transparent) 0%,
-    rgba(255,255,255,0.1) 35%,
-    color-mix(in srgb, var(--right-color) 55%, transparent) 65%,
-    rgba(255,255,255,0.1) 100%
-  );
-  filter: blur(1px);
-  animation: borderRotate 6s linear infinite;
-  z-index: -1;
-}
+/* no .judge-border-glow — removed the rotating glow card look */
+.judge-border-glow { display: none; }
 .judge-inner {
   position: relative;
-  display: flex; flex-direction: column; gap: 10px;
-  background: rgba(6,8,18,0.85);
-  backdrop-filter: blur(28px);
-  -webkit-backdrop-filter: blur(28px);
-  border-radius: 20px;
-  padding: 14px 24px 16px;
+  display: flex; flex-direction: column; gap: 8px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--left-color) 12%, rgba(6,8,18,0.94)),
+    color-mix(in srgb, var(--right-color) 12%, rgba(6,8,18,0.94))
+  );
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 80px rgba(0,0,0,0.75), 0 0 0 1px rgba(255,255,255,0.04) inset;
+  padding: 12px 24px 16px;
 }
 .judges-header {
-  display: flex; align-items: center; gap: 10px;
+  display: flex; align-items: center; gap: 8px;
 }
 .judges-label {
   font-family: 'Inter', sans-serif;
-  font-size: 10px; font-weight: 700;
-  letter-spacing: 0.28em;
-  color: rgba(255,255,255,0.35);
+  font-size: 9px; font-weight: 700;
+  letter-spacing: 0.32em;
+  color: rgba(255,255,255,0.28);
   text-transform: uppercase;
   white-space: nowrap; flex-shrink: 0;
 }
 .judges-line {
   flex: 1; height: 1px;
-  background: rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.07);
 }
 .judge-cards-row {
-  display: flex; gap: 12px;
+  display: flex; gap: 8px;
 }
 
-/* Judge card — parallelogram shape */
+/* Judge card — sharp parallelogram */
 .judge-card {
   display: flex; flex-direction: column;
-  align-items: center; gap: 10px;
-  min-width: 148px;
-  padding: 10px 14px;
-  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
-  background: rgba(255,255,255,0.025);
-  transition: box-shadow 0.25s ease, background 0.25s ease;
+  align-items: center; gap: 7px;
+  min-width: 130px;
+  padding: 8px 12px;
+  clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.06);
+  transition: background 0.25s ease, box-shadow 0.25s ease;
 }
 
-/* Unvoted: frosted glass with gentle pulse */
+/* Unvoted: dim pulse */
 .card-unvoted {
-  background: rgba(255,255,255,0.08) !important;
+  background: rgba(255,255,255,0.06) !important;
   animation: cardPulse 2.2s ease-in-out infinite;
 }
 
@@ -642,27 +659,28 @@ body.transparent-page #app {
 }
 
 .voted-left {
-  background: color-mix(in srgb, var(--left-color) 9%, transparent);
-  box-shadow: 0 0 28px color-mix(in srgb, var(--left-color) 35%, transparent),
-              inset 0 0 14px color-mix(in srgb, var(--left-color) 8%, transparent);
+  background: color-mix(in srgb, var(--left-color) 12%, transparent);
+  border-color: color-mix(in srgb, var(--left-color) 40%, transparent);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--left-color) 25%, transparent);
 }
 .voted-right {
-  background: color-mix(in srgb, var(--right-color) 9%, transparent);
-  box-shadow: 0 0 28px color-mix(in srgb, var(--right-color) 35%, transparent),
-              inset 0 0 14px color-mix(in srgb, var(--right-color) 8%, transparent);
+  background: color-mix(in srgb, var(--right-color) 12%, transparent);
+  border-color: color-mix(in srgb, var(--right-color) 40%, transparent);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--right-color) 25%, transparent);
 }
 .voted-tie {
-  background: rgba(251,191,36,0.07);
-  box-shadow: 0 0 28px rgba(251,191,36,0.28), inset 0 0 14px rgba(251,191,36,0.06);
+  background: rgba(255,255,255,0.06);
+  border-color: rgba(255,255,255,0.20);
+  box-shadow: none;
 }
 
 /* Judge name + arrow row */
-.judge-row { display: flex; align-items: center; gap: 11px; }
+.judge-row { display: flex; align-items: center; gap: 9px; }
 .judge-name {
   font-family: 'Anton SC', sans-serif;
-  font-size: 28px;
-  color: rgba(255,255,255,0.92);
-  letter-spacing: 0.07em;
+  font-size: 22px;
+  color: rgba(255,255,255,0.90);
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   line-height: 1;
 }
@@ -688,6 +706,18 @@ body.transparent-page #app {
   filter: drop-shadow(0 0 8px var(--right-color));
 }
 
+/* Tie state */
+.judge-name-tie { color: rgba(255,255,255,0.32) !important; }
+.tie-badge {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px; letter-spacing: 0.35em;
+  color: rgba(255,255,255,0.55);
+  text-align: center; width: 100%;
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 4px; padding: 2px 0;
+  animation: cardBurst 280ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+
 /* Vote track bar */
 .vote-track {
   width: 100%; height: 10px;
@@ -711,7 +741,6 @@ body.transparent-page #app {
   background: linear-gradient(90deg, color-mix(in srgb, var(--right-color) 70%, black), var(--right-color));
   box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 90%, transparent);
 }
-.fill-tie   { width: 100%; background: linear-gradient(90deg, #b45309, #fbbf24); box-shadow: 0 0 14px rgba(251,191,36,0.9); }
 .fill-blank { width: 0%; background: transparent; }
 
 /* ══════════════════════════════════════════════════
@@ -775,6 +804,13 @@ body.transparent-page #app {
 .bottom-edge-left  { left: 0;  background: linear-gradient(to right, var(--left-color), transparent); }
 .bottom-edge-right { right: 0; background: linear-gradient(to left, var(--right-color), transparent); }
 
+/* ── Picture mode: img-group — fixed width so image doesn't stretch on panel expand ── */
+.img-group {
+  position: relative;
+  width: 46vw;       /* matches panel's normal 46% of 100vw */
+  flex-shrink: 0;
+}
+
 /* ── Picture mode ────────────────────────────────── */
 .battler-img {
   position: relative; z-index: 10;
@@ -799,10 +835,10 @@ body.transparent-page #app {
   bottom: 0; left: 0; right: 0;
   z-index: 20;
   padding: 10vh 3vw 5vh;
-  background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%);
-  display: flex; align-items: flex-end; gap: 10px;
+  background: none;
+  display: flex; flex-direction: column; align-items: flex-start; gap: 6px;
 }
-.name-overlay-right { flex-direction: row-reverse; }
+.name-overlay-right { align-items: flex-end; }
 .name-text {
   font-family: 'Anton SC', sans-serif;
   font-size: clamp(22px, 4.5vw, 72px);
@@ -913,23 +949,26 @@ body.transparent-page #app {
 .fade-indicator-enter-from,
 .fade-indicator-leave-to     { opacity: 0; }
 
-/* ── Winner tag ──────────────────────────────────── */
-.winner-tag {
-  position: absolute;
-  top: 40%; left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 60;
+/* ── Winner label — Anton SC, same design language as name ── */
+.winner-label {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(18px, 3.2vw, 58px);
-  color: #fff;
-  letter-spacing: 0.22em;
+  font-size: clamp(14px, 2.2vw, 38px);
+  letter-spacing: 0.5em;
   text-transform: uppercase;
-  border: 3px solid rgba(255,255,255,0.8);
-  padding: 8px 28px;
-  background: rgba(0,0,0,0.45);
-  animation: winnerStamp 300ms cubic-bezier(0.2, 0, 0.3, 1) both;
-  animation-delay: 300ms;
+  color: #fff;
+  line-height: 1;
+  text-align: center;
   opacity: 0;
+  animation: winnerStamp 380ms cubic-bezier(0.2, 0, 0.3, 1) both;
+  animation-delay: 250ms;
+}
+.winner-label-left {
+  text-shadow: 3px 3px 0 var(--left-color),
+               0 0 40px color-mix(in srgb, var(--left-color) 65%, transparent);
+}
+.winner-label-right {
+  text-shadow: -3px 3px 0 var(--right-color),
+               0 0 40px color-mix(in srgb, var(--right-color) 65%, transparent);
 }
 
 /* ══════════════════════════════════════════════════
@@ -1008,14 +1047,29 @@ body.transparent-page #app {
   100% { transform: translateX(110vw); opacity: 0; }
 }
 
-/* Judge panel slams down (bounce easing applied via class) */
+/* Judge panel drops from top edge */
 @keyframes slideDown {
-  from { transform: translateY(-220px); }
+  from { transform: translateY(-100%); }
   to   { transform: translateY(0); }
 }
 @keyframes slideUp {
   from { transform: translateY(0); }
-  to   { transform: translateY(-220px); }
+  to   { transform: translateY(-100%); }
+}
+
+/* Judge slams from above into vertical center of screen, rests at larger scale */
+@keyframes judgeSlamCenter {
+  0%   { transform: translateY(-160%) scale(3.0);  opacity: 0; filter: blur(14px); }
+  52%  { transform: translateY(42vh)  scale(1.28); opacity: 1; filter: blur(0); }
+  68%  { transform: translateY(42vh)  scale(1.48); }
+  82%  { transform: translateY(42vh)  scale(1.33); }
+  100% { transform: translateY(42vh)  scale(1.38); opacity: 1; }
+}
+
+/* Judge scales back down while retreating to top */
+@keyframes judgeRetreatTop {
+  0%   { transform: translateY(42vh) scale(1.38); }
+  100% { transform: translateY(0)    scale(1); }
 }
 
 /* Card burst entrance on score reveal */
@@ -1039,9 +1093,9 @@ body.transparent-page #app {
 
 /* WINNER stamp */
 @keyframes winnerStamp {
-  0%   { transform: translate(-50%, -50%) scale(2.8); opacity: 0; }
-  60%  { transform: translate(-50%, -50%) scale(0.94); opacity: 1; }
-  100% { transform: translate(-50%, -50%) scale(1);    opacity: 1; }
+  0%   { transform: scale(1.5) translateY(-10px); opacity: 0; filter: blur(6px); }
+  60%  { transform: scale(0.97) translateY(1px);  opacity: 1; filter: blur(0); }
+  100% { transform: scale(1) translateY(0);        opacity: 1; filter: blur(0); }
 }
 
 /* Placeholder breathing */
@@ -1050,11 +1104,7 @@ body.transparent-page #app {
   50%       { opacity: 0.5; }
 }
 
-/* Judge border rotation */
-@keyframes borderRotate {
-  0%   { filter: blur(1px) hue-rotate(0deg); }
-  100% { filter: blur(1px) hue-rotate(360deg); }
-}
+/* (borderRotate removed — judge card no longer uses rotating glow border) */
 
 /* ── Animation utility classes ───────────────────── */
 .slam-in-left  { animation: leftSlamIn  450ms cubic-bezier(0.2, 0, 0.3, 1) both; }
@@ -1067,7 +1117,10 @@ body.transparent-page #app {
 .slide-left-out  { animation: hardCutLeft  320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
 .slide-right-out { animation: hardCutRight 320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
 
-.slide-down { animation: slideDown 480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
-.slide-up   { animation: slideUp   300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
+.slide-down       { animation: slideDown       480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
+.slide-up         { animation: slideUp         300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
+.judge-slam-center { animation: judgeSlamCenter 680ms cubic-bezier(0.2,  0,   0.3, 1) both; }
+.judge-retreat-top { animation: judgeRetreatTop 500ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
+.judge-at-top      { transform: translateY(0); }
 </style>
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -462,20 +462,22 @@ onUnmounted(() => {
 </template>
 
 <style>
-/* ── Screen-reader only ─────────────────────────────────────── */
-.sr-only {
-  position: absolute; width: 1px; height: 1px; padding: 0;
-  margin: -1px; overflow: hidden; clip: rect(0,0,0,0);
-  white-space: nowrap; border: 0;
-}
-
-/* ── Transparent background (OBS) ──────────────────────────── */
+/* ── Transparent background (OBS) — must be global ─────────── */
 html.transparent-page,
 body.transparent-page,
 html.transparent-page #app,
 body.transparent-page #app {
   background: transparent !important;
   background-color: transparent !important;
+}
+</style>
+
+<style scoped>
+/* ── Screen-reader only ─────────────────────────────────────── */
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0;
+  margin: -1px; overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
 }
 
 /* ── Root ───────────────────────────────────────────────────── */
@@ -1068,3 +1070,4 @@ body.transparent-page #app {
 .slide-down { animation: slideDown 480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
 .slide-up   { animation: slideUp   300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
 </style>
+

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -33,6 +33,8 @@ const hideJudgeDecision = ref(true)
 const showVotingIndicator = ref(false)
 // votesVisible: false until score is revealed — hides vote state on judge cards
 const votesVisible = ref(false)
+// battlePhase: tracks current phase to guard against stale score WS events
+const battlePhase = ref('IDLE')
 
 // ── Animation state (standard mode only) ──────────────────────────────────
 // judgeAnim: '' | 'slide-down' | 'slide-up' (also used for smoke mode panel)
@@ -174,6 +176,8 @@ watch(battleJudges, (newVal) => {
 
 // ── Score reveal ───────────────────────────────────────────────────────────
 const updateScore = async (msg) => {
+  // Guard: if phase already reset to LOCKED, this is a stale WS event — ignore it
+  if (battlePhase.value === 'LOCKED') return
   showVotingIndicator.value = false
   rightScore.value = msg.right
   leftScore.value  = msg.left
@@ -184,10 +188,10 @@ const updateScore = async (msg) => {
 
   // Shake on slam landing (~350ms into animation)
   await useDelay().wait(350)
-  if (unmounted) return
+  if (unmounted || battlePhase.value === 'LOCKED') return
   stageShaking.value = true
   await useDelay().wait(80)
-  if (unmounted) return
+  if (unmounted || battlePhase.value === 'LOCKED') return
   stageShaking.value = false
 
   // Reveal votes as slam settles
@@ -195,17 +199,17 @@ const updateScore = async (msg) => {
 
   // Audience reads the votes
   await useDelay().wait(1500)
-  if (unmounted) return
+  if (unmounted || battlePhase.value === 'LOCKED') return
 
   // Phase 2: panel scales down and retreats to top
   judgeAnim.value = 'judge-retreat-top'
   await useDelay().wait(550)
-  if (unmounted) return
+  if (unmounted || battlePhase.value === 'LOCKED') return
   judgeAnim.value = 'judge-at-top'
 
   // Brief pause before winner reveal
   await useDelay().wait(150)
-  if (unmounted) return
+  if (unmounted || battlePhase.value === 'LOCKED') return
 
   currentWinner.value = msg.message
 
@@ -215,7 +219,7 @@ const updateScore = async (msg) => {
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-right'
     await useDelay().wait(100)
-    if (unmounted) return
+    if (unmounted || battlePhase.value === 'LOCKED') return
     rightReset.value = true
   } else if (msg.message === 1) {
     // Right wins: VS rockets left, right panel expands
@@ -223,7 +227,7 @@ const updateScore = async (msg) => {
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-left'
     await useDelay().wait(100)
-    if (unmounted) return
+    if (unmounted || battlePhase.value === 'LOCKED') return
     leftReset.value = true
   }
   // msg.message === -1: tie — panels stay
@@ -245,11 +249,22 @@ onMounted(async () => {
     if (msg?.showImages !== undefined) overlayConfig.value = msg
   })
 
-  // Phase subscription: VOTING phase shows the voting indicator
+  // Phase subscription: track phase for stale-event guard; VOTING shows indicator
   const cPhase = createClient()
   clients.push(cPhase)
   subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
-    showVotingIndicator.value = msg?.phase === 'VOTING'
+    if (!msg?.phase) return
+    battlePhase.value = msg.phase
+    showVotingIndicator.value = msg.phase === 'VOTING'
+    if (msg.phase === 'LOCKED') {
+      // Next was clicked — dismiss any in-progress result overlay immediately
+      hideJudgeDecision.value = true
+      judgeAnim.value         = ''
+      votesVisible.value      = false
+      winnerTagVisible.value  = false
+      leftWin.value           = false
+      rightWin.value          = false
+    }
   })
 
   if (!isSmoke.value) {

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -433,7 +433,7 @@ body.transparent-page #app {
   flex-shrink: 0; flex-wrap: wrap;
 }
 .dot {
-  width: clamp(4px, 0.6vw, 7px); height: clamp(4px, 0.6vw, 7px);
+  width: clamp(6px, 0.9vw, 11px); height: clamp(6px, 0.9vw, 11px);
   border-radius: 50%;
   border: 1.5px solid currentColor;
   opacity: 0.25;
@@ -445,7 +445,7 @@ body.transparent-page #app {
 
 /* ── Name label ───────────────────────────────────────── */
 .col-name {
-  font-size: clamp(5px, 0.8vw, 9px);
+  font-size: clamp(8px, 1.1vw, 14px);
   letter-spacing: 0.1em;
   text-align: center;
   margin-top: 3px; margin-bottom: 5px;
@@ -506,7 +506,7 @@ body.transparent-page #app {
 
 /* ── FLIP column slide (TransitionGroup move) ─────────── */
 .col-move {
-  transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 0.85s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 /* ══════════════════════════════════════════════════

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -364,6 +364,8 @@ body.transparent-page #app {
   flex: 1;
   display: flex; flex-direction: column; align-items: center;
   height: 100%;
+  /* Cap columns so full bars (7/7) only graze the bottom quarter of the ghost names */
+  max-height: 68%;
 }
 
 /* ── Bar wrap + bar ───────────────────────────────────── */
@@ -488,7 +490,7 @@ body.transparent-page #app {
 }
 .bg-name {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(22px, 5.5vw, 72px);
+  font-size: clamp(32px, 8vw, 110px);
   letter-spacing: 0.06em; line-height: 1;
   opacity: 0.1;
   white-space: nowrap;

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -433,7 +433,7 @@ body.transparent-page #app {
   flex-shrink: 0; flex-wrap: wrap;
 }
 .dot {
-  width: clamp(6px, 0.9vw, 11px); height: clamp(6px, 0.9vw, 11px);
+  width: clamp(8px, 1.3vw, 16px); height: clamp(8px, 1.3vw, 16px);
   border-radius: 50%;
   border: 1.5px solid currentColor;
   opacity: 0.25;
@@ -445,7 +445,7 @@ body.transparent-page #app {
 
 /* ── Name label ───────────────────────────────────────── */
 .col-name {
-  font-size: clamp(8px, 1.1vw, 14px);
+  font-size: clamp(11px, 1.6vw, 20px);
   letter-spacing: 0.1em;
   text-align: center;
   margin-top: 3px; margin-bottom: 5px;

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -142,6 +142,12 @@ onMounted(async () => {
 
   const cScore = createClient(); clients.push(cScore)
   subscribeToChannel(cScore, '/topic/battle/score', updateScore)
+
+  const cPhase = createClient(); clients.push(cPhase)
+  subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
+    // When phase resets to LOCKED (Next was clicked), dismiss result overlay immediately
+    if (msg?.phase === 'LOCKED') showResult.value = false
+  })
 })
 
 onBeforeUnmount(() => {

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -1,92 +1,753 @@
-<template>
-    <div class="p-8 bg-transparent">
-      <!-- Histogram -->
-      <div class="fixed bottom-0 left-0 w-full px-6 pb-6 bg-transparent">
-        <TransitionGroup
-          name="bar"
-          tag="div"
-          class="flex items-end gap-4 min-h-[500px] justify-center"
-        >
-          <div
-            v-for="(item, idx) in smokeParticipants"
-            :key="item.name"
-            class="flex flex-col items-center transition-all duration-500 ease-in-out"
-          >
-            <!-- Label (name + score) above -->
-            <div
-              class="text-2xl font-anton text-white px-3 py-1 rounded"
-              :class="colors[idx % colors.length]"
-            >
-              {{ item.name }}
-            </div>
-  
-            <!-- Image (stays fixed vertically) -->
-            <img
-              v-if="imageMap[item.name]"
-              :src="imageMap[item.name]"
-              alt="icon"
-              class="w-48 h-auto transition-transform duration-500"
-            />
-  
-            <!-- Bar -->
-            <div
-              class="relative w-full bg-gray-200/30  rounded-t transition-all duration-500 ease-in-out flex items-center justify-center"
-              :style="{ height: item.score * 60 + 'px' }"
-            >
-              <!-- Centered Score inside -->
-              <span 
-                v-if="item.score != 0"
-                class="absolute font-anton inset-0 flex items-center justify-center text-white font-bold"
-                :style="{ fontSize: `${item.score * 10 + 20}px` }"
-              >
-                {{ item.score }}
-              </span>
-            </div>
-          </div>
-        </TransitionGroup>
-      </div>
-    </div>
-  </template>
-  
+<!-- BES-frontend/src/views/Chart.vue -->
 <script setup>
-  import { getImage, getSmokeList } from '@/utils/api'
+import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
+import { getSmokeList, getOverlayConfig, getBattleJudges } from '@/utils/api'
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket'
-import { onMounted, onUnmounted, ref, watch } from 'vue'
-const imageMap = ref({})
+import { useDelay } from '@/utils/utils'
+import { barHeightPct, findScoreGainers } from '@/utils/smokeChartHelpers'
+
+// ── Overlay config ──────────────────────────────────────────────────────────
+const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+
+// ── Chart data ──────────────────────────────────────────────────────────────
+// Position 0 = active left, 1 = active right, 2+ = queue
 const smokeParticipants = ref([])
-const colors = ref(['bg-red-500', 'bg-blue-500','bg-gray-800','bg-gray-800','bg-gray-800','bg-gray-800','bg-gray-800','bg-gray-800'])
 
-const updateList = (msg)=>{
-    if (msg?.battlers) smokeParticipants.value = msg.battlers
-}
+// ── Judge data ──────────────────────────────────────────────────────────────
+const battleJudges = ref(null)       // { judges: [{ id, name, vote }] }
+const votesVisible = ref(false)
 
+// ── Result overlay ──────────────────────────────────────────────────────────
+const showResult    = ref(false)
+const resultState   = ref(null)  // { winner: 0|1|-1, leftName, rightName }
+
+// ── Champion overlay ────────────────────────────────────────────────────────
+const showChampion  = ref(false)
+const champName     = ref('')
+const champColor    = ref('#dc2626')
+
+// ── Score pop animation ─────────────────────────────────────────────────────
+const scorePopNames = ref(new Set())
+
+// ── WebSocket clients ───────────────────────────────────────────────────────
+const clients = []
+const subscribedVoteTopics = new Set()
+let unmounted = false
+
+// ── Computed ────────────────────────────────────────────────────────────────
+const activeLeft  = computed(() => smokeParticipants.value[0] ?? null)
+const activeRight = computed(() => smokeParticipants.value[1] ?? null)
+
+// ── Score pop: watch for score increases ────────────────────────────────────
 watch(
   smokeParticipants,
-  async (newPlayers) => {
-    for (const player of newPlayers) {
-      if (!imageMap.value[player.name]) {
-        imageMap.value[player.name] = await getImage(`${player.name}.png`)
-      }
-    }
+  (next, prev) => {
+    if (!prev?.length) return
+    const gainers = findScoreGainers(prev, next)
+    gainers.forEach(name => {
+      scorePopNames.value = new Set([...scorePopNames.value, name])
+      setTimeout(() => {
+        scorePopNames.value = new Set([...scorePopNames.value].filter(n => n !== name))
+      }, 600)
+    })
   },
-  { deep: true, immediate: true } // also run on first load
+  { deep: true }
 )
-const wsClient = ref(null)
 
-onMounted(async ()=>{
-    wsClient.value = createClient()
-    subscribeToChannel(wsClient.value, "/topic/battle/smoke", (msg) => updateList(msg))
-    const smoke = await getSmokeList()
-    if (smoke?.list) smokeParticipants.value = smoke.list
-})
+// ── WebSocket handlers ──────────────────────────────────────────────────────
+const updateList = (msg) => {
+  if (msg?.battlers) smokeParticipants.value = msg.battlers
+}
 
-onUnmounted(() => {
-    deactivateClient(wsClient.value)
-})
-  </script>
-  
-  <style scoped>
-  .bar-move {
-    transition: transform 0.5s ease;
+const updateBattleJudge = (msg) => {
+  battleJudges.value = msg
+  msg.judges.forEach(j => {
+    const topic = `/topic/battle/vote/${j.id}`
+    if (!subscribedVoteTopics.has(topic)) {
+      subscribedVoteTopics.add(topic)
+      const c = createClient(); clients.push(c)
+      subscribeToChannel(c, topic, (m) => updateJudgeVote(m))
+    }
+  })
+}
+
+const updateJudgeVote = (msg) => {
+  if (!battleJudges.value?.judges) return
+  battleJudges.value = {
+    ...battleJudges.value,
+    judges: battleJudges.value.judges.map(j =>
+      j.id === msg.judge ? { ...j, vote: msg.vote } : j
+    )
   }
-  </style>
+}
+
+// Capture active names at reveal time so result overlay stays correct after queue shifts
+const updateScore = async (msg) => {
+  const leftName  = activeLeft.value?.name  ?? ''
+  const rightName = activeRight.value?.name ?? ''
+  const winner    = msg.message // 0 | 1 | -1
+
+  // Check for champion (any fighter reaching 7)
+  const allParticipants = smokeParticipants.value
+  const champParticipant = allParticipants.find(p => p.score >= 7)
+
+  if (champParticipant) {
+    champName.value  = champParticipant.name
+    const idx = allParticipants.indexOf(champParticipant)
+    champColor.value = idx === 0
+      ? overlayConfig.value.leftColor
+      : idx === 1
+        ? overlayConfig.value.rightColor
+        : overlayConfig.value.leftColor
+    showChampion.value = true
+    return  // Champion overlay never auto-dismisses
+  }
+
+  // Regular result overlay
+  resultState.value = { winner, leftName, rightName }
+  votesVisible.value = true
+  showResult.value = true
+
+  await useDelay().wait(4000)
+  if (unmounted) return
+  showResult.value = false
+  votesVisible.value = false
+}
+
+// ── Mount ───────────────────────────────────────────────────────────────────
+onMounted(async () => {
+  document.documentElement.classList.add('transparent-page')
+  document.body.classList.add('transparent-page')
+
+  const config = await getOverlayConfig()
+  overlayConfig.value = config
+
+  const smoke = await getSmokeList()
+  if (smoke?.list) smokeParticipants.value = smoke.list
+
+  battleJudges.value = await getBattleJudges()
+
+  const cConfig = createClient(); clients.push(cConfig)
+  subscribeToChannel(cConfig, '/topic/battle/overlay-config', (msg) => {
+    if (msg?.leftColor !== undefined) overlayConfig.value = msg
+  })
+
+  const cSmoke = createClient(); clients.push(cSmoke)
+  subscribeToChannel(cSmoke, '/topic/battle/smoke', updateList)
+
+  const cJudges = createClient(); clients.push(cJudges)
+  subscribeToChannel(cJudges, '/topic/battle/judges', updateBattleJudge)
+
+  const cScore = createClient(); clients.push(cScore)
+  subscribeToChannel(cScore, '/topic/battle/score', updateScore)
+})
+
+onBeforeUnmount(() => {
+  unmounted = true
+  clients.forEach(c => { if (c) deactivateClient(c) })
+  document.documentElement.classList.remove('transparent-page')
+  document.body.classList.remove('transparent-page')
+})
+</script>
+
+<template>
+  <div
+    class="smoke-root"
+    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
+  >
+    <!-- Atmospheric background bleeds -->
+    <div class="atmo-bleed" aria-hidden="true"></div>
+
+    <!-- Header -->
+    <div class="smoke-header" aria-hidden="true">
+      <span class="smoke-title">7 TO SMOKE</span>
+    </div>
+
+    <!-- Bar chart -->
+    <div class="smoke-chart">
+      <TransitionGroup tag="div" name="col" class="smoke-cols">
+        <template v-for="(item, idx) in smokeParticipants" :key="item.name">
+          <!-- VS chip between position 0 and 1 -->
+          <div v-if="idx === 1" class="vs-chip" aria-hidden="true">VS</div>
+
+          <!-- Queue gap spacer between position 1 and 2 -->
+          <div v-if="idx === 2" class="queue-gap" aria-hidden="true"></div>
+
+          <!-- Fighter column -->
+          <div
+            class="smoke-col"
+            :class="{
+              'col-active-left':  idx === 0,
+              'col-active-right': idx === 1,
+            }"
+          >
+            <div class="bar-wrap">
+              <div
+                class="bar"
+                :class="{ 'score-pop': scorePopNames.has(item.name) }"
+                :style="{ height: barHeightPct(item.score) + '%' }"
+                :aria-label="`${item.name}: ${item.score} points`"
+              ></div>
+            </div>
+            <div class="dots-row" aria-hidden="true">
+              <div
+                v-for="d in 7"
+                :key="d"
+                class="dot"
+                :class="{ filled: d <= item.score }"
+              ></div>
+            </div>
+            <div class="col-name">{{ item.name }}</div>
+          </div>
+        </template>
+      </TransitionGroup>
+
+      <!-- Floating pill: active pair indicator -->
+      <div
+        v-if="activeLeft && activeRight"
+        class="float-pill"
+        role="status"
+        :aria-label="`Now battling: ${activeLeft.name} vs ${activeRight.name}`"
+      >
+        <span class="pill-name pill-left">{{ activeLeft.name }}</span>
+        <span class="pill-vs">VS</span>
+        <span class="pill-name pill-right">{{ activeRight.name }}</span>
+        <div class="pill-sep" aria-hidden="true"></div>
+        <span class="pill-pts">{{ activeLeft.score }} PTS · {{ activeRight.score }} PTS</span>
+      </div>
+    </div>
+
+    <!-- Result overlay (win / tie) -->
+    <Transition name="result-fade">
+      <div
+        v-if="showResult && resultState && !showChampion"
+        class="result-overlay"
+        role="status"
+        aria-live="assertive"
+      >
+        <!-- Win header -->
+        <template v-if="resultState.winner === 0">
+          <div class="result-name result-left">{{ resultState.leftName }}</div>
+          <div class="result-sub">TAKES THE POINT</div>
+        </template>
+        <template v-else-if="resultState.winner === 1">
+          <div class="result-name result-right">{{ resultState.rightName }}</div>
+          <div class="result-sub">TAKES THE POINT</div>
+        </template>
+        <template v-else>
+          <div class="result-name result-tie">IT'S A TIE</div>
+          <div class="result-sub">BOTH EARN A POINT</div>
+        </template>
+
+        <!-- Judge cards -->
+        <div v-if="battleJudges?.judges" class="judge-inner">
+          <div class="judges-header" aria-hidden="true">
+            <span class="judges-line"></span>
+            <span class="judges-label">JUDGES</span>
+            <span class="judges-line"></span>
+          </div>
+          <div class="judge-cards-row" role="list">
+            <div
+              v-for="(j, index) in battleJudges.judges"
+              :key="index"
+              class="judge-card card-burst"
+              :class="{
+                'voted-left':  j.vote === 0,
+                'voted-right': j.vote === 1,
+                'voted-tie':   j.vote === -1,
+              }"
+              :style="{ animationDelay: `${index * 55}ms` }"
+              role="listitem"
+              :aria-label="`${j.name}: ${j.vote === 0 ? 'voted left' : j.vote === 1 ? 'voted right' : 'tie'}`"
+            >
+              <div v-if="j.vote !== -1" class="judge-row">
+                <span class="vote-arrow vote-arrow-left" :class="{ 'arrow-lit-left': j.vote === 0 }" aria-hidden="true"></span>
+                <span class="judge-name">{{ j.name }}</span>
+                <span class="vote-arrow vote-arrow-right" :class="{ 'arrow-lit-right': j.vote === 1 }" aria-hidden="true"></span>
+              </div>
+              <div v-else class="judge-row">
+                <span class="judge-name judge-name-tie">{{ j.name }}</span>
+              </div>
+              <div v-if="j.vote !== -1" class="vote-track" aria-hidden="true">
+                <div class="vote-fill" :class="{ 'fill-left': j.vote === 0, 'fill-right': j.vote === 1, 'fill-blank': j.vote !== 0 && j.vote !== 1 }"></div>
+              </div>
+              <div v-else class="tie-badge" aria-hidden="true">TIE</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
+    <!-- Champion overlay -->
+    <Transition name="champ-fade">
+      <div
+        v-if="showChampion"
+        class="champion-overlay"
+        :style="{ '--champ-color': champColor }"
+        role="status"
+        aria-live="assertive"
+        :aria-label="`${champName} is the 7 to Smoke champion`"
+      >
+        <div class="champ-burst" aria-hidden="true"></div>
+        <div class="champ-name">{{ champName }}</div>
+        <div class="champ-sub">7 TO SMOKE CHAMPION</div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style>
+/* OBS transparent background — must be global */
+html.transparent-page,
+body.transparent-page,
+html.transparent-page #app,
+body.transparent-page #app {
+  background: transparent !important;
+  background-color: transparent !important;
+}
+</style>
+
+<style scoped>
+/* ── Root ─────────────────────────────────────────────── */
+.smoke-root {
+  position: fixed;
+  inset: 0;
+  font-family: 'Anton SC', sans-serif;
+  background: #06080e;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  --left-color:  #dc2626;
+  --right-color: #2563eb;
+}
+
+/* ── Atmospheric bleeds ───────────────────────────────── */
+.atmo-bleed {
+  position: absolute; inset: 0; z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 60% 60% at 0% 100%,   color-mix(in srgb, var(--left-color)  16%, transparent) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 60% at 100% 100%, color-mix(in srgb, var(--right-color) 16%, transparent) 0%, transparent 70%);
+}
+
+/* ── Header ───────────────────────────────────────────── */
+.smoke-header {
+  position: relative; z-index: 2; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 18px 6px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  background: rgba(0,0,0,0.35);
+  backdrop-filter: blur(8px);
+}
+.smoke-title {
+  font-size: clamp(10px, 1.4vw, 16px);
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.5);
+}
+
+/* ── Chart area ───────────────────────────────────────── */
+.smoke-chart {
+  position: relative; z-index: 2;
+  flex: 1; min-height: 0;
+  display: flex; flex-direction: column;
+}
+
+.smoke-cols {
+  flex: 1; min-height: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 10px 14px 0;
+  gap: 5px;
+  overflow: hidden;
+}
+
+/* ── Fighter column ───────────────────────────────────── */
+.smoke-col {
+  flex: 1;
+  display: flex; flex-direction: column; align-items: center;
+  height: 100%;
+}
+
+/* ── Bar wrap + bar ───────────────────────────────────── */
+.bar-wrap {
+  flex: 1; width: 100%;
+  display: flex; flex-direction: column; justify-content: flex-end;
+  position: relative;
+}
+/* Dashed goal line at top */
+.bar-wrap::before {
+  content: '';
+  position: absolute; top: 0; left: 0; right: 0;
+  border-top: 1px dashed rgba(255,255,255,0.07);
+}
+.bar {
+  width: 100%;
+  border-radius: 5px 5px 2px 2px;
+  min-height: 3px;
+  position: relative; overflow: hidden;
+  transition: height 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  /* Default: waiting/gray */
+  background: linear-gradient(0deg, #181818 0%, #2a2a2a 100%);
+}
+/* Glossy top highlight — only on active bars */
+.bar::after {
+  content: '';
+  position: absolute; top: 0; left: 0; right: 0; height: 45%;
+  background: linear-gradient(180deg, rgba(255,255,255,0.14) 0%, transparent 100%);
+  border-radius: 5px 5px 0 0;
+  pointer-events: none;
+  display: none;
+}
+
+/* Active left — red */
+.col-active-left .bar {
+  background: linear-gradient(0deg,
+    color-mix(in srgb, var(--left-color) 35%, #000) 0%,
+    var(--left-color) 75%,
+    color-mix(in srgb, var(--left-color) 50%, #fff) 100%
+  );
+  box-shadow:
+    0 0 22px color-mix(in srgb, var(--left-color) 65%, transparent),
+    0 0 60px color-mix(in srgb, var(--left-color) 25%, transparent),
+    inset 0 0 0 1.5px rgba(255,255,255,0.2);
+}
+.col-active-left .bar::after { display: block; }
+
+/* Active right — blue */
+.col-active-right .bar {
+  background: linear-gradient(0deg,
+    color-mix(in srgb, var(--right-color) 35%, #000) 0%,
+    var(--right-color) 75%,
+    color-mix(in srgb, var(--right-color) 50%, #fff) 100%
+  );
+  box-shadow:
+    0 0 22px color-mix(in srgb, var(--right-color) 65%, transparent),
+    0 0 60px color-mix(in srgb, var(--right-color) 25%, transparent),
+    inset 0 0 0 1.5px rgba(255,255,255,0.2);
+}
+.col-active-right .bar::after { display: block; }
+
+/* ── Dots row ─────────────────────────────────────────── */
+.dots-row {
+  display: flex; gap: 2px; margin-top: 5px; justify-content: center;
+  flex-shrink: 0; flex-wrap: wrap;
+}
+.dot {
+  width: clamp(4px, 0.6vw, 7px); height: clamp(4px, 0.6vw, 7px);
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  opacity: 0.25;
+  color: rgba(255,255,255,0.5);
+}
+.dot.filled { opacity: 1; background: currentColor; }
+.col-active-left  .dot { color: var(--left-color); }
+.col-active-right .dot { color: var(--right-color); }
+
+/* ── Name label ───────────────────────────────────────── */
+.col-name {
+  font-size: clamp(5px, 0.8vw, 9px);
+  letter-spacing: 0.1em;
+  text-align: center;
+  margin-top: 3px; margin-bottom: 5px;
+  color: rgba(255,255,255,0.28);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  width: 100%; padding: 0 2px;
+}
+.col-active-left .col-name {
+  color: color-mix(in srgb, var(--left-color) 50%, #fff);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--left-color) 80%, transparent);
+}
+.col-active-right .col-name {
+  color: color-mix(in srgb, var(--right-color) 50%, #fff);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--right-color) 80%, transparent);
+}
+
+/* ── VS chip ──────────────────────────────────────────── */
+.vs-chip {
+  flex: 0 0 clamp(16px, 2.2vw, 26px);
+  align-self: flex-end;
+  margin-bottom: clamp(20px, 3vw, 30px);
+  display: flex; align-items: center; justify-content: center;
+  font-size: clamp(7px, 0.9vw, 10px);
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.5);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 4px;
+  background: rgba(255,255,255,0.04);
+  padding: 3px 0; line-height: 1;
+}
+
+/* ── Queue gap ────────────────────────────────────────── */
+.queue-gap { flex: 0 0 clamp(8px, 1.4vw, 16px); }
+
+/* ── Floating pill ────────────────────────────────────── */
+.float-pill {
+  position: absolute;
+  bottom: 10px; left: 50%; transform: translateX(-50%);
+  z-index: 3;
+  display: flex; align-items: center; gap: 7px;
+  background: rgba(0,0,0,0.65);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 99px;
+  padding: 4px 16px;
+  white-space: nowrap;
+}
+.pill-name {
+  font-size: clamp(9px, 1.3vw, 15px);
+  letter-spacing: 0.08em;
+}
+.pill-left  { color: color-mix(in srgb, var(--left-color)  50%, #fff); }
+.pill-right { color: color-mix(in srgb, var(--right-color) 50%, #fff); }
+.pill-vs {
+  font-size: clamp(7px, 0.85vw, 10px);
+  letter-spacing: 0.15em;
+  color: rgba(255,255,255,0.35);
+  padding: 0 2px;
+}
+.pill-sep {
+  width: 1px; height: 12px;
+  background: rgba(255,255,255,0.12);
+}
+.pill-pts {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: clamp(6px, 0.75vw, 8px);
+  letter-spacing: 0.12em;
+  color: rgba(255,255,255,0.3);
+}
+
+/* ── FLIP column slide (TransitionGroup move) ─────────── */
+.col-move {
+  transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ══════════════════════════════════════════════════
+   RESULT OVERLAY
+══════════════════════════════════════════════════ */
+.result-overlay {
+  position: absolute; inset: 0; z-index: 50;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 6px;
+  background: rgba(6, 8, 18, 0.72);
+  backdrop-filter: blur(4px);
+}
+
+.result-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(28px, 5.5vw, 88px);
+  letter-spacing: 0.07em;
+  line-height: 1;
+  text-transform: uppercase;
+  animation: resultSlam 520ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+.result-left {
+  color: #fff;
+  text-shadow: 4px 4px 0 var(--left-color),
+               0 0 50px color-mix(in srgb, var(--left-color) 50%, transparent);
+}
+.result-right {
+  color: #fff;
+  text-shadow: -4px 4px 0 var(--right-color),
+               0 0 50px color-mix(in srgb, var(--right-color) 50%, transparent);
+}
+.result-tie {
+  color: #fff;
+  text-shadow: 0 0 40px rgba(255,255,255,0.3);
+}
+.result-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: clamp(9px, 1.1vw, 16px);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.35);
+  margin-top: 2px; margin-bottom: 16px;
+}
+
+/* Judge inner container */
+.judge-inner {
+  position: relative;
+  display: flex; flex-direction: column; gap: 8px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--left-color)  12%, rgba(6,8,18,0.94)),
+    color-mix(in srgb, var(--right-color) 12%, rgba(6,8,18,0.94))
+  );
+  backdrop-filter: blur(24px);
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.12);
+  box-shadow: 0 24px 80px rgba(0,0,0,0.75), 0 0 0 1px rgba(255,255,255,0.04) inset;
+  padding: 12px 24px 16px;
+}
+.judges-header { display: flex; align-items: center; gap: 8px; }
+.judges-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 9px; font-weight: 700;
+  letter-spacing: 0.32em; color: rgba(255,255,255,0.28);
+  text-transform: uppercase; white-space: nowrap; flex-shrink: 0;
+}
+.judges-line { flex: 1; height: 1px; background: rgba(255,255,255,0.07); }
+.judge-cards-row { display: flex; gap: 8px; }
+
+/* Judge card — parallelogram */
+.judge-card {
+  display: flex; flex-direction: column; align-items: center; gap: 7px;
+  min-width: 130px; padding: 8px 12px;
+  clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+.voted-left {
+  background: color-mix(in srgb, var(--left-color)  12%, transparent);
+  border-color: color-mix(in srgb, var(--left-color)  40%, transparent);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--left-color)  25%, transparent);
+}
+.voted-right {
+  background: color-mix(in srgb, var(--right-color) 12%, transparent);
+  border-color: color-mix(in srgb, var(--right-color) 40%, transparent);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--right-color) 25%, transparent);
+}
+.voted-tie {
+  background: rgba(255,255,255,0.06);
+  border-color: rgba(255,255,255,0.20);
+}
+.judge-row { display: flex; align-items: center; gap: 9px; }
+.judge-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 22px; color: rgba(255,255,255,0.90);
+  letter-spacing: 0.06em; text-transform: uppercase; line-height: 1;
+}
+.judge-name-tie { color: rgba(255,255,255,0.32) !important; }
+.vote-arrow {
+  display: inline-block; width: 18px; height: 18px; flex-shrink: 0;
+  background: rgba(255,255,255,0.15); opacity: 0.2;
+  transition: opacity 0.2s ease, background 0.2s ease, filter 0.2s ease;
+}
+.vote-arrow-left  { clip-path: polygon(100% 0%, 0% 50%, 100% 100%); }
+.vote-arrow-right { clip-path: polygon(0% 0%, 100% 50%, 0% 100%); }
+.arrow-lit-left  { opacity: 1; background: var(--left-color);  filter: drop-shadow(0 0 8px var(--left-color)); }
+.arrow-lit-right { opacity: 1; background: var(--right-color); filter: drop-shadow(0 0 8px var(--right-color)); }
+.tie-badge {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px; letter-spacing: 0.35em;
+  color: rgba(255,255,255,0.55); text-align: center; width: 100%;
+  border: 1px solid rgba(255,255,255,0.18); border-radius: 4px; padding: 2px 0;
+}
+.vote-track {
+  width: 100%; height: 10px;
+  background: rgba(255,255,255,0.1); border-radius: 9999px; overflow: hidden;
+}
+.vote-fill { height: 100%; border-radius: 9999px; width: 0%; }
+.fill-left  {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--left-color)  70%, black), var(--left-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--left-color)  90%, transparent);
+}
+.fill-right {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--right-color) 70%, black), var(--right-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 90%, transparent);
+}
+.fill-blank { background: transparent; }
+
+/* Result overlay fade transition */
+.result-fade-enter-active { transition: opacity 0.25s ease; }
+.result-fade-leave-active  { transition: opacity 0.4s ease; }
+.result-fade-enter-from, .result-fade-leave-to { opacity: 0; }
+
+/* ══════════════════════════════════════════════════
+   CHAMPION OVERLAY
+══════════════════════════════════════════════════ */
+.champion-overlay {
+  position: absolute; inset: 0; z-index: 60;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 10px;
+  background: rgba(4, 5, 12, 0.88);
+  --champ-color: #dc2626;
+}
+.champ-burst {
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(
+    ellipse 70% 60% at 50% 50%,
+    color-mix(in srgb, var(--champ-color) 30%, transparent) 0%,
+    transparent 70%
+  );
+  animation: champBurst 0.6s ease-out both;
+}
+.champ-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(36px, 7vw, 110px);
+  letter-spacing: 0.08em; line-height: 1;
+  text-transform: uppercase;
+  color: #fff;
+  text-shadow: 4px 4px 0 var(--champ-color),
+               0 0 60px color-mix(in srgb, var(--champ-color) 60%, transparent);
+  animation: champSlam 720ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+.champ-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: clamp(10px, 1.3vw, 18px);
+  letter-spacing: 0.4em; text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+  animation: champSubFade 0.5s ease both;
+  animation-delay: 0.45s;
+  opacity: 0;
+}
+
+.champ-fade-enter-active { transition: opacity 0.2s ease; }
+.champ-fade-leave-active  { transition: opacity 0.5s ease; }
+.champ-fade-enter-from, .champ-fade-leave-to { opacity: 0; }
+
+/* ══════════════════════════════════════════════════
+   KEYFRAMES
+══════════════════════════════════════════════════ */
+@keyframes resultSlam {
+  0%   { transform: scale(2.2) translateY(-16px); opacity: 0; filter: blur(10px); }
+  55%  { transform: scale(0.97) translateY(0);    opacity: 1; filter: blur(0); }
+  72%  { transform: scale(1.03); }
+  85%  { transform: scale(0.99); }
+  100% { transform: scale(1); }
+}
+
+@keyframes champSlam {
+  0%   { transform: scale(2.5) translateY(-20px); opacity: 0; filter: blur(12px); }
+  55%  { transform: scale(0.96) translateY(0);    opacity: 1; filter: blur(0); }
+  72%  { transform: scale(1.04); }
+  85%  { transform: scale(0.99); }
+  100% { transform: scale(1); }
+}
+
+@keyframes champBurst {
+  0%   { opacity: 0; transform: scale(0.5); }
+  60%  { opacity: 1; transform: scale(1.05); }
+  100% { opacity: 0.85; transform: scale(1); }
+}
+
+@keyframes champSubFade {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes scorePop {
+  0%   { transform: scaleY(1) scaleX(1); filter: brightness(1); }
+  18%  { transform: scaleY(1.07) scaleX(1.04); filter: brightness(2.5); }
+  38%  { transform: scaleY(0.96) scaleX(1.02); filter: brightness(1.5); }
+  58%  { transform: scaleY(1.02) scaleX(1.01); filter: brightness(1.1); }
+  100% { transform: scaleY(1) scaleX(1); filter: brightness(1); }
+}
+.score-pop {
+  animation: scorePop 600ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+
+@keyframes cardBurst {
+  0%   { transform: scale(1.4) skewX(-5deg); opacity: 0; }
+  65%  { transform: scale(0.97) skewX(0);   opacity: 1; }
+  100% { transform: scale(1) skewX(0);      opacity: 1; }
+}
+.card-burst {
+  animation: cardBurst 280ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+</style>

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -15,7 +15,6 @@ const smokeParticipants = ref([])
 
 // ── Judge data ──────────────────────────────────────────────────────────────
 const battleJudges = ref(null)       // { judges: [{ id, name, vote }] }
-const votesVisible = ref(false)
 
 // ── Result overlay ──────────────────────────────────────────────────────────
 const showResult    = ref(false)
@@ -56,10 +55,26 @@ watch(
 
 // ── WebSocket handlers ──────────────────────────────────────────────────────
 const updateList = (msg) => {
-  if (msg?.battlers) smokeParticipants.value = msg.battlers
+  if (!msg?.battlers) return
+  smokeParticipants.value = msg.battlers
+  // Champion check runs here — after scores are updated in the list
+  if (!showChampion.value) {
+    const champ = msg.battlers.find(p => p.score >= 7)
+    if (champ) {
+      champName.value  = champ.name
+      const idx = msg.battlers.indexOf(champ)
+      champColor.value = idx === 0
+        ? overlayConfig.value.leftColor
+        : idx === 1
+          ? overlayConfig.value.rightColor
+          : overlayConfig.value.leftColor
+      showChampion.value = true
+    }
+  }
 }
 
 const updateBattleJudge = (msg) => {
+  if (!msg?.judges) return
   battleJudges.value = msg
   msg.judges.forEach(j => {
     const topic = `/topic/battle/vote/${j.id}`
@@ -83,35 +98,17 @@ const updateJudgeVote = (msg) => {
 
 // Capture active names at reveal time so result overlay stays correct after queue shifts
 const updateScore = async (msg) => {
+  if (showChampion.value) return
   const leftName  = activeLeft.value?.name  ?? ''
   const rightName = activeRight.value?.name ?? ''
   const winner    = msg.message // 0 | 1 | -1
 
-  // Check for champion (any fighter reaching 7)
-  const allParticipants = smokeParticipants.value
-  const champParticipant = allParticipants.find(p => p.score >= 7)
-
-  if (champParticipant) {
-    champName.value  = champParticipant.name
-    const idx = allParticipants.indexOf(champParticipant)
-    champColor.value = idx === 0
-      ? overlayConfig.value.leftColor
-      : idx === 1
-        ? overlayConfig.value.rightColor
-        : overlayConfig.value.leftColor
-    showChampion.value = true
-    return  // Champion overlay never auto-dismisses
-  }
-
-  // Regular result overlay
   resultState.value = { winner, leftName, rightName }
-  votesVisible.value = true
   showResult.value = true
 
   await useDelay().wait(4000)
   if (unmounted) return
   showResult.value = false
-  votesVisible.value = false
 }
 
 // ── Mount ───────────────────────────────────────────────────────────────────
@@ -120,7 +117,7 @@ onMounted(async () => {
   document.body.classList.add('transparent-page')
 
   const config = await getOverlayConfig()
-  overlayConfig.value = config
+  if (config?.leftColor !== undefined) overlayConfig.value = config
 
   const smoke = await getSmokeList()
   if (smoke?.list) smokeParticipants.value = smoke.list
@@ -249,7 +246,7 @@ onBeforeUnmount(() => {
           <div class="judge-cards-row" role="list">
             <div
               v-for="(j, index) in battleJudges.judges"
-              :key="index"
+              :key="j.id"
               class="judge-card card-burst"
               :class="{
                 'voted-left':  j.vote === 0,
@@ -579,7 +576,7 @@ body.transparent-page #app {
   border-radius: 14px;
   border: 1px solid rgba(255,255,255,0.12);
   box-shadow: 0 24px 80px rgba(0,0,0,0.75), 0 0 0 1px rgba(255,255,255,0.04) inset;
-  padding: 12px 24px 16px;
+  padding: 10px 20px 14px;
 }
 .judges-header { display: flex; align-items: center; gap: 8px; }
 .judges-label {

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -102,10 +102,10 @@ const updateScore = async (msg) => {
   const leftName  = activeLeft.value?.name  ?? ''
   const rightName = activeRight.value?.name ?? ''
   const winner    = msg.message // 0 | 1 | -1
-  // Snapshot judges so vote colors persist even if battleJudges is cleared for next match
-  const judges = battleJudges.value?.judges
-    ? JSON.parse(JSON.stringify(battleJudges.value.judges))
-    : null
+  // Fetch fresh judge votes from API at reveal time — avoids race where per-judge WS
+  // subscriptions haven't connected yet and the local battleJudges still shows stale/cleared votes
+  const freshJudges = await getBattleJudges()
+  const judges = freshJudges?.judges ?? battleJudges.value?.judges ?? null
 
   resultState.value = { winner, leftName, rightName, judges }
   showResult.value = true

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -105,6 +105,30 @@ const updateScore = async (msg) => {
   const leftName  = activeLeft.value?.name  ?? ''
   const rightName = activeRight.value?.name ?? ''
   const winner    = msg.message // 0 | 1 | -1
+
+  // Immediately reflect the score gain on the bar — the scorePopNames watcher fires the pop animation
+  if (winner === 0 && smokeParticipants.value.length > 0) {
+    smokeParticipants.value = smokeParticipants.value.map((p, i) =>
+      i === 0 ? { ...p, score: p.score + 1 } : p
+    )
+  } else if (winner === 1 && smokeParticipants.value.length > 1) {
+    smokeParticipants.value = smokeParticipants.value.map((p, i) =>
+      i === 1 ? { ...p, score: p.score + 1 } : p
+    )
+  }
+  // winner === -1 (tie): no score change
+
+  // Champion check: did the winner just reach 7?
+  if (!showChampion.value && (winner === 0 || winner === 1)) {
+    const champ = smokeParticipants.value[winner]
+    if (champ && champ.score >= 7) {
+      champName.value  = champ.name
+      champColor.value = winner === 0 ? overlayConfig.value.leftColor : overlayConfig.value.rightColor
+      showChampion.value = true
+      return  // champion overlay takes over — skip the regular result overlay
+    }
+  }
+
   // Fetch fresh judge votes from API at reveal time — avoids race where per-judge WS
   // subscriptions haven't connected yet and the local battleJudges still shows stale/cleared votes
   const freshJudges = await getBattleJudges()

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -96,14 +96,18 @@ const updateJudgeVote = (msg) => {
   }
 }
 
-// Capture active names at reveal time so result overlay stays correct after queue shifts
+// Capture active names + judge state at reveal time so result overlay stays correct after queue shifts
 const updateScore = async (msg) => {
   if (showChampion.value) return
   const leftName  = activeLeft.value?.name  ?? ''
   const rightName = activeRight.value?.name ?? ''
   const winner    = msg.message // 0 | 1 | -1
+  // Snapshot judges so vote colors persist even if battleJudges is cleared for next match
+  const judges = battleJudges.value?.judges
+    ? JSON.parse(JSON.stringify(battleJudges.value.judges))
+    : null
 
-  resultState.value = { winner, leftName, rightName }
+  resultState.value = { winner, leftName, rightName, judges }
   showResult.value = true
 
   await useDelay().wait(4000)
@@ -199,18 +203,15 @@ onBeforeUnmount(() => {
         </template>
       </TransitionGroup>
 
-      <!-- Floating pill: active pair indicator -->
+      <!-- Design B: ghost names behind chart -->
       <div
         v-if="activeLeft && activeRight"
-        class="float-pill"
-        role="status"
-        :aria-label="`Now battling: ${activeLeft.name} vs ${activeRight.name}`"
+        class="bg-names"
+        aria-hidden="true"
       >
-        <span class="pill-name pill-left">{{ activeLeft.name }}</span>
-        <span class="pill-vs">VS</span>
-        <span class="pill-name pill-right">{{ activeRight.name }}</span>
-        <div class="pill-sep" aria-hidden="true"></div>
-        <span class="pill-pts">{{ activeLeft.score }} PTS · {{ activeRight.score }} PTS</span>
+        <span class="bg-name bg-name-left">{{ activeLeft.name }}</span>
+        <span class="bg-vs">VS</span>
+        <span class="bg-name bg-name-right">{{ activeRight.name }}</span>
       </div>
     </div>
 
@@ -233,11 +234,11 @@ onBeforeUnmount(() => {
         </template>
         <template v-else>
           <div class="result-name result-tie">IT'S A TIE</div>
-          <div class="result-sub">BOTH EARN A POINT</div>
+          <div class="result-sub">NO POINTS AWARDED</div>
         </template>
 
-        <!-- Judge cards -->
-        <div v-if="battleJudges?.judges" class="judge-inner">
+        <!-- Judge cards (snapshot at reveal time — not live battleJudges) -->
+        <div v-if="resultState.judges" class="judge-inner">
           <div class="judges-header" aria-hidden="true">
             <span class="judges-line"></span>
             <span class="judges-label">JUDGES</span>
@@ -245,7 +246,7 @@ onBeforeUnmount(() => {
           </div>
           <div class="judge-cards-row" role="list">
             <div
-              v-for="(j, index) in battleJudges.judges"
+              v-for="(j, index) in resultState.judges"
               :key="j.id"
               class="judge-card card-burst"
               :class="{
@@ -477,41 +478,28 @@ body.transparent-page #app {
 /* ── Queue gap ────────────────────────────────────────── */
 .queue-gap { flex: 0 0 clamp(8px, 1.4vw, 16px); }
 
-/* ── Floating pill ────────────────────────────────────── */
-.float-pill {
-  position: absolute;
-  bottom: 10px; left: 50%; transform: translateX(-50%);
-  z-index: 3;
-  display: flex; align-items: center; gap: 7px;
-  background: rgba(0,0,0,0.65);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255,255,255,0.1);
-  border-radius: 99px;
-  padding: 4px 16px;
+/* ── Design B: ghost names behind chart ───────────────── */
+.bg-names {
+  position: absolute; z-index: 1;
+  top: 4%; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 14px;
+  pointer-events: none;
+}
+.bg-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(22px, 5.5vw, 72px);
+  letter-spacing: 0.06em; line-height: 1;
+  opacity: 0.1;
   white-space: nowrap;
 }
-.pill-name {
-  font-size: clamp(9px, 1.3vw, 15px);
-  letter-spacing: 0.08em;
-}
-.pill-left  { color: color-mix(in srgb, var(--left-color)  50%, #fff); }
-.pill-right { color: color-mix(in srgb, var(--right-color) 50%, #fff); }
-.pill-vs {
-  font-size: clamp(7px, 0.85vw, 10px);
-  letter-spacing: 0.15em;
-  color: rgba(255,255,255,0.35);
-  padding: 0 2px;
-}
-.pill-sep {
-  width: 1px; height: 12px;
-  background: rgba(255,255,255,0.12);
-}
-.pill-pts {
-  font-family: 'Inter', sans-serif;
-  font-weight: 700;
-  font-size: clamp(6px, 0.75vw, 8px);
-  letter-spacing: 0.12em;
-  color: rgba(255,255,255,0.3);
+.bg-name-left  { color: var(--left-color);  text-shadow: 0 0 40px var(--left-color); }
+.bg-name-right { color: var(--right-color); text-shadow: 0 0 40px var(--right-color); }
+.bg-vs {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(10px, 2vw, 24px); letter-spacing: 0.2em;
+  color: rgba(255,255,255,0.08);
+  flex-shrink: 0; padding: 0 8px;
 }
 
 /* ── FLIP column slide (TransitionGroup move) ─────────── */

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -19,6 +19,7 @@ const battleJudges = ref(null)       // { judges: [{ id, name, vote }] }
 // ── Result overlay ──────────────────────────────────────────────────────────
 const showResult    = ref(false)
 const resultState   = ref(null)  // { winner: 0|1|-1, leftName, rightName }
+const battlePhase   = ref('IDLE') // mirrors backend phase — used to discard stale score events
 
 // ── Champion overlay ────────────────────────────────────────────────────────
 const showChampion  = ref(false)
@@ -100,6 +101,7 @@ const updateJudgeVote = (msg) => {
 const updateScore = async (msg) => {
   if (showChampion.value) return
   if (showResult.value) return  // already displaying a result — ignore duplicate events
+  if (battlePhase.value === 'LOCKED') return  // next round already started — stale event
   const leftName  = activeLeft.value?.name  ?? ''
   const rightName = activeRight.value?.name ?? ''
   const winner    = msg.message // 0 | 1 | -1
@@ -145,8 +147,10 @@ onMounted(async () => {
 
   const cPhase = createClient(); clients.push(cPhase)
   subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
-    // When phase resets to LOCKED (Next was clicked), dismiss result overlay immediately
-    if (msg?.phase === 'LOCKED') showResult.value = false
+    if (!msg?.phase) return
+    battlePhase.value = msg.phase
+    // When phase resets to LOCKED (Next was clicked), dismiss any visible result overlay
+    if (msg.phase === 'LOCKED') showResult.value = false
   })
 })
 

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -99,6 +99,7 @@ const updateJudgeVote = (msg) => {
 // Capture active names + judge state at reveal time so result overlay stays correct after queue shifts
 const updateScore = async (msg) => {
   if (showChampion.value) return
+  if (showResult.value) return  // already displaying a result — ignore duplicate events
   const leftName  = activeLeft.value?.name  ?? ''
   const rightName = activeRight.value?.name ?? ''
   const winner    = msg.message // 0 | 1 | -1

--- a/BES-frontend/src/views/__tests__/BattleOverlay.test.js
+++ b/BES-frontend/src/views/__tests__/BattleOverlay.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createWebHistory } from 'vue-router'
+
+vi.mock('@/utils/api', () => ({
+  getBattleJudges: vi.fn().mockResolvedValue({ judges: [] }),
+  getCurrentBattlePair: vi.fn().mockResolvedValue(null),
+  getImage: vi.fn().mockResolvedValue(null),
+  getOverlayConfig: vi.fn().mockResolvedValue({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }),
+}))
+vi.mock('@/utils/websocket', () => ({
+  createClient: vi.fn().mockReturnValue({ value: null }),
+  deactivateClient: vi.fn(),
+  subscribeToChannel: vi.fn(),
+}))
+vi.mock('../Chart.vue', () => ({ default: { template: '<div />' } }))
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [{ path: '/battle/overlay', component: { template: '<div />' } }],
+})
+
+const BattleOverlay = (await import('../BattleOverlay.vue')).default
+
+describe('BattleOverlay.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.documentElement.classList.remove('transparent-page')
+  })
+
+  it('mounts without errors', async () => {
+    const wrapper = mount(BattleOverlay, {
+      global: { plugins: [router] },
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('adds transparent-page class to html on mount', async () => {
+    mount(BattleOverlay, { global: { plugins: [router] } })
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.documentElement.classList.contains('transparent-page')).toBe(true)
+  })
+
+  it('renders .overlay-root element', async () => {
+    const wrapper = mount(BattleOverlay, { global: { plugins: [router] } })
+    expect(wrapper.find('.overlay-root').exists()).toBe(true)
+  })
+})

--- a/BES-frontend/vite.config.js
+++ b/BES-frontend/vite.config.js
@@ -15,4 +15,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5050',
+      '/ws': {
+        target: 'http://localhost:5050',
+        ws: true,
+      },
+    },
+  },
 })

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -212,10 +212,12 @@ public class BattleController {
             Files.createDirectories(uploadDir);
         }
         String originalFilename = file.getOriginalFilename();
-        String extension = (originalFilename != null && originalFilename.contains("."))
-            ? originalFilename.substring(originalFilename.lastIndexOf('.'))
-            : "";
-        String safeFilename = UUID.randomUUID().toString() + extension;
+        if (originalFilename == null || originalFilename.isBlank()) {
+            return ResponseEntity.badRequest().body("Filename is required");
+        }
+        // Preserve original filename (so overlay can look up by participant name).
+        // Strip any path separators to prevent directory traversal.
+        String safeFilename = originalFilename.replaceAll("[/\\\\]", "_");
         Path dest = uploadDir.resolve(safeFilename).normalize();
         if (!dest.startsWith(uploadDir.normalize())) {
             return ResponseEntity.badRequest().body("Invalid file path");

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -37,6 +37,7 @@ import com.example.BES.dtos.battle.SetBattlerPairDto;
 import com.example.BES.dtos.battle.SetBattlePhaseDto;
 import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
 import com.example.BES.dtos.battle.SetVoteDto;
 import com.example.BES.services.BattleService;
@@ -300,5 +301,17 @@ public class BattleController {
     public ResponseEntity<?> setBracketState(@Valid @RequestBody SetBracketStateDto dto){
         battleService.setBracketStateService(dto);
         return ResponseEntity.ok(Map.of("message", "Bracket state updated"));
+    }
+
+    @GetMapping("/overlay-config")
+    public ResponseEntity<?> getOverlayConfig() {
+        return ResponseEntity.ok(battleService.getOverlayConfig());
+    }
+
+    @PostMapping("/overlay-config")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> setOverlayConfig(@Valid @RequestBody SetOverlayConfigDto dto) {
+        battleService.setOverlayConfigService(dto);
+        return ResponseEntity.ok(battleService.getOverlayConfig());
     }
 }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java
@@ -1,0 +1,22 @@
+package com.example.BES.dtos.battle;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class SetOverlayConfigDto {
+
+    @NotNull
+    private Boolean showImages;
+
+    @NotNull
+    @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "leftColor must be a valid 6-digit hex color")
+    private String leftColor;
+
+    @NotNull
+    @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "rightColor must be a valid 6-digit hex color")
+    private String rightColor;
+
+    public Boolean isShowImages() { return showImages; }
+    public String getLeftColor()  { return leftColor; }
+    public String getRightColor() { return rightColor; }
+}

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -236,11 +236,12 @@ public class BattleService {
     }
 
     public void setOverlayConfigService(SetOverlayConfigDto dto) {
-        overlayConfig = new HashMap<>();
-        overlayConfig.put("showImages", dto.isShowImages());
-        overlayConfig.put("leftColor",  dto.getLeftColor());
-        overlayConfig.put("rightColor", dto.getRightColor());
-        messagingTemplate.convertAndSend("/topic/battle/overlay-config", overlayConfig);
+        Map<String, Object> newConfig = new HashMap<>();
+        newConfig.put("showImages", dto.isShowImages());
+        newConfig.put("leftColor",  dto.getLeftColor());
+        newConfig.put("rightColor", dto.getRightColor());
+        overlayConfig = newConfig;
+        messagingTemplate.convertAndSend("/topic/battle/overlay-config", newConfig);
     }
 
     public class BattleJudge {

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -3,6 +3,7 @@ package com.example.BES.services;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -13,6 +14,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import com.example.BES.dtos.battle.SetBattleModeDto;
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
 import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
@@ -34,6 +36,11 @@ public class BattleService {
     private List<Battler> battlers = new ArrayList<>();
     // IDLE | LOCKED | VOTING | REVEALED
     private String battlePhase = "IDLE";
+    private Map<String, Object> overlayConfig = new HashMap<>(Map.of(
+        "showImages", true,
+        "leftColor",  "#dc2626",
+        "rightColor", "#2563eb"
+    ));
     public List<String> getModes() {
         return modes;
     }
@@ -222,6 +229,18 @@ public class BattleService {
         if ("REVEALED".equals(phase)) return;
         battlePhase = phase;
         messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+    }
+
+    public Map<String, Object> getOverlayConfig() {
+        return overlayConfig;
+    }
+
+    public void setOverlayConfigService(SetOverlayConfigDto dto) {
+        overlayConfig = new HashMap<>();
+        overlayConfig.put("showImages", dto.isShowImages());
+        overlayConfig.put("leftColor",  dto.getLeftColor());
+        overlayConfig.put("rightColor", dto.getRightColor());
+        messagingTemplate.convertAndSend("/topic/battle/overlay-config", overlayConfig);
     }
 
     public class BattleJudge {

--- a/BES/src/main/resources/db/migration/V18__add_overlay_config.sql
+++ b/BES/src/main/resources/db/migration/V18__add_overlay_config.sql
@@ -1,0 +1,2 @@
+ALTER TABLE event
+  ADD COLUMN overlay_config JSONB NOT NULL DEFAULT '{"showImages": true, "leftColor": "#dc2626", "rightColor": "#2563eb"}';

--- a/BES/src/main/resources/db/migration/V18__add_overlay_config.sql
+++ b/BES/src/main/resources/db/migration/V18__add_overlay_config.sql
@@ -1,2 +1,0 @@
-ALTER TABLE event
-  ADD COLUMN overlay_config JSONB NOT NULL DEFAULT '{"showImages": true, "leftColor": "#dc2626", "rightColor": "#2563eb"}';

--- a/BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java
@@ -216,4 +216,49 @@ public class BattleControllerIntegrationTest {
                 .andExpect(jsonPath("$.list").isArray())
                 .andExpect(jsonPath("$.list[0].name").value("Alice"));
     }
+
+    @Test
+    @WithMockUser
+    public void testGetOverlayConfig_returnsValidStructure() throws Exception {
+        mockMvc.perform(get("/api/v1/battle/overlay-config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.showImages").exists())
+                .andExpect(jsonPath("$.leftColor").exists())
+                .andExpect(jsonPath("$.rightColor").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "ORGANISER")
+    public void testSetOverlayConfig_updatesAndReturns() throws Exception {
+        String body = "{\"showImages\":false,\"leftColor\":\"#ff0000\",\"rightColor\":\"#0000ff\"}";
+
+        mockMvc.perform(post("/api/v1/battle/overlay-config")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.showImages").value(false))
+                .andExpect(jsonPath("$.leftColor").value("#ff0000"))
+                .andExpect(jsonPath("$.rightColor").value("#0000ff"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ORGANISER")
+    public void testSetOverlayConfig_rejectsInvalidHexColor() throws Exception {
+        String body = "{\"showImages\":true,\"leftColor\":\"notacolor\",\"rightColor\":\"#2563eb\"}";
+
+        mockMvc.perform(post("/api/v1/battle/overlay-config")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testSetOverlayConfig_requiresAuth() throws Exception {
+        String body = "{\"showImages\":true,\"leftColor\":\"#dc2626\",\"rightColor\":\"#2563eb\"}";
+
+        mockMvc.perform(post("/api/v1/battle/overlay-config")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().is4xxClientError());
+    }
 }

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -2,6 +2,7 @@ package com.example.BES.services;
 
 import com.example.BES.dtos.battle.SetBattlerPairDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetVoteDto;
 import com.example.BES.models.Judge;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -158,5 +163,43 @@ class BattleServiceTest {
         lenient().when(dto.getId()).thenReturn(99L);
 
         assertThat(service.setVoteService(dto)).isEqualTo(-2);
+    }
+
+    @Test
+    void getOverlayConfig_returnsDefaults() {
+        Map<String, Object> config = service.getOverlayConfig();
+        assertThat(config.get("showImages")).isEqualTo(true);
+        assertThat(config.get("leftColor")).isEqualTo("#dc2626");
+        assertThat(config.get("rightColor")).isEqualTo("#2563eb");
+    }
+
+    @Test
+    void setOverlayConfigService_updatesInMemoryState() {
+        SetOverlayConfigDto dto = mock(SetOverlayConfigDto.class);
+        when(dto.isShowImages()).thenReturn(false);
+        when(dto.getLeftColor()).thenReturn("#ff0000");
+        when(dto.getRightColor()).thenReturn("#0000ff");
+
+        service.setOverlayConfigService(dto);
+
+        Map<String, Object> config = service.getOverlayConfig();
+        assertThat(config.get("showImages")).isEqualTo(false);
+        assertThat(config.get("leftColor")).isEqualTo("#ff0000");
+        assertThat(config.get("rightColor")).isEqualTo("#0000ff");
+    }
+
+    @Test
+    void setOverlayConfigService_broadcastsToWebSocket() {
+        SetOverlayConfigDto dto = mock(SetOverlayConfigDto.class);
+        when(dto.isShowImages()).thenReturn(true);
+        when(dto.getLeftColor()).thenReturn("#aabbcc");
+        when(dto.getRightColor()).thenReturn("#112233");
+
+        service.setOverlayConfigService(dto);
+
+        verify(messagingTemplate).convertAndSend(
+            eq("/topic/battle/overlay-config"),
+            any(Map.class)
+        );
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - BES_ALLOWED_ORIGINS=${BES_ALLOWED_ORIGINS}
     volumes:
     - ./credentials.json:/credentials.json:ro
+    - uploads:/uploads
 
   frontend:
     build:
@@ -47,3 +48,4 @@ services:
 
 volumes:
   postgres:
+  uploads:

--- a/docs/superpowers/plans/2026-05-27-7-to-smoke-overlay-redesign.md
+++ b/docs/superpowers/plans/2026-05-27-7-to-smoke-overlay-redesign.md
@@ -1,0 +1,1067 @@
+# 7-to-Smoke Overlay Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign `Chart.vue` (and clean up `BattleOverlay.vue` smoke mode) to show a bold glowing bar chart matching the 1v1 overlay's visual style, with FLIP queue sliding, score pop animations, judge result overlay, and champion takeover overlay.
+
+**Architecture:** Chart.vue is a full rewrite as a standalone full-screen overlay component. It owns all WebSocket subscriptions for smoke mode. BattleOverlay.vue's smoke section already renders `<Chart />`, but currently also subscribes to the same topics and shows a conflicting judge panel — those are removed in Task 6. A small helper module extracts testable pure functions.
+
+**Tech Stack:** Vue 3 Composition API, CSS custom properties (`--left-color`/`--right-color`), Vue `TransitionGroup` (for FLIP), `useDelay` from utils/utils.js, existing WebSocket helpers (createClient/subscribeToChannel/deactivateClient), existing API helpers (getSmokeList, getOverlayConfig, getBattleJudges).
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `BES-frontend/src/utils/smokeChartHelpers.js` | Create — pure helpers for bar height + score gainer detection |
+| `BES-frontend/src/utils/__tests__/smokeChartHelpers.test.js` | Create — Vitest tests |
+| `BES-frontend/src/views/Chart.vue` | Full rewrite — new overlay UI |
+| `BES-frontend/src/views/BattleOverlay.vue` | Modify — remove isSmoke WS block, guard judge panel |
+
+---
+
+## Key Data Shapes (read before coding)
+
+```js
+// smokeParticipants — from getSmokeList() → { list: [...] } and WS /topic/battle/smoke → { battlers: [...] }
+// [{ name: "VIBRAZE", score: 3 }, { name: "KRAZIX", score: 4 }, { name: "RYZEN", score: 2 }, ...]
+// Index 0 = active left, index 1 = active right, index 2+ = waiting queue
+
+// battleJudges — from getBattleJudges() and WS /topic/battle/judges
+// { judges: [{ id: 1, name: "JUDGE A", vote: -3|0|1|-1|null }] }
+// vote: -3 = cleared (new match), 0 = voted left, 1 = voted right, -1 = tie, null = not yet voted
+
+// Score reveal — WS /topic/battle/score
+// { left: <leftScore>, right: <rightScore>, message: 0|1|-1 }
+// message: 0 = left wins, 1 = right wins, -1 = tie
+
+// overlayConfig — from getOverlayConfig() and WS /topic/battle/overlay-config
+// { showImages: bool, leftColor: "#dc2626", rightColor: "#2563eb" }
+```
+
+---
+
+## Task 1: Pure helpers + tests
+
+**Files:**
+- Create: `BES-frontend/src/utils/smokeChartHelpers.js`
+- Create: `BES-frontend/src/utils/__tests__/smokeChartHelpers.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+// BES-frontend/src/utils/__tests__/smokeChartHelpers.test.js
+import { describe, it, expect } from 'vitest'
+import { barHeightPct, findScoreGainers } from '../smokeChartHelpers'
+
+describe('barHeightPct', () => {
+  it('returns 0 for score 0', () => {
+    expect(barHeightPct(0)).toBe(0)
+  })
+  it('returns 100 for score 7', () => {
+    expect(barHeightPct(7)).toBe(100)
+  })
+  it('returns correct percentage for mid scores', () => {
+    expect(barHeightPct(3)).toBeCloseTo(42.857, 2)
+    expect(barHeightPct(4)).toBeCloseTo(57.143, 2)
+  })
+  it('clamps to 100 if score exceeds 7', () => {
+    expect(barHeightPct(8)).toBe(100)
+  })
+})
+
+describe('findScoreGainers', () => {
+  it('returns names whose score increased', () => {
+    const prev = [{ name: 'A', score: 2 }, { name: 'B', score: 1 }]
+    const next = [{ name: 'A', score: 3 }, { name: 'B', score: 1 }]
+    expect(findScoreGainers(prev, next)).toEqual(['A'])
+  })
+  it('returns empty array when no scores changed', () => {
+    const participants = [{ name: 'A', score: 2 }, { name: 'B', score: 1 }]
+    expect(findScoreGainers(participants, participants)).toEqual([])
+  })
+  it('handles new participant with no previous score', () => {
+    const prev = [{ name: 'A', score: 1 }]
+    const next = [{ name: 'A', score: 1 }, { name: 'B', score: 1 }]
+    expect(findScoreGainers(prev, next)).toEqual(['B'])
+  })
+  it('returns multiple gainers', () => {
+    const prev = [{ name: 'A', score: 1 }, { name: 'B', score: 1 }]
+    const next = [{ name: 'A', score: 2 }, { name: 'B', score: 2 }]
+    expect(findScoreGainers(prev, next)).toEqual(['A', 'B'])
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd BES-frontend && npm test -- smokeChartHelpers
+```
+Expected: FAIL — "Cannot find module '../smokeChartHelpers'"
+
+- [ ] **Step 3: Create the helper module**
+
+```js
+// BES-frontend/src/utils/smokeChartHelpers.js
+
+/**
+ * Returns bar height as a percentage (0–100) for a given score out of 7.
+ * Clamped to 100 so bars never overflow their container.
+ */
+export const barHeightPct = (score) => Math.min((score / 7) * 100, 100)
+
+/**
+ * Given two snapshots of participants, returns the names of participants
+ * whose score increased between snapshots. Used to trigger score pop animation.
+ */
+export const findScoreGainers = (prevParticipants, nextParticipants) => {
+  const prevMap = Object.fromEntries(prevParticipants.map(p => [p.name, p.score]))
+  return nextParticipants
+    .filter(n => n.score > (prevMap[n.name] ?? 0))
+    .map(n => n.name)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd BES-frontend && npm test -- smokeChartHelpers
+```
+Expected: PASS — 8 tests passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/utils/smokeChartHelpers.js BES-frontend/src/utils/__tests__/smokeChartHelpers.test.js
+git commit -m "feat: add smoke chart pure helpers + tests"
+```
+
+---
+
+## Task 2: Chart.vue — base structure, bar chart, floating pill, WebSocket
+
+**Files:**
+- Modify: `BES-frontend/src/views/Chart.vue` (full rewrite)
+
+**Context:** The current Chart.vue (87 lines) is a placeholder with basic Tailwind bars and image loading. Replace it entirely. The new Chart.vue is a self-contained full-screen overlay. It mounts `transparent-page` class (for OBS), subscribes to all smoke WebSocket topics, and renders the bar chart.
+
+**Important:** `position: fixed; inset: 0` on the root div means Chart.vue works both as a standalone route (`/battle/chart`) and when embedded inside BattleOverlay.vue's smoke section.
+
+- [ ] **Step 1: Write the full Chart.vue rewrite**
+
+```vue
+<!-- BES-frontend/src/views/Chart.vue -->
+<script setup>
+import { computed, nextTick, onMounted, onBeforeUnmount, ref, watch } from 'vue'
+import { getSmokeList, getOverlayConfig, getBattleJudges } from '@/utils/api'
+import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket'
+import { useDelay } from '@/utils/utils'
+import { barHeightPct, findScoreGainers } from '@/utils/smokeChartHelpers'
+
+// ── Overlay config ──────────────────────────────────────────────────────────
+const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+
+// ── Chart data ──────────────────────────────────────────────────────────────
+// Position 0 = active left, 1 = active right, 2+ = queue
+const smokeParticipants = ref([])
+
+// ── Judge data ──────────────────────────────────────────────────────────────
+const battleJudges = ref(null)       // { judges: [{ id, name, vote }] }
+const votesVisible = ref(false)
+
+// ── Result overlay ──────────────────────────────────────────────────────────
+const showResult    = ref(false)
+const resultState   = ref(null)  // { winner: 0|1|-1, leftName, rightName }
+
+// ── Champion overlay ────────────────────────────────────────────────────────
+const showChampion  = ref(false)
+const champName     = ref('')
+const champColor    = ref('#dc2626')
+
+// ── Score pop animation ─────────────────────────────────────────────────────
+const scorePopNames = ref(new Set())
+
+// ── WebSocket clients ───────────────────────────────────────────────────────
+const clients = []
+const subscribedVoteTopics = new Set()
+let unmounted = false
+
+// ── Computed ────────────────────────────────────────────────────────────────
+const activeLeft  = computed(() => smokeParticipants.value[0] ?? null)
+const activeRight = computed(() => smokeParticipants.value[1] ?? null)
+
+// ── Score pop: watch for score increases ────────────────────────────────────
+watch(
+  smokeParticipants,
+  (next, prev) => {
+    if (!prev?.length) return
+    const gainers = findScoreGainers(prev, next)
+    gainers.forEach(name => {
+      scorePopNames.value = new Set([...scorePopNames.value, name])
+      setTimeout(() => {
+        scorePopNames.value = new Set([...scorePopNames.value].filter(n => n !== name))
+      }, 600)
+    })
+  },
+  { deep: true }
+)
+
+// ── WebSocket handlers ──────────────────────────────────────────────────────
+const updateList = (msg) => {
+  if (msg?.battlers) smokeParticipants.value = msg.battlers
+}
+
+const updateBattleJudge = (msg) => {
+  battleJudges.value = msg
+  msg.judges.forEach(j => {
+    const topic = `/topic/battle/vote/${j.id}`
+    if (!subscribedVoteTopics.has(topic)) {
+      subscribedVoteTopics.add(topic)
+      const c = createClient(); clients.push(c)
+      subscribeToChannel(c, topic, (m) => updateJudgeVote(m))
+    }
+  })
+}
+
+const updateJudgeVote = (msg) => {
+  if (!battleJudges.value?.judges) return
+  battleJudges.value = {
+    ...battleJudges.value,
+    judges: battleJudges.value.judges.map(j =>
+      j.id === msg.judge ? { ...j, vote: msg.vote } : j
+    )
+  }
+}
+
+// Capture active names at reveal time so result overlay stays correct after queue shifts
+const updateScore = async (msg) => {
+  const leftName  = activeLeft.value?.name  ?? ''
+  const rightName = activeRight.value?.name ?? ''
+  const winner    = msg.message // 0 | 1 | -1
+
+  // Check for champion (any fighter reaching 7)
+  const allParticipants = smokeParticipants.value
+  const champParticipant = allParticipants.find(p => p.score >= 7)
+
+  if (champParticipant) {
+    champName.value  = champParticipant.name
+    const idx = allParticipants.indexOf(champParticipant)
+    champColor.value = idx === 0
+      ? overlayConfig.value.leftColor
+      : idx === 1
+        ? overlayConfig.value.rightColor
+        : overlayConfig.value.leftColor
+    showChampion.value = true
+    return  // Champion overlay never auto-dismisses
+  }
+
+  // Regular result overlay
+  resultState.value = { winner, leftName, rightName }
+  votesVisible.value = true
+  showResult.value = true
+
+  await useDelay().wait(4000)
+  if (unmounted) return
+  showResult.value = false
+  votesVisible.value = false
+}
+
+// ── Mount ───────────────────────────────────────────────────────────────────
+onMounted(async () => {
+  document.documentElement.classList.add('transparent-page')
+  document.body.classList.add('transparent-page')
+
+  const config = await getOverlayConfig()
+  overlayConfig.value = config
+
+  const smoke = await getSmokeList()
+  if (smoke?.list) smokeParticipants.value = smoke.list
+
+  battleJudges.value = await getBattleJudges()
+
+  const cConfig = createClient(); clients.push(cConfig)
+  subscribeToChannel(cConfig, '/topic/battle/overlay-config', (msg) => {
+    if (msg?.leftColor !== undefined) overlayConfig.value = msg
+  })
+
+  const cSmoke = createClient(); clients.push(cSmoke)
+  subscribeToChannel(cSmoke, '/topic/battle/smoke', updateList)
+
+  const cJudges = createClient(); clients.push(cJudges)
+  subscribeToChannel(cJudges, '/topic/battle/judges', updateBattleJudge)
+
+  const cScore = createClient(); clients.push(cScore)
+  subscribeToChannel(cScore, '/topic/battle/score', updateScore)
+})
+
+onBeforeUnmount(() => {
+  unmounted = true
+  clients.forEach(c => { if (c) deactivateClient(c) })
+  document.documentElement.classList.remove('transparent-page')
+  document.body.classList.remove('transparent-page')
+})
+</script>
+
+<template>
+  <div
+    class="smoke-root"
+    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
+  >
+    <!-- Atmospheric background bleeds -->
+    <div class="atmo-bleed" aria-hidden="true"></div>
+
+    <!-- Header -->
+    <div class="smoke-header" aria-hidden="true">
+      <span class="smoke-title">7 TO SMOKE</span>
+    </div>
+
+    <!-- Bar chart -->
+    <div class="smoke-chart">
+      <TransitionGroup tag="div" name="col" class="smoke-cols">
+        <template v-for="(item, idx) in smokeParticipants" :key="item.name">
+          <!-- VS chip between position 0 and 1 -->
+          <div v-if="idx === 1" class="vs-chip" aria-hidden="true">VS</div>
+
+          <!-- Queue gap spacer between position 1 and 2 -->
+          <div v-if="idx === 2" class="queue-gap" aria-hidden="true"></div>
+
+          <!-- Fighter column -->
+          <div
+            class="smoke-col"
+            :class="{
+              'col-active-left':  idx === 0,
+              'col-active-right': idx === 1,
+            }"
+          >
+            <div class="bar-wrap">
+              <div
+                class="bar"
+                :class="{ 'score-pop': scorePopNames.has(item.name) }"
+                :style="{ height: barHeightPct(item.score) + '%' }"
+                :aria-label="`${item.name}: ${item.score} points`"
+              ></div>
+            </div>
+            <div class="dots-row" aria-hidden="true">
+              <div
+                v-for="d in 7"
+                :key="d"
+                class="dot"
+                :class="{ filled: d <= item.score }"
+              ></div>
+            </div>
+            <div class="col-name">{{ item.name }}</div>
+          </div>
+        </template>
+      </TransitionGroup>
+
+      <!-- Floating pill: active pair indicator -->
+      <div
+        v-if="activeLeft && activeRight"
+        class="float-pill"
+        role="status"
+        :aria-label="`Now battling: ${activeLeft.name} vs ${activeRight.name}`"
+      >
+        <span class="pill-name pill-left">{{ activeLeft.name }}</span>
+        <span class="pill-vs">VS</span>
+        <span class="pill-name pill-right">{{ activeRight.name }}</span>
+        <div class="pill-sep" aria-hidden="true"></div>
+        <span class="pill-pts">{{ activeLeft.score }} PTS · {{ activeRight.score }} PTS</span>
+      </div>
+    </div>
+
+    <!-- Result overlay (win / tie) -->
+    <Transition name="result-fade">
+      <div
+        v-if="showResult && resultState && !showChampion"
+        class="result-overlay"
+        role="status"
+        :aria-live="'assertive'"
+      >
+        <!-- Win header -->
+        <template v-if="resultState.winner === 0">
+          <div class="result-name result-left">{{ resultState.leftName }}</div>
+          <div class="result-sub">TAKES THE POINT</div>
+        </template>
+        <template v-else-if="resultState.winner === 1">
+          <div class="result-name result-right">{{ resultState.rightName }}</div>
+          <div class="result-sub">TAKES THE POINT</div>
+        </template>
+        <template v-else>
+          <div class="result-name result-tie">IT'S A TIE</div>
+          <div class="result-sub">BOTH EARN A POINT</div>
+        </template>
+
+        <!-- Judge cards -->
+        <div v-if="battleJudges?.judges" class="judge-inner">
+          <div class="judges-header" aria-hidden="true">
+            <span class="judges-line"></span>
+            <span class="judges-label">JUDGES</span>
+            <span class="judges-line"></span>
+          </div>
+          <div class="judge-cards-row" role="list">
+            <div
+              v-for="(j, index) in battleJudges.judges"
+              :key="index"
+              class="judge-card card-burst"
+              :class="{
+                'voted-left':  j.vote === 0,
+                'voted-right': j.vote === 1,
+                'voted-tie':   j.vote === -1,
+              }"
+              :style="{ animationDelay: `${index * 55}ms` }"
+              role="listitem"
+              :aria-label="`${j.name}: ${j.vote === 0 ? 'voted left' : j.vote === 1 ? 'voted right' : 'tie'}`"
+            >
+              <div v-if="j.vote !== -1" class="judge-row">
+                <span class="vote-arrow vote-arrow-left" :class="{ 'arrow-lit-left': j.vote === 0 }" aria-hidden="true"></span>
+                <span class="judge-name">{{ j.name }}</span>
+                <span class="vote-arrow vote-arrow-right" :class="{ 'arrow-lit-right': j.vote === 1 }" aria-hidden="true"></span>
+              </div>
+              <div v-else class="judge-row">
+                <span class="judge-name judge-name-tie">{{ j.name }}</span>
+              </div>
+              <div v-if="j.vote !== -1" class="vote-track" aria-hidden="true">
+                <div class="vote-fill" :class="{ 'fill-left': j.vote === 0, 'fill-right': j.vote === 1, 'fill-blank': j.vote !== 0 && j.vote !== 1 }"></div>
+              </div>
+              <div v-else class="tie-badge" aria-hidden="true">TIE</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
+    <!-- Champion overlay -->
+    <Transition name="champ-fade">
+      <div
+        v-if="showChampion"
+        class="champion-overlay"
+        :style="{ '--champ-color': champColor }"
+        role="status"
+        aria-live="assertive"
+        :aria-label="`${champName} is the 7 to Smoke champion`"
+      >
+        <div class="champ-burst" aria-hidden="true"></div>
+        <div class="champ-name">{{ champName }}</div>
+        <div class="champ-sub">7 TO SMOKE CHAMPION</div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style>
+/* OBS transparent background — must be global */
+html.transparent-page,
+body.transparent-page,
+html.transparent-page #app,
+body.transparent-page #app {
+  background: transparent !important;
+  background-color: transparent !important;
+}
+</style>
+
+<style scoped>
+/* ── Root ─────────────────────────────────────────────── */
+.smoke-root {
+  position: fixed;
+  inset: 0;
+  font-family: 'Anton SC', sans-serif;
+  background: #06080e;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  --left-color:  #dc2626;
+  --right-color: #2563eb;
+}
+
+/* ── Atmospheric bleeds ───────────────────────────────── */
+.atmo-bleed {
+  position: absolute; inset: 0; z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 60% 60% at 0% 100%,   color-mix(in srgb, var(--left-color)  16%, transparent) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 60% at 100% 100%, color-mix(in srgb, var(--right-color) 16%, transparent) 0%, transparent 70%);
+}
+
+/* ── Header ───────────────────────────────────────────── */
+.smoke-header {
+  position: relative; z-index: 2; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 18px 6px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  background: rgba(0,0,0,0.35);
+  backdrop-filter: blur(8px);
+}
+.smoke-title {
+  font-size: clamp(10px, 1.4vw, 16px);
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.5);
+}
+
+/* ── Chart area ───────────────────────────────────────── */
+.smoke-chart {
+  position: relative; z-index: 2;
+  flex: 1; min-height: 0;
+  display: flex; flex-direction: column;
+}
+
+.smoke-cols {
+  flex: 1; min-height: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 10px 14px 0;
+  gap: 5px;
+  overflow: hidden;
+}
+
+/* ── Fighter column ───────────────────────────────────── */
+.smoke-col {
+  flex: 1;
+  display: flex; flex-direction: column; align-items: center;
+  height: 100%;
+}
+
+/* ── Bar wrap + bar ───────────────────────────────────── */
+.bar-wrap {
+  flex: 1; width: 100%;
+  display: flex; flex-direction: column; justify-content: flex-end;
+  position: relative;
+}
+/* Dashed goal line at top */
+.bar-wrap::before {
+  content: '';
+  position: absolute; top: 0; left: 0; right: 0;
+  border-top: 1px dashed rgba(255,255,255,0.07);
+}
+.bar {
+  width: 100%;
+  border-radius: 5px 5px 2px 2px;
+  min-height: 3px;
+  position: relative; overflow: hidden;
+  transition: height 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  /* Default: waiting/gray */
+  background: linear-gradient(0deg, #181818 0%, #2a2a2a 100%);
+}
+/* Glossy top highlight — only on active bars */
+.bar::after {
+  content: '';
+  position: absolute; top: 0; left: 0; right: 0; height: 45%;
+  background: linear-gradient(180deg, rgba(255,255,255,0.14) 0%, transparent 100%);
+  border-radius: 5px 5px 0 0;
+  pointer-events: none;
+  display: none;
+}
+
+/* Active left — red */
+.col-active-left .bar {
+  background: linear-gradient(0deg,
+    color-mix(in srgb, var(--left-color) 35%, #000) 0%,
+    var(--left-color) 75%,
+    color-mix(in srgb, var(--left-color) 50%, #fff) 100%
+  );
+  box-shadow:
+    0 0 22px color-mix(in srgb, var(--left-color) 65%, transparent),
+    0 0 60px color-mix(in srgb, var(--left-color) 25%, transparent),
+    inset 0 0 0 1.5px rgba(255,255,255,0.2);
+}
+.col-active-left .bar::after { display: block; }
+
+/* Active right — blue */
+.col-active-right .bar {
+  background: linear-gradient(0deg,
+    color-mix(in srgb, var(--right-color) 35%, #000) 0%,
+    var(--right-color) 75%,
+    color-mix(in srgb, var(--right-color) 50%, #fff) 100%
+  );
+  box-shadow:
+    0 0 22px color-mix(in srgb, var(--right-color) 65%, transparent),
+    0 0 60px color-mix(in srgb, var(--right-color) 25%, transparent),
+    inset 0 0 0 1.5px rgba(255,255,255,0.2);
+}
+.col-active-right .bar::after { display: block; }
+
+/* ── Dots row ─────────────────────────────────────────── */
+.dots-row {
+  display: flex; gap: 2px; margin-top: 5px; justify-content: center;
+  flex-shrink: 0; flex-wrap: wrap;
+}
+.dot {
+  width: clamp(4px, 0.6vw, 7px); height: clamp(4px, 0.6vw, 7px);
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  opacity: 0.25;
+  color: rgba(255,255,255,0.5);
+}
+.dot.filled { opacity: 1; background: currentColor; }
+.col-active-left  .dot { color: var(--left-color); }
+.col-active-right .dot { color: var(--right-color); }
+
+/* ── Name label ───────────────────────────────────────── */
+.col-name {
+  font-size: clamp(5px, 0.8vw, 9px);
+  letter-spacing: 0.1em;
+  text-align: center;
+  margin-top: 3px; margin-bottom: 5px;
+  color: rgba(255,255,255,0.28);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  width: 100%; padding: 0 2px;
+}
+.col-active-left .col-name {
+  color: color-mix(in srgb, var(--left-color) 50%, #fff);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--left-color) 80%, transparent);
+}
+.col-active-right .col-name {
+  color: color-mix(in srgb, var(--right-color) 50%, #fff);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--right-color) 80%, transparent);
+}
+
+/* ── VS chip ──────────────────────────────────────────── */
+.vs-chip {
+  flex: 0 0 clamp(16px, 2.2vw, 26px);
+  align-self: flex-end;
+  margin-bottom: clamp(20px, 3vw, 30px);
+  display: flex; align-items: center; justify-content: center;
+  font-size: clamp(7px, 0.9vw, 10px);
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.5);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 4px;
+  background: rgba(255,255,255,0.04);
+  padding: 3px 0; line-height: 1;
+}
+
+/* ── Queue gap ────────────────────────────────────────── */
+.queue-gap { flex: 0 0 clamp(8px, 1.4vw, 16px); }
+
+/* ── Floating pill ────────────────────────────────────── */
+.float-pill {
+  position: absolute;
+  bottom: 10px; left: 50%; transform: translateX(-50%);
+  z-index: 3;
+  display: flex; align-items: center; gap: 7px;
+  background: rgba(0,0,0,0.65);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 99px;
+  padding: 4px 16px;
+  white-space: nowrap;
+}
+.pill-name {
+  font-size: clamp(9px, 1.3vw, 15px);
+  letter-spacing: 0.08em;
+}
+.pill-left  { color: color-mix(in srgb, var(--left-color)  50%, #fff); }
+.pill-right { color: color-mix(in srgb, var(--right-color) 50%, #fff); }
+.pill-vs {
+  font-size: clamp(7px, 0.85vw, 10px);
+  letter-spacing: 0.15em;
+  color: rgba(255,255,255,0.35);
+  padding: 0 2px;
+}
+.pill-sep {
+  width: 1px; height: 12px;
+  background: rgba(255,255,255,0.12);
+}
+.pill-pts {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: clamp(6px, 0.75vw, 8px);
+  letter-spacing: 0.12em;
+  color: rgba(255,255,255,0.3);
+}
+
+/* ── FLIP column slide (TransitionGroup move) ─────────── */
+.col-move {
+  transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ══════════════════════════════════════════════════
+   RESULT OVERLAY
+══════════════════════════════════════════════════ */
+.result-overlay {
+  position: absolute; inset: 0; z-index: 50;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 6px;
+  background: rgba(6, 8, 18, 0.72);
+  backdrop-filter: blur(4px);
+}
+
+.result-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(28px, 5.5vw, 88px);
+  letter-spacing: 0.07em;
+  line-height: 1;
+  text-transform: uppercase;
+  animation: resultSlam 520ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+.result-left {
+  color: #fff;
+  text-shadow: 4px 4px 0 var(--left-color),
+               0 0 50px color-mix(in srgb, var(--left-color) 50%, transparent);
+}
+.result-right {
+  color: #fff;
+  text-shadow: -4px 4px 0 var(--right-color),
+               0 0 50px color-mix(in srgb, var(--right-color) 50%, transparent);
+}
+.result-tie {
+  color: #fff;
+  text-shadow: 0 0 40px rgba(255,255,255,0.3);
+}
+.result-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: clamp(9px, 1.1vw, 16px);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.35);
+  margin-top: 2px; margin-bottom: 16px;
+}
+
+/* Judge inner container — copied from BattleOverlay.vue */
+.judge-inner {
+  position: relative;
+  display: flex; flex-direction: column; gap: 8px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--left-color)  12%, rgba(6,8,18,0.94)),
+    color-mix(in srgb, var(--right-color) 12%, rgba(6,8,18,0.94))
+  );
+  backdrop-filter: blur(24px);
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.12);
+  box-shadow: 0 24px 80px rgba(0,0,0,0.75), 0 0 0 1px rgba(255,255,255,0.04) inset;
+  padding: 12px 24px 16px;
+}
+.judges-header { display: flex; align-items: center; gap: 8px; }
+.judges-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 9px; font-weight: 700;
+  letter-spacing: 0.32em; color: rgba(255,255,255,0.28);
+  text-transform: uppercase; white-space: nowrap; flex-shrink: 0;
+}
+.judges-line { flex: 1; height: 1px; background: rgba(255,255,255,0.07); }
+.judge-cards-row { display: flex; gap: 8px; }
+
+/* Judge card — parallelogram */
+.judge-card {
+  display: flex; flex-direction: column; align-items: center; gap: 7px;
+  min-width: 130px; padding: 8px 12px;
+  clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+.voted-left {
+  background: color-mix(in srgb, var(--left-color)  12%, transparent);
+  border-color: color-mix(in srgb, var(--left-color)  40%, transparent);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--left-color)  25%, transparent);
+}
+.voted-right {
+  background: color-mix(in srgb, var(--right-color) 12%, transparent);
+  border-color: color-mix(in srgb, var(--right-color) 40%, transparent);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--right-color) 25%, transparent);
+}
+.voted-tie {
+  background: rgba(255,255,255,0.06);
+  border-color: rgba(255,255,255,0.20);
+}
+.judge-row { display: flex; align-items: center; gap: 9px; }
+.judge-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 22px; color: rgba(255,255,255,0.90);
+  letter-spacing: 0.06em; text-transform: uppercase; line-height: 1;
+}
+.judge-name-tie { color: rgba(255,255,255,0.32) !important; }
+.vote-arrow {
+  display: inline-block; width: 18px; height: 18px; flex-shrink: 0;
+  background: rgba(255,255,255,0.15); opacity: 0.2;
+  transition: opacity 0.2s ease, background 0.2s ease, filter 0.2s ease;
+}
+.vote-arrow-left  { clip-path: polygon(100% 0%, 0% 50%, 100% 100%); }
+.vote-arrow-right { clip-path: polygon(0% 0%, 100% 50%, 0% 100%); }
+.arrow-lit-left  { opacity: 1; background: var(--left-color);  filter: drop-shadow(0 0 8px var(--left-color)); }
+.arrow-lit-right { opacity: 1; background: var(--right-color); filter: drop-shadow(0 0 8px var(--right-color)); }
+.tie-badge {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px; letter-spacing: 0.35em;
+  color: rgba(255,255,255,0.55); text-align: center; width: 100%;
+  border: 1px solid rgba(255,255,255,0.18); border-radius: 4px; padding: 2px 0;
+}
+.vote-track {
+  width: 100%; height: 10px;
+  background: rgba(255,255,255,0.1); border-radius: 9999px; overflow: hidden;
+}
+.vote-fill { height: 100%; border-radius: 9999px; width: 0%; }
+.fill-left  {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--left-color)  70%, black), var(--left-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--left-color)  90%, transparent);
+}
+.fill-right {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--right-color) 70%, black), var(--right-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 90%, transparent);
+}
+.fill-blank { background: transparent; }
+
+/* Result overlay fade transition */
+.result-fade-enter-active { transition: opacity 0.25s ease; }
+.result-fade-leave-active  { transition: opacity 0.4s ease; }
+.result-fade-enter-from, .result-fade-leave-to { opacity: 0; }
+
+/* ══════════════════════════════════════════════════
+   CHAMPION OVERLAY
+══════════════════════════════════════════════════ */
+.champion-overlay {
+  position: absolute; inset: 0; z-index: 60;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 10px;
+  background: rgba(4, 5, 12, 0.88);
+  --champ-color: #dc2626;
+}
+.champ-burst {
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(
+    ellipse 70% 60% at 50% 50%,
+    color-mix(in srgb, var(--champ-color) 30%, transparent) 0%,
+    transparent 70%
+  );
+  animation: champBurst 0.6s ease-out both;
+}
+.champ-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(36px, 7vw, 110px);
+  letter-spacing: 0.08em; line-height: 1;
+  text-transform: uppercase;
+  color: #fff;
+  text-shadow: 4px 4px 0 var(--champ-color),
+               0 0 60px color-mix(in srgb, var(--champ-color) 60%, transparent);
+  animation: champSlam 720ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+.champ-sub {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: clamp(10px, 1.3vw, 18px);
+  letter-spacing: 0.4em; text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+  animation: champSubFade 0.5s ease both;
+  animation-delay: 0.45s;
+  opacity: 0;
+}
+
+.champ-fade-enter-active { transition: opacity 0.2s ease; }
+.champ-fade-leave-active  { transition: opacity 0.5s ease; }
+.champ-fade-enter-from, .champ-fade-leave-to { opacity: 0; }
+
+/* ══════════════════════════════════════════════════
+   KEYFRAMES
+══════════════════════════════════════════════════ */
+@keyframes resultSlam {
+  0%   { transform: scale(2.2) translateY(-16px); opacity: 0; filter: blur(10px); }
+  55%  { transform: scale(0.97) translateY(0);    opacity: 1; filter: blur(0); }
+  72%  { transform: scale(1.03); }
+  85%  { transform: scale(0.99); }
+  100% { transform: scale(1); }
+}
+
+@keyframes champSlam {
+  0%   { transform: scale(2.5) translateY(-20px); opacity: 0; filter: blur(12px); }
+  55%  { transform: scale(0.96) translateY(0);    opacity: 1; filter: blur(0); }
+  72%  { transform: scale(1.04); }
+  85%  { transform: scale(0.99); }
+  100% { transform: scale(1); }
+}
+
+@keyframes champBurst {
+  0%   { opacity: 0; transform: scale(0.5); }
+  60%  { opacity: 1; transform: scale(1.05); }
+  100% { opacity: 0.85; transform: scale(1); }
+}
+
+@keyframes champSubFade {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes scorePop {
+  0%   { transform: scaleY(1) scaleX(1); filter: brightness(1); }
+  18%  { transform: scaleY(1.07) scaleX(1.04); filter: brightness(2.5); }
+  38%  { transform: scaleY(0.96) scaleX(1.02); filter: brightness(1.5); }
+  58%  { transform: scaleY(1.02) scaleX(1.01); filter: brightness(1.1); }
+  100% { transform: scaleY(1) scaleX(1); filter: brightness(1); }
+}
+.score-pop {
+  animation: scorePop 600ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+
+@keyframes cardBurst {
+  0%   { transform: scale(1.4) skewX(-5deg); opacity: 0; }
+  65%  { transform: scale(0.97) skewX(0);   opacity: 1; }
+  100% { transform: scale(1) skewX(0);      opacity: 1; }
+}
+.card-burst {
+  animation: cardBurst 280ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+</style>
+```
+
+- [ ] **Step 2: Run the frontend to verify it builds**
+
+```bash
+cd BES-frontend && npm run build
+```
+Expected: build succeeds with no errors
+
+- [ ] **Step 3: Run dev server and open `/battle/chart` in browser to verify layout**
+
+```bash
+cd BES-frontend && npm run dev
+```
+Open `http://localhost:5173/battle/chart` — should see dark overlay with "7 TO SMOKE" header. No data yet (no WebSocket running), so empty chart area with floating pill showing nothing. No console errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/views/Chart.vue BES-frontend/src/utils/smokeChartHelpers.js BES-frontend/src/utils/__tests__/smokeChartHelpers.test.js
+git commit -m "feat: rewrite Chart.vue as bold 7-to-smoke bar chart overlay"
+```
+
+---
+
+## Task 3: Update BattleOverlay.vue — remove conflicting smoke subscriptions + judge panel
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleOverlay.vue`
+
+**Context:** BattleOverlay.vue currently subscribes to battle topics when `isSmoke=true` AND renders the judge panel for both modes. Chart.vue now owns all smoke WebSocket logic, so BattleOverlay must stop competing. Two changes needed:
+
+1. In `onMounted`, guard the smoke subscription block: delete it (Chart.vue handles this now)
+2. On the judge panel `v-if`, add `&& !isSmoke` so the panel is hidden in smoke mode
+
+- [ ] **Step 1: Remove the isSmoke subscription block from onMounted**
+
+Find this block in `BES-frontend/src/views/BattleOverlay.vue` (around line 255):
+
+```js
+  if (isSmoke.value) {
+    battleJudges.value = await getBattleJudges()
+    const cJudges = createClient(); clients.push(cJudges)
+    const cPair   = createClient(); clients.push(cPair)
+    const cScore  = createClient(); clients.push(cScore)
+    subscribeToChannel(cJudges, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
+    subscribeToChannel(cPair,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
+    subscribeToChannel(cScore,  '/topic/battle/score',       (msg) => updateScore(msg))
+  } else {
+    battleJudges.value = await getBattleJudges()
+    const res = await getCurrentBattlePair()
+    if (res) await updateBattlePair(res)
+    const cPair2   = createClient(); clients.push(cPair2)
+    const cScore2  = createClient(); clients.push(cScore2)
+    const cJudges2 = createClient(); clients.push(cJudges2)
+    subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
+    subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => updateScore(msg))
+    subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
+  }
+```
+
+Replace the entire if/else block with a guard so subscriptions only happen in standard mode:
+
+```js
+  if (!isSmoke.value) {
+    battleJudges.value = await getBattleJudges()
+    const res = await getCurrentBattlePair()
+    if (res) await updateBattlePair(res)
+    const cPair2   = createClient(); clients.push(cPair2)
+    const cScore2  = createClient(); clients.push(cScore2)
+    const cJudges2 = createClient(); clients.push(cJudges2)
+    subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
+    subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => updateScore(msg))
+    subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
+  }
+```
+
+(Chart.vue handles all smoke-mode subscriptions — BattleOverlay must not duplicate them.)
+
+- [ ] **Step 2: Guard the judge panel with !isSmoke**
+
+Find the judge panel `v-if` in the template (around line 316):
+
+```html
+    <div
+      v-if="battleJudges?.judges?.length"
+      class="judge-panel"
+```
+
+Change to:
+
+```html
+    <div
+      v-if="battleJudges?.judges?.length && !isSmoke"
+      class="judge-panel"
+```
+
+- [ ] **Step 3: Build to verify no errors**
+
+```bash
+cd BES-frontend && npm run build
+```
+Expected: build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleOverlay.vue
+git commit -m "fix: remove duplicate smoke WS subscriptions and judge panel from BattleOverlay smoke mode"
+```
+
+---
+
+## Task 4: Final verification
+
+**Files:** Read-only
+
+- [ ] **Step 1: Run all frontend tests**
+
+```bash
+cd BES-frontend && npm test
+```
+Expected: all tests pass including the new smokeChartHelpers tests
+
+- [ ] **Step 2: Manual smoke test with Docker**
+
+```bash
+docker-compose up --build --no-cache
+```
+
+Steps to verify:
+1. Log in as Admin/Organiser, go to `/battle/control`, start a 7-to-Smoke format event
+2. Open `/battle/chart` in a second tab — should see the dark overlay with "7 TO SMOKE" header, bar columns for each participant
+3. Active pair shows colored (red/blue) bars; waiting fighters show gray bars
+4. VS chip appears between active columns; floating pill at bottom shows "NAME VS NAME · X PTS · Y PTS"
+5. In BattleControl, announce a winner — result overlay should appear on `/battle/chart` with winner name slamming in + judge cards
+6. Announce another match — result overlay auto-dismisses after 4 seconds
+7. When a fighter reaches 7 points — champion overlay appears and stays
+8. Open `/battle/overlay?isSmoke=true` — same chart view without BattleOverlay's old judge panel competing
+
+- [ ] **Step 3: Commit if any minor fixes were made during testing**
+
+```bash
+git add -p  # review carefully, stage only what was changed
+git commit -m "fix: smoke overlay manual test adjustments"
+```
+
+---
+
+## Notes for the Implementer
+
+**TransitionGroup FLIP:** Vue's `<TransitionGroup>` handles FLIP automatically when you give each item a stable `:key` (fighter name) and define `.col-move` with a transition. No manual `getBoundingClientRect` needed — Vue does it.
+
+**Score pop timing:** The `setTimeout` in the watch is 600ms — matches the `scorePop` animation duration. After 600ms the class is removed. If the score changes again while the animation is still running, a new Set is created so the class is removed for the old instance and re-applied for the new one.
+
+**Champion detection:** `updateScore` checks for any participant with `score >= 7` _at the time the score event arrives_. The server sends the updated scores, so by the time `updateScore` fires, `smokeParticipants` should reflect the new scores from the preceding smoke update. If timing is tight, a brief `nextTick` wait may be needed before checking.
+
+**Transparent background:** Both Chart.vue (standalone at `/battle/chart`) and BattleOverlay.vue (at `/battle/overlay`) add `transparent-page` to the HTML root for OBS. Chart.vue's `onBeforeUnmount` removes these classes, which is safe since BattleOverlay.vue's `onUnmounted` also removes them.
+
+**overlayConfig.leftColor vs leftColor:** The API returns `{ leftColor, rightColor }` and WS sends the same shape. BattleOverlay.vue uses `overlayConfig.leftColor` in `:style` binding. Chart.vue uses the same shape. Be consistent.

--- a/docs/superpowers/plans/2026-05-27-battle-overlay-improvements.md
+++ b/docs/superpowers/plans/2026-05-27-battle-overlay-improvements.md
@@ -1,0 +1,1910 @@
+# BattleOverlay Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a live overlay-config WebSocket channel (colors + image toggle), overhaul the 1v1 overlay UI to use custom team colors and angular design, and replace all animations with hard-impact underground-aesthetic keyframes.
+
+**Architecture:** A new `overlay-config` topic carries `{ showImages, leftColor, rightColor }` from BattleControl → BattleOverlay via WebSocket, persisted in-memory in BattleService (same pattern as `battlePhase`). BattleOverlay.vue is fully rewritten: both panels use left-only positioning so winner centering works from either side, votes are hidden until score is revealed, and every animation uses hard-attack bezier curves. Smoke mode (`isSmoke=true`) is untouched throughout.
+
+**Tech Stack:** Spring Boot (BattleService/BattleController), Flyway migration, Vue 3 `<script setup>`, STOMP WebSocket, CSS keyframe animations
+
+---
+
+### Task 1: DB Migration V17
+
+**Files:**
+- Create: `BES/src/main/resources/db/migration/V17__add_overlay_config.sql`
+
+- [ ] **Step 1: Create migration file**
+
+```sql
+ALTER TABLE event
+  ADD COLUMN overlay_config JSONB DEFAULT '{"showImages": true, "leftColor": "#dc2626", "rightColor": "#2563eb"}';
+```
+
+- [ ] **Step 2: Verify no existing V17 file conflicts**
+
+Run: `ls BES/src/main/resources/db/migration/`
+Expected: `V16__add_pickup_crew.sql` is the latest; no V17 exists.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/resources/db/migration/V17__add_overlay_config.sql
+git commit -m "feat: add overlay_config JSONB column to event table (V17)"
+```
+
+---
+
+### Task 2: DTO — SetOverlayConfigDto
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java`
+
+- [ ] **Step 1: Create the DTO**
+
+```java
+package com.example.BES.dtos.battle;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class SetOverlayConfigDto {
+
+    @NotNull
+    private Boolean showImages;
+
+    @NotNull
+    @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "leftColor must be a valid 6-digit hex color")
+    private String leftColor;
+
+    @NotNull
+    @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "rightColor must be a valid 6-digit hex color")
+    private String rightColor;
+
+    public Boolean isShowImages() { return showImages; }
+    public String getLeftColor()  { return leftColor; }
+    public String getRightColor() { return rightColor; }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java
+git commit -m "feat: add SetOverlayConfigDto with hex color validation"
+```
+
+---
+
+### Task 3: BattleService — overlay config in-memory
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/BattleService.java`
+
+The service already holds `battlePhase`, `currentPair`, etc. in memory. `overlayConfig` follows the same pattern.
+
+- [ ] **Step 1: Add field and import to BattleService**
+
+At the top of the class, after the existing `private String battlePhase = "IDLE";` field (line 36), add:
+
+```java
+import java.util.HashMap;
+```
+
+Add to imports section at top of file (after existing imports).
+
+Then add field after `private String battlePhase = "IDLE";`:
+
+```java
+private Map<String, Object> overlayConfig = new HashMap<>(Map.of(
+    "showImages", true,
+    "leftColor",  "#dc2626",
+    "rightColor", "#2563eb"
+));
+```
+
+- [ ] **Step 2: Add getOverlayConfig and setOverlayConfigService methods**
+
+Add these two methods after `getBattlePhase()` / `setBattlePhaseService()`:
+
+```java
+public Map<String, Object> getOverlayConfig() {
+    return overlayConfig;
+}
+
+public void setOverlayConfigService(SetOverlayConfigDto dto) {
+    overlayConfig = new HashMap<>();
+    overlayConfig.put("showImages", dto.isShowImages());
+    overlayConfig.put("leftColor",  dto.getLeftColor());
+    overlayConfig.put("rightColor", dto.getRightColor());
+    messagingTemplate.convertAndSend("/topic/battle/overlay-config", overlayConfig);
+}
+```
+
+Add the import for `SetOverlayConfigDto` in the imports section:
+
+```java
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
+```
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run: `cd BES && mvn compile -q`
+Expected: BUILD SUCCESS with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/BattleService.java
+git commit -m "feat: add overlay config in-memory state and WS broadcast to BattleService"
+```
+
+---
+
+### Task 4: BattleController — overlay config endpoints
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/controllers/BattleController.java`
+
+- [ ] **Step 1: Add import for SetOverlayConfigDto**
+
+In the imports section of `BattleController.java` (alongside existing `battle` dto imports):
+
+```java
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
+```
+
+- [ ] **Step 2: Add two new endpoints**
+
+Add after the existing `@PostMapping("/bracket")` endpoint (before the closing `}`):
+
+```java
+@GetMapping("/overlay-config")
+public ResponseEntity<?> getOverlayConfig() {
+    return ResponseEntity.ok(battleService.getOverlayConfig());
+}
+
+@PostMapping("/overlay-config")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> setOverlayConfig(@Valid @RequestBody SetOverlayConfigDto dto) {
+    battleService.setOverlayConfigService(dto);
+    return ResponseEntity.ok(battleService.getOverlayConfig());
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd BES && mvn compile -q`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/controllers/BattleController.java
+git commit -m "feat: add GET/POST /api/v1/battle/overlay-config endpoints"
+```
+
+---
+
+### Task 5: BattleService unit tests — overlay config
+
+**Files:**
+- Modify: `BES/src/test/java/com/example/BES/services/BattleServiceTest.java`
+
+The existing test class uses `@ExtendWith(MockitoExtension.class)` with `@InjectMocks BattleService service`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these test methods to `BattleServiceTest.java` (after the existing `setBattlePhase_setsVOTING` test):
+
+```java
+@Test
+void getOverlayConfig_returnsDefaults() {
+    Map<String, Object> config = service.getOverlayConfig();
+    assertThat(config.get("showImages")).isEqualTo(true);
+    assertThat(config.get("leftColor")).isEqualTo("#dc2626");
+    assertThat(config.get("rightColor")).isEqualTo("#2563eb");
+}
+
+@Test
+void setOverlayConfigService_updatesInMemoryState() {
+    SetOverlayConfigDto dto = mock(SetOverlayConfigDto.class);
+    when(dto.isShowImages()).thenReturn(false);
+    when(dto.getLeftColor()).thenReturn("#ff0000");
+    when(dto.getRightColor()).thenReturn("#0000ff");
+
+    service.setOverlayConfigService(dto);
+
+    Map<String, Object> config = service.getOverlayConfig();
+    assertThat(config.get("showImages")).isEqualTo(false);
+    assertThat(config.get("leftColor")).isEqualTo("#ff0000");
+    assertThat(config.get("rightColor")).isEqualTo("#0000ff");
+}
+
+@Test
+void setOverlayConfigService_broadcastsToWebSocket() {
+    SetOverlayConfigDto dto = mock(SetOverlayConfigDto.class);
+    when(dto.isShowImages()).thenReturn(true);
+    when(dto.getLeftColor()).thenReturn("#aabbcc");
+    when(dto.getRightColor()).thenReturn("#112233");
+
+    service.setOverlayConfigService(dto);
+
+    verify(messagingTemplate).convertAndSend(
+        eq("/topic/battle/overlay-config"),
+        any(Map.class)
+    );
+}
+```
+
+Add the missing import to the test file:
+
+```java
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
+import java.util.Map;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd BES && mvn test -Dtest=BattleServiceTest -q`
+Expected: 3 new test failures (methods not implemented yet — but actually Task 3 already implemented them, so these should pass).
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd BES && mvn test -Dtest=BattleServiceTest`
+Expected: All tests PASS including the 3 new ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+git commit -m "test: add overlay config unit tests for BattleService"
+```
+
+---
+
+### Task 6: BattleControllerIntegrationTest — overlay config endpoints
+
+**Files:**
+- Modify: `BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java`
+
+The existing test class uses `@SpringBootTest + @AutoConfigureMockMvc + @ActiveProfiles("test")` with a real `BattleService` bean and a mocked `SimpMessagingTemplate`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these test methods to `BattleControllerIntegrationTest.java`:
+
+```java
+@Test
+@WithMockUser
+public void testGetOverlayConfig_returnsDefaults() throws Exception {
+    mockMvc.perform(get("/api/v1/battle/overlay-config"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.showImages").value(true))
+            .andExpect(jsonPath("$.leftColor").value("#dc2626"))
+            .andExpect(jsonPath("$.rightColor").value("#2563eb"));
+}
+
+@Test
+@WithMockUser(roles = "ORGANISER")
+public void testSetOverlayConfig_updatesAndReturns() throws Exception {
+    String body = "{\"showImages\":false,\"leftColor\":\"#ff0000\",\"rightColor\":\"#0000ff\"}";
+
+    mockMvc.perform(post("/api/v1/battle/overlay-config")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.showImages").value(false))
+            .andExpect(jsonPath("$.leftColor").value("#ff0000"))
+            .andExpect(jsonPath("$.rightColor").value("#0000ff"));
+}
+
+@Test
+@WithMockUser(roles = "ORGANISER")
+public void testSetOverlayConfig_rejectsInvalidHexColor() throws Exception {
+    String body = "{\"showImages\":true,\"leftColor\":\"notacolor\",\"rightColor\":\"#2563eb\"}";
+
+    mockMvc.perform(post("/api/v1/battle/overlay-config")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().isBadRequest());
+}
+
+@Test
+public void testSetOverlayConfig_requiresAuth() throws Exception {
+    String body = "{\"showImages\":true,\"leftColor\":\"#dc2626\",\"rightColor\":\"#2563eb\"}";
+
+    mockMvc.perform(post("/api/v1/battle/overlay-config")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().is4xxClientError());
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd BES && mvn test -Dtest=BattleControllerIntegrationTest -q`
+Expected: All tests PASS (endpoints were implemented in Task 4).
+
+- [ ] **Step 3: Run full backend test suite to catch regressions**
+
+Run: `cd BES && mvn test`
+Expected: BUILD SUCCESS, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java
+git commit -m "test: add integration tests for overlay-config endpoints"
+```
+
+---
+
+### Task 7: Frontend API — overlay config functions
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js`
+- Modify: `BES-frontend/src/utils/__tests__/api.test.js`
+
+- [ ] **Step 1: Write the failing tests first**
+
+Add to `BES-frontend/src/utils/__tests__/api.test.js`, inside the main `describe('api.js', ...)` block:
+
+```js
+describe('getOverlayConfig', () => {
+  it('calls /api/v1/battle/overlay-config with GET', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }),
+    })
+
+    const result = await api.getOverlayConfig()
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/battle/overlay-config', {
+      credentials: 'include',
+    })
+    expect(result.showImages).toBe(true)
+  })
+
+  it('returns fallback defaults on fetch error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network error'))
+
+    const result = await api.getOverlayConfig()
+
+    expect(result).toEqual({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+  })
+})
+
+describe('setOverlayConfig', () => {
+  it('calls /api/v1/battle/overlay-config with POST and JSON body', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true })
+
+    await api.setOverlayConfig({ showImages: false, leftColor: '#ff0000', rightColor: '#0000ff' })
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/battle/overlay-config', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ showImages: false, leftColor: '#ff0000', rightColor: '#0000ff' }),
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to see them fail**
+
+Run: `cd BES-frontend && npm test -- --reporter=verbose 2>&1 | grep -A2 "getOverlayConfig\|setOverlayConfig"`
+Expected: FAIL — `api.getOverlayConfig is not a function`
+
+- [ ] **Step 3: Add the two functions to api.js**
+
+Add at the end of `BES-frontend/src/utils/api.js`:
+
+```js
+export const getOverlayConfig = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/overlay-config`, {
+      credentials: 'include',
+    })
+    return res.ok ? await res.json() : { showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }
+  } catch (err) {
+    console.log(err)
+    return { showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }
+  }
+}
+
+export const setOverlayConfig = async (config) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/overlay-config`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(config),
+    })
+  } catch (err) {
+    console.log(err)
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd BES-frontend && npm test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js BES-frontend/src/utils/__tests__/api.test.js
+git commit -m "feat: add getOverlayConfig and setOverlayConfig API functions"
+```
+
+---
+
+### Task 8: BattleControl.vue — Overlay settings panel
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue`
+
+Add a compact, collapsible "Overlay" settings panel with left/right color pickers and an image toggle. Color changes broadcast on the `change` event (not `input`) to avoid flooding.
+
+- [ ] **Step 1: Add imports and refs**
+
+In the `<script setup>` section, add `getOverlayConfig` and `setOverlayConfig` to the existing api import line:
+
+```js
+import { addBattleJudge, battleJudgeVote, getAllJudges, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
+```
+
+Add the new ref after the existing `const showResetConfirm = ref(false)` line:
+
+```js
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+```
+
+- [ ] **Step 2: Load initial config in onMounted**
+
+In the existing `onMounted` block, add near the top (alongside other initial fetches):
+
+```js
+const savedConfig = await getOverlayConfig()
+if (savedConfig?.showImages !== undefined) overlayConfig.value = savedConfig
+```
+
+- [ ] **Step 3: Add pushOverlayConfig helper**
+
+Add after the `overlayConfig` ref declaration:
+
+```js
+const pushOverlayConfig = async () => {
+  await setOverlayConfig(overlayConfig.value)
+}
+```
+
+- [ ] **Step 4: Add Overlay panel to template**
+
+Find the section in the template that contains the judge assignment controls (the area with `addBattleJudge`/`removeBattleJudge` buttons). Add the following panel directly after that section:
+
+```html
+<!-- Overlay Settings -->
+<details class="overlay-settings-panel">
+  <summary class="overlay-settings-summary">Overlay Settings</summary>
+  <div class="overlay-settings-body">
+    <div class="overlay-setting-row">
+      <span class="overlay-setting-label">Left Color</span>
+      <div class="overlay-color-group">
+        <input
+          type="color"
+          v-model="overlayConfig.leftColor"
+          @change="pushOverlayConfig"
+          class="overlay-color-swatch"
+          title="Left team color"
+        />
+        <input
+          type="text"
+          v-model="overlayConfig.leftColor"
+          @change="pushOverlayConfig"
+          maxlength="7"
+          placeholder="#dc2626"
+          class="overlay-hex-input"
+        />
+      </div>
+    </div>
+    <div class="overlay-setting-row">
+      <span class="overlay-setting-label">Right Color</span>
+      <div class="overlay-color-group">
+        <input
+          type="color"
+          v-model="overlayConfig.rightColor"
+          @change="pushOverlayConfig"
+          class="overlay-color-swatch"
+          title="Right team color"
+        />
+        <input
+          type="text"
+          v-model="overlayConfig.rightColor"
+          @change="pushOverlayConfig"
+          maxlength="7"
+          placeholder="#2563eb"
+          class="overlay-hex-input"
+        />
+      </div>
+    </div>
+    <div class="overlay-setting-row">
+      <span class="overlay-setting-label">Show Images</span>
+      <label class="overlay-toggle">
+        <input
+          type="checkbox"
+          v-model="overlayConfig.showImages"
+          @change="pushOverlayConfig"
+        />
+        <span class="overlay-toggle-track"></span>
+      </label>
+    </div>
+  </div>
+</details>
+```
+
+- [ ] **Step 5: Add scoped styles for the overlay panel**
+
+Add to the `<style scoped>` section of `BattleControl.vue`:
+
+```css
+.overlay-settings-panel {
+  background: #1a1a1a;
+  border: 1px solid #2c2c2c;
+  border-radius: 12px;
+  margin-top: 12px;
+  overflow: hidden;
+}
+.overlay-settings-summary {
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #f0f0f0;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+.overlay-settings-summary::-webkit-details-marker { display: none; }
+.overlay-settings-body {
+  padding: 4px 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.overlay-setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.overlay-setting-label {
+  font-size: 13px;
+  color: rgba(240,240,240,0.65);
+}
+.overlay-color-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.overlay-color-swatch {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 0;
+  background: none;
+}
+.overlay-hex-input {
+  width: 80px;
+  background: #111;
+  border: 1px solid #2c2c2c;
+  border-radius: 6px;
+  color: #f0f0f0;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', monospace;
+  padding: 4px 8px;
+}
+.overlay-toggle { display: flex; align-items: center; cursor: pointer; }
+.overlay-toggle input { display: none; }
+.overlay-toggle-track {
+  width: 36px;
+  height: 20px;
+  background: #2c2c2c;
+  border-radius: 10px;
+  position: relative;
+  transition: background 0.2s;
+}
+.overlay-toggle input:checked + .overlay-toggle-track { background: #e53935; }
+.overlay-toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+.overlay-toggle input:checked + .overlay-toggle-track::after { transform: translateX(16px); }
+```
+
+- [ ] **Step 6: Verify dev server starts without errors**
+
+Run: `cd BES-frontend && npm run dev`
+Expected: Server starts; navigate to `/battle/control` and confirm the Overlay Settings panel appears and is functional.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: add Overlay Settings panel to BattleControl (colors + image toggle)"
+```
+
+---
+
+### Task 9: BattleOverlay.vue — complete rewrite
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleOverlay.vue`
+
+This is a full replacement of the script, template, and style sections. The smoke mode (`isSmoke=true`) section is preserved exactly. The standard mode (`isSmoke=false`) gets the new UI, animations, and overlay config.
+
+**Key changes from current:**
+- Right panel: `right: 0` → `left: 54%; width: 46%` (fixes winner centering for right-side winners)
+- Judge votes hidden during voting (`votesVisible` ref); revealed all at once on score
+- `/topic/battle/phase` VOTING → `showVotingIndicator` wired up (currently empty callback)
+- New `/topic/battle/overlay-config` subscription + initial GET fetch
+- All animation keyframes replaced with hard-attack bezier curves
+- CSS custom properties `--left-color` / `--right-color` drive all color treatments
+- Judge cards: parallelogram `clip-path`, frosted glass when unvoted
+- Picture mode: `aspect-ratio: 3/4` portrait, name overlaid at bottom
+- Name-only mode: giant vertically-centered Anton SC names
+
+- [ ] **Step 1: Write a smoke test for BattleOverlay**
+
+Create `BES-frontend/src/views/__tests__/BattleOverlay.test.js`:
+
+```js
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createWebHistory } from 'vue-router'
+
+// Mock heavy dependencies
+vi.mock('@/utils/api', () => ({
+  getBattleJudges: vi.fn().mockResolvedValue({ judges: [] }),
+  getCurrentBattlePair: vi.fn().mockResolvedValue(null),
+  getImage: vi.fn().mockResolvedValue(null),
+  getOverlayConfig: vi.fn().mockResolvedValue({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }),
+}))
+vi.mock('@/utils/websocket', () => ({
+  createClient: vi.fn().mockReturnValue({ value: null }),
+  deactivateClient: vi.fn(),
+  subscribeToChannel: vi.fn(),
+}))
+vi.mock('./Chart.vue', () => ({ default: { template: '<div />' } }))
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [{ path: '/battle/overlay', component: { template: '<div />' } }],
+})
+
+// Dynamically import after mocks are set up
+const BattleOverlay = (await import('../BattleOverlay.vue')).default
+
+describe('BattleOverlay.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.documentElement.classList.remove('transparent-page')
+  })
+
+  it('mounts without errors', async () => {
+    const wrapper = mount(BattleOverlay, {
+      global: { plugins: [router] },
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('adds transparent-page class to html on mount', async () => {
+    mount(BattleOverlay, { global: { plugins: [router] } })
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.documentElement.classList.contains('transparent-page')).toBe(true)
+  })
+
+  it('initializes overlayConfig with defaults', async () => {
+    const wrapper = mount(BattleOverlay, { global: { plugins: [router] } })
+    // The root element should have CSS custom property bindings
+    expect(wrapper.find('.overlay-root').exists()).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the smoke test to see it fail (BattleOverlay not yet rewritten)**
+
+Run: `cd BES-frontend && npm test -- src/views/__tests__/BattleOverlay.test.js`
+Expected: At least one test fails (the current BattleOverlay won't have getOverlayConfig imported).
+
+- [ ] **Step 3: Rewrite BattleOverlay.vue — script section**
+
+Replace the entire `<script setup>` section with:
+
+```vue
+<script setup>
+import { getBattleJudges, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
+import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket';
+import { computed, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useDelay } from '@/utils/utils';
+import { useRoute } from 'vue-router'
+import Chart from './Chart.vue';
+
+const route = useRoute()
+
+// ── Overlay config (live from BattleControl + API) ─────────────────────────
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+
+// ── Battle state ───────────────────────────────────────────────────────────
+const imageLeft  = ref(null)
+const imageRight = ref(null)
+
+let client = createClient()
+const subscribedTopics = new Set()
+const rightName  = ref('')
+const leftName   = ref('')
+const leftScore  = ref(0)
+const rightScore = ref(0)
+const currentWinner = ref(-2)
+const battleJudges  = ref([])
+
+// Judge panel visibility: true = off-screen (idle/battle), false = visible (score revealed)
+const hideJudgeDecision = ref(true)
+
+// ── Voting state ───────────────────────────────────────────────────────────
+// showVotingIndicator: true when /topic/battle/phase emits VOTING
+const showVotingIndicator = ref(false)
+// votesVisible: false until score is revealed — hides vote state on judge cards
+const votesVisible = ref(false)
+
+// ── Animation state (standard mode only) ──────────────────────────────────
+// judgeAnim: '' | 'slide-down' | 'slide-up' (also used for smoke mode panel)
+const judgeAnim = ref('')
+// leftWin / rightWin: winner-expand CSS class trigger
+const leftWin  = ref(false)
+const rightWin = ref(false)
+// leftReset / rightReset: loser/winner exit animation trigger
+const leftReset  = ref(false)
+const rightReset = ref(false)
+// vsAnim: '' | 'rush-in' | 'knock-left' | 'knock-right'
+const vsAnim = ref('')
+// stageShaking: brief shake burst on VS landing (~340ms into entrance)
+const stageShaking = ref(false)
+// winnerTagVisible: WINNER stamp appears after winner is determined
+const winnerTagVisible = ref(false)
+// glitching: glitch overlay during next-pair transition
+const glitching = ref(false)
+
+const isSmoke = computed(() => route.query.isSmoke === 'true')
+
+const judgePanelClass = computed(() => {
+  if (isSmoke.value) return 'smoke-judge-always-on'
+  return judgeAnim.value
+})
+
+// ── Entrance animation ─────────────────────────────────────────────────────
+const runEntrance = async () => {
+  await useDelay().wait(50) // allow DOM to clear previous animation classes
+  hideJudgeDecision.value = true
+  vsAnim.value = 'rush-in'
+  await useDelay().wait(340) // VS hits undershoot trough at ~340ms
+  stageShaking.value = true
+  await useDelay().wait(120)
+  stageShaking.value = false
+}
+
+// ── Battle pair update ─────────────────────────────────────────────────────
+const updateBattlePair = async (msg) => {
+  if (!msg) return
+
+  // SMOKE MODE: only wipe judge votes, keep panel on screen
+  if (isSmoke.value) {
+    if (battleJudges.value?.judges) {
+      battleJudges.value = {
+        ...battleJudges.value,
+        judges: battleJudges.value.judges.map(j => ({ ...j, vote: -3 }))
+      }
+    }
+    return
+  }
+
+  // STANDARD MODE: if a winner is currently showing, run exit sequence first
+  if (!hideJudgeDecision.value) {
+    glitching.value = true
+    judgeAnim.value = 'slide-up'
+    await useDelay().wait(100)
+
+    if (currentWinner.value === 0) {
+      leftReset.value = true
+    } else if (currentWinner.value === 1) {
+      rightReset.value = true
+    } else {
+      leftReset.value  = true
+      rightReset.value = true
+    }
+    vsAnim.value = ''
+
+    await useDelay().wait(280)
+    glitching.value          = false
+    hideJudgeDecision.value  = true
+    judgeAnim.value          = ''
+    votesVisible.value       = false
+    winnerTagVisible.value   = false
+    await useDelay().wait(50)
+    leftReset.value  = false
+    rightReset.value = false
+  }
+
+  // Reset all state before new pair
+  leftWin.value          = false
+  rightWin.value         = false
+  currentWinner.value    = -2
+  vsAnim.value           = ''
+  showVotingIndicator.value = false
+  votesVisible.value     = false
+  winnerTagVisible.value = false
+
+  leftName.value   = msg.left
+  rightName.value  = msg.right
+  leftScore.value  = msg.leftScore  ?? 0
+  rightScore.value = msg.rightScore ?? 0
+  imageLeft.value  = await getImage(`${msg.left}.png`)
+  imageRight.value = await getImage(`${msg.right}.png`)
+
+  await runEntrance()
+}
+
+// ── Judge list update ──────────────────────────────────────────────────────
+const updateBattleJudge = (msg) => {
+  battleJudges.value = msg
+  battleJudges.value.judges.forEach(j => {
+    const topic = `/topic/battle/vote/${j.id}`
+    if (!subscribedTopics.has(topic)) {
+      subscribedTopics.add(topic)
+      subscribeToChannel(createClient(), topic, (m) => updateJudgeVote(m))
+    }
+  })
+}
+
+// ── Judge vote update (internal only — hidden until score reveal) ──────────
+const updateJudgeVote = (msg) => {
+  const updatedJudges = battleJudges.value.judges.map(j =>
+    j.id === msg.judge ? { ...j, vote: msg.vote } : j
+  )
+  battleJudges.value = { ...battleJudges.value, judges: updatedJudges }
+}
+
+watch(battleJudges, (newVal) => {
+  if (!newVal?.judges) return
+  newVal.judges.forEach(j => {
+    const topic = `/topic/battle/vote/${j.id}`
+    if (!subscribedTopics.has(topic)) {
+      subscribedTopics.add(topic)
+      subscribeToChannel(createClient(), topic, (m) => updateJudgeVote(m))
+    }
+  })
+}, { deep: true })
+
+// ── Score reveal ───────────────────────────────────────────────────────────
+const updateScore = async (msg) => {
+  judgeAnim.value          = 'slide-down'
+  hideJudgeDecision.value  = false
+  showVotingIndicator.value = false
+  rightScore.value = msg.right
+  leftScore.value  = msg.left
+
+  // Reveal votes shortly after panel starts dropping
+  await useDelay().wait(200)
+  votesVisible.value = true
+
+  // Winner determination after cards have burst in
+  await useDelay().wait(800)
+  currentWinner.value = msg.message
+
+  if (msg.message === 0) {
+    // Left wins: VS rockets right (toward loser), left panel expands
+    leftWin.value          = true
+    winnerTagVisible.value = true
+    vsAnim.value           = 'knock-right'
+    await useDelay().wait(100)
+    rightReset.value = true   // right (loser) hard-cuts off screen
+  } else if (msg.message === 1) {
+    // Right wins: VS rockets left (toward loser), right panel expands
+    rightWin.value         = true
+    winnerTagVisible.value = true
+    vsAnim.value           = 'knock-left'
+    await useDelay().wait(100)
+    leftReset.value = true    // left (loser) hard-cuts off screen
+  }
+  // msg.message === -1: tie — no winner state, panels stay
+}
+
+// ── Mount ──────────────────────────────────────────────────────────────────
+onMounted(async () => {
+  document.documentElement.classList.add('transparent-page')
+  document.body.classList.add('transparent-page')
+
+  // Fetch initial overlay config (survives OBS refresh)
+  const config = await getOverlayConfig()
+  if (config?.showImages !== undefined) overlayConfig.value = config
+
+  // Live overlay config updates from BattleControl
+  subscribeToChannel(createClient(), '/topic/battle/overlay-config', (msg) => {
+    if (msg?.showImages !== undefined) overlayConfig.value = msg
+  })
+
+  // Phase subscription: VOTING phase shows the voting indicator
+  subscribeToChannel(createClient(), '/topic/battle/phase', (msg) => {
+    showVotingIndicator.value = msg?.phase === 'VOTING'
+  })
+
+  if (isSmoke.value) {
+    battleJudges.value = await getBattleJudges()
+    subscribeToChannel(createClient(), '/topic/battle/judges',     (msg) => updateBattleJudge(msg))
+    subscribeToChannel(createClient(), '/topic/battle/battle-pair',(msg) => updateBattlePair(msg))
+    subscribeToChannel(createClient(), '/topic/battle/score',      (msg) => updateScore(msg))
+  } else {
+    battleJudges.value = await getBattleJudges()
+    const res = await getCurrentBattlePair()
+    if (res) await updateBattlePair(res)
+    subscribeToChannel(createClient(), '/topic/battle/battle-pair',(msg) => updateBattlePair(msg))
+    subscribeToChannel(createClient(), '/topic/battle/score',      (msg) => updateScore(msg))
+    subscribeToChannel(createClient(), '/topic/battle/judges',     (msg) => updateBattleJudge(msg))
+  }
+})
+
+onBeforeUnmount(() => { deactivateClient(client.value) })
+
+onUnmounted(() => {
+  document.documentElement.classList.remove('transparent-page')
+  document.body.classList.remove('transparent-page')
+  const appRoot = document.getElementById('app')
+  if (appRoot) appRoot.style.background = ''
+})
+</script>
+```
+
+- [ ] **Step 4: Rewrite BattleOverlay.vue — template section**
+
+Replace the entire `<template>` section with:
+
+```vue
+<template>
+  <div
+    class="overlay-root"
+    :class="{ 'stage-shake': stageShaking }"
+    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
+  >
+    <!-- Screen-reader live region -->
+    <div class="sr-only" role="status" aria-live="assertive" aria-atomic="true">
+      <template v-if="currentWinner === 0">{{ leftName }} wins!</template>
+      <template v-else-if="currentWinner === 1">{{ rightName }} wins!</template>
+      <template v-else-if="currentWinner === -1">Tie between {{ leftName }} and {{ rightName }}!</template>
+    </div>
+
+    <!-- Glitch transition overlay -->
+    <div v-if="glitching" class="glitch-overlay" aria-hidden="true"></div>
+
+    <!-- Structural decorators — standard mode only -->
+    <template v-if="!isSmoke">
+      <div class="center-divider" aria-hidden="true"></div>
+      <div class="scanlines"      aria-hidden="true"></div>
+      <div class="color-bleed color-bleed-left"  aria-hidden="true"></div>
+      <div class="color-bleed color-bleed-right" aria-hidden="true"></div>
+    </template>
+
+    <!-- ══════════════════════════════════════════════════
+         JUDGE PANEL — shared across both modes
+    ═══════════════════════════════════════════════════ -->
+    <div
+      v-if="battleJudges?.judges?.length"
+      class="judge-panel"
+      :class="judgePanelClass"
+      role="region"
+      aria-label="Judges"
+      aria-live="polite"
+      aria-atomic="false"
+    >
+      <div class="judge-border-glow" aria-hidden="true"></div>
+      <div class="judge-inner">
+        <div class="judges-header" aria-hidden="true">
+          <span class="judges-line"></span>
+          <span class="judges-label">JUDGES</span>
+          <span class="judges-line"></span>
+        </div>
+        <div class="judge-cards-row" role="list">
+          <div
+            v-for="(j, index) in battleJudges.judges"
+            :key="index"
+            class="judge-card"
+            role="listitem"
+            :aria-label="`${j.name}: ${j.vote === 0 ? 'voted left' : j.vote === 1 ? 'voted right' : j.vote === -1 ? 'voted tie' : 'awaiting vote'}`"
+            :class="{
+              'voted-left':   votesVisible && j.vote === 0,
+              'voted-right':  votesVisible && j.vote === 1,
+              'voted-tie':    votesVisible && j.vote === -1,
+              'card-unvoted': !votesVisible,
+              'card-burst':    votesVisible,
+            }"
+            :style="votesVisible ? { animationDelay: `${index * 55}ms` } : {}"
+          >
+            <div class="judge-row">
+              <span
+                class="vote-arrow vote-arrow-left"
+                :class="{ 'arrow-lit-left': votesVisible && j.vote === 0 }"
+                aria-hidden="true"
+              ></span>
+              <span class="judge-name">{{ j.name }}</span>
+              <span
+                class="vote-arrow vote-arrow-right"
+                :class="{ 'arrow-lit-right': votesVisible && j.vote === 1 }"
+                aria-hidden="true"
+              ></span>
+            </div>
+            <div class="vote-track" aria-hidden="true">
+              <div
+                class="vote-fill"
+                :class="{
+                  'fill-left':  votesVisible && j.vote === 0,
+                  'fill-right': votesVisible && j.vote === 1,
+                  'fill-tie':   votesVisible && j.vote === -1,
+                  'fill-blank': !votesVisible || j.vote === -3 || j.vote === null,
+                }"
+              ></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════════════════
+         STANDARD BATTLE  (isSmoke = false)
+    ═══════════════════════════════════════════════════ -->
+    <template v-if="!isSmoke">
+
+      <!-- Left battler panel -->
+      <div
+        class="battler-panel left-panel"
+        :class="{
+          'slam-in-left':   hideJudgeDecision,
+          'slide-left-out': leftReset,
+          'panel-winner':   leftWin,
+        }"
+        role="region"
+        :aria-label="`Left: ${leftName || 'TBD'}${leftScore > 0 ? ', score ' + leftScore : ''}${leftWin ? ' — winner' : ''}`"
+      >
+        <div class="panel-color-wash panel-color-wash-left" aria-hidden="true"></div>
+
+        <!-- Picture mode -->
+        <template v-if="overlayConfig.showImages">
+          <img v-if="imageLeft" :src="imageLeft" :alt="leftName" class="battler-img" />
+          <div v-else class="battler-placeholder" aria-hidden="true"></div>
+          <div class="name-overlay">
+            <span class="name-text name-text-left">{{ leftName || '???' }}</span>
+            <span v-if="leftScore > 0" class="score-badge">{{ leftScore }}</span>
+          </div>
+        </template>
+
+        <!-- Name-only mode -->
+        <template v-else>
+          <div class="name-center-wrap">
+            <span class="name-giant name-giant-left">{{ leftName || '???' }}</span>
+            <span v-if="leftScore > 0" class="score-badge-large">{{ leftScore }}</span>
+          </div>
+        </template>
+
+        <div class="corner-accent corner-accent-tl" aria-hidden="true"></div>
+        <div class="bottom-edge bottom-edge-left"   aria-hidden="true"></div>
+        <div v-if="winnerTagVisible && leftWin" class="winner-tag" aria-hidden="true">WINNER</div>
+      </div>
+
+      <!-- VS badge -->
+      <div
+        class="vs-badge"
+        :class="[vsAnim, { 'vs-gone': currentWinner !== -2 && vsAnim !== 'knock-left' && vsAnim !== 'knock-right' }]"
+        aria-hidden="true"
+      >
+        <span class="vs-text">VS</span>
+      </div>
+
+      <!-- Right battler panel -->
+      <div
+        class="battler-panel right-panel"
+        :class="{
+          'slam-in-right':   hideJudgeDecision,
+          'slide-right-out': rightReset,
+          'panel-winner':    rightWin,
+        }"
+        role="region"
+        :aria-label="`Right: ${rightName || 'TBD'}${rightScore > 0 ? ', score ' + rightScore : ''}${rightWin ? ' — winner' : ''}`"
+      >
+        <div class="panel-color-wash panel-color-wash-right" aria-hidden="true"></div>
+
+        <!-- Picture mode -->
+        <template v-if="overlayConfig.showImages">
+          <img v-if="imageRight" :src="imageRight" :alt="rightName" class="battler-img" />
+          <div v-else class="battler-placeholder" aria-hidden="true"></div>
+          <div class="name-overlay name-overlay-right">
+            <span class="name-text name-text-right">{{ rightName || '???' }}</span>
+            <span v-if="rightScore > 0" class="score-badge">{{ rightScore }}</span>
+          </div>
+        </template>
+
+        <!-- Name-only mode -->
+        <template v-else>
+          <div class="name-center-wrap">
+            <span class="name-giant name-giant-right">{{ rightName || '???' }}</span>
+            <span v-if="rightScore > 0" class="score-badge-large">{{ rightScore }}</span>
+          </div>
+        </template>
+
+        <div class="corner-accent corner-accent-tr" aria-hidden="true"></div>
+        <div class="bottom-edge bottom-edge-right"  aria-hidden="true"></div>
+        <div v-if="winnerTagVisible && rightWin" class="winner-tag" aria-hidden="true">WINNER</div>
+      </div>
+
+      <!-- Voting indicator — visible during VOTING phase -->
+      <transition name="fade-indicator">
+        <div v-if="showVotingIndicator" class="voting-indicator" aria-label="Judges are voting">
+          <span class="voting-dot" aria-hidden="true"></span>
+          <span class="voting-label">JUDGES VOTING</span>
+        </div>
+      </transition>
+
+    </template>
+
+    <!-- ══════════════════════════════════════════════════
+         SMOKE MODE  (isSmoke = true)
+    ═══════════════════════════════════════════════════ -->
+    <template v-else>
+      <Chart />
+    </template>
+
+  </div>
+</template>
+```
+
+- [ ] **Step 5: Rewrite BattleOverlay.vue — style section**
+
+Replace the entire `<style>` section with:
+
+```vue
+<style>
+/* ── Screen-reader only ─────────────────────────────────────── */
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0;
+  margin: -1px; overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+
+/* ── Transparent background (OBS) ──────────────────────────── */
+html.transparent-page,
+body.transparent-page,
+html.transparent-page #app,
+body.transparent-page #app {
+  background: transparent !important;
+  background-color: transparent !important;
+}
+
+/* ── Root ───────────────────────────────────────────────────── */
+.overlay-root {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw; height: 100vh;
+  overflow: hidden;
+  font-family: 'Anton SC', sans-serif;
+  /* Default CSS custom properties — overridden by :style binding */
+  --left-color: #dc2626;
+  --right-color: #2563eb;
+}
+
+/* ── Stage shake ────────────────────────────────────────────── */
+.stage-shake {
+  animation: stageShake 120ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+
+/* ── Glitch overlay ─────────────────────────────────────────── */
+.glitch-overlay {
+  position: absolute; inset: 0;
+  z-index: 100;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent, transparent 4px,
+    rgba(255,255,255,0.04) 4px, rgba(255,255,255,0.04) 8px
+  );
+  animation: glitchFlicker 380ms steps(1) forwards;
+}
+
+/* ── Center divider ─────────────────────────────────────────── */
+.center-divider {
+  position: absolute;
+  top: 0; bottom: 0;
+  left: calc(50% - 1px);
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgba(255,255,255,0.12) 30%,
+    rgba(255,255,255,0.22) 50%,
+    rgba(255,255,255,0.12) 70%,
+    transparent 100%
+  );
+  transform: skewX(-3deg);
+  z-index: 5;
+  pointer-events: none;
+}
+
+/* ── Scanlines ──────────────────────────────────────────────── */
+.scanlines {
+  position: absolute; inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px, transparent 3px,
+    rgba(0,0,0,0.035) 3px, rgba(0,0,0,0.035) 4px
+  );
+}
+
+/* ── Global color bleeds ────────────────────────────────────── */
+.color-bleed {
+  position: absolute; inset: 0;
+  pointer-events: none; z-index: 1;
+}
+.color-bleed-left {
+  background: radial-gradient(
+    ellipse 45% 55% at 0% 100%,
+    color-mix(in srgb, var(--left-color) 16%, transparent),
+    transparent 70%
+  );
+}
+.color-bleed-right {
+  background: radial-gradient(
+    ellipse 45% 55% at 100% 100%,
+    color-mix(in srgb, var(--right-color) 16%, transparent),
+    transparent 70%
+  );
+}
+
+/* ══════════════════════════════════════════════════
+   JUDGE PANEL
+══════════════════════════════════════════════════ */
+.judge-panel {
+  position: absolute;
+  top: 18px; left: 0; right: 0;
+  z-index: 50;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  transform: translateY(-220px);
+}
+.smoke-judge-always-on {
+  transform: translateY(0) !important;
+  animation: none !important;
+}
+.judge-border-glow {
+  position: absolute; inset: -1px;
+  border-radius: 22px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--left-color) 55%, transparent) 0%,
+    rgba(255,255,255,0.1) 35%,
+    color-mix(in srgb, var(--right-color) 55%, transparent) 65%,
+    rgba(255,255,255,0.1) 100%
+  );
+  filter: blur(1px);
+  animation: borderRotate 6s linear infinite;
+  z-index: -1;
+}
+.judge-inner {
+  position: relative;
+  display: flex; flex-direction: column; gap: 10px;
+  background: rgba(6,8,18,0.85);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  border-radius: 20px;
+  padding: 14px 24px 16px;
+}
+.judges-header {
+  display: flex; align-items: center; gap: 10px;
+}
+.judges-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.28em;
+  color: rgba(255,255,255,0.35);
+  text-transform: uppercase;
+  white-space: nowrap; flex-shrink: 0;
+}
+.judges-line {
+  flex: 1; height: 1px;
+  background: rgba(255,255,255,0.1);
+}
+.judge-cards-row {
+  display: flex; gap: 12px;
+}
+
+/* Judge card — parallelogram shape */
+.judge-card {
+  display: flex; flex-direction: column;
+  align-items: center; gap: 10px;
+  min-width: 148px;
+  padding: 10px 14px;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  border: 1.5px solid rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.025);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+/* Unvoted: frosted glass with gentle pulse */
+.card-unvoted {
+  background: rgba(255,255,255,0.08) !important;
+  border-color: rgba(255,255,255,0.18) !important;
+  animation: cardPulse 2.2s ease-in-out infinite;
+}
+
+/* Burst in when votes are revealed */
+.card-burst {
+  animation: cardBurst 280ms cubic-bezier(0.2, 0, 0.3, 1) both;
+}
+
+.voted-left {
+  border-color: color-mix(in srgb, var(--left-color) 65%, transparent);
+  background: color-mix(in srgb, var(--left-color) 9%, transparent);
+  box-shadow: 0 0 28px color-mix(in srgb, var(--left-color) 35%, transparent),
+              inset 0 0 14px color-mix(in srgb, var(--left-color) 8%, transparent);
+}
+.voted-right {
+  border-color: color-mix(in srgb, var(--right-color) 65%, transparent);
+  background: color-mix(in srgb, var(--right-color) 9%, transparent);
+  box-shadow: 0 0 28px color-mix(in srgb, var(--right-color) 35%, transparent),
+              inset 0 0 14px color-mix(in srgb, var(--right-color) 8%, transparent);
+}
+.voted-tie {
+  border-color: rgba(251,191,36,0.65);
+  background: rgba(251,191,36,0.07);
+  box-shadow: 0 0 28px rgba(251,191,36,0.28), inset 0 0 14px rgba(251,191,36,0.06);
+}
+
+/* Judge name + arrow row */
+.judge-row { display: flex; align-items: center; gap: 11px; }
+.judge-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 28px;
+  color: rgba(255,255,255,0.92);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+/* Direction arrows */
+.vote-arrow {
+  display: inline-block;
+  width: 18px; height: 18px; flex-shrink: 0;
+  background: rgba(255,255,255,0.15);
+  opacity: 0.2;
+  transition: opacity 0.2s ease, background 0.2s ease, filter 0.2s ease;
+}
+.vote-arrow-left  { clip-path: polygon(100% 0%, 0% 50%, 100% 100%); }
+.vote-arrow-right { clip-path: polygon(0% 0%, 100% 50%, 0% 100%); }
+.arrow-lit-left {
+  opacity: 1;
+  background: var(--left-color);
+  filter: drop-shadow(0 0 8px var(--left-color));
+}
+.arrow-lit-right {
+  opacity: 1;
+  background: var(--right-color);
+  filter: drop-shadow(0 0 8px var(--right-color));
+}
+
+/* Vote track bar */
+.vote-track {
+  width: 100%; height: 10px;
+  background: rgba(255,255,255,0.1);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+.vote-fill {
+  height: 100%;
+  border-radius: 9999px;
+  transition: background 0.25s ease, width 0.25s ease;
+  width: 0%;
+}
+.fill-left  {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--left-color) 70%, black), var(--left-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--left-color) 90%, transparent);
+}
+.fill-right {
+  width: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--right-color) 70%, black), var(--right-color));
+  box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 90%, transparent);
+}
+.fill-tie   { width: 100%; background: linear-gradient(90deg, #b45309, #fbbf24); box-shadow: 0 0 14px rgba(251,191,36,0.9); }
+.fill-blank { width: 0%; background: transparent; }
+
+/* ══════════════════════════════════════════════════
+   BATTLER PANELS
+   Both panels use left-only positioning so winner
+   centering (left:0, width:100%) works from either side.
+══════════════════════════════════════════════════ */
+.battler-panel {
+  position: absolute;
+  bottom: 0;
+  height: 100vh;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: flex-end;
+  /* CSS transition for winner expand */
+  transition: left 420ms cubic-bezier(0.2, 0, 0.3, 1),
+              width 420ms cubic-bezier(0.2, 0, 0.3, 1);
+}
+.left-panel  { left: 0;    width: 46%; }
+.right-panel { left: 54%;  width: 46%; }
+
+/* Winner: both panels expand to full width from left:0 */
+.panel-winner { left: 0 !important; width: 100% !important; }
+
+/* Panel color wash (gradient overlay) */
+.panel-color-wash {
+  position: absolute; inset: 0;
+  pointer-events: none; z-index: 0;
+}
+.panel-color-wash-left {
+  background: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--left-color) 55%, black) 0%,
+    color-mix(in srgb, var(--left-color) 15%, transparent) 40%,
+    transparent 70%
+  );
+}
+.panel-color-wash-right {
+  background: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--right-color) 55%, black) 0%,
+    color-mix(in srgb, var(--right-color) 15%, transparent) 40%,
+    transparent 70%
+  );
+}
+
+/* Corner accent bars (3px vertical, fade down in team color) */
+.corner-accent {
+  position: absolute; top: 0;
+  width: 3px; height: 28%;
+  pointer-events: none; z-index: 3;
+}
+.corner-accent-tl { left: 0;  background: linear-gradient(to bottom, var(--left-color), transparent); }
+.corner-accent-tr { right: 0; background: linear-gradient(to bottom, var(--right-color), transparent); }
+
+/* Bottom edge lines (3px horizontal, fade inward) */
+.bottom-edge {
+  position: absolute; bottom: 0;
+  height: 3px; width: 40%;
+  pointer-events: none; z-index: 3;
+}
+.bottom-edge-left  { left: 0;  background: linear-gradient(to right, var(--left-color), transparent); }
+.bottom-edge-right { right: 0; background: linear-gradient(to left, var(--right-color), transparent); }
+
+/* ── Picture mode ────────────────────────────────── */
+.battler-img {
+  position: relative; z-index: 10;
+  width: 100%;
+  aspect-ratio: 3/4;
+  object-fit: cover;
+  object-position: top;
+  max-height: 85vh;
+  display: block;
+}
+.battler-placeholder {
+  position: relative; z-index: 10;
+  width: 12vw; height: 30vh;
+  margin-bottom: 8vh;
+  border-radius: 8px;
+  border: 1.5px dashed rgba(255,255,255,0.18);
+  background: rgba(255,255,255,0.03);
+  animation: placeholderBreath 3s ease-in-out infinite;
+}
+.name-overlay {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  z-index: 20;
+  padding: 5vh 1.5vw 2vh;
+  background: linear-gradient(to top, rgba(0,0,0,0.80) 0%, transparent 100%);
+  display: flex; align-items: flex-end; gap: 10px;
+}
+.name-overlay-right { flex-direction: row-reverse; }
+.name-text {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(18px, 3vw, 52px);
+  text-transform: uppercase;
+  color: #fff;
+  line-height: 1; letter-spacing: 0.07em;
+}
+.name-text-left {
+  text-shadow: 3px 3px 0 var(--left-color),
+               0 0 30px color-mix(in srgb, var(--left-color) 60%, transparent);
+}
+.name-text-right {
+  text-shadow: -3px 3px 0 var(--right-color),
+               0 0 30px color-mix(in srgb, var(--right-color) 60%, transparent);
+}
+
+/* ── Name-only mode ──────────────────────────────── */
+.name-center-wrap {
+  position: absolute;
+  top: 50%; transform: translateY(-50%);
+  z-index: 20;
+  width: 90%;
+  display: flex; flex-direction: column;
+  align-items: center; gap: 14px;
+  padding: 0 8px;
+}
+.name-giant {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(28px, 5.5vw, 90px);
+  text-transform: uppercase;
+  color: #fff;
+  line-height: 1; letter-spacing: 0.06em;
+  word-break: break-word; text-align: center;
+}
+.name-giant-left {
+  text-shadow: 4px 4px 0 var(--left-color),
+               0 0 50px color-mix(in srgb, var(--left-color) 50%, transparent);
+}
+.name-giant-right {
+  text-shadow: -4px 4px 0 var(--right-color),
+               0 0 50px color-mix(in srgb, var(--right-color) 50%, transparent);
+}
+
+/* Score badges */
+.score-badge {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(12px, 1.6vw, 28px);
+  line-height: 1;
+  color: rgba(255,255,255,0.92);
+  background: rgba(255,255,255,0.15);
+  border: 1px solid rgba(255,255,255,0.25);
+  border-radius: 6px;
+  padding: 2px 8px;
+  letter-spacing: 0.05em;
+}
+.score-badge-large {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(16px, 2.5vw, 42px);
+  color: rgba(255,255,255,0.6);
+  letter-spacing: 0.05em;
+}
+
+/* ── VS badge ────────────────────────────────────── */
+.vs-badge {
+  position: absolute;
+  bottom: 2.5vh;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+}
+.vs-text {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(24px, 4.2vw, 72px);
+  color: rgba(255,255,255,0.88);
+  letter-spacing: 0.14em;
+  text-shadow: 0 0 40px rgba(255,255,255,0.25);
+  clip-path: polygon(10% 0%, 90% 0%, 100% 50%, 90% 100%, 10% 100%, 0% 50%);
+  background: rgba(0,0,0,0.25);
+  padding: 4px 22px 4px 18px;
+  display: block;
+}
+.vs-gone { display: none; }
+
+/* ── Voting indicator ────────────────────────────── */
+.voting-indicator {
+  position: absolute;
+  bottom: 2vh; left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: flex; align-items: center; gap: 8px;
+}
+.voting-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: #ef4444;
+  animation: votingPulse 1.2s ease-in-out infinite;
+}
+.voting-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.2em;
+  color: rgba(255,255,255,0.45);
+  text-transform: uppercase;
+}
+/* Fade transition for voting indicator */
+.fade-indicator-enter-active,
+.fade-indicator-leave-active { transition: opacity 0.3s ease; }
+.fade-indicator-enter-from,
+.fade-indicator-leave-to     { opacity: 0; }
+
+/* ── Winner tag ──────────────────────────────────── */
+.winner-tag {
+  position: absolute;
+  top: 40%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 60;
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(18px, 3.2vw, 58px);
+  color: #fff;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border: 3px solid rgba(255,255,255,0.8);
+  padding: 8px 28px;
+  background: rgba(0,0,0,0.45);
+  animation: winnerStamp 300ms cubic-bezier(0.2, 0, 0.3, 1) both;
+  animation-delay: 300ms;
+  opacity: 0;
+}
+
+/* ══════════════════════════════════════════════════
+   KEYFRAMES
+══════════════════════════════════════════════════ */
+
+/* Stage shake on VS landing */
+@keyframes stageShake {
+  0%   { transform: translate(0,    0);  }
+  15%  { transform: translate(-4px, 3px); }
+  30%  { transform: translate(5px, -2px); }
+  45%  { transform: translate(-3px, 4px); }
+  60%  { transform: translate(4px, -3px); }
+  75%  { transform: translate(-2px, 2px); }
+  100% { transform: translate(0,    0);  }
+}
+
+/* Glitch flicker during next-pair transition */
+@keyframes glitchFlicker {
+  0%   { opacity: 1;   clip-path: inset(0% 0 0% 0); transform: skewX(0); }
+  12%  { opacity: 0;   }
+  25%  { opacity: 1;   clip-path: inset(20% 0 30% 0); transform: skewX(2deg); }
+  37%  { opacity: 0.7; }
+  50%  { opacity: 1;   clip-path: inset(55% 0 5% 0);  transform: skewX(-1deg) translateX(3px); }
+  62%  { opacity: 0.4; }
+  75%  { opacity: 1;   clip-path: inset(10% 0 78% 0); transform: skewX(3deg); }
+  87%  { opacity: 0.8; }
+  100% { opacity: 0;   }
+}
+
+/* Left panel slams in from left edge */
+@keyframes leftSlamIn {
+  0%   { transform: translateX(-72vw); }
+  82%  { transform: translateX(3px); }
+  100% { transform: translateX(0); }
+}
+
+/* Right panel slams in from right edge */
+@keyframes rightSlamIn {
+  0%   { transform: translateX(72vw); }
+  82%  { transform: translateX(-3px); }
+  100% { transform: translateX(0); }
+}
+
+/* VS rushes in from in-front-of-camera (scale 6→0.72→1.10→1) */
+@keyframes vsRushIn {
+  0%   { transform: translateX(-50%) scale(6);    opacity: 0.5; }
+  55%  { transform: translateX(-50%) scale(0.72); opacity: 1;   }
+  75%  { transform: translateX(-50%) scale(1.10); }
+  100% { transform: translateX(-50%) scale(1);    }
+}
+
+/* VS rockets toward right (left wins — loser is right) */
+@keyframes vsKnockRight {
+  0%   { transform: translateX(-50%) scale(1);    opacity: 1; }
+  18%  { transform: translateX(-50%) scale(1.25); }
+  100% { transform: translateX(80vw) scale(0.3) rotate(55deg); opacity: 0; }
+}
+
+/* VS rockets toward left (right wins — loser is left) */
+@keyframes vsKnockLeft {
+  0%   { transform: translateX(-50%) scale(1);    opacity: 1; }
+  18%  { transform: translateX(-50%) scale(1.25); }
+  100% { transform: translateX(-130vw) scale(0.3) rotate(-55deg); opacity: 0; }
+}
+
+/* Loser hard-cuts off left edge */
+@keyframes hardCutLeft {
+  0%   { transform: translateX(0);      opacity: 1; }
+  100% { transform: translateX(-110vw); opacity: 0; }
+}
+
+/* Loser hard-cuts off right edge */
+@keyframes hardCutRight {
+  0%   { transform: translateX(0);     opacity: 1; }
+  100% { transform: translateX(110vw); opacity: 0; }
+}
+
+/* Judge panel slams down (bounce easing applied via class) */
+@keyframes slideDown {
+  from { transform: translateY(-220px); }
+  to   { transform: translateY(0); }
+}
+@keyframes slideUp {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-220px); }
+}
+
+/* Card burst entrance on score reveal */
+@keyframes cardBurst {
+  0%   { transform: scale(1.4) skewX(-5deg); opacity: 0; }
+  65%  { transform: scale(0.97) skewX(0);   opacity: 1; }
+  100% { transform: scale(1) skewX(0);      opacity: 1; }
+}
+
+/* Unvoted card pulse */
+@keyframes cardPulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.58; }
+}
+
+/* Voting dot pulse */
+@keyframes votingPulse {
+  0%, 100% { transform: scale(1);   opacity: 1; }
+  50%       { transform: scale(1.6); opacity: 0.4; }
+}
+
+/* WINNER stamp */
+@keyframes winnerStamp {
+  0%   { transform: translate(-50%, -50%) scale(2.8); opacity: 0; }
+  60%  { transform: translate(-50%, -50%) scale(0.94); opacity: 1; }
+  100% { transform: translate(-50%, -50%) scale(1);    opacity: 1; }
+}
+
+/* Placeholder breathing */
+@keyframes placeholderBreath {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.5; }
+}
+
+/* Judge border rotation */
+@keyframes borderRotate {
+  0%   { filter: blur(1px) hue-rotate(0deg); }
+  100% { filter: blur(1px) hue-rotate(360deg); }
+}
+
+/* ── Animation utility classes ───────────────────── */
+.slam-in-left  { animation: leftSlamIn  450ms cubic-bezier(0.2, 0, 0.3, 1) both; }
+.slam-in-right { animation: rightSlamIn 450ms cubic-bezier(0.2, 0, 0.3, 1) both; }
+
+.rush-in      { animation: vsRushIn    520ms cubic-bezier(0.12, 0, 0.2, 1) both; }
+.knock-right  { animation: vsKnockRight 380ms cubic-bezier(0.55, 0, 1, 0.45) forwards; }
+.knock-left   { animation: vsKnockLeft  380ms cubic-bezier(0.55, 0, 1, 0.45) forwards; }
+
+.slide-left-out  { animation: hardCutLeft  320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
+.slide-right-out { animation: hardCutRight 320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
+
+.slide-down { animation: slideDown 480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
+.slide-up   { animation: slideUp   300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
+</style>
+```
+
+- [ ] **Step 6: Run the smoke tests**
+
+Run: `cd BES-frontend && npm test -- src/views/__tests__/BattleOverlay.test.js`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 7: Run full frontend test suite**
+
+Run: `cd BES-frontend && npm test`
+Expected: All tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleOverlay.vue BES-frontend/src/views/__tests__/BattleOverlay.test.js
+git commit -m "feat: rewrite BattleOverlay — new UI, angular design, hard-impact animations, overlay config, voting indicator"
+```
+
+---
+
+### Task 10: Manual verification
+
+- [ ] **Step 1: Start both services**
+
+```bash
+# Terminal 1 (backend)
+cd BES && mvn spring-boot:run
+
+# Terminal 2 (frontend)
+cd BES-frontend && npm run dev
+```
+
+- [ ] **Step 2: Verify overlay config endpoint**
+
+Visit `http://localhost:5050/api/v1/battle/overlay-config` in browser.
+Expected: `{"showImages":true,"leftColor":"#dc2626","rightColor":"#2563eb"}`
+
+- [ ] **Step 3: Verify OBS overlay at `/battle/overlay`**
+
+Open `http://localhost:5173/battle/overlay` in browser.
+Expected:
+- Page background is transparent (checkerboard visible if using OBS browser source simulator)
+- Both panels are positioned correctly (left 46%, right from 54%)
+- No panel visible until a battle pair is set
+
+- [ ] **Step 4: End-to-end battle flow**
+
+1. Log in as organiser, navigate to `/battle/control`
+2. Set up a battle pair → `initiateBattlePair` fires
+3. Overlay: both name panels slam in from edges, VS rushes in from front, stage shakes at ~340ms
+4. Click "Open Voting" → overlay shows pulsing red dot + "JUDGES VOTING" text; judge panel stays off-screen
+5. Submit judge votes → votes stored internally, nothing visible on overlay
+6. Click "Get Score" → judge panel slams down, vote cards burst in (staggered 55ms), winner expands, loser hard-cuts off screen
+7. VS rockets off toward loser side with 55° spin
+8. WINNER tag stamps in
+9. Click "Next" → glitch overlay fires, panels exit, new entrance sequence
+
+- [ ] **Step 5: Verify overlay config panel in BattleControl**
+
+In BattleControl, open "Overlay Settings", change left color to `#00ff00`.
+Expected: Overlay at `/battle/overlay` immediately reflects the new color on both panels, color bleeds, fill bars, and glow effects.
+
+- [ ] **Step 6: Verify picture/no-picture toggle**
+
+Toggle "Show Images" off in BattleControl.
+Expected: Overlay switches to giant Anton SC names centered on each half, with team-color text shadows.
+Toggle back on.
+Expected: Overlay returns to portrait-image layout.
+
+- [ ] **Step 7: Commit final**
+
+```bash
+git add .
+git commit -m "chore: manual verification complete"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] §1 Architecture — Unified Overlay Config: Tasks 1–7 implement the full GET/POST/WS stack
+- [x] §1 Overlay panel in BattleControl: Task 8
+- [x] §2 UI Design — CSS custom properties, left-only panel positioning: Task 9 CSS
+- [x] §2 No-picture mode (giant Anton SC, vertically centered): Task 9 template + CSS
+- [x] §2 Picture mode (3/4 portrait, name overlaid at bottom): Task 9 template + CSS
+- [x] §2 Structural elements (divider, corner bars, bottom edges, color bleeds, scanlines): Task 9 CSS
+- [x] §2 Judge cards (parallelogram clip-path, frosted glass unvoted, color-variable glow): Task 9 CSS
+- [x] §3 Animation: Entrance (slam-in + VS rush-in + stage shake): Task 9 script + CSS
+- [x] §3 Animation: Voting indicator wired to `/topic/battle/phase` VOTING: Task 9 script
+- [x] §3 Animation: Score reveal (panel drop + card burst stagger): Task 9 script + CSS
+- [x] §3 Animation: Winner expansion + loser hard-cut + VS knock-off: Task 9 script + CSS
+- [x] §3 Animation: Glitch cut + reset + new entrance: Task 9 script + CSS
+- [x] §3 Judge votes hidden during voting, `votesVisible` only true after score: Task 9 script
+- [x] §4 Smoke mode untouched: Task 9 template preserves `<template v-else><Chart /></template>`
+- [x] §5 DB Migration V17: Task 1
+
+**Type/name consistency check:**
+- `votesVisible` — used in script (Task 9) and template (Task 9): ✓
+- `showVotingIndicator` — used in script (Task 9) and template (Task 9): ✓
+- `vsAnim` values: `'rush-in'`, `'knock-left'`, `'knock-right'` — match CSS classes `.rush-in`, `.knock-left`, `.knock-right`: ✓
+- `slam-in-left` / `slam-in-right` — CSS class names match template `:class` bindings: ✓
+- `slide-left-out` / `slide-right-out` — CSS class names match template `:class` bindings for `leftReset` / `rightReset`: ✓
+- `getOverlayConfig` / `setOverlayConfig` — imported in api.js (Task 7) and used in BattleControl (Task 8) and BattleOverlay (Task 9): ✓
+- `SetOverlayConfigDto` — created Task 2, imported in BattleController Task 4, tested Task 5: ✓
+- `card-unvoted` CSS class — defined in style (Task 9), applied in template when `!votesVisible`: ✓
+- `card-burst` CSS class — defined in style (Task 9), applied in template when `votesVisible`: ✓

--- a/docs/superpowers/specs/2026-05-27-7-to-smoke-overlay-redesign.md
+++ b/docs/superpowers/specs/2026-05-27-7-to-smoke-overlay-redesign.md
@@ -1,0 +1,237 @@
+# 7-to-Smoke Overlay Redesign
+
+## Goal
+
+Redesign the 7-to-Smoke overlay (`Chart.vue` / `BattleOverlay.vue` smoke mode) to match the boldness and visual style of the existing 1v1 battle overlay — same fonts, color system, judge card UI, and animation language.
+
+---
+
+## Scope
+
+Two files are involved:
+- `BES-frontend/src/views/Chart.vue` — the `/battle/chart` public view (OBS source or projector)
+- `BES-frontend/src/views/BattleOverlay.vue` — the smoke-mode section within the 1v1 overlay (conditionally rendered when `overlayMode === 'smoke'`)
+
+Both share the same visual design. The implementation lives primarily in `Chart.vue`.
+
+---
+
+## Design Decisions
+
+### Layout
+
+**Option C — Floating pill.** No separate bottom strip. A frosted-glass pill is absolutely positioned at the bottom-center of the chart area. It shows `LEFT NAME VS RIGHT NAME · X PTS · Y PTS`. The chart fills the full height.
+
+### Bar Chart
+
+- One vertical bar per participant, growing from the bottom.
+- Bar height = `(points / 7) * 100%` of the bar-wrap height.
+- **Active left** (position 0 in queue): red gradient using `--left-color`; glow box-shadow.
+- **Active right** (position 1 in queue): blue gradient using `--right-color`; glow box-shadow.
+- **Waiting** (all others): neutral gray `#181818 → #2a2a2a`, no glow.
+- VS chip between the active pair columns.
+- Gap/spacer between active pair and rest of queue.
+- 7 score dots per fighter beneath the bar; filled dot = point earned. Active dots use team color, waiting dots use muted white.
+- Name label below dots. Active names use team color with glow-only text-shadow `0 0 12px color-mix(in srgb, var(--color) 80%, transparent)`. No hard pixel shadow at this size.
+
+### Floating Pill
+
+```
+[ VIBRAZE  VS  KRAZIX  ·  3 PTS · 4 PTS ]
+```
+
+- `position: absolute; bottom: 10px; left: 50%; transform: translateX(-50%)`
+- `background: rgba(0,0,0,0.65); backdrop-filter: blur(10px); border-radius: 99px`
+- Names use `--left-color` / `--right-color` mix
+- Anton SC font for names and VS; Inter for PTS label
+
+### Color System
+
+Identical to the existing 1v1 overlay. CSS custom properties on the overlay root:
+
+```css
+--left-color: #dc2626;   /* default red */
+--right-color: #2563eb;  /* default blue */
+```
+
+Driven by `overlayConfig` from `BattleControl.vue` via WebSocket (same mechanism as 1v1).
+
+### Queue Order
+
+Left-to-right column order mirrors `rounds` array from BattleControl. Index 0 = active left, index 1 = active right, index 2+ = waiting queue in order.
+
+### Terminology
+
+- UI text: "PTS" not "SMOKE" (e.g. `3 PTS · 4 PTS`, `TAKES THE POINT`)
+- Format name stays "7 TO SMOKE" in the header badge
+
+---
+
+## Animations
+
+### FLIP Sliding (queue reorder)
+
+When a match ends and the queue shifts, columns slide to their new positions instead of teleporting:
+
+1. Snapshot `getBoundingClientRect().left` for every `.col` before DOM update.
+2. Re-render at new positions with `transition: none`.
+3. `requestAnimationFrame` → apply inverse `translateX` to each col (so they appear to still be in old position).
+4. Second `requestAnimationFrame` → clear inline transform with `transition: transform 0.55s cubic-bezier(0.4,0,0.2,1)`. Columns animate to new positions.
+
+### Score Pop (point gained)
+
+When a fighter's score increases, their bar plays a bounce + brightness flash:
+
+```css
+@keyframes scorePop {
+  0%   { transform: scaleY(1) scaleX(1); filter: brightness(1); }
+  18%  { transform: scaleY(1.07) scaleX(1.04); filter: brightness(2.5); }
+  38%  { transform: scaleY(0.96) scaleX(1.02); filter: brightness(1.5); }
+  58%  { transform: scaleY(1.02) scaleX(1.01); filter: brightness(1.1); }
+  100% { transform: scaleY(1) scaleX(1); filter: brightness(1); }
+}
+```
+
+A radial glow burst (`glowBurst` keyframe) also radiates from the bar top using the team color.
+
+### Bar Height Transition
+
+`transition: height 0.6s cubic-bezier(0.22, 1, 0.36, 1)` on `.bar`. Score pop animation fires after height transition.
+
+---
+
+## Result Overlay
+
+Shown after the organiser announces the result (`REVEALED` phase). Displayed over the chart.
+
+### Win
+
+```
+[ VIBRAZE ]          (large Anton SC, team color, hard shadow 4px 4px 0 var(--color) + glow)
+TAKES THE POINT      (subtitle, muted)
+
+[ Judge cards ]
+```
+
+### Tie
+
+```
+IT'S A TIE           (large Anton SC, white)
+BOTH EARN A POINT    (subtitle)
+
+[ Judge cards — tie style ]
+```
+
+### Judge Card Container
+
+Matches 1v1 `BattleOverlay.vue` exactly:
+
+```css
+.judge-inner {
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--left-color) 12%, rgba(6,8,18,0.94)),
+    color-mix(in srgb, var(--right-color) 12%, rgba(6,8,18,0.94))
+  );
+  backdrop-filter: blur(24px);
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.12);
+  box-shadow: 0 24px 80px rgba(0,0,0,0.75), 0 0 0 1px rgba(255,255,255,0.04) inset;
+  padding: 10px 20px 14px;
+}
+```
+
+### Judge Card (per judge)
+
+Parallelogram shape via `clip-path`:
+
+```css
+clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%);
+```
+
+- Voted left: red tint, red border glow
+- Voted right: blue tint, blue border glow
+- Tie: neutral, no arrows, just dimmed name + `TIE` badge
+
+### Vote Track Bar
+
+Single gradient bar (not pips) showing vote split:
+
+```css
+.vote-track { height: 10px; background: rgba(255,255,255,0.1); border-radius: 9999px; }
+.fill-left  { background: linear-gradient(90deg, color-mix(in srgb, var(--left-color) 70%, black), var(--left-color)); }
+.fill-right { background: linear-gradient(90deg, color-mix(in srgb, var(--right-color) 70%, black), var(--right-color)); }
+```
+
+### Direction Arrows
+
+```css
+.vote-arrow-left  { clip-path: polygon(100% 0%, 0% 50%, 100% 100%); }
+.vote-arrow-right { clip-path: polygon(0% 0%, 100% 50%, 0% 100%); }
+```
+
+Lit arrow uses team color + `filter: drop-shadow(0 0 8px var(--color))`.
+
+### Judge Card Entrance Animation
+
+Judge container slams onto screen at 120% scale, then springs to 100% (matching the 1v1 VS chip entrance). After a pause, scales down and moves to the top of the screen.
+
+### Auto-dismiss
+
+Result overlay auto-dismisses after ~4 seconds (same as 1v1).
+
+---
+
+## Champion Overlay
+
+When any fighter reaches 7 points, a full-screen takeover replaces the normal result overlay.
+
+```
+[ FIGHTER NAME ]     (champSlam animation — scale in from 2.5x, spring to 1x)
+7 TO SMOKE CHAMPION  (subtitle fades in after name)
+```
+
+Background: radial glow burst using `--champ-color` (winner's team color).
+
+```css
+@keyframes champSlam {
+  0%   { transform: scale(2.5) translateY(-20px); opacity: 0; filter: blur(12px); }
+  55%  { transform: scale(0.96) translateY(0);   opacity: 1; filter: blur(0); }
+  72%  { transform: scale(1.04); }
+  85%  { transform: scale(0.99); }
+  100% { transform: scale(1); }
+}
+```
+
+This does NOT auto-dismiss — it persists until the organiser transitions away.
+
+---
+
+## Queue Logic (reference — already correct in BattleControl.vue)
+
+- **Left wins**: winner stays at position 0, loser moves to end of queue.
+- **Right wins**: winner moves to position 0, loser moves to end.
+- **Tie**: both go to end of queue, next two take over. No score change.
+
+Champion check runs after every score update: `if (score >= 7) → showChampion()`.
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `BES-frontend/src/views/Chart.vue` | Full redesign — new bar chart layout, FLIP animation, score pop, result overlay, champion overlay |
+| `BES-frontend/src/views/BattleOverlay.vue` | Smoke mode section: swap old UI for new `<SmokeChart>` component (or inline) |
+
+If Chart.vue grows large, extract reusable pieces:
+- `SmokeBarChart.vue` — the bar chart + floating pill
+- `SmokeResultOverlay.vue` — win/tie result overlay
+- `SmokeChampionOverlay.vue` — champion takeover
+
+---
+
+## Out of Scope
+
+- Backend changes (none needed — uses existing WebSocket state)
+- BattleControl.vue logic changes (queue/tie logic is already correct)
+- New API endpoints

--- a/docs/superpowers/specs/2026-05-27-battle-overlay-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-27-battle-overlay-improvements-design.md
@@ -1,0 +1,142 @@
+# BattleOverlay Improvements — Design Spec
+_Date: 2026-05-27_
+
+## Overview
+
+Three improvements to `BES-frontend/src/views/BattleOverlay.vue` for the 1v1 standard battle mode:
+
+1. **Picture toggle** — organiser can switch between image mode and name-focus mode live
+2. **Animation overhaul** — underground/street aesthetic: hard cuts, physical impacts, no smooth easing
+3. **UI redesign** — customizable colors, angular design language, transparent-aware layout
+
+---
+
+## 1. Architecture — Unified Overlay Config (Approach A)
+
+A single new WebSocket topic carries all overlay settings from BattleControl to the overlay.
+
+**New WebSocket topic:** `/topic/battle/overlay-config`
+
+**Payload:**
+```json
+{
+  "showImages": true,
+  "leftColor": "#dc2626",
+  "rightColor": "#2563eb"
+}
+```
+
+**Backend changes:**
+- New endpoint: `POST /api/v1/battle/overlay-config` — accepts the payload, broadcasts to `/topic/battle/overlay-config`, persists to DB
+- New `overlay_config` JSONB column on `Event` table (see migration V17 in §5) — config survives OBS browser source refresh
+- New `GET /api/v1/battle/overlay-config` — overlay fetches current config on mount (scoped to active event)
+
+**BattleControl changes:**
+- New "Overlay" settings panel (compact, collapsible) with:
+  - Left color picker + hex input
+  - Right color picker + hex input
+  - Show Images toggle (on/off)
+- Color changes broadcast on `change` event (not on every keypress) to avoid flooding WebSocket
+
+**BattleOverlay changes:**
+- Subscribe to `/topic/battle/overlay-config` on mount
+- Fetch initial config via `GET` on mount
+- Apply `--left-color` and `--right-color` as CSS custom properties on the root element
+- Reactively switch between picture mode and name mode based on `showImages`
+
+---
+
+## 2. UI Design
+
+### Layout system
+- **Both panels** use `left`-only positioning internally (`left:0; width:46%` and `left:54%; width:46%`) — not `right:0` — so winner centering animations work correctly from either side
+- **CSS custom properties** on `.overlay-root`: `--left-color` and `--right-color` drive all color treatments
+- **Transparent background**: existing `transparent-page` class preserved; checkerboard only visible in dev/mockup
+
+### Structural elements (both modes)
+| Element | Description |
+|---------|-------------|
+| Diagonal slash divider | Thin skewed line at center, subtle white glow gradient |
+| Corner accent bars | 3px vertical bars top-left and top-right, fade downward in respective team color |
+| Bottom edge lines | 3px horizontal lines at bottom corners, fade inward in respective team color |
+| Color bleeds | Soft diagonal color gradients from each corner, low opacity (~18%) |
+| Scanlines | Repeating 4px pattern, `rgba(0,0,0,0.035)` — gritty CRT texture |
+
+### No-picture mode
+- Giant **Anton SC** name text, vertically centered in each half
+- Left name: `text-align:left`, color shadow (`3px 3px 0 var(--left-color, 0.65)` + wide glow)
+- Right name: `text-align:right`, color shadow using `--right-color`
+- No role tag labels
+- VS badge: hexagonal clip-path, centered, appears on entrance
+
+### Picture mode
+- Portrait image: waist-to-head crop (`aspect-ratio: 3/4`), bottom-anchored
+- Name overlaid at bottom of image via absolute-positioned gradient overlay — name partially covers the waist
+- Same large Anton SC font and color shadow as no-picture mode
+- Lighter panel gradient (not the heavy bottom wash of the original)
+
+### Judge cards
+| State | Visual |
+|-------|--------|
+| Waiting (unvoted) | Frosted glass (`rgba(255,255,255,0.1)`), white border, gentle pulse animation |
+| Voted left | Left-color glow, colored border, fill bar, lit left arrow |
+| Voted right | Right-color glow, colored border, fill bar, lit right arrow |
+| Voted tie | Amber glow, amber border, amber fill bar, both arrows lit |
+
+Cards use a parallelogram clip-path (`clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%)`) for an angular shape. Cards are **hidden** (off-screen) during the voting phase and only revealed when Get Score is triggered.
+
+---
+
+## 3. Animation Overhaul
+
+**Philosophy:** Hard cuts, not smooth transitions. Every moment lands like a DJ dropping a beat — no easing in, no fades, just impact.
+
+### Entrance
+1. Both name panels slam in simultaneously from their respective edges
+   - Easing: `cubic-bezier(0.2, 0, 0.3, 1)` — fast attack, single tight overshoot at ~60% then settles
+   - Duration: 450ms
+2. VS badge rushes in from "in front of camera"
+   - Scale: 6× → 0.72× (deep undershoot) → 1.10× → 1.0×
+   - Duration: 520ms, easing `cubic-bezier(0.12, 0, 0.2, 1)`
+   - Stage shake fires at ~340ms (when VS hits undershoot trough)
+
+### During voting
+- Judge panel remains **off-screen** (translated above viewport) — crowd sees nothing
+- Subtle "Judges voting" indicator at bottom with pulsing red dot
+
+### Score reveal (Get Score)
+- Judge panel slams down from top (bounce easing, 480ms)
+- All vote cards burst in simultaneously — staggered by only 55ms each so it reads as one hit
+- Each card: scale punch from 1.4× with skew, settles to 1× (280ms)
+
+### Winner announcement
+1. Judge panel slides back up (300ms, hard ease-out)
+2. VS scale-punches to 1.25× (brief brace) then rockets off toward **loser's side** with 55° spin, arcing slightly downward — duration 380ms
+3. Loser panel hard-cuts off screen in the **opposite direction** (320ms)
+4. Winner panel transitions: `left → 0`, `width → 100%`, name grows to `~6.5vw`, text-shadow deepens (420ms CSS transition)
+5. WINNER tag stamps in at 300ms
+
+### Next pair transition
+1. Glitch overlay fires (380ms)
+2. Winner panel hard-cuts off screen (delayed 100ms into glitch)
+3. Full state reset (names, judges, VS, config)
+4. New pair enters with fresh entrance sequence
+
+---
+
+## 4. Scope Boundary
+
+This spec covers **standard 1v1 battle mode only** (`isSmoke = false`). Smoke mode layout is unchanged — it embeds `<Chart />` and has its own animation logic.
+
+The BattleControl "Overlay" panel is new UI but intentionally minimal — two color pickers and one toggle. No additional BattleControl refactoring in scope.
+
+---
+
+## 5. DB Migration
+
+New migration `V17__add_overlay_config.sql`:
+```sql
+ALTER TABLE event ADD COLUMN overlay_config JSONB DEFAULT '{"showImages": true, "leftColor": "#dc2626", "rightColor": "#2563eb"}';
+```
+
+Default value ensures backward compatibility — existing events get the original red/blue colors with images on by default.

--- a/docs/test-scripts/battle-e2e.js
+++ b/docs/test-scripts/battle-e2e.js
@@ -1,0 +1,521 @@
+#!/usr/bin/env node
+/**
+ * BES E2E Battle Test Script
+ *
+ * Automatically sets up a full battle event from scratch and runs through
+ * the entire bracket with automated judge votes.
+ *
+ * Usage:  node docs/test-scripts/battle-e2e.js
+ * Requires: Node 18+, BES running at http://localhost (Docker)
+ *
+ * What it does:
+ *   1. Creates genre + 3 judges + event (access code 1234)
+ *   2. Adds 16 walk-in participants with real stage names
+ *   3. Submits audition scores from all 3 judges
+ *   4. Seeds a 16-player bracket by rank (score descending)
+ *   5. Assigns battle judges
+ *   6. Runs all 15 matches (R16 → QF → SF → Final) with delays
+ *   7. Votes mix of left win / right win / tie each match
+ *
+ * Open in browser while running:
+ *   http://localhost/battle/overlay   (stream overlay)
+ *   http://localhost/battle/judge     (judge view — pick a name)
+ *   http://localhost/battle/bracket   (bracket visualization)
+ */
+
+'use strict';
+
+const BASE            = 'http://localhost';
+const EVENT_NAME      = 'E2E Battle Test';
+const GENRE_NAME      = 'popping';  // must match existing genre name (case-sensitive)
+const ACCESS_CODE     = '1234';
+const ADMIN_USER      = process.env.BES_ADMIN_USER ?? 'admin';
+const ADMIN_PASS      = process.env.BES_ADMIN_PASSWORD ?? 'change-me-admin';
+const DELAY_LOCKED_MS = 3_000;   // pause in LOCKED before opening voting
+const DELAY_VOTED_MS  = 1_500;   // pause after all votes before tallying
+const DELAY_REVEAL_MS = 5_000;   // pause in REVEALED so you can see the result
+
+// ─── Participants ────────────────────────────────────────────────────────────
+// 16 real-feeling dance-scene stage names, varied lengths
+const STAGE_NAMES = [
+  'Lil Flex',          // short
+  'Nova',              // very short
+  'Thunderfoot',       // medium
+  'Ray',               // very short
+  'Mikael Breakz',     // medium-long
+  'SoulsnatcH',        // medium
+  'Dyzee',             // short
+  'Victor Manuelle',   // long
+  'Frosty',            // short
+  'KID KRAZZY',        // medium
+  'Morphine',          // medium
+  'BeatRockah',        // medium
+  'Wickedboy',         // medium
+  'TONIIBOI',          // medium
+  'Shinsekai no Ryuu', // long
+  'El Fuego del Sur',  // long
+];
+
+// Prefix with "E2E" so we can clean up dupes reliably on each run
+const JUDGE_NAMES = ['E2E Alpha', 'E2E Beta', 'E2E Gamma'];
+
+// Scores per judge per participant (index 0 = highest scorer = seed 1)
+// Small variance between judges to keep it realistic
+const JUDGE_SCORES = [
+  [97, 94, 91, 88, 85, 83, 81, 79, 77, 75, 73, 71, 69, 67, 65, 63],
+  [95, 92, 90, 87, 84, 82, 80, 78, 76, 74, 72, 70, 68, 66, 64, 62],
+  [96, 93, 89, 86, 83, 81, 79, 78, 75, 73, 71, 70, 68, 65, 63, 61],
+];
+
+// ─── Vote pattern ────────────────────────────────────────────────────────────
+// 15 matches total: 8 (R16) + 4 (QF) + 2 (SF) + 1 (Final)
+// Each entry: [judge0_vote, judge1_vote, judge2_vote]
+// 0 = left wins,  1 = right wins,  2 = tie
+// Winner = majority; tie in counts → left wins (predictable champion: Lil Flex)
+const MATCH_VOTES = [
+  /* R16 */ [0, 0, 0],  // M1  left wins   (seed  1 beats seed 16)
+             [1, 1, 0],  // M2  right wins  (upset: seed 15 beats seed  2)
+             [0, 0, 1],  // M3  left wins   (seed  3 beats seed 14)
+             [1, 1, 1],  // M4  right wins  (upset: seed 13 beats seed  4)
+             [0, 0, 0],  // M5  left wins   (seed  5 beats seed 12)
+             [0, 2, 1],  // M6  left wins   (seed  6 beats seed 11, one tie vote)
+             [2, 1, 1],  // M7  right wins  (seed 10 beats seed  7, one tie vote)
+             [0, 0, 0],  // M8  left wins   (seed  8 beats seed  9)
+  /* QF  */ [0, 0, 0],  // M9  left wins
+             [1, 1, 0],  // M10 right wins
+             [0, 1, 0],  // M11 left wins
+             [1, 1, 1],  // M12 right wins
+  /* SF  */ [0, 0, 0],  // M13 left wins
+             [1, 0, 1],  // M14 right wins
+  /* FIN */ [0, 0, 0],  // M15 left wins  → champion
+];
+
+// ─── Networking ──────────────────────────────────────────────────────────────
+const jar = {};
+
+function parseCookies(res) {
+  for (const raw of (res.headers.getSetCookie?.() ?? [])) {
+    const [pair] = raw.split(';');
+    const eq = pair.indexOf('=');
+    if (eq > 0) jar[pair.slice(0, eq).trim()] = pair.slice(eq + 1).trim();
+  }
+}
+
+function cookieHeader() {
+  return Object.entries(jar).map(([k, v]) => `${k}=${v}`).join('; ');
+}
+
+async function req(method, path, body) {
+  const headers = { Accept: 'application/json', Cookie: cookieHeader() };
+  if (method !== 'GET') {
+    headers['Content-Type'] = 'application/json';
+    // CSRF is disabled in SecurityConfig — no X-XSRF-TOKEN needed
+  }
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body != null ? JSON.stringify(body) : undefined,
+    redirect: 'manual',
+  });
+  parseCookies(res);
+  return res;
+}
+
+const get  = (p)    => req('GET',    p);
+const post = (p, b) => req('POST',   p, b);
+const del  = (p, b) => req('DELETE', p, b);
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// ─── Logging helpers ─────────────────────────────────────────────────────────
+const C = { reset: '\x1b[0m', bold: '\x1b[1m', cyan: '\x1b[36m', green: '\x1b[32m',
+            red: '\x1b[31m', yellow: '\x1b[33m', dim: '\x1b[2m' };
+
+function ts()  { return `${C.dim}[${new Date().toISOString().slice(11,19)}]${C.reset}`; }
+function log(m)  { console.log(`${ts()} ${m}`); }
+function ok(m)   { console.log(`${ts()} ${C.green}✓${C.reset} ${m}`); }
+function warn(m) { console.log(`${ts()} ${C.yellow}⚠${C.reset}  ${m}`); }
+function fail(m) { console.log(`${ts()} ${C.red}✗${C.reset} ${m}`); }
+function hdr(m)  { console.log(`\n${C.bold}${C.yellow}══════ ${m} ══════${C.reset}`); }
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+function majority(votes) {
+  const l = votes.filter(v => v === 0).length;
+  const r = votes.filter(v => v === 1).length;
+  return r > l ? 'right' : 'left'; // ties → left
+}
+
+function pName(p) {
+  return p?.participantName ?? p?.stageName ?? p?.name ?? p?.displayName ?? '???';
+}
+
+function pScore(s) {
+  return s?.averageScore ?? s?.avgScore ?? s?.average ?? s?.totalScore ?? s?.score ?? 0;
+}
+
+function emptyRounds() {
+  return {
+    Top16: Array(8).fill(null).map(() => [null, null, null]),
+    Top8:  Array(4).fill(null).map(() => [null, null, null]),
+    Top4:  Array(2).fill(null).map(() => [null, null, null]),
+    Top2:  [[null, null, null]],
+    Top1:  [[null]],
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+
+  // ── 1. Login ──────────────────────────────────────────────────────────────
+  hdr('LOGIN');
+  const loginRes = await post('/api/v1/auth/login', { username: ADMIN_USER, password: ADMIN_PASS });
+  if (!loginRes.ok) {
+    fail(`Login failed (status ${loginRes.status}) — is Docker running?`);
+    process.exit(1);
+  }
+  ok(`Logged in as ${ADMIN_USER}`);
+
+  // ── 2. Genre ──────────────────────────────────────────────────────────────
+  hdr('GENRE');
+  // Genre "popping" already exists in DB — just verify it's there
+  const genreListR = await get('/api/v1/event/genre');
+  const genreList  = genreListR.ok ? await genreListR.json() : [];
+  const genreExists = genreList.some(g => g.genreName === GENRE_NAME);
+  if (!genreExists) {
+    // Create it if missing
+    const gr = await post('/api/v1/admin/genre', { name: GENRE_NAME });
+    gr.ok ? ok(`Genre "${GENRE_NAME}" created`) : warn(`Genre create returned ${gr.status}`);
+  } else {
+    ok(`Genre "${GENRE_NAME}" found in global list`);
+  }
+
+  // ── 3. Judges (clean up first, then create fresh) ─────────────────────────
+  hdr('JUDGES');
+  // Remove E2E judges cleanly:
+  //  1. Delete all scores for the test event (removes FK score→judge references)
+  //  2. Unlink E2E judges from every event (removes FK event_judge→judge references)
+  //  3. Delete judges globally
+  {
+    // Delete test event scores first so score FK doesn't block judge deletion
+    const evListR0 = await get('/api/v1/event/events');
+    const evList0  = evListR0.ok ? await evListR0.json() : [];
+    const testEv   = evList0.find(e => (e.eventName ?? e.name) === EVENT_NAME);
+    if (testEv) {
+      const sdR = await del('/api/v1/admin/score', { event_id: testEv.id });
+      sdR.ok ? log(`  Cleared scores for "${EVENT_NAME}" (event id=${testEv.id})`)
+             : warn(`  Score clear returned ${sdR.status} (may be empty)`);
+    }
+
+    // Find all E2E judges globally
+    const allR  = await get('/api/v1/event/judges');
+    const all   = allR.ok ? await allR.json() : [];
+    const e2eJs = all.filter(j => JUDGE_NAMES.includes(j.judgeName));
+
+    if (e2eJs.length) {
+      // Unlink from every event
+      const evListR = await get('/api/v1/event/events');
+      const evList  = evListR.ok ? await evListR.json() : [];
+      for (const ev of evList) {
+        const evName  = ev.eventName ?? ev.name;
+        const evJdgR  = await get(`/api/v1/event/${encodeURIComponent(evName)}/judges`);
+        const evJdgs  = evJdgR.ok ? await evJdgR.json() : [];
+        for (const j of evJdgs.filter(j => JUDGE_NAMES.includes(j.judgeName))) {
+          await del(`/api/v1/event/${encodeURIComponent(evName)}/judge/${j.judgeId}`);
+          log(`  Unlinked "${j.judgeName}" from event "${evName}"`);
+        }
+      }
+
+      // Delete globally (scores already removed, so no FK block)
+      for (const j of e2eJs) {
+        const dr = await del('/api/v1/admin/judge', { id: j.judgeId });
+        dr.ok
+          ? log(`  Deleted stale judge "${j.judgeName}" id=${j.judgeId}`)
+          : warn(`  Could not delete judge ${j.judgeId} — may still have refs`);
+      }
+      ok(`Cleaned up ${e2eJs.length} stale test judge(s)`);
+    } else {
+      log('  No stale E2E judges found');
+    }
+  }
+
+  const judgeIds = [];
+  for (const name of JUDGE_NAMES) {
+    const r   = await post('/api/v1/admin/judge', { judgeName: name });
+    const all = r.ok ? await r.json() : [];
+    const found = Array.isArray(all) ? all.find(j => j.judgeName === name) : null;
+    if (found) {
+      judgeIds.push(found.judgeId);
+      ok(`Created judge "${name}" id=${found.judgeId}`);
+    } else {
+      fail(`Cannot create judge "${name}"`);
+      process.exit(1);
+    }
+  }
+
+  // ── 4. Event ──────────────────────────────────────────────────────────────
+  hdr('EVENT');
+  const evListR = await get('/api/v1/event/events');
+  const evList  = evListR.ok ? await evListR.json() : [];
+  let event = evList.find(e => (e.eventName ?? e.name) === EVENT_NAME);
+
+  if (!event) {
+    const r = await post('/api/v1/event', { eventName: EVENT_NAME, paymentRequired: false });
+    if (!r.ok) { fail('Failed to create event'); process.exit(1); }
+    const evList2R = await get('/api/v1/event/events');
+    const evList2  = evList2R.ok ? await evList2R.json() : [];
+    event = evList2.find(e => (e.eventName ?? e.name) === EVENT_NAME);
+    ok(`Event "${EVENT_NAME}" created`);
+  } else {
+    warn(`Event "${EVENT_NAME}" already exists (id=${event.id})`);
+  }
+
+  if (!event) { fail('Event not found after creation'); process.exit(1); }
+  const eventId = event.id;
+  log(`Event ID: ${eventId}`);
+
+  // Access code
+  const acR = await post('/api/v1/event/access-code', { eventId, newCode: ACCESS_CODE });
+  acR.ok ? ok(`Access code set to ${ACCESS_CODE}`) : warn('Access code update returned non-OK (may already be set)');
+
+  // Link genre (genreName must be an array per backend DTO)
+  const linkedR = await get(`/api/v1/event/${encodeURIComponent(EVENT_NAME)}/genres`);
+  const linked  = linkedR.ok ? await linkedR.json() : [];
+  if (!linked.some(g => g.genreName === GENRE_NAME)) {
+    const lgR = await post('/api/v1/event/genre', {
+      eventName: EVENT_NAME,
+      genreName: [GENRE_NAME],
+      genreFormats: {},
+    });
+    lgR.ok ? ok(`Genre "${GENRE_NAME}" linked to event`) : warn(`Genre link returned ${lgR.status}`);
+  } else {
+    ok(`Genre "${GENRE_NAME}" already linked`);
+  }
+
+  // Note: do NOT call POST /{event}/judge — that endpoint always creates a new judge row
+  // (see JudgeService.addJudgeToEvent). ScoreService looks up judges globally by name,
+  // so the globally-created judges above are sufficient for score submission.
+
+  // ── 5. Walk-in participants ───────────────────────────────────────────────
+  hdr('PARTICIPANTS');
+  const ptCheckR = await get(`/api/v1/event/participants/${encodeURIComponent(EVENT_NAME)}`);
+  const existing = ptCheckR.ok ? await ptCheckR.json() : [];
+  const existingNames = new Set(existing.map(p => pName(p)));
+
+  let added = 0;
+  for (let i = 0; i < STAGE_NAMES.length; i++) {
+    const name  = STAGE_NAMES[i];
+    const judge = JUDGE_NAMES[i % JUDGE_NAMES.length];
+    if (existingNames.has(name)) {
+      log(`  ${C.dim}skip${C.reset} ${name} (already exists)`);
+      continue;
+    }
+    // Use empty judgeName for walk-ins to avoid findByName duplicate issues;
+    // judge assignment happens implicitly via score submission
+    const r = await post('/api/v1/event/walkins/', {
+      name,
+      eventName: EVENT_NAME,
+      genre:     GENRE_NAME,
+      judgeName: '',
+      teamMembers: [],
+      teamName:    '',
+    });
+    r.ok ? log(`  + ${name}`) : warn(`  Failed to add ${name} (${r.status})`);
+    added++;
+  }
+  ok(`Participants ready (${added} added, ${existingNames.size} already existed)`);
+
+  // ── 6. Scores ─────────────────────────────────────────────────────────────
+  hdr('AUDITION SCORES');
+  const ptR    = await get(`/api/v1/event/participants/${encodeURIComponent(EVENT_NAME)}`);
+  const ptList = ptR.ok ? await ptR.json() : [];
+  log(`Participants found: ${ptList.length}`);
+
+  for (let ji = 0; ji < JUDGE_NAMES.length; ji++) {
+    const judgeName = JUDGE_NAMES[ji];
+    const participantScore = ptList.map(p => {
+      const name = pName(p);
+      const idx  = STAGE_NAMES.indexOf(name);
+      // ParticipantScoreDto expects "participantName" (not "name")
+      return { participantName: name, score: idx >= 0 ? JUDGE_SCORES[ji][idx] : 75 };
+    });
+    const r = await post('/api/v1/event/scores', {
+      eventName: EVENT_NAME,
+      genreName: GENRE_NAME,
+      judgeName,
+      participantScore,
+    });
+    r.ok ? ok(`Scores from ${judgeName}`) : warn(`Score submit by ${judgeName} returned ${r.status}`);
+  }
+
+  // ── 7. Bracket seeding ────────────────────────────────────────────────────
+  hdr('BRACKET SEEDING');
+  const sdR   = await get(`/api/v1/event/scores/${encodeURIComponent(EVENT_NAME)}`);
+  const sdRaw = sdR.ok ? await sdR.json() : [];
+
+  // Aggregate — handle both "one row per participant" and "one row per judge×participant"
+  const scoreMap = {};
+  for (const s of sdRaw) {
+    const name = pName(s);
+    if (!scoreMap[name]) scoreMap[name] = { name, ...s, _total: 0, _count: 0 };
+    const v = pScore(s);
+    scoreMap[name]._total += v;
+    scoreMap[name]._count += 1;
+  }
+
+  const ranked = Object.values(scoreMap)
+    .map(s => ({ ...s, _avg: s._count > 0 ? s._total / s._count : 0 }))
+    .sort((a, b) => b._avg - a._avg)
+    .slice(0, 16);
+
+  if (ranked.length < 16) {
+    fail(`Only ${ranked.length} scored participants — need exactly 16`);
+    process.exit(1);
+  }
+
+  log('Seeding (rank → name → avg):');
+  ranked.forEach((p, i) => log(`  ${String(i+1).padStart(2)}. ${pName(p).padEnd(20)} ${p._avg.toFixed(1)}`));
+
+  // Build bracket: seed 1 vs 16, 2 vs 15, …, 8 vs 9
+  const rounds = emptyRounds();
+  for (let i = 0; i < 8; i++) {
+    rounds.Top16[i] = [ranked[i], ranked[15 - i], null];
+  }
+
+  const seedR = await post('/api/v1/battle/bracket', { rounds, topSize: '16' });
+  seedR.ok ? ok('Bracket posted to server') : warn(`Bracket post returned ${seedR.status}`);
+
+  // ── 8. Battle judges ──────────────────────────────────────────────────────
+  hdr('BATTLE JUDGES');
+
+  // Response shape: { judges: [{ id, name, vote }, …] }
+  function parseBJudges(raw) {
+    if (Array.isArray(raw)) return raw;
+    if (raw && Array.isArray(raw.judges)) return raw.judges;
+    return [];
+  }
+
+  // Clear any stale battle judges
+  const staleR = await get('/api/v1/battle/judges');
+  const stale  = parseBJudges(staleR.ok ? await staleR.json() : []);
+  for (const bj of stale) {
+    await del('/api/v1/battle/judge', { id: Number(bj.id) });
+  }
+  if (stale.length) log(`Cleared ${stale.length} stale battle judge(s)`);
+
+  // Assign our 3 judges
+  for (const jid of judgeIds) {
+    const r = await post('/api/v1/battle/judge', { id: Number(jid) });
+    r.ok ? ok(`Battle judge id=${jid} assigned`) : warn(`Battle judge assign returned ${r.status}`);
+  }
+
+  const bjR     = await get('/api/v1/battle/judges');
+  const bJudges = parseBJudges(bjR.ok ? await bjR.json() : []);
+  if (bJudges.length < 1) {
+    fail('No battle judges registered — cannot vote');
+    process.exit(1);
+  }
+  log(`Battle judges: ${bJudges.map(j => `${j.name ?? j.judgeName}(${j.id})`).join(', ')}`);
+
+  // ── 9. Reset phase ────────────────────────────────────────────────────────
+  await post('/api/v1/battle/phase', { phase: 'IDLE' });
+  log('Phase reset to IDLE');
+
+  // ── 10. Battle sequence ───────────────────────────────────────────────────
+  hdr('READY');
+  console.log(`
+  ${C.bold}Open these in your browser now:${C.reset}
+    ${C.cyan}http://localhost/battle/overlay${C.reset}   ← stream overlay
+    ${C.cyan}http://localhost/battle/bracket${C.reset}   ← live bracket
+    ${C.cyan}http://localhost/battle/judge${C.reset}     ← judge view (open 3 tabs, pick a name each)
+
+  Starting in 8 seconds…
+`);
+  await sleep(8_000);
+
+  const roundOrder = [
+    { key: 'Top16', label: 'ROUND OF 16',  count: 8, nextKey: 'Top8' },
+    { key: 'Top8',  label: 'QUARTER-FINAL',count: 4, nextKey: 'Top4' },
+    { key: 'Top4',  label: 'SEMI-FINAL',   count: 2, nextKey: 'Top2' },
+    { key: 'Top2',  label: 'FINAL',        count: 1, nextKey: 'Top1' },
+  ];
+
+  let matchIndex = 0;
+
+  for (const { key, label, count, nextKey } of roundOrder) {
+    hdr(label);
+
+    for (let pairIdx = 0; pairIdx < count; pairIdx++) {
+      const pair   = rounds[key][pairIdx];
+      const left   = pair[0];
+      const right  = pair[1];
+      const votes  = MATCH_VOTES[matchIndex];
+      const side   = majority(votes);
+      const winner = side === 'left' ? left : right;
+
+      const lName = pName(left);
+      const rName = pName(right);
+
+      console.log(`\n  ${C.bold}Match ${matchIndex + 1}${C.reset}  ${C.cyan}${lName}${C.reset} vs ${C.cyan}${rName}${C.reset}`);
+
+      // ── LOCKED ──
+      await post('/api/v1/battle/phase', { phase: 'LOCKED' });
+      await post('/api/v1/battle/battle-pair', { leftBattler: left, rightBattler: right });
+      log(`  → LOCKED  (${lName} ↔ ${rName})`);
+      await sleep(DELAY_LOCKED_MS);
+
+      // ── VOTING ──
+      await post('/api/v1/battle/phase', { phase: 'VOTING' });
+      log(`  → VOTING`);
+      await sleep(500); // tiny gap so overlay can show VOTING before votes arrive
+
+      for (let ji = 0; ji < bJudges.length; ji++) {
+        const vote    = votes[ji] ?? 0;
+        const jName   = bJudges[ji].name ?? bJudges[ji].judgeName ?? `Judge ${ji+1}`;
+        const voteStr = ['LEFT ←', 'RIGHT →', 'TIE ~'][vote] ?? '?';
+        await post('/api/v1/battle/vote', { id: Number(bJudges[ji].id), vote: Number(vote) });
+        log(`  → ${jName} voted ${voteStr}`);
+        await sleep(300);
+      }
+
+      await sleep(DELAY_VOTED_MS);
+
+      // Tally
+      await post('/api/v1/battle/score');
+
+      // Update bracket
+      rounds[key][pairIdx][2] = winner;
+      const nextPairIdx = Math.floor(pairIdx / 2);
+      const nextSide    = pairIdx % 2; // 0=left slot, 1=right slot
+      if (nextKey === 'Top1') {
+        rounds['Top1'][0][0] = winner;
+      } else if (nextKey) {
+        if (!rounds[nextKey][nextPairIdx]) rounds[nextKey][nextPairIdx] = [null, null, null];
+        rounds[nextKey][nextPairIdx][nextSide] = winner;
+      }
+      await post('/api/v1/battle/bracket', { rounds, topSize: '16' });
+
+      // ── REVEALED ──
+      await post('/api/v1/battle/phase', { phase: 'REVEALED' });
+      console.log(`  → REVEALED  ${C.bold}${C.green}${pName(winner)} WINS${C.reset}`);
+      await sleep(DELAY_REVEAL_MS);
+
+      matchIndex++;
+    }
+  }
+
+  // ── 11. Finish ────────────────────────────────────────────────────────────
+  const champion = rounds['Top1'][0][0];
+  await post('/api/v1/battle/phase', { phase: 'IDLE' });
+
+  console.log(`
+${C.bold}${C.yellow}════════════════════════════════${C.reset}
+${C.bold}${C.yellow}  🏆  CHAMPION: ${pName(champion)}${C.reset}
+${C.bold}${C.yellow}════════════════════════════════${C.reset}
+`);
+  ok('Phase set to IDLE — done!');
+}
+
+main().catch(e => {
+  console.error('\nFatal error:', e.message ?? e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **7-to-smoke overlay full redesign** (`Chart.vue`): vertical bar chart with team colors/glows, score dots, ghost name watermarks, FLIP queue slide animation, score pop animation, result overlay with judge cards, champion takeover screen
- **Smoke-specific fixes**: tie flow advances without rematch, tie text corrected to "NO POINTS AWARDED", winning fighter's score updates immediately on announce (bar grows + pop fires), queue reorder on Next is purely a FLIP slide
- **Race condition fix — both overlays**: rushing through Next after Get Score no longer re-announces the old winner. Both `Chart.vue` and `BattleOverlay.vue` track `battlePhase` and drop stale score WS events when already LOCKED; every `await` checkpoint guards against mid-animation phase changes
- **Blank panel fix** (`BattleOverlay.vue`): when the full winner animation played out normally (not rushed), the loser panel stayed off-screen for the next pair. LOCKED phase handler now resets `leftReset`/`rightReset` so `updateBattlePair` can render the new pair correctly

## Test Plan

- [x] 7-to-smoke: get score → winner bar grows + score pop + result overlay with judge colors appear simultaneously
- [x] 7-to-smoke: click Next after result → queue FLIP slides, no score jump (already updated)
- [x] 7-to-smoke: rush Next immediately after Get Score → overlay skips, no winner re-announcement
- [x] 7-to-smoke: tie → "NO POINTS AWARDED", Next available, no rematch
- [x] 7-to-smoke: fighter hits 7 pts → champion overlay fires immediately on announce
- [x] Regular 1v1: let full animation play (winner expands, loser exits) → click Next → both panels render correctly for new pair
- [x] Regular 1v1: rush Next after Get Score → overlay collapses, new pair loads without winner replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)