### PR TITLE
feat: BattleJudge redesign — dark UI, overlay colors, vote persistence, full-screen

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -24,7 +24,7 @@ const isAuthenticated = computed(() => authStore.isAuthenticated)
 
 /** Hide the navbar on full-screen / immersive routes */
 const hideNav = computed(() =>
-  ['Login', 'StreamOverlay', 'BattleJudge', 'BracketVisualization'].includes(route.name)
+  ['Login', 'StreamOverlay', 'Battle Judge', 'BracketVisualization'].includes(route.name)
 )
 
 /**

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -649,12 +649,12 @@ onUnmounted(() => {
   align-items: center; justify-content: center; gap: 12px;
   background: rgba(6,10,20,0.78);
   backdrop-filter: blur(4px);
-  pointer-events: none;
 }
 .blocker-icon { font-size: 2.2rem; }
 .blocker-text {
-  font-family: 'Anton SC', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: clamp(14px, 2.5vw, 22px);
+  font-weight: 800;
   letter-spacing: 0.22em; text-transform: uppercase;
   color: rgba(251,191,36,0.85);
 }

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -396,9 +396,10 @@ onUnmounted(() => {
 <style scoped>
 /* ── Root ───────────────────────────────────────────────────── */
 .judge-root {
+  position: fixed;
+  inset: 0;
   display: flex;
   flex-direction: column;
-  height: 100dvh;
   background: #060a14;
   overflow: hidden;
   user-select: none;
@@ -559,8 +560,8 @@ onUnmounted(() => {
 .is-voted .panel-bg-right { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--right-color) 75%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--right-color) 22%, #060a14) 0%, color-mix(in srgb, var(--right-color) 42%, #060a14) 100%); }
 .is-voted .panel-bg-tie   { background: radial-gradient(ellipse 95% 85% at 50% 50%, rgba(100,116,139,0.65) 0%, transparent 72%), linear-gradient(180deg, #0f1624 0%, #253649 100%); }
 
-/* Dim — not chosen after vote */
-.is-dim { opacity: 0.2; filter: saturate(0.15); pointer-events: none; }
+/* Dim — not chosen after vote (keep tappable for vote revocation) */
+.is-dim { opacity: 0.2; filter: saturate(0.15); }
 
 /* ── Panel inner ────────────────────────────────────────────── */
 .panel-inner {

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -397,7 +397,7 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-/* ── Root ─────────────────────────────────────────── */
+/* ── Root ───────────────────────────────────────────────────── */
 .judge-root {
   display: flex;
   flex-direction: column;
@@ -406,18 +406,21 @@ onUnmounted(() => {
   overflow: hidden;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
-  font-family: 'Anton SC', sans-serif;
+  font-family: 'Inter', sans-serif;
+  --left-color:  #dc2626;
+  --right-color: #2563eb;
 }
 
-/* ── Header ───────────────────────────────────────── */
+/* ── Header ─────────────────────────────────────────────────── */
 .judge-header {
   flex-shrink: 0;
+  height: 56px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 20px;
-  background: rgba(255, 255, 255, 0.022);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.065);
+  padding: 0 16px;
+  background: rgba(255,255,255,0.022);
+  border-bottom: 1px solid rgba(255,255,255,0.065);
   backdrop-filter: blur(16px);
   z-index: 20;
 }
@@ -425,478 +428,348 @@ onUnmounted(() => {
 .header-brand {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .brand-pip {
-  width: 7px;
-  height: 7px;
+  width: 6px; height: 6px;
   border-radius: 50%;
-  flex-shrink: 0;
   animation: pipPulse 2.4s ease-in-out infinite;
 }
-.pip-red  { background: #ef4444; box-shadow: 0 0 10px rgba(239,68,68,0.8); }
-.pip-blue { background: #3b82f6; box-shadow: 0 0 10px rgba(59,130,246,0.8); animation-delay: 1.2s; }
+.pip-left  { background: var(--left-color);  box-shadow: 0 0 8px var(--left-color); }
+.pip-right { background: var(--right-color); box-shadow: 0 0 8px var(--right-color); animation-delay: 1.2s; }
 
 .brand-wordmark {
   font-family: 'Anton SC', sans-serif;
-  font-size: 12px;
+  font-size: 11px;
   letter-spacing: 0.25em;
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(255,255,255,0.28);
   text-transform: uppercase;
 }
 
-.selector-wrap {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
+.header-center { flex: 1; display: flex; justify-content: center; }
+.header-right  { flex-shrink: 0; }
 
-.selector-eyebrow {
-  font-family: 'Inter', sans-serif;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.2em;
-  color: rgba(255, 255, 255, 0.3);
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-/* ── Phase blocker (IDLE — covers entire root) ────── */
-.phase-blocker {
-  position: absolute;
-  inset: 0;
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(6, 10, 20, 0.96);
-  backdrop-filter: blur(6px);
-}
-.phase-blocker-inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  text-align: center;
-}
-.phase-blocker-icon { font-size: 2.5rem; }
-.phase-blocker-title {
-  font-family: 'Anton SC', sans-serif;
-  font-size: clamp(16px, 3vw, 24px);
-  letter-spacing: 0.15em;
-  color: rgba(255,255,255,0.5);
-  text-transform: uppercase;
-}
-
-.idle-selector-wrap {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
-}
-
-.idle-selector-eyebrow {
-  font-family: 'Inter', sans-serif;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.2em;
-  color: rgba(255, 255, 255, 0.3);
-  text-transform: uppercase;
-}
-
-/* ── Header center (phase pill + pair names) ──────── */
-.header-center {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  flex: 1;
-  min-width: 0;
-}
+/* Phase pill */
 .phase-pill {
   font-family: 'Inter', sans-serif;
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  padding: 2px 8px;
-  border-radius: 999px;
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 0.2em; text-transform: uppercase;
+  padding: 3px 10px; border-radius: 999px;
   border: 1px solid transparent;
 }
-.phase-pill--idle    { background: rgba(71,85,105,0.3); color: rgba(148,163,184,0.6); border-color: rgba(71,85,105,0.4); }
-.phase-pill--locked  { background: rgba(245,158,11,0.15); color: rgba(251,191,36,0.9); border-color: rgba(245,158,11,0.4); }
-.phase-pill--voting  { background: rgba(6,182,212,0.15); color: rgba(6,182,212,0.95); border-color: rgba(6,182,212,0.4); animation: votingPulse 1.6s ease-in-out infinite; }
-.phase-pill--revealed { background: rgba(16,185,129,0.15); color: rgba(52,211,153,0.95); border-color: rgba(16,185,129,0.4); }
+.phase-pill--idle     { background: rgba(71,85,105,0.3);   color: rgba(148,163,184,0.6);  border-color: rgba(71,85,105,0.4); }
+.phase-pill--locked   { background: rgba(245,158,11,0.15); color: rgba(251,191,36,0.9);   border-color: rgba(245,158,11,0.4); }
+.phase-pill--voting   { background: rgba(6,182,212,0.15);  color: rgba(6,182,212,0.95);   border-color: rgba(6,182,212,0.4); animation: votingPillPulse 1.6s ease-in-out infinite; }
+.phase-pill--revealed { background: rgba(16,185,129,0.15); color: rgba(52,211,153,0.95);  border-color: rgba(16,185,129,0.4); }
 
-.pair-label {
-  font-family: 'Inter', sans-serif;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  color: rgba(255,255,255,0.7);
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  max-width: 240px;
+/* Judge chip */
+.judge-chip {
+  display: flex; align-items: center; gap: 5px;
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--left-color) 12%, rgba(6,10,20,0.8));
+  border: 1px solid color-mix(in srgb, var(--left-color) 40%, transparent);
+  border-radius: 999px;
 }
-.vs-sep {
-  color: rgba(255,255,255,0.35);
-  font-weight: 400;
-  margin: 0 4px;
+.judge-chip-label { font-size: 8px; font-weight: 700; letter-spacing: 0.18em; color: rgba(255,255,255,0.35); }
+.judge-chip-name  { font-size: 10px; font-weight: 800; letter-spacing: 0.1em; color: rgba(255,255,255,0.9); text-transform: uppercase; }
+.judge-chip-clear {
+  background: none; border: none; cursor: pointer;
+  font-size: 10px; color: rgba(255,255,255,0.3);
+  padding: 0 2px; line-height: 1; transition: color 0.15s;
 }
+.judge-chip-clear:hover { color: rgba(255,255,255,0.8); }
 
-/* ── Panels container ─────────────────────────────── */
+/* ── Names bar ──────────────────────────────────────────────── */
+.names-bar {
+  flex-shrink: 0;
+  height: 10%;
+  display: flex;
+  min-height: 36px;
+}
+.name-cell {
+  flex: 1; display: flex;
+  align-items: center; justify-content: center;
+  padding: 0 12px; overflow: hidden;
+}
+.name-cell-left  { background: color-mix(in srgb, var(--left-color)  12%, transparent); border-right: 1px solid rgba(255,255,255,0.04); }
+.name-cell-right { background: color-mix(in srgb, var(--right-color) 12%, transparent); }
+.name-cell-text {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(13px, 2.8vw, 22px);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  text-overflow: ellipsis; overflow: hidden; white-space: nowrap;
+}
+.name-cell-left  .name-cell-text { color: color-mix(in srgb, var(--left-color)  90%, white); }
+.name-cell-right .name-cell-text { color: color-mix(in srgb, var(--right-color) 90%, white); }
+
+/* ── Panels wrap ────────────────────────────────────────────── */
 .panels-wrap {
   flex: 1;
   display: flex;
-  overflow: hidden;
+  flex-direction: column;
   position: relative;
+  overflow: hidden;
 }
 
-/* ── Phase overlays (inside panels-wrap) ──────────── */
-.panels-overlay {
-  position: absolute;
-  inset: 0;
-  z-index: 15;
+/* Color bleeds */
+.bleed {
+  position: absolute; bottom: 0;
+  width: 50%; height: 35%;
+  pointer-events: none; z-index: 1;
+}
+.bleed-left  { left: 0;  background: radial-gradient(ellipse at 0% 100%, color-mix(in srgb, var(--left-color)  14%, transparent), transparent 70%); }
+.bleed-right { right: 0; background: radial-gradient(ellipse at 100% 100%, color-mix(in srgb, var(--right-color) 14%, transparent), transparent 70%); }
+
+/* LR row */
+.lr-row {
+  flex: 1;
+  display: flex;
+  gap: 2px;
+}
+
+/* TIE row */
+.tie-row {
+  flex-shrink: 0;
+  height: 20%;
+  min-height: 64px;
+  padding-top: 2px;
+}
+
+/* ── Vote panel — shared ────────────────────────────────────── */
+.vote-panel {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+  border: none; outline: none; cursor: pointer;
+  overflow: hidden; background: transparent;
+  transition: opacity 0.3s ease, filter 0.3s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.lr-row  .vote-panel { flex: 1; }
+.tie-row .vote-panel { width: 100%; height: 100%; }
+
+/* Panel backgrounds */
+.panel-bg {
+  position: absolute; inset: 0;
+  transition: opacity 0.3s ease;
+}
+.panel-bg-left {
+  background:
+    radial-gradient(ellipse 80% 70% at 50% 62%, color-mix(in srgb, var(--left-color) 45%, transparent) 0%, transparent 75%),
+    linear-gradient(180deg, color-mix(in srgb, var(--left-color) 8%, #060a14) 0%, color-mix(in srgb, var(--left-color) 18%, #060a14) 100%);
+}
+.panel-bg-right {
+  background:
+    radial-gradient(ellipse 80% 70% at 50% 62%, color-mix(in srgb, var(--right-color) 45%, transparent) 0%, transparent 75%),
+    linear-gradient(180deg, color-mix(in srgb, var(--right-color) 8%, #060a14) 0%, color-mix(in srgb, var(--right-color) 18%, #060a14) 100%);
+}
+.panel-bg-tie {
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 50%, rgba(71,85,105,0.35) 0%, transparent 75%),
+    linear-gradient(180deg, #0a0e18 0%, #111827 100%);
+}
+
+/* Armed — brighter background */
+.is-armed .panel-bg-left  { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--left-color)  65%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--left-color)  18%, #060a14) 0%, color-mix(in srgb, var(--left-color)  35%, #060a14) 100%); }
+.is-armed .panel-bg-right { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--right-color) 65%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--right-color) 18%, #060a14) 0%, color-mix(in srgb, var(--right-color) 35%, #060a14) 100%); }
+.is-armed .panel-bg-tie   { background: radial-gradient(ellipse 95% 85% at 50% 50%, rgba(100,116,139,0.55) 0%, transparent 72%), linear-gradient(180deg, #0f1624 0%, #1e2e48 100%); }
+.is-armed { animation: armedPulse 1.4s ease-in-out infinite; }
+
+/* Voted — max glow */
+.is-voted .panel-bg-left  { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--left-color)  75%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--left-color)  22%, #060a14) 0%, color-mix(in srgb, var(--left-color)  42%, #060a14) 100%); }
+.is-voted .panel-bg-right { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--right-color) 75%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--right-color) 22%, #060a14) 0%, color-mix(in srgb, var(--right-color) 42%, #060a14) 100%); }
+.is-voted .panel-bg-tie   { background: radial-gradient(ellipse 95% 85% at 50% 50%, rgba(100,116,139,0.65) 0%, transparent 72%), linear-gradient(180deg, #0f1624 0%, #253649 100%); }
+
+/* Dim — not chosen after vote */
+.is-dim { opacity: 0.2; filter: saturate(0.15); pointer-events: none; }
+
+/* ── Panel inner ────────────────────────────────────────────── */
+.panel-inner {
+  position: relative; z-index: 5;
+  display: flex; flex-direction: column;
+  align-items: center;
+  gap: clamp(6px, 1.5vh, 18px);
+}
+
+.direction-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(28px, 5vw, 64px);
+  letter-spacing: 0.2em; text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+  line-height: 1;
+  transition: color 0.3s ease, letter-spacing 0.3s ease, text-shadow 0.3s ease;
+}
+.direction-tie { font-size: clamp(18px, 3.5vw, 42px); }
+
+.is-armed .direction-label {
+  color: rgba(255,255,255,0.92);
+  letter-spacing: 0.26em;
+}
+.panel-left.is-armed  .direction-label { text-shadow: 0 0 32px color-mix(in srgb, var(--left-color)  70%, transparent); }
+.panel-right.is-armed .direction-label { text-shadow: 0 0 32px color-mix(in srgb, var(--right-color) 70%, transparent); }
+.panel-tie.is-armed   .direction-label { text-shadow: 0 0 32px rgba(148,163,184,0.6); }
+
+.is-voted .direction-label { color: rgba(255,255,255,0.8); }
+
+.panel-feedback {
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(8px, 1.2vw, 12px);
+  font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: rgba(255,255,255,0.85);
+  opacity: 0; transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.panel-feedback.visible { opacity: 1; transform: translateY(0); }
+
+/* ── Vote locked wash ───────────────────────────────────────── */
+.vote-locked-wash {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  height: 42%; z-index: 6; pointer-events: none;
+}
+.wash-left  { background: linear-gradient(to top, color-mix(in srgb, var(--left-color)  80%, black) 0%, color-mix(in srgb, var(--left-color)  40%, transparent) 65%, transparent 100%); }
+.wash-right { background: linear-gradient(to top, color-mix(in srgb, var(--right-color) 80%, black) 0%, color-mix(in srgb, var(--right-color) 40%, transparent) 65%, transparent 100%); }
+.wash-tie   { background: linear-gradient(to top, rgba(71,85,105,0.85) 0%, rgba(71,85,105,0.35) 65%, transparent 100%); }
+
+.vote-locked-text {
+  position: absolute; bottom: 9%; left: 0; right: 0;
+  text-align: center;
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(10px, 1.6vw, 15px);
+  font-weight: 900; letter-spacing: 0.24em; text-transform: uppercase;
+  color: white; z-index: 7; pointer-events: none;
+}
+
+/* ── Phase blocker ──────────────────────────────────────────── */
+.panels-blocker {
+  position: absolute; inset: 0; z-index: 15;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  background: rgba(6,10,20,0.78);
+  backdrop-filter: blur(4px);
   pointer-events: none;
 }
-.locked-overlay  { background: rgba(6, 10, 20, 0.72); backdrop-filter: blur(3px); }
-.revealed-overlay { background: rgba(6, 10, 20, 0.82); backdrop-filter: blur(4px); }
-
-.panels-overlay-inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  text-align: center;
-  padding: 0 20px;
-}
-.overlay-lock-icon { font-size: 2rem; }
-.overlay-title {
+.blocker-icon { font-size: 2.2rem; }
+.blocker-text {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(14px, 2.5vw, 20px);
-  letter-spacing: 0.18em;
+  font-size: clamp(14px, 2.5vw, 22px);
+  letter-spacing: 0.22em; text-transform: uppercase;
   color: rgba(251,191,36,0.85);
 }
-.overlay-sub {
-  font-family: 'Inter', sans-serif;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  color: rgba(255,255,255,0.4);
+
+/* ── REVEALED banner ────────────────────────────────────────── */
+.revealed-banner {
+  position: absolute; bottom: 0; left: 0; right: 0; z-index: 20;
+  height: 52%;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: flex-end;
+  padding-bottom: 8%;
+  pointer-events: none;
 }
-.overlay-winner-name {
+.banner-left  { background: linear-gradient(to top, color-mix(in srgb, var(--left-color)  85%, black) 0%, color-mix(in srgb, var(--left-color)  30%, transparent) 72%, transparent 100%); }
+.banner-right { background: linear-gradient(to top, color-mix(in srgb, var(--right-color) 85%, black) 0%, color-mix(in srgb, var(--right-color) 30%, transparent) 72%, transparent 100%); }
+.banner-tie   { background: linear-gradient(to top, rgba(71,85,105,0.85) 0%, rgba(71,85,105,0.3) 72%, transparent 100%); }
+.banner-winner-name {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(24px, 5vw, 52px);
-  letter-spacing: 0.1em;
-  color: rgba(255,255,255,0.95);
-  line-height: 1;
-  text-transform: uppercase;
+  font-size: clamp(28px, 5.5vw, 58px);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: white; line-height: 1;
 }
-.overlay-winner-label {
+.banner-wins {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(16px, 3.5vw, 36px);
-  letter-spacing: 0.25em;
+  font-size: clamp(14px, 2.5vw, 30px);
+  letter-spacing: 0.35em; text-transform: uppercase;
   color: rgba(52,211,153,0.9);
 }
 
-/* ── Phase transition ─────────────────────────────── */
+/* ── Bottom sheet ───────────────────────────────────────────── */
+.sheet-backdrop {
+  position: fixed; inset: 0; z-index: 50;
+  background: rgba(6,10,20,0.65);
+  backdrop-filter: blur(4px);
+  display: flex; align-items: flex-end;
+}
+.bottom-sheet {
+  width: 100%;
+  background: #0d1220;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  border-radius: 16px 16px 0 0;
+  padding: 8px 16px 32px;
+}
+.sheet-handle {
+  width: 32px; height: 4px;
+  background: rgba(255,255,255,0.15);
+  border-radius: 999px;
+  margin: 0 auto 14px;
+}
+.sheet-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px; font-weight: 800;
+  letter-spacing: 0.25em; text-transform: uppercase;
+  color: rgba(255,255,255,0.3);
+  text-align: center; margin-bottom: 14px;
+}
+.sheet-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.sheet-name-chip {
+  padding: 14px 8px;
+  border-radius: 10px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  display: flex; align-items: center; justify-content: center;
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(15px, 3vw, 22px);
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: rgba(255,255,255,0.75);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+.sheet-name-chip:active,
+.sheet-name-chip:hover {
+  background: color-mix(in srgb, var(--left-color) 16%, rgba(255,255,255,0.05));
+  border-color: color-mix(in srgb, var(--left-color) 45%, transparent);
+  color: rgba(255,255,255,0.95);
+}
+
+/* ── Transitions ────────────────────────────────────────────── */
 .phase-fade-enter-active,
-.phase-fade-leave-active { transition: opacity 0.35s ease; }
+.phase-fade-leave-active { transition: opacity 0.3s ease; }
 .phase-fade-enter-from,
 .phase-fade-leave-to { opacity: 0; }
 
-@keyframes votingPulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(6,182,212,0.4); }
-  50% { box-shadow: 0 0 0 4px rgba(6,182,212,0); }
-}
+.sheet-slide-enter-active { transition: transform 0.32s cubic-bezier(0.34, 1.2, 0.64, 1); }
+.sheet-slide-leave-active { transition: transform 0.22s cubic-bezier(0.4, 0, 1, 1); }
+.sheet-slide-enter-from,
+.sheet-slide-leave-to { transform: translateY(100%); }
 
-.vote-panel {
-  flex: 1;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  outline: none;
-  cursor: pointer;
-  overflow: hidden;
-  background: #060a14; /* solid dark base so transparent gradient parts don't show white */
-  transition: flex 0.55s cubic-bezier(0.34, 1.56, 0.64, 1);
-  -webkit-tap-highlight-color: transparent;
-}
-.tie-panel { flex: 0.62; }
+.banner-slide-enter-active { transition: transform 0.45s cubic-bezier(0.2, 0, 0.3, 1), opacity 0.3s ease; }
+.banner-slide-leave-active { transition: opacity 0.2s ease; }
+.banner-slide-enter-from { transform: translateY(100%); opacity: 0; }
+.banner-slide-leave-to { opacity: 0; }
 
-/* Soft gradient divider between panels — fades naturally at top and bottom */
-.vote-panel + .vote-panel::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 10%;
-  bottom: 10%;
-  width: 1px;
-  background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.08) 30%, rgba(255,255,255,0.08) 70%, transparent);
-  pointer-events: none;
-  z-index: 20;
-}
-
-/* Expand active panel slightly */
-.vote-panel.is-active { flex: 1.12; }
-.tie-panel.is-active  { flex: 0.74; }
-
-/* ── Panel background fill ────────────────────────── */
-.panel-fill {
-  position: absolute;
-  inset: 0;
-  transition: opacity 0.4s ease;
-}
-
-.left-fill {
-  background:
-    radial-gradient(ellipse 80% 70% at 50% 65%, rgba(220,38,38,0.55) 0%, rgba(127,17,17,0.35) 55%, transparent 80%),
-    linear-gradient(180deg, #1a0505 0%, #2e0a0a 50%, #1a0505 100%);
-}
-.tie-fill {
-  background:
-    radial-gradient(ellipse 80% 70% at 50% 65%, rgba(71,85,105,0.6) 0%, rgba(30,41,59,0.4) 55%, transparent 80%),
-    linear-gradient(180deg, #0a0e18 0%, #141e30 50%, #0a0e18 100%);
-}
-.right-fill {
-  background:
-    radial-gradient(ellipse 80% 70% at 50% 65%, rgba(37,99,235,0.55) 0%, rgba(17,40,140,0.35) 55%, transparent 80%),
-    linear-gradient(180deg, #050916 0%, #0a1535 50%, #050916 100%);
-}
-
-/* Active backgrounds: brighter radial center */
-.left-panel.is-active .left-fill {
-  background:
-    radial-gradient(ellipse 95% 85% at 50% 62%, rgba(239,68,68,0.72) 0%, rgba(185,28,28,0.5) 42%, transparent 72%),
-    linear-gradient(180deg, #220808 0%, #420d0d 50%, #220808 100%);
-}
-.tie-panel.is-active .tie-fill {
-  background:
-    radial-gradient(ellipse 95% 85% at 50% 62%, rgba(100,116,139,0.7) 0%, rgba(51,65,85,0.5) 48%, transparent 72%),
-    linear-gradient(180deg, #0f1624 0%, #1e2e48 50%, #0f1624 100%);
-}
-.right-panel.is-active .right-fill {
-  background:
-    radial-gradient(ellipse 95% 85% at 50% 62%, rgba(59,130,246,0.72) 0%, rgba(29,78,216,0.5) 42%, transparent 72%),
-    linear-gradient(180deg, #060b22 0%, #0e1e50 50%, #060b22 100%);
-}
-
-/* Confirmed: brief bright flash */
-.is-confirmed .left-fill  { animation: flashRed   0.45s ease-out; }
-.is-confirmed .tie-fill   { animation: flashSlate 0.45s ease-out; }
-.is-confirmed .right-fill { animation: flashBlue  0.45s ease-out; }
-
-/* ── Edge accent line ─────────────────────────────── */
-.edge-accent {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  opacity: 0;
-  transition: opacity 0.4s ease;
-  pointer-events: none;
-}
-.left-accent  { right: 0; background: linear-gradient(to bottom, transparent 0%, rgba(239,68,68,0.7) 30%, rgba(239,68,68,0.7) 70%, transparent 100%); }
-.right-accent { left: 0;  background: linear-gradient(to bottom, transparent 0%, rgba(59,130,246,0.7) 30%, rgba(59,130,246,0.7) 70%, transparent 100%); }
-
-.is-active .edge-accent { opacity: 1; }
-
-/* ── Shimmer sweep ────────────────────────────────── */
-.panel-shimmer {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0;
-  background: linear-gradient(
-    110deg,
-    transparent 25%,
-    rgba(255,255,255,0.055) 50%,
-    transparent 75%
-  );
-  background-size: 250% 100%;
-  transition: opacity 0.3s ease;
-}
-.is-active .panel-shimmer {
-  opacity: 1;
-  animation: shimmer 2.2s linear infinite;
-}
-
-/* ── Panel inner content ──────────────────────────── */
-.panel-inner {
-  position: relative;
-  z-index: 5;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(10px, 2.2vh, 26px);
-}
-
-/* Direction label */
-.dir-label {
-  margin: 0;
-  font-family: 'Anton SC', sans-serif;
-  font-size: clamp(22px, 4vw, 52px);
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: rgba(255,255,255,0.45);
-  line-height: 1;
-  transition: color 0.3s ease, text-shadow 0.3s ease, letter-spacing 0.35s ease;
-}
-.is-active .dir-label {
-  color: rgba(255,255,255,0.95);
-  letter-spacing: 0.26em;
-}
-.left-panel.is-active .dir-label  { text-shadow: 0 0 40px rgba(239,68,68,0.65), 0 2px 0 rgba(0,0,0,0.5); }
-.tie-panel.is-active .dir-label   { text-shadow: 0 0 40px rgba(148,163,184,0.55), 0 2px 0 rgba(0,0,0,0.5); }
-.right-panel.is-active .dir-label { text-shadow: 0 0 40px rgba(59,130,246,0.65), 0 2px 0 rgba(0,0,0,0.5); }
-
-/* Image frame */
-.img-frame {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.panel-img {
-  width: clamp(96px, 17vw, 200px);
-  height: clamp(96px, 17vw, 200px);
-  object-fit: contain;
-  position: relative;
-  z-index: 2;
-  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-              filter 0.35s ease;
-  filter: drop-shadow(0 16px 40px rgba(0,0,0,0.7));
-}
-.left-img  { transform: rotate(-45deg); }
-.right-img { transform: rotate(45deg); }
-
-.is-active .panel-img {
-  filter: drop-shadow(0 0 28px rgba(255,255,255,0.28))
-          drop-shadow(0 16px 40px rgba(0,0,0,0.6));
-}
-.left-panel.is-active .left-img  { transform: rotate(-45deg) scale(1.14); }
-.right-panel.is-active .right-img { transform: rotate(45deg) scale(1.14); }
-.tie-panel.is-active .panel-img   { transform: scale(1.12); }
-
-/* Image halo glow */
-.img-halo {
-  position: absolute;
-  width: clamp(80px, 14vw, 160px);
-  height: clamp(80px, 14vw, 160px);
-  border-radius: 50%;
-  filter: blur(32px);
-  opacity: 0;
-  z-index: 1;
-  transition: opacity 0.5s ease;
-  pointer-events: none;
-}
-.red-halo     { background: rgba(239,68,68,0.7); }
-.neutral-halo { background: rgba(100,116,139,0.6); }
-.blue-halo    { background: rgba(59,130,246,0.7); }
-
-.is-active .img-halo {
-  opacity: 1;
-  animation: haloBreath 1.9s ease-in-out infinite;
-}
-
-/* Feedback row */
-.feedback-row {
-  font-family: 'Inter', sans-serif;
-  font-size: clamp(9px, 1.4vw, 13px);
-  font-weight: 700;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: rgba(255,255,255,0.88);
-  text-align: center;
-  padding: 0 10px;
-  white-space: nowrap;
-  opacity: 0;
-  transform: translateY(7px);
-  transition: opacity 0.25s ease, transform 0.25s ease;
-}
-.feedback-row.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-.check-mark {
-  display: inline-block;
-  font-size: 1.15em;
-  margin-right: 2px;
-  animation: checkPop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-/* ── Pulse ring border ────────────────────────────── */
-.pulse-ring {
-  position: absolute;
-  inset: 0;
-  border: 2px solid transparent;
-  pointer-events: none;
-  z-index: 8;
-  transition: border-color 0.3s ease;
-}
-.left-panel.is-active .left-ring    { border-color: rgba(239,68,68,0.55); animation: ringPulse 1.5s ease-in-out infinite; }
-.tie-panel.is-active .neutral-ring  { border-color: rgba(148,163,184,0.45); animation: ringPulse 1.5s ease-in-out infinite; }
-.right-panel.is-active .blue-ring   { border-color: rgba(59,130,246,0.55); animation: ringPulse 1.5s ease-in-out infinite; }
-
-.left-panel.is-confirmed .left-ring    { border-color: rgba(239,68,68,0.9); animation: confirmBurst 0.55s ease-out forwards; }
-.tie-panel.is-confirmed .neutral-ring  { border-color: rgba(148,163,184,0.9); animation: confirmBurst 0.55s ease-out forwards; }
-.right-panel.is-confirmed .blue-ring   { border-color: rgba(59,130,246,0.9); animation: confirmBurst 0.55s ease-out forwards; }
-
-/* ── Keyframes ────────────────────────────────────── */
+/* ── Keyframes ──────────────────────────────────────────────── */
 @keyframes pipPulse {
   0%, 100% { opacity: 1; transform: scale(1); }
-  50%       { opacity: 0.35; transform: scale(0.65); }
+  50%       { opacity: 0.3; transform: scale(0.6); }
+}
+@keyframes votingPillPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(6,182,212,0.4); }
+  50%       { box-shadow: 0 0 0 4px rgba(6,182,212,0); }
+}
+@keyframes armedPulse {
+  0%, 100% { box-shadow: inset 0 0 0 1.5px rgba(255,255,255,0); }
+  50%       { box-shadow: inset 0 0 0 1.5px rgba(255,255,255,0.18); }
 }
 
-@keyframes shimmer {
-  0%   { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-@keyframes haloBreath {
-  0%, 100% { transform: scale(1);    opacity: 0.85; }
-  50%       { transform: scale(1.4); opacity: 0.38; }
-}
-
-@keyframes ringPulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.28; }
-}
-
-@keyframes confirmBurst {
-  0%   { inset: 0;     opacity: 1; }
-  60%  { inset: -6px;  opacity: 0.8; }
-  100% { inset: -22px; opacity: 0; }
-}
-
-@keyframes checkPop {
-  0%   { transform: scale(0); }
-  70%  { transform: scale(1.3); }
-  100% { transform: scale(1); }
-}
-
-@keyframes flashRed {
-  0%   { filter: brightness(1); }
-  25%  { filter: brightness(2.4) saturate(1.4); }
-  100% { filter: brightness(1); }
-}
-@keyframes flashSlate {
-  0%   { filter: brightness(1); }
-  25%  { filter: brightness(2.2); }
-  100% { filter: brightness(1); }
-}
-@keyframes flashBlue {
-  0%   { filter: brightness(1); }
-  25%  { filter: brightness(2.4) saturate(1.4); }
-  100% { filter: brightness(1); }
+/* ── Tablet: center at max 480px ────────────────────────────── */
+@media (min-width: 600px) {
+  .judge-root {
+    max-width: 480px;
+    margin: 0 auto;
+    border-left:  1px solid rgba(255,255,255,0.05);
+    border-right: 1px solid rgba(255,255,255,0.05);
+  }
 }
 </style>

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -47,6 +47,7 @@ function selectJudge(j) {
 }
 
 function clearJudge() {
+  clearVote()
   judgeId.value   = null
   judgeName.value = ''
   localStorage.removeItem(LS_JUDGE_ID)
@@ -58,7 +59,6 @@ function clearJudge() {
     if (idx !== -1) wsClients.splice(idx, 1)
     voteClient = null
   }
-  clearVote()
 }
 
 // ── Vote state ──────────────────────────────────────────────────────────────
@@ -111,7 +111,7 @@ const wsClients  = []
 let   voteClient = null
 
 function setupVoteSubscription() {
-  if (!judgeId.value || voteClient) return
+  if (judgeId.value == null || voteClient) return
   voteClient = createClient()
   wsClients.push(voteClient)
   subscribeToChannel(voteClient, `/topic/battle/vote/${judgeId.value}`, (msg) => {

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -93,7 +93,14 @@ function restoreVoteFromStorage() {
 
 async function handleClick(side) {
   if (battlePhase.value !== 'VOTING') return
-  if (confirmedVote.value !== null) return   // already voted — locked
+  // Tapping the already-voted panel — no-op
+  if (confirmedVote.value === side) return
+  // Tapping a different panel while voted — revoke and arm the new panel
+  if (confirmedVote.value !== null) {
+    clearVote()
+    active.value = side
+    return
+  }
   if (active.value === side) {
     const res = await battleJudgeVote(judgeId.value, side)
     if (!res?.ok) return   // POST failed — stay armed, let judge try again
@@ -226,16 +233,6 @@ onUnmounted(() => {
       </div>
     </header>
 
-    <!-- ── Names bar ───────────────────────────────────────────── -->
-    <div class="names-bar">
-      <div class="name-cell name-cell-left">
-        <span class="name-cell-text">{{ leftName || '???' }}</span>
-      </div>
-      <div class="name-cell name-cell-right">
-        <span class="name-cell-text">{{ rightName || '???' }}</span>
-      </div>
-    </div>
-
     <!-- ── Panels wrap ─────────────────────────────────────────── -->
     <div class="panels-wrap" role="group" aria-label="Vote options">
 
@@ -295,7 +292,7 @@ onUnmounted(() => {
         >
           <div class="panel-bg panel-bg-left" aria-hidden="true"></div>
           <div class="panel-inner">
-            <span class="direction-label">LEFT</span>
+            <span class="direction-label">{{ leftName || 'LEFT' }}</span>
             <div
               class="panel-feedback"
               :class="{ visible: active === 0 && confirmedVote === null }"
@@ -323,7 +320,7 @@ onUnmounted(() => {
         >
           <div class="panel-bg panel-bg-right" aria-hidden="true"></div>
           <div class="panel-inner">
-            <span class="direction-label">RIGHT</span>
+            <span class="direction-label">{{ rightName || 'RIGHT' }}</span>
             <div
               class="panel-feedback"
               :class="{ visible: active === 1 && confirmedVote === null }"
@@ -481,28 +478,7 @@ onUnmounted(() => {
 }
 .judge-chip-clear:hover { color: rgba(255,255,255,0.8); }
 
-/* ── Names bar ──────────────────────────────────────────────── */
-.names-bar {
-  flex-shrink: 0;
-  height: 10%;
-  display: flex;
-  min-height: 36px;
-}
-.name-cell {
-  flex: 1; display: flex;
-  align-items: center; justify-content: center;
-  padding: 0 12px; overflow: hidden;
-}
-.name-cell-left  { background: color-mix(in srgb, var(--left-color)  12%, transparent); border-right: 1px solid rgba(255,255,255,0.04); }
-.name-cell-right { background: color-mix(in srgb, var(--right-color) 12%, transparent); }
-.name-cell-text {
-  font-family: 'Anton SC', sans-serif;
-  font-size: clamp(13px, 2.8vw, 22px);
-  letter-spacing: 0.1em; text-transform: uppercase;
-  text-overflow: ellipsis; overflow: hidden; white-space: nowrap;
-}
-.name-cell-left  .name-cell-text { color: color-mix(in srgb, var(--left-color)  90%, white); }
-.name-cell-right .name-cell-text { color: color-mix(in srgb, var(--right-color) 90%, white); }
+/* ── (names bar removed — names shown on panels) ───────────── */
 
 /* ── Panels wrap ────────────────────────────────────────────── */
 .panels-wrap {
@@ -596,17 +572,20 @@ onUnmounted(() => {
 
 .direction-label {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(28px, 5vw, 64px);
-  letter-spacing: 0.2em; text-transform: uppercase;
+  font-size: clamp(18px, 5.5vw, 44px);
+  letter-spacing: 0.08em; text-transform: uppercase;
   color: rgba(255,255,255,0.4);
-  line-height: 1;
-  transition: color 0.3s ease, letter-spacing 0.3s ease, text-shadow 0.3s ease;
+  line-height: 1.1;
+  text-align: center;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 90%;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
 }
-.direction-tie { font-size: clamp(18px, 3.5vw, 42px); }
+.direction-tie { font-size: clamp(16px, 4vw, 32px); }
 
 .is-armed .direction-label {
   color: rgba(255,255,255,0.92);
-  letter-spacing: 0.26em;
 }
 .panel-left.is-armed  .direction-label { text-shadow: 0 0 32px color-mix(in srgb, var(--left-color)  70%, transparent); }
 .panel-right.is-armed .direction-label { text-shadow: 0 0 32px color-mix(in srgb, var(--right-color) 70%, transparent); }

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -1,78 +1,182 @@
 <script setup>
-import leftHand from '@/assets/lefthand.png'
-import rightHand from '@/assets/righthand.png'
-import tie from '@/assets/no.png'
-import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { battleJudgeVote, getBattleJudges, getBattlePhase, getCurrentBattlePair } from '@/utils/api'
+import { battleJudgeVote, getBattleJudges, getBattlePhase, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 
-const active = ref(null)
-const confirmed = ref(null)
-const battleJudges = ref([])
-const selectedJudge = ref("")
-const battleJudgesName = computed(() => {
-  const judges = battleJudges.value?.judges ?? []
-  return judges.map(j => j.name)
-})
+// ── Overlay config ──────────────────────────────────────────────────────────
+const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
 
-const battlePhase = ref('IDLE')
-const leftName = ref('')
-const rightName = ref('')
+// ── Battle state ────────────────────────────────────────────────────────────
+const battlePhase    = ref('IDLE')
+const leftName       = ref('')
+const rightName      = ref('')
 const revealedWinner = ref(-2)
+const battleJudges   = ref({ judges: [] })
+
+// ── Judge identity ──────────────────────────────────────────────────────────
+const judgeId         = ref(null)   // number | null
+const judgeName       = ref('')
+const showJudgePicker = ref(false)
+
+const LS_JUDGE_ID   = 'battleJudgeId'
+const LS_JUDGE_NAME = 'battleJudgeName'
+
+function resolveJudgeIdentity(judges) {
+  const storedId = localStorage.getItem(LS_JUDGE_ID)
+  if (!storedId) { showJudgePicker.value = true; return }
+  const id = Number(storedId)
+  const match = judges.find(j => j.id === id)
+  if (!match) {
+    localStorage.removeItem(LS_JUDGE_ID)
+    localStorage.removeItem(LS_JUDGE_NAME)
+    showJudgePicker.value = true
+    return
+  }
+  judgeId.value   = id
+  judgeName.value = match.name
+  setupVoteSubscription()
+}
+
+function selectJudge(j) {
+  judgeId.value   = j.id
+  judgeName.value = j.name
+  localStorage.setItem(LS_JUDGE_ID,   String(j.id))
+  localStorage.setItem(LS_JUDGE_NAME, j.name)
+  showJudgePicker.value = false
+  setupVoteSubscription()
+}
+
+function clearJudge() {
+  judgeId.value   = null
+  judgeName.value = ''
+  localStorage.removeItem(LS_JUDGE_ID)
+  localStorage.removeItem(LS_JUDGE_NAME)
+  showJudgePicker.value = true
+}
+
+// ── Vote state ──────────────────────────────────────────────────────────────
+const active        = ref(null)   // armed: 0 | 1 | -1 | null
+const confirmedVote = ref(null)   // confirmed: 0 | 1 | -1 | null
+
+function voteStorageKey() {
+  if (judgeId.value == null || !leftName.value || !rightName.value) return null
+  return `battleVote_${judgeId.value}_${leftName.value}_${rightName.value}`
+}
+
+function saveVote(vote) {
+  const key = voteStorageKey()
+  if (!key) return
+  localStorage.setItem(key, JSON.stringify({ vote, leftName: leftName.value, rightName: rightName.value }))
+}
+
+function clearVote() {
+  const key = voteStorageKey()
+  if (key) localStorage.removeItem(key)
+  confirmedVote.value = null
+  active.value        = null
+}
+
+function restoreVoteFromStorage() {
+  const key = voteStorageKey()
+  if (!key) return null
+  const raw = localStorage.getItem(key)
+  if (!raw) return null
+  try { return JSON.parse(raw).vote } catch { return null }
+}
 
 async function handleClick(side) {
   if (battlePhase.value !== 'VOTING') return
+  if (confirmedVote.value !== null) return   // already voted — locked
   if (active.value === side) {
-    const judges = battleJudges.value?.judges ?? []
-    const id = judges.filter(j => j.name === selectedJudge.value).map(j => j.id)
-    await battleJudgeVote(id, side)
-    active.value = null
-    confirmed.value = side
-    setTimeout(() => { confirmed.value = null }, 1800)
+    await battleJudgeVote(judgeId.value, side)
+    confirmedVote.value = side
+    active.value        = null
+    saveVote(side)
+    if (navigator.vibrate) navigator.vibrate(40)
   } else {
     active.value = side
   }
 }
 
-const wsClients = []
+// ── WebSocket ───────────────────────────────────────────────────────────────
+const wsClients  = []
+let   voteClient = null
 
+function setupVoteSubscription() {
+  if (!judgeId.value || voteClient) return
+  voteClient = createClient()
+  wsClients.push(voteClient)
+  subscribeToChannel(voteClient, `/topic/battle/vote/${judgeId.value}`, (msg) => {
+    if (msg.vote !== -3) {
+      confirmedVote.value = msg.vote
+      active.value        = null
+    }
+  })
+}
+
+// ── Mount ───────────────────────────────────────────────────────────────────
 onMounted(async () => {
-  battleJudges.value = await getBattleJudges()
+  // 1. Overlay colors
+  const config = await getOverlayConfig()
+  if (config?.leftColor) overlayConfig.value = config
 
+  // 2. Phase
   const phaseData = await getBattlePhase()
   battlePhase.value = phaseData?.phase ?? 'IDLE'
 
+  // 3. Current pair (must come before vote restore so key is correct)
   const pairData = await getCurrentBattlePair()
   if (pairData) {
-    leftName.value = pairData.left ?? ''
+    leftName.value  = pairData.left  ?? ''
     rightName.value = pairData.right ?? ''
   }
 
-  // Each subscription needs its own client — subscribeToChannel sets onConnect,
-  // so sharing one client means every call overwrites the previous handler.
-  const cPhase = createClient(); wsClients.push(cPhase)
-  const cPair  = createClient(); wsClients.push(cPair)
-  const cScore = createClient(); wsClients.push(cScore)
-  const cJudge = createClient(); wsClients.push(cJudge)
+  // 4. Judges + identity
+  battleJudges.value = await getBattleJudges()
+  resolveJudgeIdentity(battleJudges.value?.judges ?? [])
+
+  // 5. Restore vote from localStorage (backend WS overrides if different)
+  if (battlePhase.value === 'VOTING') {
+    const stored = restoreVoteFromStorage()
+    if (stored !== null) confirmedVote.value = stored
+  }
+
+  // 6. WS subscriptions
+  const cOverlay = createClient(); wsClients.push(cOverlay)
+  const cPhase   = createClient(); wsClients.push(cPhase)
+  const cPair    = createClient(); wsClients.push(cPair)
+  const cScore   = createClient(); wsClients.push(cScore)
+  const cJudges  = createClient(); wsClients.push(cJudges)
+
+  subscribeToChannel(cOverlay, '/topic/battle/overlay-config', (msg) => {
+    if (msg?.leftColor) overlayConfig.value = msg
+  })
 
   subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
+    if (!msg?.phase) return
     battlePhase.value = msg.phase
     if (msg.phase === 'LOCKED') {
-      active.value = null
-      confirmed.value = null
+      clearVote()
       revealedWinner.value = -2
     }
   })
+
   subscribeToChannel(cPair, '/topic/battle/battle-pair', (msg) => {
-    leftName.value = msg.left ?? ''
+    leftName.value  = msg.left  ?? ''
     rightName.value = msg.right ?? ''
+    clearVote()
   })
+
   subscribeToChannel(cScore, '/topic/battle/score', (msg) => {
     revealedWinner.value = msg.message
   })
-  subscribeToChannel(cJudge, '/topic/battle/judges', (msg) => {
+
+  subscribeToChannel(cJudges, '/topic/battle/judges', (msg) => {
     battleJudges.value = msg
+    if (judgeId.value != null) {
+      const still = (msg?.judges ?? []).find(j => j.id === judgeId.value)
+      if (!still) clearJudge()
+    }
   })
 })
 

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -227,7 +227,7 @@ onUnmounted(() => {
     </header>
 
     <!-- ── Names bar ───────────────────────────────────────────── -->
-    <div v-if="leftName || rightName" class="names-bar" aria-hidden="true">
+    <div class="names-bar" aria-hidden="true">
       <div class="name-cell name-cell-left">
         <span class="name-cell-text">{{ leftName || '???' }}</span>
       </div>

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -230,6 +230,9 @@ onUnmounted(() => {
           <span class="judge-chip-name">{{ judgeName }}</span>
           <button class="judge-chip-clear" @click="clearJudge" aria-label="Change judge">✕</button>
         </div>
+        <button v-else class="pick-judge-btn" @click="showJudgePicker = true">
+          SELECT JUDGE
+        </button>
       </div>
     </header>
 
@@ -405,6 +408,7 @@ onUnmounted(() => {
   user-select: none;
   -webkit-tap-highlight-color: transparent;
   font-family: 'Inter', sans-serif;
+  touch-action: manipulation;
   --left-color:  #dc2626;
   --right-color: #2563eb;
 }
@@ -478,6 +482,19 @@ onUnmounted(() => {
   padding: 0 2px; line-height: 1; transition: color 0.15s;
 }
 .judge-chip-clear:hover { color: rgba(255,255,255,0.8); }
+
+.pick-judge-btn {
+  font-family: 'Inter', sans-serif;
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 0.2em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 999px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: rgba(255,255,255,0.7);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.pick-judge-btn:active { background: rgba(255,255,255,0.15); color: white; }
 
 /* ── (names bar removed — names shown on panels) ───────────── */
 

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -227,7 +227,7 @@ onUnmounted(() => {
     </header>
 
     <!-- ── Names bar ───────────────────────────────────────────── -->
-    <div class="names-bar" aria-hidden="true">
+    <div class="names-bar">
       <div class="name-cell name-cell-left">
         <span class="name-cell-text">{{ leftName || '???' }}</span>
       </div>
@@ -290,7 +290,7 @@ onUnmounted(() => {
           }"
           @click="handleClick(0)"
           :disabled="battlePhase !== 'VOTING'"
-          :aria-label="confirmedVote === 0 ? 'Left — vote locked' : active === 0 ? 'Left — tap again to confirm' : 'Vote Left'"
+          :aria-label="confirmedVote === 0 ? `${leftName || 'Left'} — vote locked` : active === 0 ? `${leftName || 'Left'} — tap again to confirm` : `Vote ${leftName || 'Left'}`"
           :aria-pressed="confirmedVote === 0"
         >
           <div class="panel-bg panel-bg-left" aria-hidden="true"></div>
@@ -318,7 +318,7 @@ onUnmounted(() => {
           }"
           @click="handleClick(1)"
           :disabled="battlePhase !== 'VOTING'"
-          :aria-label="confirmedVote === 1 ? 'Right — vote locked' : active === 1 ? 'Right — tap again to confirm' : 'Vote Right'"
+          :aria-label="confirmedVote === 1 ? `${rightName || 'Right'} — vote locked` : active === 1 ? `${rightName || 'Right'} — tap again to confirm` : `Vote ${rightName || 'Right'}`"
           :aria-pressed="confirmedVote === 1"
         >
           <div class="panel-bg panel-bg-right" aria-hidden="true"></div>

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -66,7 +66,7 @@ function voteStorageKey() {
 function saveVote(vote) {
   const key = voteStorageKey()
   if (!key) return
-  localStorage.setItem(key, JSON.stringify({ vote, leftName: leftName.value, rightName: rightName.value }))
+  localStorage.setItem(key, JSON.stringify({ vote, leftName: leftName.value, rightName: rightName.value, timestamp: Date.now() }))
 }
 
 function clearVote() {

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -194,196 +194,205 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="judge-root" role="main" aria-label="Battle Judge voting panel">
+  <div
+    class="judge-root"
+    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
+    role="main"
+    aria-label="Battle Judge voting panel"
+  >
 
-    <!-- ── IDLE overlay ───────────────────────────── -->
-    <Transition name="phase-fade">
-      <div v-if="battlePhase === 'IDLE'" class="phase-blocker idle-blocker" aria-live="polite">
-        <div class="phase-blocker-inner">
-          <span class="phase-blocker-icon">⏳</span>
-          <p class="phase-blocker-title">Waiting for battle setup…</p>
-          <div class="idle-selector-wrap" role="group" aria-label="Select your judge name">
-            <span class="idle-selector-eyebrow">VOTING AS</span>
-            <div class="w-64">
-              <ReusableDropdown
-                v-model="selectedJudge"
-                labelId=""
-                :options="battleJudgesName"
-                placeholder="Select your name…"
-              />
-            </div>
+    <!-- ── Header ──────────────────────────────────────────────── -->
+    <header class="judge-header">
+      <div class="header-brand">
+        <span class="brand-pip pip-left" aria-hidden="true"></span>
+        <span class="brand-wordmark">BATTLE JUDGE</span>
+        <span class="brand-pip pip-right" aria-hidden="true"></span>
+      </div>
+
+      <div class="header-center">
+        <span
+          class="phase-pill"
+          :class="`phase-pill--${battlePhase.toLowerCase()}`"
+          aria-live="polite"
+        >{{ battlePhase }}</span>
+      </div>
+
+      <div class="header-right">
+        <div v-if="judgeName" class="judge-chip">
+          <span class="judge-chip-label">AS</span>
+          <span class="judge-chip-name">{{ judgeName }}</span>
+          <button class="judge-chip-clear" @click="clearJudge" aria-label="Change judge">✕</button>
+        </div>
+      </div>
+    </header>
+
+    <!-- ── Names bar ───────────────────────────────────────────── -->
+    <div v-if="leftName || rightName" class="names-bar" aria-hidden="true">
+      <div class="name-cell name-cell-left">
+        <span class="name-cell-text">{{ leftName || '???' }}</span>
+      </div>
+      <div class="name-cell name-cell-right">
+        <span class="name-cell-text">{{ rightName || '???' }}</span>
+      </div>
+    </div>
+
+    <!-- ── Panels wrap ─────────────────────────────────────────── -->
+    <div class="panels-wrap" role="group" aria-label="Vote options">
+
+      <!-- Color bleeds -->
+      <div class="bleed bleed-left"  aria-hidden="true"></div>
+      <div class="bleed bleed-right" aria-hidden="true"></div>
+
+      <!-- Phase blocker (LOCKED / IDLE) -->
+      <Transition name="phase-fade">
+        <div
+          v-if="battlePhase === 'LOCKED' || battlePhase === 'IDLE'"
+          class="panels-blocker"
+          aria-live="polite"
+        >
+          <span class="blocker-icon">{{ battlePhase === 'LOCKED' ? '🔒' : '⏳' }}</span>
+          <span class="blocker-text">{{ battlePhase === 'LOCKED' ? 'VOTING NOT OPEN' : 'WAITING…' }}</span>
+        </div>
+      </Transition>
+
+      <!-- REVEALED banner -->
+      <Transition name="banner-slide">
+        <div
+          v-if="battlePhase === 'REVEALED'"
+          class="revealed-banner"
+          :class="revealedWinner === 0 ? 'banner-left' : revealedWinner === 1 ? 'banner-right' : 'banner-tie'"
+          aria-live="assertive"
+        >
+          <template v-if="revealedWinner === 0">
+            <span class="banner-winner-name">{{ leftName }}</span>
+            <span class="banner-wins">WINS</span>
+          </template>
+          <template v-else-if="revealedWinner === 1">
+            <span class="banner-winner-name">{{ rightName }}</span>
+            <span class="banner-wins">WINS</span>
+          </template>
+          <template v-else-if="revealedWinner === -1">
+            <span class="banner-wins">TIE</span>
+          </template>
+        </div>
+      </Transition>
+
+      <!-- LR row -->
+      <div class="lr-row">
+
+        <!-- LEFT -->
+        <button
+          class="vote-panel panel-left"
+          :class="{
+            'is-armed': active === 0 && confirmedVote === null,
+            'is-voted': confirmedVote === 0,
+            'is-dim':   confirmedVote !== null && confirmedVote !== 0,
+          }"
+          @click="handleClick(0)"
+          :disabled="battlePhase !== 'VOTING'"
+          :aria-label="confirmedVote === 0 ? 'Left — vote locked' : active === 0 ? 'Left — tap again to confirm' : 'Vote Left'"
+          :aria-pressed="confirmedVote === 0"
+        >
+          <div class="panel-bg panel-bg-left" aria-hidden="true"></div>
+          <div class="panel-inner">
+            <span class="direction-label">LEFT</span>
+            <div
+              class="panel-feedback"
+              :class="{ visible: active === 0 && confirmedVote === null }"
+              aria-live="polite"
+            >TAP AGAIN TO CONFIRM</div>
+          </div>
+          <template v-if="confirmedVote === 0">
+            <div class="vote-locked-wash wash-left" aria-hidden="true"></div>
+            <div class="vote-locked-text" aria-hidden="true">✓ VOTE LOCKED</div>
+          </template>
+        </button>
+
+        <!-- RIGHT -->
+        <button
+          class="vote-panel panel-right"
+          :class="{
+            'is-armed': active === 1 && confirmedVote === null,
+            'is-voted': confirmedVote === 1,
+            'is-dim':   confirmedVote !== null && confirmedVote !== 1,
+          }"
+          @click="handleClick(1)"
+          :disabled="battlePhase !== 'VOTING'"
+          :aria-label="confirmedVote === 1 ? 'Right — vote locked' : active === 1 ? 'Right — tap again to confirm' : 'Vote Right'"
+          :aria-pressed="confirmedVote === 1"
+        >
+          <div class="panel-bg panel-bg-right" aria-hidden="true"></div>
+          <div class="panel-inner">
+            <span class="direction-label">RIGHT</span>
+            <div
+              class="panel-feedback"
+              :class="{ visible: active === 1 && confirmedVote === null }"
+              aria-live="polite"
+            >TAP AGAIN TO CONFIRM</div>
+          </div>
+          <template v-if="confirmedVote === 1">
+            <div class="vote-locked-wash wash-right" aria-hidden="true"></div>
+            <div class="vote-locked-text" aria-hidden="true">✓ VOTE LOCKED</div>
+          </template>
+        </button>
+
+      </div><!-- /lr-row -->
+
+      <!-- TIE row -->
+      <div class="tie-row">
+        <button
+          class="vote-panel panel-tie"
+          :class="{
+            'is-armed': active === -1 && confirmedVote === null,
+            'is-voted': confirmedVote === -1,
+            'is-dim':   confirmedVote !== null && confirmedVote !== -1,
+          }"
+          @click="handleClick(-1)"
+          :disabled="battlePhase !== 'VOTING'"
+          :aria-label="confirmedVote === -1 ? 'Tie — vote locked' : active === -1 ? 'Tie — tap again to confirm' : 'Vote Tie'"
+          :aria-pressed="confirmedVote === -1"
+        >
+          <div class="panel-bg panel-bg-tie" aria-hidden="true"></div>
+          <div class="panel-inner">
+            <span class="direction-label direction-tie">TIE</span>
+            <div
+              class="panel-feedback"
+              :class="{ visible: active === -1 && confirmedVote === null }"
+              aria-live="polite"
+            >TAP AGAIN TO CONFIRM</div>
+          </div>
+          <template v-if="confirmedVote === -1">
+            <div class="vote-locked-wash wash-tie" aria-hidden="true"></div>
+            <div class="vote-locked-text" aria-hidden="true">✓ VOTE LOCKED</div>
+          </template>
+        </button>
+      </div><!-- /tie-row -->
+
+    </div><!-- /panels-wrap -->
+
+    <!-- ── Judge picker bottom sheet ───────────────────────────── -->
+    <Transition name="sheet-slide">
+      <div
+        v-if="showJudgePicker"
+        class="sheet-backdrop"
+        role="dialog"
+        aria-label="Select your name"
+      >
+        <div class="bottom-sheet">
+          <div class="sheet-handle" aria-hidden="true"></div>
+          <p class="sheet-title">WHO ARE YOU?</p>
+          <div class="sheet-grid">
+            <button
+              v-for="j in (battleJudges?.judges ?? [])"
+              :key="j.id"
+              class="sheet-name-chip"
+              @click="selectJudge(j)"
+            >{{ j.name }}</button>
           </div>
         </div>
       </div>
     </Transition>
 
-    <!-- ── Header bar ─────────────────────────────── -->
-    <header class="judge-header">
-      <div class="header-brand">
-        <span class="brand-pip pip-red"></span>
-        <span class="brand-wordmark">BATTLE JUDGE</span>
-        <span class="brand-pip pip-blue"></span>
-      </div>
-
-      <!-- Phase pill + pair names -->
-      <div class="header-center" aria-live="polite">
-        <span
-          class="phase-pill"
-          :class="`phase-pill--${battlePhase.toLowerCase()}`"
-        >{{ battlePhase }}</span>
-        <span v-if="leftName && (battlePhase === 'LOCKED' || battlePhase === 'VOTING')" class="pair-label">
-          {{ leftName }} <span class="vs-sep">vs</span> {{ rightName }}
-        </span>
-      </div>
-
-      <div class="selector-wrap" role="group" aria-label="Voting as">
-        <span class="selector-eyebrow" aria-hidden="true">VOTING AS</span>
-        <div class="w-52">
-          <ReusableDropdown
-            v-model="selectedJudge"
-            labelId=""
-            :options="battleJudgesName"
-            placeholder="Select judge…"
-          />
-        </div>
-      </div>
-    </header>
-
-    <!-- ── Voting panels ──────────────────────────── -->
-    <div class="panels-wrap" role="group" aria-label="Vote options">
-
-      <!-- LOCKED overlay: voting not yet open -->
-      <Transition name="phase-fade">
-        <div v-if="battlePhase === 'LOCKED'" class="panels-overlay locked-overlay" aria-live="polite">
-          <div class="panels-overlay-inner">
-            <i class="overlay-lock-icon">🔒</i>
-            <p class="overlay-title">VOTING NOT OPEN</p>
-            <p class="overlay-sub">Waiting for the organiser to open voting</p>
-          </div>
-        </div>
-      </Transition>
-
-      <!-- REVEALED overlay: winner announced -->
-      <Transition name="phase-fade">
-        <div v-if="battlePhase === 'REVEALED'" class="panels-overlay revealed-overlay" aria-live="assertive">
-          <div class="panels-overlay-inner">
-            <template v-if="revealedWinner === 0">
-              <p class="overlay-winner-name">{{ leftName }}</p>
-              <p class="overlay-winner-label">WINS</p>
-            </template>
-            <template v-else-if="revealedWinner === 1">
-              <p class="overlay-winner-name">{{ rightName }}</p>
-              <p class="overlay-winner-label">WINS</p>
-            </template>
-            <template v-else-if="revealedWinner === -1">
-              <p class="overlay-winner-label">TIE</p>
-            </template>
-          </div>
-        </div>
-      </Transition>
-
-      <!-- ── Left ── -->
-      <button
-        class="vote-panel left-panel"
-        :class="{ 'is-active': active === 0, 'is-confirmed': confirmed === 0 }"
-        @click="handleClick(0)"
-        :aria-label="confirmed === 0 ? 'Left — vote confirmed' : active === 0 ? 'Left — tap again to confirm' : 'Vote Left'"
-        :aria-pressed="active === 0 || confirmed === 0"
-      >
-        <div class="panel-fill left-fill" aria-hidden="true"></div>
-        <div class="edge-accent left-accent" aria-hidden="true"></div>
-        <div class="panel-shimmer" aria-hidden="true"></div>
-
-        <div class="panel-inner">
-          <p class="dir-label" aria-hidden="true">LEFT</p>
-          <div class="img-frame" aria-hidden="true">
-            <div class="img-halo red-halo"></div>
-            <img :src="leftHand" class="panel-img left-img" alt="" />
-          </div>
-          <div
-            class="feedback-row"
-            :class="{ visible: active === 0 || confirmed === 0 }"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <template v-if="confirmed === 0">
-              <span class="check-mark" aria-hidden="true">✓</span> VOTE LOCKED
-            </template>
-            <template v-else-if="active === 0">TAP AGAIN TO CONFIRM</template>
-          </div>
-        </div>
-
-        <div class="pulse-ring left-ring" aria-hidden="true"></div>
-      </button>
-
-      <!-- ── Tie ── -->
-      <button
-        class="vote-panel tie-panel"
-        :class="{ 'is-active': active === -1, 'is-confirmed': confirmed === -1 }"
-        @click="handleClick(-1)"
-        :aria-label="confirmed === -1 ? 'Tie — vote confirmed' : active === -1 ? 'Tie — tap again to confirm' : 'Vote Tie'"
-        :aria-pressed="active === -1 || confirmed === -1"
-      >
-        <div class="panel-fill tie-fill" aria-hidden="true"></div>
-        <div class="panel-shimmer" aria-hidden="true"></div>
-
-        <div class="panel-inner">
-          <p class="dir-label" aria-hidden="true">TIE</p>
-          <div class="img-frame" aria-hidden="true">
-            <div class="img-halo neutral-halo"></div>
-            <img :src="tie" class="panel-img" alt="" />
-          </div>
-          <div
-            class="feedback-row"
-            :class="{ visible: active === -1 || confirmed === -1 }"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <template v-if="confirmed === -1">
-              <span class="check-mark" aria-hidden="true">✓</span> VOTE LOCKED
-            </template>
-            <template v-else-if="active === -1">TAP AGAIN TO CONFIRM</template>
-          </div>
-        </div>
-
-        <div class="pulse-ring neutral-ring" aria-hidden="true"></div>
-      </button>
-
-      <!-- ── Right ── -->
-      <button
-        class="vote-panel right-panel"
-        :class="{ 'is-active': active === 1, 'is-confirmed': confirmed === 1 }"
-        @click="handleClick(1)"
-        :aria-label="confirmed === 1 ? 'Right — vote confirmed' : active === 1 ? 'Right — tap again to confirm' : 'Vote Right'"
-        :aria-pressed="active === 1 || confirmed === 1"
-      >
-        <div class="panel-fill right-fill" aria-hidden="true"></div>
-        <div class="edge-accent right-accent" aria-hidden="true"></div>
-        <div class="panel-shimmer" aria-hidden="true"></div>
-
-        <div class="panel-inner">
-          <p class="dir-label" aria-hidden="true">RIGHT</p>
-          <div class="img-frame" aria-hidden="true">
-            <div class="img-halo blue-halo"></div>
-            <img :src="rightHand" class="panel-img right-img" alt="" />
-          </div>
-          <div
-            class="feedback-row"
-            :class="{ visible: active === 1 || confirmed === 1 }"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <template v-if="confirmed === 1">
-              <span class="check-mark" aria-hidden="true">✓</span> VOTE LOCKED
-            </template>
-            <template v-else-if="active === 1">TAP AGAIN TO CONFIRM</template>
-          </div>
-        </div>
-
-        <div class="pulse-ring blue-ring" aria-hidden="true"></div>
-      </button>
-
-    </div>
   </div>
 </template>
 

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -52,6 +52,13 @@ function clearJudge() {
   localStorage.removeItem(LS_JUDGE_ID)
   localStorage.removeItem(LS_JUDGE_NAME)
   showJudgePicker.value = true
+  if (voteClient) {
+    deactivateClient(voteClient)
+    const idx = wsClients.indexOf(voteClient)
+    if (idx !== -1) wsClients.splice(idx, 1)
+    voteClient = null
+  }
+  clearVote()
 }
 
 // ── Vote state ──────────────────────────────────────────────────────────────
@@ -88,7 +95,8 @@ async function handleClick(side) {
   if (battlePhase.value !== 'VOTING') return
   if (confirmedVote.value !== null) return   // already voted — locked
   if (active.value === side) {
-    await battleJudgeVote(judgeId.value, side)
+    const res = await battleJudgeVote(judgeId.value, side)
+    if (!res?.ok) return   // POST failed — stay armed, let judge try again
     confirmedVote.value = side
     active.value        = null
     saveVote(side)
@@ -107,7 +115,7 @@ function setupVoteSubscription() {
   voteClient = createClient()
   wsClients.push(voteClient)
   subscribeToChannel(voteClient, `/topic/battle/vote/${judgeId.value}`, (msg) => {
-    if (msg.vote !== -3) {
+    if (msg.vote === 0 || msg.vote === 1 || msg.vote === -1) {
       confirmedVote.value = msg.vote
       active.value        = null
     }

--- a/docs/superpowers/plans/2026-05-27-battle-judge-redesign.md
+++ b/docs/superpowers/plans/2026-05-27-battle-judge-redesign.md
@@ -1,0 +1,980 @@
+# BattleJudge Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild `BattleJudge.vue` with a bold, dark UI matching BattleOverlay, overlay-config-driven colors, localStorage-persisted judge identity and vote state, and a LEFT/RIGHT side-by-side + TIE-at-bottom layout.
+
+**Architecture:** Single-file Vue SFC rebuild. No new components. All state in `<script setup>`. Colors driven by `--left-color` / `--right-color` CSS custom properties sourced from `getOverlayConfig()` + WebSocket. Judge identity and vote stored in `localStorage`, cross-checked against backend on mount.
+
+**Tech Stack:** Vue 3 `<script setup>`, Vitest (manual verification only — no existing component tests in codebase), STOMP WebSocket via `@/utils/websocket`, `@/utils/api`
+
+---
+
+## Task 1: Create feature branch
+
+**Files:**
+- No file changes — git operations only
+
+- [ ] **Step 1: Fetch and create branch**
+
+```bash
+cd /Users/bennylim/Documents/BES
+git fetch origin
+git checkout -b feature/battle-judge-redesign
+git rebase origin/master
+```
+
+Expected: branch created cleanly off latest master.
+
+- [ ] **Step 2: Force-push branch to remote**
+
+```bash
+git push -u origin feature/battle-judge-redesign --force-with-lease
+```
+
+Expected: remote branch created.
+
+- [ ] **Step 3: Add rebase-on-switch alias to shell profile**
+
+Add this to `~/.zshrc` so switching to any feature branch always pulls latest master first:
+
+```bash
+gswm() {
+  git fetch origin
+  git checkout "$1" 2>/dev/null || git checkout -b "$1"
+  git rebase origin/master
+}
+```
+
+Run to reload:
+```bash
+source ~/.zshrc
+```
+
+From now on, use `gswm feature/battle-judge-redesign` instead of `git checkout`.
+
+---
+
+## Task 2: Rebuild `<script setup>`
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleJudge.vue` — replace entire `<script setup>` block
+
+- [ ] **Step 1: Replace the entire `<script setup>` block**
+
+Replace everything between `<script setup>` and `</script>` with:
+
+```javascript
+import { battleJudgeVote, getBattleJudges, getBattlePhase, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
+import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
+import { onMounted, onUnmounted, ref } from 'vue'
+
+// ── Overlay config ──────────────────────────────────────────────────────────
+const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+
+// ── Battle state ────────────────────────────────────────────────────────────
+const battlePhase    = ref('IDLE')
+const leftName       = ref('')
+const rightName      = ref('')
+const revealedWinner = ref(-2)
+const battleJudges   = ref({ judges: [] })
+
+// ── Judge identity ──────────────────────────────────────────────────────────
+const judgeId         = ref(null)   // number | null
+const judgeName       = ref('')
+const showJudgePicker = ref(false)
+
+const LS_JUDGE_ID   = 'battleJudgeId'
+const LS_JUDGE_NAME = 'battleJudgeName'
+
+function resolveJudgeIdentity(judges) {
+  const storedId = localStorage.getItem(LS_JUDGE_ID)
+  if (!storedId) { showJudgePicker.value = true; return }
+  const id = Number(storedId)
+  const match = judges.find(j => j.id === id)
+  if (!match) {
+    localStorage.removeItem(LS_JUDGE_ID)
+    localStorage.removeItem(LS_JUDGE_NAME)
+    showJudgePicker.value = true
+    return
+  }
+  judgeId.value   = id
+  judgeName.value = match.name
+  setupVoteSubscription()
+}
+
+function selectJudge(j) {
+  judgeId.value   = j.id
+  judgeName.value = j.name
+  localStorage.setItem(LS_JUDGE_ID,   String(j.id))
+  localStorage.setItem(LS_JUDGE_NAME, j.name)
+  showJudgePicker.value = false
+  setupVoteSubscription()
+}
+
+function clearJudge() {
+  judgeId.value   = null
+  judgeName.value = ''
+  localStorage.removeItem(LS_JUDGE_ID)
+  localStorage.removeItem(LS_JUDGE_NAME)
+  showJudgePicker.value = true
+}
+
+// ── Vote state ──────────────────────────────────────────────────────────────
+const active        = ref(null)   // armed: 0 | 1 | -1 | null
+const confirmedVote = ref(null)   // confirmed: 0 | 1 | -1 | null
+
+function voteStorageKey() {
+  if (judgeId.value == null || !leftName.value || !rightName.value) return null
+  return `battleVote_${judgeId.value}_${leftName.value}_${rightName.value}`
+}
+
+function saveVote(vote) {
+  const key = voteStorageKey()
+  if (!key) return
+  localStorage.setItem(key, JSON.stringify({ vote, leftName: leftName.value, rightName: rightName.value }))
+}
+
+function clearVote() {
+  const key = voteStorageKey()
+  if (key) localStorage.removeItem(key)
+  confirmedVote.value = null
+  active.value        = null
+}
+
+function restoreVoteFromStorage() {
+  const key = voteStorageKey()
+  if (!key) return null
+  const raw = localStorage.getItem(key)
+  if (!raw) return null
+  try { return JSON.parse(raw).vote } catch { return null }
+}
+
+async function handleClick(side) {
+  if (battlePhase.value !== 'VOTING') return
+  if (confirmedVote.value !== null) return   // already voted — locked
+  if (active.value === side) {
+    await battleJudgeVote(judgeId.value, side)
+    confirmedVote.value = side
+    active.value        = null
+    saveVote(side)
+    if (navigator.vibrate) navigator.vibrate(40)
+  } else {
+    active.value = side
+  }
+}
+
+// ── WebSocket ───────────────────────────────────────────────────────────────
+const wsClients  = []
+let   voteClient = null
+
+function setupVoteSubscription() {
+  if (!judgeId.value || voteClient) return
+  voteClient = createClient()
+  wsClients.push(voteClient)
+  subscribeToChannel(voteClient, `/topic/battle/vote/${judgeId.value}`, (msg) => {
+    if (msg.vote !== -3) {
+      confirmedVote.value = msg.vote
+      active.value        = null
+    }
+  })
+}
+
+// ── Mount ───────────────────────────────────────────────────────────────────
+onMounted(async () => {
+  // 1. Overlay colors
+  const config = await getOverlayConfig()
+  if (config?.leftColor) overlayConfig.value = config
+
+  // 2. Phase
+  const phaseData = await getBattlePhase()
+  battlePhase.value = phaseData?.phase ?? 'IDLE'
+
+  // 3. Current pair (must come before vote restore so key is correct)
+  const pairData = await getCurrentBattlePair()
+  if (pairData) {
+    leftName.value  = pairData.left  ?? ''
+    rightName.value = pairData.right ?? ''
+  }
+
+  // 4. Judges + identity
+  battleJudges.value = await getBattleJudges()
+  resolveJudgeIdentity(battleJudges.value?.judges ?? [])
+
+  // 5. Restore vote from localStorage (backend WS overrides if different)
+  if (battlePhase.value === 'VOTING') {
+    const stored = restoreVoteFromStorage()
+    if (stored !== null) confirmedVote.value = stored
+  }
+
+  // 6. WS subscriptions
+  const cOverlay = createClient(); wsClients.push(cOverlay)
+  const cPhase   = createClient(); wsClients.push(cPhase)
+  const cPair    = createClient(); wsClients.push(cPair)
+  const cScore   = createClient(); wsClients.push(cScore)
+  const cJudges  = createClient(); wsClients.push(cJudges)
+
+  subscribeToChannel(cOverlay, '/topic/battle/overlay-config', (msg) => {
+    if (msg?.leftColor) overlayConfig.value = msg
+  })
+
+  subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
+    if (!msg?.phase) return
+    battlePhase.value = msg.phase
+    if (msg.phase === 'LOCKED') {
+      clearVote()
+      revealedWinner.value = -2
+    }
+  })
+
+  subscribeToChannel(cPair, '/topic/battle/battle-pair', (msg) => {
+    leftName.value  = msg.left  ?? ''
+    rightName.value = msg.right ?? ''
+    clearVote()
+  })
+
+  subscribeToChannel(cScore, '/topic/battle/score', (msg) => {
+    revealedWinner.value = msg.message
+  })
+
+  subscribeToChannel(cJudges, '/topic/battle/judges', (msg) => {
+    battleJudges.value = msg
+    if (judgeId.value != null) {
+      const still = (msg?.judges ?? []).find(j => j.id === judgeId.value)
+      if (!still) clearJudge()
+    }
+  })
+})
+
+onUnmounted(() => {
+  wsClients.forEach(c => deactivateClient(c))
+})
+```
+
+- [ ] **Step 2: Verify the dev server starts without errors**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run dev 2>&1 | head -30
+```
+
+Expected: no compile errors. If there are import errors, check that `getOverlayConfig` exists in `@/utils/api` (it should — it was added in the previous overlay improvements feature).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleJudge.vue
+git commit -m "feat(battle-judge): rebuild script setup — overlay config, judge identity, vote persistence"
+```
+
+---
+
+## Task 3: Rebuild `<template>`
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleJudge.vue` — replace entire `<template>` block
+
+- [ ] **Step 1: Replace the entire `<template>` block**
+
+Replace everything between `<template>` and `</template>` with:
+
+```html
+<template>
+  <div
+    class="judge-root"
+    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
+    role="main"
+    aria-label="Battle Judge voting panel"
+  >
+
+    <!-- ── Header ──────────────────────────────────────────────── -->
+    <header class="judge-header">
+      <div class="header-brand">
+        <span class="brand-pip pip-left" aria-hidden="true"></span>
+        <span class="brand-wordmark">BATTLE JUDGE</span>
+        <span class="brand-pip pip-right" aria-hidden="true"></span>
+      </div>
+
+      <div class="header-center">
+        <span
+          class="phase-pill"
+          :class="`phase-pill--${battlePhase.toLowerCase()}`"
+          aria-live="polite"
+        >{{ battlePhase }}</span>
+      </div>
+
+      <div class="header-right">
+        <div v-if="judgeName" class="judge-chip">
+          <span class="judge-chip-label">AS</span>
+          <span class="judge-chip-name">{{ judgeName }}</span>
+          <button class="judge-chip-clear" @click="clearJudge" aria-label="Change judge">✕</button>
+        </div>
+      </div>
+    </header>
+
+    <!-- ── Names bar ───────────────────────────────────────────── -->
+    <div v-if="leftName || rightName" class="names-bar" aria-hidden="true">
+      <div class="name-cell name-cell-left">
+        <span class="name-cell-text">{{ leftName || '???' }}</span>
+      </div>
+      <div class="name-cell name-cell-right">
+        <span class="name-cell-text">{{ rightName || '???' }}</span>
+      </div>
+    </div>
+
+    <!-- ── Panels wrap ─────────────────────────────────────────── -->
+    <div class="panels-wrap" role="group" aria-label="Vote options">
+
+      <!-- Color bleeds -->
+      <div class="bleed bleed-left"  aria-hidden="true"></div>
+      <div class="bleed bleed-right" aria-hidden="true"></div>
+
+      <!-- Phase blocker (LOCKED / IDLE) -->
+      <Transition name="phase-fade">
+        <div
+          v-if="battlePhase === 'LOCKED' || battlePhase === 'IDLE'"
+          class="panels-blocker"
+          aria-live="polite"
+        >
+          <span class="blocker-icon">{{ battlePhase === 'LOCKED' ? '🔒' : '⏳' }}</span>
+          <span class="blocker-text">{{ battlePhase === 'LOCKED' ? 'VOTING NOT OPEN' : 'WAITING…' }}</span>
+        </div>
+      </Transition>
+
+      <!-- REVEALED banner -->
+      <Transition name="banner-slide">
+        <div
+          v-if="battlePhase === 'REVEALED'"
+          class="revealed-banner"
+          :class="revealedWinner === 0 ? 'banner-left' : revealedWinner === 1 ? 'banner-right' : 'banner-tie'"
+          aria-live="assertive"
+        >
+          <template v-if="revealedWinner === 0">
+            <span class="banner-winner-name">{{ leftName }}</span>
+            <span class="banner-wins">WINS</span>
+          </template>
+          <template v-else-if="revealedWinner === 1">
+            <span class="banner-winner-name">{{ rightName }}</span>
+            <span class="banner-wins">WINS</span>
+          </template>
+          <template v-else-if="revealedWinner === -1">
+            <span class="banner-wins">TIE</span>
+          </template>
+        </div>
+      </Transition>
+
+      <!-- LR row -->
+      <div class="lr-row">
+
+        <!-- LEFT -->
+        <button
+          class="vote-panel panel-left"
+          :class="{
+            'is-armed': active === 0 && confirmedVote === null,
+            'is-voted': confirmedVote === 0,
+            'is-dim':   confirmedVote !== null && confirmedVote !== 0,
+          }"
+          @click="handleClick(0)"
+          :disabled="battlePhase !== 'VOTING'"
+          :aria-label="confirmedVote === 0 ? 'Left — vote locked' : active === 0 ? 'Left — tap again to confirm' : 'Vote Left'"
+          :aria-pressed="confirmedVote === 0"
+        >
+          <div class="panel-bg panel-bg-left" aria-hidden="true"></div>
+          <div class="panel-inner">
+            <span class="direction-label">LEFT</span>
+            <div
+              class="panel-feedback"
+              :class="{ visible: active === 0 && confirmedVote === null }"
+              aria-live="polite"
+            >TAP AGAIN TO CONFIRM</div>
+          </div>
+          <template v-if="confirmedVote === 0">
+            <div class="vote-locked-wash wash-left" aria-hidden="true"></div>
+            <div class="vote-locked-text" aria-hidden="true">✓ VOTE LOCKED</div>
+          </template>
+        </button>
+
+        <!-- RIGHT -->
+        <button
+          class="vote-panel panel-right"
+          :class="{
+            'is-armed': active === 1 && confirmedVote === null,
+            'is-voted': confirmedVote === 1,
+            'is-dim':   confirmedVote !== null && confirmedVote !== 1,
+          }"
+          @click="handleClick(1)"
+          :disabled="battlePhase !== 'VOTING'"
+          :aria-label="confirmedVote === 1 ? 'Right — vote locked' : active === 1 ? 'Right — tap again to confirm' : 'Vote Right'"
+          :aria-pressed="confirmedVote === 1"
+        >
+          <div class="panel-bg panel-bg-right" aria-hidden="true"></div>
+          <div class="panel-inner">
+            <span class="direction-label">RIGHT</span>
+            <div
+              class="panel-feedback"
+              :class="{ visible: active === 1 && confirmedVote === null }"
+              aria-live="polite"
+            >TAP AGAIN TO CONFIRM</div>
+          </div>
+          <template v-if="confirmedVote === 1">
+            <div class="vote-locked-wash wash-right" aria-hidden="true"></div>
+            <div class="vote-locked-text" aria-hidden="true">✓ VOTE LOCKED</div>
+          </template>
+        </button>
+
+      </div><!-- /lr-row -->
+
+      <!-- TIE row -->
+      <div class="tie-row">
+        <button
+          class="vote-panel panel-tie"
+          :class="{
+            'is-armed': active === -1 && confirmedVote === null,
+            'is-voted': confirmedVote === -1,
+            'is-dim':   confirmedVote !== null && confirmedVote !== -1,
+          }"
+          @click="handleClick(-1)"
+          :disabled="battlePhase !== 'VOTING'"
+          :aria-label="confirmedVote === -1 ? 'Tie — vote locked' : active === -1 ? 'Tie — tap again to confirm' : 'Vote Tie'"
+          :aria-pressed="confirmedVote === -1"
+        >
+          <div class="panel-bg panel-bg-tie" aria-hidden="true"></div>
+          <div class="panel-inner">
+            <span class="direction-label direction-tie">TIE</span>
+            <div
+              class="panel-feedback"
+              :class="{ visible: active === -1 && confirmedVote === null }"
+              aria-live="polite"
+            >TAP AGAIN TO CONFIRM</div>
+          </div>
+          <template v-if="confirmedVote === -1">
+            <div class="vote-locked-wash wash-tie" aria-hidden="true"></div>
+            <div class="vote-locked-text" aria-hidden="true">✓ VOTE LOCKED</div>
+          </template>
+        </button>
+      </div><!-- /tie-row -->
+
+    </div><!-- /panels-wrap -->
+
+    <!-- ── Judge picker bottom sheet ───────────────────────────── -->
+    <Transition name="sheet-slide">
+      <div
+        v-if="showJudgePicker"
+        class="sheet-backdrop"
+        role="dialog"
+        aria-label="Select your name"
+      >
+        <div class="bottom-sheet">
+          <div class="sheet-handle" aria-hidden="true"></div>
+          <p class="sheet-title">WHO ARE YOU?</p>
+          <div class="sheet-grid">
+            <button
+              v-for="j in (battleJudges?.judges ?? [])"
+              :key="j.id"
+              class="sheet-name-chip"
+              @click="selectJudge(j)"
+            >{{ j.name }}</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Verify template renders without errors in the browser**
+
+Open `http://localhost:5173/battle/judge`. Expected: page loads, shows header with "BATTLE JUDGE" wordmark and a phase pill. No console errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleJudge.vue
+git commit -m "feat(battle-judge): rebuild template — new layout with LR row, TIE row, bottom sheet, revealed banner"
+```
+
+---
+
+## Task 4: Rebuild `<style scoped>`
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleJudge.vue` — replace entire `<style scoped>` block
+
+- [ ] **Step 1: Replace the entire `<style scoped>` block**
+
+Replace everything between `<style scoped>` and `</style>` with:
+
+```css
+/* ── Root ───────────────────────────────────────────────────── */
+.judge-root {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  background: #060a14;
+  overflow: hidden;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  font-family: 'Inter', sans-serif;
+  --left-color:  #dc2626;
+  --right-color: #2563eb;
+}
+
+/* ── Header ─────────────────────────────────────────────────── */
+.judge-header {
+  flex-shrink: 0;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  background: rgba(255,255,255,0.022);
+  border-bottom: 1px solid rgba(255,255,255,0.065);
+  backdrop-filter: blur(16px);
+  z-index: 20;
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.brand-pip {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  animation: pipPulse 2.4s ease-in-out infinite;
+}
+.pip-left  { background: var(--left-color);  box-shadow: 0 0 8px var(--left-color); }
+.pip-right { background: var(--right-color); box-shadow: 0 0 8px var(--right-color); animation-delay: 1.2s; }
+
+.brand-wordmark {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  color: rgba(255,255,255,0.28);
+  text-transform: uppercase;
+}
+
+.header-center { flex: 1; display: flex; justify-content: center; }
+.header-right  { flex-shrink: 0; }
+
+/* Phase pill */
+.phase-pill {
+  font-family: 'Inter', sans-serif;
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 0.2em; text-transform: uppercase;
+  padding: 3px 10px; border-radius: 999px;
+  border: 1px solid transparent;
+}
+.phase-pill--idle     { background: rgba(71,85,105,0.3);   color: rgba(148,163,184,0.6);  border-color: rgba(71,85,105,0.4); }
+.phase-pill--locked   { background: rgba(245,158,11,0.15); color: rgba(251,191,36,0.9);   border-color: rgba(245,158,11,0.4); }
+.phase-pill--voting   { background: rgba(6,182,212,0.15);  color: rgba(6,182,212,0.95);   border-color: rgba(6,182,212,0.4); animation: votingPillPulse 1.6s ease-in-out infinite; }
+.phase-pill--revealed { background: rgba(16,185,129,0.15); color: rgba(52,211,153,0.95);  border-color: rgba(16,185,129,0.4); }
+
+/* Judge chip */
+.judge-chip {
+  display: flex; align-items: center; gap: 5px;
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--left-color) 12%, rgba(6,10,20,0.8));
+  border: 1px solid color-mix(in srgb, var(--left-color) 40%, transparent);
+  border-radius: 999px;
+}
+.judge-chip-label { font-size: 8px; font-weight: 700; letter-spacing: 0.18em; color: rgba(255,255,255,0.35); }
+.judge-chip-name  { font-size: 10px; font-weight: 800; letter-spacing: 0.1em; color: rgba(255,255,255,0.9); text-transform: uppercase; }
+.judge-chip-clear {
+  background: none; border: none; cursor: pointer;
+  font-size: 10px; color: rgba(255,255,255,0.3);
+  padding: 0 2px; line-height: 1; transition: color 0.15s;
+}
+.judge-chip-clear:hover { color: rgba(255,255,255,0.8); }
+
+/* ── Names bar ──────────────────────────────────────────────── */
+.names-bar {
+  flex-shrink: 0;
+  height: 10%;
+  display: flex;
+  min-height: 36px;
+}
+.name-cell {
+  flex: 1; display: flex;
+  align-items: center; justify-content: center;
+  padding: 0 12px; overflow: hidden;
+}
+.name-cell-left  { background: color-mix(in srgb, var(--left-color)  12%, transparent); border-right: 1px solid rgba(255,255,255,0.04); }
+.name-cell-right { background: color-mix(in srgb, var(--right-color) 12%, transparent); }
+.name-cell-text {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(13px, 2.8vw, 22px);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  text-overflow: ellipsis; overflow: hidden; white-space: nowrap;
+}
+.name-cell-left  .name-cell-text { color: color-mix(in srgb, var(--left-color)  90%, white); }
+.name-cell-right .name-cell-text { color: color-mix(in srgb, var(--right-color) 90%, white); }
+
+/* ── Panels wrap ────────────────────────────────────────────── */
+.panels-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Color bleeds */
+.bleed {
+  position: absolute; bottom: 0;
+  width: 50%; height: 35%;
+  pointer-events: none; z-index: 1;
+}
+.bleed-left  { left: 0;  background: radial-gradient(ellipse at 0% 100%, color-mix(in srgb, var(--left-color)  14%, transparent), transparent 70%); }
+.bleed-right { right: 0; background: radial-gradient(ellipse at 100% 100%, color-mix(in srgb, var(--right-color) 14%, transparent), transparent 70%); }
+
+/* LR row */
+.lr-row {
+  flex: 1;
+  display: flex;
+  gap: 2px;
+}
+
+/* TIE row */
+.tie-row {
+  flex-shrink: 0;
+  height: 20%;
+  min-height: 64px;
+  padding-top: 2px;
+}
+
+/* ── Vote panel — shared ────────────────────────────────────── */
+.vote-panel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none; outline: none; cursor: pointer;
+  overflow: hidden; background: transparent;
+  transition: opacity 0.3s ease, filter 0.3s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.lr-row   .vote-panel { flex: 1; }
+.tie-row  .vote-panel { width: 100%; height: 100%; }
+
+/* Panel backgrounds */
+.panel-bg {
+  position: absolute; inset: 0;
+  transition: opacity 0.3s ease;
+}
+.panel-bg-left {
+  background:
+    radial-gradient(ellipse 80% 70% at 50% 62%, color-mix(in srgb, var(--left-color) 45%, transparent) 0%, transparent 75%),
+    linear-gradient(180deg, color-mix(in srgb, var(--left-color) 8%, #060a14) 0%, color-mix(in srgb, var(--left-color) 18%, #060a14) 100%);
+}
+.panel-bg-right {
+  background:
+    radial-gradient(ellipse 80% 70% at 50% 62%, color-mix(in srgb, var(--right-color) 45%, transparent) 0%, transparent 75%),
+    linear-gradient(180deg, color-mix(in srgb, var(--right-color) 8%, #060a14) 0%, color-mix(in srgb, var(--right-color) 18%, #060a14) 100%);
+}
+.panel-bg-tie {
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 50%, rgba(71,85,105,0.35) 0%, transparent 75%),
+    linear-gradient(180deg, #0a0e18 0%, #111827 100%);
+}
+
+/* Armed — brighter background */
+.is-armed .panel-bg-left  { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--left-color)  65%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--left-color)  18%, #060a14) 0%, color-mix(in srgb, var(--left-color)  35%, #060a14) 100%); }
+.is-armed .panel-bg-right { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--right-color) 65%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--right-color) 18%, #060a14) 0%, color-mix(in srgb, var(--right-color) 35%, #060a14) 100%); }
+.is-armed .panel-bg-tie   { background: radial-gradient(ellipse 95% 85% at 50% 50%, rgba(100,116,139,0.55) 0%, transparent 72%), linear-gradient(180deg, #0f1624 0%, #1e2e48 100%); }
+.is-armed { animation: armedPulse 1.4s ease-in-out infinite; }
+
+/* Voted — max glow */
+.is-voted .panel-bg-left  { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--left-color)  75%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--left-color)  22%, #060a14) 0%, color-mix(in srgb, var(--left-color)  42%, #060a14) 100%); }
+.is-voted .panel-bg-right { background: radial-gradient(ellipse 95% 85% at 50% 62%, color-mix(in srgb, var(--right-color) 75%, transparent) 0%, transparent 72%), linear-gradient(180deg, color-mix(in srgb, var(--right-color) 22%, #060a14) 0%, color-mix(in srgb, var(--right-color) 42%, #060a14) 100%); }
+.is-voted .panel-bg-tie   { background: radial-gradient(ellipse 95% 85% at 50% 50%, rgba(100,116,139,0.65) 0%, transparent 72%), linear-gradient(180deg, #0f1624 0%, #253649 100%); }
+
+/* Dim — not chosen after vote */
+.is-dim { opacity: 0.2; filter: saturate(0.15); pointer-events: none; }
+
+/* ── Panel inner ────────────────────────────────────────────── */
+.panel-inner {
+  position: relative; z-index: 5;
+  display: flex; flex-direction: column;
+  align-items: center;
+  gap: clamp(6px, 1.5vh, 18px);
+}
+
+.direction-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(28px, 5vw, 64px);
+  letter-spacing: 0.2em; text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+  line-height: 1;
+  transition: color 0.3s ease, letter-spacing 0.3s ease, text-shadow 0.3s ease;
+}
+.direction-tie { font-size: clamp(18px, 3.5vw, 42px); }
+
+.is-armed .direction-label {
+  color: rgba(255,255,255,0.92);
+  letter-spacing: 0.26em;
+}
+.panel-left.is-armed  .direction-label { text-shadow: 0 0 32px color-mix(in srgb, var(--left-color)  70%, transparent); }
+.panel-right.is-armed .direction-label { text-shadow: 0 0 32px color-mix(in srgb, var(--right-color) 70%, transparent); }
+.panel-tie.is-armed   .direction-label { text-shadow: 0 0 32px rgba(148,163,184,0.6); }
+
+.is-voted .direction-label { color: rgba(255,255,255,0.8); }
+
+.panel-feedback {
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(8px, 1.2vw, 12px);
+  font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  color: rgba(255,255,255,0.85);
+  opacity: 0; transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.panel-feedback.visible { opacity: 1; transform: translateY(0); }
+
+/* ── Vote locked wash ───────────────────────────────────────── */
+.vote-locked-wash {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  height: 42%; z-index: 6; pointer-events: none;
+}
+.wash-left  { background: linear-gradient(to top, color-mix(in srgb, var(--left-color)  80%, black) 0%, color-mix(in srgb, var(--left-color)  40%, transparent) 65%, transparent 100%); }
+.wash-right { background: linear-gradient(to top, color-mix(in srgb, var(--right-color) 80%, black) 0%, color-mix(in srgb, var(--right-color) 40%, transparent) 65%, transparent 100%); }
+.wash-tie   { background: linear-gradient(to top, rgba(71,85,105,0.85) 0%, rgba(71,85,105,0.35) 65%, transparent 100%); }
+
+.vote-locked-text {
+  position: absolute; bottom: 9%; left: 0; right: 0;
+  text-align: center;
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(10px, 1.6vw, 15px);
+  font-weight: 900; letter-spacing: 0.24em; text-transform: uppercase;
+  color: white; z-index: 7; pointer-events: none;
+}
+
+/* ── Phase blocker ──────────────────────────────────────────── */
+.panels-blocker {
+  position: absolute; inset: 0; z-index: 15;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  background: rgba(6,10,20,0.78);
+  backdrop-filter: blur(4px);
+  pointer-events: none;
+}
+.blocker-icon { font-size: 2.2rem; }
+.blocker-text {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(14px, 2.5vw, 22px);
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: rgba(251,191,36,0.85);
+}
+
+/* ── REVEALED banner ────────────────────────────────────────── */
+.revealed-banner {
+  position: absolute; bottom: 0; left: 0; right: 0; z-index: 20;
+  height: 52%;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: flex-end;
+  padding-bottom: 8%;
+  pointer-events: none;
+}
+.banner-left  { background: linear-gradient(to top, color-mix(in srgb, var(--left-color)  85%, black) 0%, color-mix(in srgb, var(--left-color)  30%, transparent) 72%, transparent 100%); }
+.banner-right { background: linear-gradient(to top, color-mix(in srgb, var(--right-color) 85%, black) 0%, color-mix(in srgb, var(--right-color) 30%, transparent) 72%, transparent 100%); }
+.banner-tie   { background: linear-gradient(to top, rgba(71,85,105,0.85) 0%, rgba(71,85,105,0.3) 72%, transparent 100%); }
+.banner-winner-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(28px, 5.5vw, 58px);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: white; line-height: 1;
+}
+.banner-wins {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(14px, 2.5vw, 30px);
+  letter-spacing: 0.35em; text-transform: uppercase;
+  color: rgba(52,211,153,0.9);
+}
+
+/* ── Bottom sheet ───────────────────────────────────────────── */
+.sheet-backdrop {
+  position: fixed; inset: 0; z-index: 50;
+  background: rgba(6,10,20,0.65);
+  backdrop-filter: blur(4px);
+  display: flex; align-items: flex-end;
+}
+.bottom-sheet {
+  width: 100%;
+  background: #0d1220;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  border-radius: 16px 16px 0 0;
+  padding: 8px 16px 32px;
+}
+.sheet-handle {
+  width: 32px; height: 4px;
+  background: rgba(255,255,255,0.15);
+  border-radius: 999px;
+  margin: 0 auto 14px;
+}
+.sheet-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px; font-weight: 800;
+  letter-spacing: 0.25em; text-transform: uppercase;
+  color: rgba(255,255,255,0.3);
+  text-align: center; margin-bottom: 14px;
+}
+.sheet-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.sheet-name-chip {
+  padding: 14px 8px;
+  border-radius: 10px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  display: flex; align-items: center; justify-content: center;
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(15px, 3vw, 22px);
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: rgba(255,255,255,0.75);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+.sheet-name-chip:active,
+.sheet-name-chip:hover {
+  background: color-mix(in srgb, var(--left-color) 16%, rgba(255,255,255,0.05));
+  border-color: color-mix(in srgb, var(--left-color) 45%, transparent);
+  color: rgba(255,255,255,0.95);
+}
+
+/* ── Transitions ────────────────────────────────────────────── */
+.phase-fade-enter-active,
+.phase-fade-leave-active { transition: opacity 0.3s ease; }
+.phase-fade-enter-from,
+.phase-fade-leave-to { opacity: 0; }
+
+.sheet-slide-enter-active { transition: transform 0.32s cubic-bezier(0.34, 1.2, 0.64, 1); }
+.sheet-slide-leave-active { transition: transform 0.22s cubic-bezier(0.4, 0, 1, 1); }
+.sheet-slide-enter-from,
+.sheet-slide-leave-to { transform: translateY(100%); }
+
+.banner-slide-enter-active { transition: transform 0.45s cubic-bezier(0.2, 0, 0.3, 1), opacity 0.3s ease; }
+.banner-slide-leave-active { transition: opacity 0.2s ease; }
+.banner-slide-enter-from { transform: translateY(100%); opacity: 0; }
+.banner-slide-leave-to { opacity: 0; }
+
+/* ── Keyframes ──────────────────────────────────────────────── */
+@keyframes pipPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.3; transform: scale(0.6); }
+}
+@keyframes votingPillPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(6,182,212,0.4); }
+  50%       { box-shadow: 0 0 0 4px rgba(6,182,212,0); }
+}
+@keyframes armedPulse {
+  0%, 100% { box-shadow: inset 0 0 0 1.5px rgba(255,255,255,0); }
+  50%       { box-shadow: inset 0 0 0 1.5px rgba(255,255,255,0.18); }
+}
+
+/* ── Tablet: center at max 480px ────────────────────────────── */
+@media (min-width: 600px) {
+  .judge-root {
+    max-width: 480px;
+    margin: 0 auto;
+    border-left:  1px solid rgba(255,255,255,0.05);
+    border-right: 1px solid rgba(255,255,255,0.05);
+  }
+}
+```
+
+- [ ] **Step 2: Check the page in a mobile viewport**
+
+In Chrome DevTools, toggle device toolbar and set to iPhone 14 Pro (393×852). Verify:
+- Header shows brand + phase pill + empty judge chip area
+- LEFT and RIGHT fill the screen side-by-side
+- TIE is clearly a full-width button at the bottom (~20% height)
+- No scroll
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleJudge.vue
+git commit -m "feat(battle-judge): full CSS rebuild — dark overlay aesthetic, overlay-config colors, voted wash"
+```
+
+---
+
+## Task 5: End-to-end verification & push
+
+**Files:**
+- No code changes — verification and git only
+
+- [ ] **Step 1: Run the frontend dev server if not already running**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run dev
+```
+
+- [ ] **Step 2: Verify judge identity flow**
+
+1. Open `http://localhost:5173/battle/judge` in a fresh private window
+2. Bottom sheet should slide up with judge name chips
+3. Tap a name → sheet dismisses, judge chip appears in header ("AS [NAME]")
+4. Hard refresh (`Cmd+Shift+R`) → sheet should NOT appear, judge chip should be restored
+5. Tap ✕ on judge chip → sheet re-appears
+
+- [ ] **Step 3: Verify vote persistence flow**
+
+With the backend running and battle phase set to VOTING:
+1. Tap LEFT once → "TAP AGAIN TO CONFIRM" appears
+2. Tap LEFT again → gradient wash floods bottom, "✓ VOTE LOCKED" appears, RIGHT and TIE dim
+3. Hard refresh → voted state restores (LEFT still glowing, others dimmed)
+
+- [ ] **Step 4: Verify phase states**
+
+Check each phase visually:
+- **LOCKED**: panels visible but "🔒 VOTING NOT OPEN" overlay covers them
+- **VOTING**: panels fully active, no overlay
+- **REVEALED**: winner banner slides up from bottom
+- **IDLE**: "⏳ WAITING…" overlay
+
+- [ ] **Step 5: Verify colors follow overlay config**
+
+In BattleControl, open Overlay Settings and change Left Color to `#7c3aed` (purple). BattleJudge should update the LEFT panel gradient within a second (via WS).
+
+- [ ] **Step 6: Docker build**
+
+```bash
+cd /Users/bennylim/Documents/BES && docker-compose up --build --no-cache -d
+```
+
+Wait for frontend container to be healthy:
+```bash
+docker-compose ps
+```
+
+Open `https://<DOMAIN>/battle/judge` and repeat steps 2–5 against the production build.
+
+- [ ] **Step 7: Force-push to remote**
+
+```bash
+git push origin feature/battle-judge-redesign --force-with-lease
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- ✅ Layout: LR side-by-side + TIE at bottom (Task 3/4)
+- ✅ Visual language matching BattleOverlay (Task 4)
+- ✅ Overlay config colors on mount + WS (Task 2)
+- ✅ Judge identity: bottom sheet, localStorage, header chip, ✕ to change (Task 2/3/4)
+- ✅ First load: sheet shown; on refresh: skip sheet (Task 2)
+- ✅ Cross-check: judge removed from list → re-show sheet (Task 2)
+- ✅ Tap-to-confirm: arm then confirm, different panel re-arms (Task 2)
+- ✅ Haptic on confirm (Task 2)
+- ✅ Vote persistence: write to localStorage + restore on mount (Task 2)
+- ✅ Backend source of truth: WS vote subscription overrides localStorage (Task 2)
+- ✅ Clear vote on LOCKED phase (Task 2)
+- ✅ Phase states: IDLE/LOCKED/VOTING/REVEALED (Task 3/4)
+- ✅ REVEALED banner with winner name + wins/tie (Task 3/4)
+- ✅ Color bleeds in corners (Task 4)
+- ✅ Responsive: clamp() font sizes, tablet max-width 480px (Task 4)
+- ✅ WS subscription for vote set up only after judge identity resolved (Task 2)
+- ✅ All 6 WS clients created separately (Task 2)

--- a/docs/superpowers/specs/2026-05-27-battle-judge-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-27-battle-judge-redesign-design.md
@@ -1,0 +1,191 @@
+# BattleJudge Redesign
+
+**Date:** 2026-05-27
+**File:** `BES-frontend/src/views/BattleJudge.vue`
+**Approach:** Option 2 — Full restructure (single-file rebuild)
+
+---
+
+## Goal
+
+Rebuild `BattleJudge.vue` with a bold, impactful UI that:
+- Matches `BattleOverlay.vue`'s dark design language
+- Uses organiser-configured left/right colors from overlay config
+- Gives judges a clear, persistent view of their own vote
+- Works well on phones and tablets
+- Survives page refresh without losing judge identity or vote state
+
+---
+
+## Layout
+
+Portrait-first, full-height (`100dvh`). Four stacked regions:
+
+```
+┌─────────────────────────────────┐
+│  HEADER                          │  ~56px
+│  brand · phase pill · judge chip │
+├─────────────────────────────────┤
+│  NAMES BAR                       │  ~10% height
+│  [LEFT NAME]    [RIGHT NAME]     │
+├──────────────┬──────────────────┤
+│              │                  │
+│   LEFT ✊    │    RIGHT ✊      │  flex: 1 (~65%)
+│              │                  │
+├──────────────┴──────────────────┤
+│         — TIE ✋ —              │  ~20% height
+└─────────────────────────────────┘
+```
+
+- LEFT and RIGHT panels: `flex: 1` each, side by side
+- TIE: full-width, fixed `~20%` of remaining height — a real button, not a strip
+- No horizontal scrolling; no vertical scrolling
+
+---
+
+## Visual Language
+
+Matches `BattleOverlay.vue`:
+
+- **Background:** `#060a14`
+- **Font:** Anton SC for direction labels (LEFT / RIGHT / TIE), Inter for everything else
+- **LEFT panel:** radial gradient using `--left-color`; border glow on active/voted
+- **RIGHT panel:** radial gradient using `--right-color`; border glow on active/voted
+- **TIE panel:** neutral slate — never colored
+- **Color bleeds:** subtle radial gradients in bottom corners (left-color bottom-left, right-color bottom-right)
+- **No scanlines** — those are stream overlay only, not appropriate for a touch interface
+
+---
+
+## Colors — Overlay Config
+
+On mount:
+1. Call `getOverlayConfig()` → `{ showImages, leftColor, rightColor }`
+2. Subscribe to `/topic/battle/overlay-config` WS for live updates
+
+Apply as CSS custom properties on `.judge-root`:
+```css
+--left-color: <leftColor from config>   /* default: #dc2626 */
+--right-color: <rightColor from config> /* default: #2563eb */
+```
+
+Colors affect: panel gradients, border glows, name bar tints, voted gradient wash, color bleeds, winner banner tint. TIE is always neutral.
+
+---
+
+## Judge Identity
+
+### First load (no judge stored in localStorage)
+- Bottom sheet slides up from the bottom over the vote panels
+- Contains a 2-column grid of judge name chips (one per active judge)
+- Tapping a name: dismisses sheet, saves to localStorage, shows judge chip in header
+- localStorage keys: `battleJudgeId` (number), `battleJudgeName` (string)
+
+### On refresh / revisit
+- On mount, read `battleJudgeId` from localStorage
+- If found: skip sheet, go straight to the voting screen with judge chip in header
+- Cross-check: if stored ID is no longer in the active judges list, clear localStorage and re-show sheet
+
+### Header judge chip
+- Small pill: `VOTING AS: DIANA  ✕`
+- Tap ✕ → clears localStorage, re-shows bottom sheet
+
+---
+
+## Vote Flow
+
+### Tap-to-confirm (unchanged from current logic)
+1. First tap → panel "arms" (pulses, shows "TAP AGAIN TO CONFIRM")
+2. Second tap on same panel → vote confirmed, calls `battleJudgeVote(judgeId, side)`
+3. Tapping a different panel while one is armed → arms the new one instead
+
+### After confirming
+- Voted panel: full glow + gradient wash floods bottom of panel + "✓ VOTE LOCKED" text
+- Other panels: dimmed (low opacity, desaturated)
+- TIE: dimmed if not voted, same glow/wash treatment if voted
+- State persists until phase transitions to `LOCKED`
+
+### Haptic feedback
+- On confirm: `navigator.vibrate(40)` if supported — brief tactile acknowledgement
+
+---
+
+## Vote Persistence (Refresh-Proof)
+
+### Writing
+On vote confirm, write to localStorage:
+```
+key:   battleVote_${judgeId}_${leftName}_${rightName}
+value: { vote: 0|1|-1, leftName, rightName, timestamp }
+```
+
+### Restoring on mount
+1. Restore judge identity from localStorage
+2. Subscribe to `/topic/battle/vote/${judgeId}` WS — backend value is source of truth
+3. Also check localStorage for a matching vote key (same judgeId + leftName + rightName)
+4. If backend vote is set (not `-3`): restore voted visual state from backend value
+5. If backend is `-3` but localStorage has a match: restore from localStorage (backend may not have processed yet)
+6. If mismatch: trust backend
+
+### Clearing
+- Vote localStorage key is cleared when phase transitions to `LOCKED` (new pair starting)
+- Judge identity localStorage is **not** cleared on phase change — persists across rounds
+
+---
+
+## Phase States
+
+| Phase | UI |
+|-------|----|
+| **IDLE** | Panels dimmed. Bottom sheet shown if no judge stored. Phase pill: "WAITING". No vote possible. |
+| **LOCKED** | Panels visible but locked — semi-transparent overlay: "🔒 VOTING NOT OPEN". Vote from previous round cleared. Phase pill: amber "LOCKED". |
+| **VOTING** | Panels fully active. If no vote: ready to tap. If voted (or restored from refresh): gradient wash + "✓ VOTE LOCKED". Phase pill: cyan pulsing "VOTING". |
+| **REVEALED** | Winner banner slides up full-width. Shows winner name large + "WINS" (or "TIE"). Voted panel stays lit. Panels non-interactive. Phase pill: green "REVEALED". |
+
+---
+
+## REVEALED State Detail
+
+- Full-width banner animates up from the bottom (slide + fade)
+- Banner background: tinted with winning side's color (or neutral for tie)
+- Content:
+  - Winner: large name text + "WINS" label below
+  - Tie: "TIE" centered
+- Judge's voted panel remains glowing beneath the banner
+- No interaction possible until phase moves to `LOCKED`
+
+---
+
+## WebSocket Subscriptions
+
+Requires 6 separate clients (existing pattern — one subscription per client):
+
+| Topic | Handler |
+|-------|---------|
+| `/topic/battle/phase` | Update `battlePhase`; on LOCKED: reset vote state |
+| `/topic/battle/battle-pair` | Update `leftName`, `rightName`; clear vote localStorage key |
+| `/topic/battle/score` | Update `revealedWinner` |
+| `/topic/battle/judges` | Update `battleJudges`; re-show picker if current judge removed |
+| `/topic/battle/vote/${judgeId}` | Restore vote state on connect — **subscribed only after judge identity is resolved** (localStorage or sheet selection) |
+| `/topic/battle/overlay-config` | Live color updates |
+
+---
+
+## Responsive Behaviour
+
+- **Phone portrait (360–430px wide):** Default layout. Names bar truncates with `text-overflow: ellipsis`.
+- **Tablet portrait (768px+):** Panels scale up naturally (flex fills height). Font sizes use `clamp()`. Max width capped at `480px` centered.
+- **Tablet landscape:** Layout unchanged — still portrait orientation locked via CSS (`max-height: 100dvh`, `overflow: hidden`).
+- Touch targets: LEFT/RIGHT panels are always `≥ 44px` wide; TIE is always `≥ 64px` tall.
+
+---
+
+## Branch Strategy
+
+New branch: `feature/battle-judge-redesign`
+- `git fetch origin`
+- `git rebase origin/master` before starting
+- Single commit per logical unit (identity, vote state, phase states, colors)
+- Force-push to remote branch after rebase
+
+When switching to this branch in future: always `git fetch && git rebase origin/master` first.


### PR DESCRIPTION
## Summary

- **Full rebuild of `BattleJudge.vue`** — dark design matching `BattleOverlay`, portrait-first layout with LEFT/RIGHT panels side-by-side and TIE full-width at bottom
- **Overlay-config colors** — LEFT/RIGHT panel gradients driven by `--left-color`/`--right-color` CSS custom props sourced from `getOverlayConfig()` + live WebSocket, same config set in BattleControl
- **Judge identity** — bottom sheet picker on first load, localStorage persistence across refreshes, header chip shows "AS [NAME] ✕" to switch; SELECT JUDGE button when no judge selected
- **Vote flow** — tap-to-confirm (arm → confirm), vote revocation by tapping a different panel, gradient wash + "✓ VOTE LOCKED" on voted panel, haptic feedback
- **Vote persistence** — localStorage key scoped to `judgeId + leftName + rightName`, restored on refresh, backend WS is source of truth
- **Phase states** — IDLE/LOCKED show blocker overlay, VOTING = active panels, REVEALED = winner banner slides up from bottom
- **Bug fixes** — `voteClient` torn down on judge switch, HTTP POST failure keeps panel armed, WS vote callback uses strict allowlist, `clearVote` runs before nulling judgeId
- **Full-screen** — `position: fixed; inset: 0` + `touch-action: manipulation` (no double-tap zoom); fixed navbar route name mismatch that was covering the header

## Test Plan

- [ ] Open `/battle/judge` on a phone — fills screen edge to edge, no navbar, no scroll
- [ ] SELECT JUDGE button visible in header → tap to open bottom sheet → tap name → judge chip shows "AS [NAME] ✕"
- [ ] Hard refresh → judge chip restored from localStorage, no picker shown
- [ ] Tap ✕ → picker re-appears
- [ ] During VOTING phase: tap LEFT once → "TAP AGAIN TO CONFIRM" appears; tap again → "✓ VOTE LOCKED", RIGHT/TIE dim
- [ ] Tap a dimmed panel → vote revokes, new panel arms for confirmation
- [ ] Hard refresh during voted state → vote state restored
- [ ] Change overlay colors in BattleControl → LEFT/RIGHT panel gradients update live
- [ ] REVEALED phase → winner banner slides up from bottom
- [ ] LOCKED phase → "🔒 VOTING NOT OPEN" blocker covers panels, vote clears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)