### PR TITLE
feat(bracket): visual overhaul + overlay race condition fixes

### DIFF
--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -469,17 +469,56 @@ export const setBattlePair = async(leftBattler, rightBattler) =>{
   }
 }
 
-export const setBattleScore = async() =>{
-  try{
-    return await fetch(`${domain}/api/v1/battle/score`,{
+export const setBattleScore = async (isFinal = false) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/score`, {
       method: 'POST',
       credentials: 'include',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      }
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isFinal })
     })
-  }catch(e){
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const resetBattleVotes = async () => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/revote`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const revealChampion = async (genreName, championName) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/champion-reveal`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ genreName, championName, dismiss: false })
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const dismissChampionReveal = async () => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/champion-reveal`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dismiss: true })
+    })
+  } catch (e) {
     console.log(e)
     return null
   }

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -16,7 +16,7 @@ const battleJudges = ref([])
 const currentBattle = ref([])
 const currentWinner = ref(-2)
 const currentRound = ref(0)
-const currentTop = ref('')
+const currentTop = ref(localStorage.getItem('currentTop') || '')
 const battlePhase = ref('IDLE')
 const showResetConfirm = ref(false)
 const finalTieBlocked = ref(false)
@@ -133,6 +133,7 @@ const initiateBattlePair = async (top, pairList) => {
   battlePhase.value = 'LOCKED'
   currentRound.value = 0
   currentTop.value = top
+  localStorage.setItem('currentTop', top)
 }
 
 const prevPair = async () => {
@@ -173,6 +174,8 @@ const nextPair = async () => {
       battlePhase.value = 'IDLE'
       currentWinner.value = -2
       currentBattle.value = []
+      currentTop.value = ''
+      localStorage.removeItem('currentTop')
     }
   }
 }
@@ -427,6 +430,32 @@ const currentGenreChampion = computed(() => {
   return rounds.value['Top2']?.[0]?.[2] ?? null
 })
 
+const isFinalInProgress = computed(() => !isSmoke.value && currentTop.value === 'Top2')
+
+// All judges have cast a vote (none still at -3 = "hasn't voted this round")
+const allJudgesVoted = computed(() => {
+  const judges = battleJudges.value?.judges ?? []
+  return judges.length > 0 && judges.every(j => j.vote !== -3)
+})
+
+// Tentative winner from live judge votes — mirrors backend scoring logic
+const tentativeWinner = computed(() => {
+  const judges = battleJudges.value?.judges ?? []
+  if (judges.some(j => j.vote === -3)) return -2   // not all voted yet
+  const leftVotes  = judges.filter(j => j.vote === 0).length
+  const rightVotes = judges.filter(j => j.vote === 1).length
+  if (leftVotes === rightVotes) return -1            // tie
+  return leftVotes > rightVotes ? 0 : 1
+})
+
+// Show "Reveal Champion" in VOTING when all judges voted + clear winner (final only)
+const showFinalReveal = computed(() =>
+  battlePhase.value === 'VOTING' &&
+  isFinalInProgress.value &&
+  allJudgesVoted.value &&
+  tentativeWinner.value !== -1
+)
+
 const allJudgeOptions = computed(() => ["", ...Object.values(allJudges.value).map(j => j.judgeName)])
 
 const submitAddBattleJudge = async (name) => {
@@ -470,6 +499,9 @@ const submitGetScore = async () => {
   const res = await setBattleScore(isFinal)
   if (res?.status === 409) {
     finalTieBlocked.value = true
+    // Re-broadcast same pair → overlay/bracket transitions to LOCKED (rematch state)
+    const [rLeft, rRight] = currentBattlePair.value ?? []
+    if (rLeft && rRight) await setBattlePair(rLeft, rRight)
     return
   }
   const data = await res.json()
@@ -480,11 +512,24 @@ const submitGetScore = async () => {
 
 const startRevote = async () => {
   await resetBattleVotes()
+  await resetJudgeVote()   // reset to -3 so allJudgesVoted tracks the fresh round
   finalTieBlocked.value = false
   currentWinner.value = -2
 }
 
 const revealChampionForGenre = async () => {
+  if (showFinalReveal.value) {
+    // Organiser revealed before broadcasting score — capture name first, then score
+    const winnerName = tentativeWinner.value === 0
+      ? currentBattlePair.value?.[0]
+      : currentBattlePair.value?.[1]
+    await submitGetScore()  // broadcasts winner to overlay and bracket
+    if (currentWinner.value === 0 || currentWinner.value === 1) {
+      await revealChampion(selectedGenre.value, winnerName)
+      revealActive.value = true
+    }
+    return
+  }
   if (!currentGenreChampion.value) return
   await revealChampion(selectedGenre.value, currentGenreChampion.value)
   revealActive.value = true
@@ -509,6 +554,8 @@ const confirmResetBracket = async () => {
   battlePhase.value = 'IDLE'
   currentWinner.value = -2
   currentBattle.value = []
+  currentTop.value = ''
+  localStorage.removeItem('currentTop')
 }
 
 watch(selectedEvent, async (newVal) => {
@@ -558,6 +605,9 @@ onMounted(async () => {
   wsClient.value = createClient()
   subscribeToChannel(wsClient.value, '/topic/battle/phase', (msg) => {
     battlePhase.value = msg.phase
+  })
+  subscribeToChannel(wsClient.value, '/topic/battle/judges', (msg) => {
+    battleJudges.value = msg   // { judges: [...] } — keeps allJudgesVoted live
   })
 })
 
@@ -1092,9 +1142,20 @@ onUnmounted(() => {
           Open Voting
         </button>
 
-        <!-- VOTING: get score / rematch -->
+        <!-- VOTING: final + all judges voted + clear winner → one-click Reveal Champion -->
         <button
-          v-if="battlePhase === 'VOTING'"
+          v-if="showFinalReveal"
+          @click="revealChampionForGenre"
+          class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl border border-amber-500/40 bg-amber-500/10
+                 text-sm font-semibold text-amber-400 hover:bg-amber-500/20 transition-all"
+        >
+          <i class="pi pi-star text-xs"></i>
+          Reveal Champion
+        </button>
+
+        <!-- VOTING: all other cases (non-final, not all voted, or tie) -->
+        <button
+          v-else-if="battlePhase === 'VOTING'"
           @click="submitGetScore"
           class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-primary-600 text-white text-sm
                  font-semibold hover:bg-primary-700 transition-all shadow-sm"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, battleJudgeVote, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, battleJudgeVote, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, resetBattleVotes, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -19,6 +19,7 @@ const currentRound = ref(0)
 const currentTop = ref('')
 const battlePhase = ref('IDLE')
 const showResetConfirm = ref(false)
+const finalTieBlocked = ref(false)
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
 
 const HEX_RE = /^#[0-9A-Fa-f]{6}$/
@@ -459,10 +460,22 @@ const submitGetScore = async () => {
   const left = currentBattle?.value[1][currentBattle?.value[0]][0]
   const right = currentBattle?.value[1][currentBattle?.value[0]][1]
   if (left === "" || right === "") return
-  const res = await setBattleScore()
+  const isFinal = !isSmoke.value && currentTop.value === 'Top2'
+  const res = await setBattleScore(isFinal)
+  if (res?.status === 409) {
+    finalTieBlocked.value = true
+    return
+  }
   const data = await res.json()
+  finalTieBlocked.value = false
   currentWinner.value = Number(data.winner)
   if (data.winner === 1 || data.winner === 0) { setWinner(currentTop.value, currentRound.value, data.winner) }
+}
+
+const startRevote = async () => {
+  await resetBattleVotes()
+  finalTieBlocked.value = false
+  currentWinner.value = -2
 }
 
 const openVoting = async () => {
@@ -971,6 +984,20 @@ onUnmounted(() => {
             'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40': battlePhase === 'REVEALED',
           }"
         >{{ battlePhase }}</span>
+      </div>
+
+      <!-- Final tie warning -->
+      <div
+        v-if="finalTieBlocked"
+        class="px-4 py-3 rounded-xl text-sm font-semibold mb-4 flex items-center justify-between gap-3
+               bg-amber-500/10 border border-amber-500/40 text-amber-400"
+      >
+        <span><i class="pi pi-exclamation-triangle mr-2"></i>TIE in Final — Revote required</span>
+        <button
+          @click="startRevote"
+          class="flex-shrink-0 px-3 py-1.5 rounded-lg bg-amber-500/20 border border-amber-500/40
+                 text-amber-400 text-xs font-bold hover:bg-amber-500/30 transition-all"
+        >START REVOTE</button>
       </div>
 
       <!-- Winner announcement -->

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, battleJudgeVote, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, resetBattleVotes, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, battleJudgeVote, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -20,6 +20,7 @@ const currentTop = ref('')
 const battlePhase = ref('IDLE')
 const showResetConfirm = ref(false)
 const finalTieBlocked = ref(false)
+const revealActive = ref(false)
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
 
 const HEX_RE = /^#[0-9A-Fa-f]{6}$/
@@ -421,6 +422,11 @@ const uniqueGenres = computed(() => {
   return [...new Set(genres)].sort()
 })
 
+const currentGenreChampion = computed(() => {
+  if (isSmoke.value) return null
+  return rounds.value['Top2']?.[0]?.[2] ?? null
+})
+
 const allJudgeOptions = computed(() => ["", ...Object.values(allJudges.value).map(j => j.judgeName)])
 
 const submitAddBattleJudge = async (name) => {
@@ -478,6 +484,17 @@ const startRevote = async () => {
   currentWinner.value = -2
 }
 
+const revealChampionForGenre = async () => {
+  if (!currentGenreChampion.value) return
+  await revealChampion(selectedGenre.value, currentGenreChampion.value)
+  revealActive.value = true
+}
+
+const dismissReveal = async () => {
+  await dismissChampionReveal()
+  revealActive.value = false
+}
+
 const openVoting = async () => {
   await setBattlePhase('VOTING')
   battlePhase.value = 'VOTING'
@@ -505,6 +522,7 @@ watch(selectedEvent, async (newVal) => {
 }, { immediate: true })
 
 watch(selectedGenre, async (newVal) => {
+  revealActive.value = false
   if (newVal) {
     localStorage.setItem("selectedGenre", newVal)
     const storedRounds = localStorage.getItem(`Top${topSize.value}${newVal}Rounds`)
@@ -1104,6 +1122,26 @@ onUnmounted(() => {
             <i class="pi pi-chevron-right text-xs"></i>
           </button>
         </template>
+
+        <!-- Champion Reveal -->
+        <button
+          v-if="currentGenreChampion && !revealActive"
+          @click="revealChampionForGenre"
+          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-amber-500/40 bg-amber-500/10
+                 text-sm font-semibold text-amber-400 hover:bg-amber-500/20 transition-all"
+        >
+          <i class="pi pi-star text-xs"></i>
+          Reveal Champion
+        </button>
+        <button
+          v-if="revealActive"
+          @click="dismissReveal"
+          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
+                 text-sm font-semibold text-content-secondary hover:bg-surface-700 transition-all"
+        >
+          <i class="pi pi-times text-xs"></i>
+          Dismiss Reveal
+        </button>
 
         <button
           @click="showResetConfirm = true"

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -56,6 +56,10 @@ const stageShaking = ref(false)
 const winnerTagVisible = ref(false)
 // glitching: glitch overlay during next-pair transition
 const glitching = ref(false)
+// animToken: incremented whenever a new pair starts (LOCKED phase or updateBattlePair).
+// updateScore captures the token at start and aborts if it changes, preventing
+// stale leftWin/rightWin assignments from a previous pair's score animation.
+let animToken = 0
 
 const isSmoke = computed(() => route.query.isSmoke === 'true')
 
@@ -93,19 +97,22 @@ const updateBattlePair = async (msg) => {
     return
   }
 
-  // STANDARD MODE: if a winner is currently showing, run exit sequence first
+  // Increment token — aborts any in-progress updateScore for the previous pair
+  animToken++
+
+  // STANDARD MODE: if the judge panel is visible, clean it up before the new pair
   if (!hideJudgeDecision.value) {
     glitching.value = true
     judgeAnim.value = 'slide-up'
     await useDelay().wait(100)
     if (unmounted) return
 
+    // Only slide a panel out if a winner was actually declared.
+    // If currentWinner is -2 the score animation was aborted mid-way — skip the
+    // panel exit so it doesn't look like a winner reveal on the wrong pair.
     if (currentWinner.value === 0) {
       leftReset.value = true
     } else if (currentWinner.value === 1) {
-      rightReset.value = true
-    } else {
-      leftReset.value  = true
       rightReset.value = true
     }
     vsAnim.value = ''
@@ -179,8 +186,13 @@ watch(battleJudges, (newVal) => {
 
 // ── Score reveal ───────────────────────────────────────────────────────────
 const updateScore = async (msg) => {
-  // Guard: if phase already reset to LOCKED, this is a stale WS event — ignore it
+  // Guard: stale event if phase already reset
   if (battlePhase.value === 'LOCKED') return
+  // Capture token — if a new pair starts (LOCKED handler or updateBattlePair) before
+  // we finish, animToken increments and all subsequent checks abort this animation.
+  const myToken = animToken
+  const ok = () => !unmounted && animToken === myToken
+
   showVotingIndicator.value = false
   rightScore.value = msg.right
   leftScore.value  = msg.left
@@ -191,10 +203,10 @@ const updateScore = async (msg) => {
 
   // Shake on slam landing (~350ms into animation)
   await useDelay().wait(350)
-  if (unmounted || battlePhase.value === 'LOCKED') return
+  if (!ok()) return
   stageShaking.value = true
   await useDelay().wait(80)
-  if (unmounted || battlePhase.value === 'LOCKED') return
+  if (!ok()) return
   stageShaking.value = false
 
   // Reveal votes as slam settles
@@ -202,17 +214,17 @@ const updateScore = async (msg) => {
 
   // Audience reads the votes
   await useDelay().wait(1500)
-  if (unmounted || battlePhase.value === 'LOCKED') return
+  if (!ok()) return
 
   // Phase 2: panel scales down and retreats to top
   judgeAnim.value = 'judge-retreat-top'
   await useDelay().wait(550)
-  if (unmounted || battlePhase.value === 'LOCKED') return
+  if (!ok()) return
   judgeAnim.value = 'judge-at-top'
 
   // Brief pause before winner reveal
   await useDelay().wait(150)
-  if (unmounted || battlePhase.value === 'LOCKED') return
+  if (!ok()) return
 
   currentWinner.value = msg.message
 
@@ -222,7 +234,7 @@ const updateScore = async (msg) => {
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-right'
     await useDelay().wait(100)
-    if (unmounted || battlePhase.value === 'LOCKED') return
+    if (!ok()) return
     rightReset.value = true
   } else if (msg.message === 1) {
     // Right wins: VS rockets left, right panel expands
@@ -230,7 +242,7 @@ const updateScore = async (msg) => {
     winnerTagVisible.value = true
     vsAnim.value           = 'knock-left'
     await useDelay().wait(100)
-    if (unmounted || battlePhase.value === 'LOCKED') return
+    if (!ok()) return
     leftReset.value = true
   }
   // msg.message === -1: tie — panels stay
@@ -260,7 +272,8 @@ onMounted(async () => {
     battlePhase.value = msg.phase
     showVotingIndicator.value = msg.phase === 'VOTING'
     if (msg.phase === 'LOCKED') {
-      // Next was clicked — dismiss any in-progress result overlay immediately
+      // Next was clicked — abort any in-progress score animation and reset overlay
+      animToken++
       hideJudgeDecision.value = true
       judgeAnim.value         = ''
       votesVisible.value      = false

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -272,8 +272,7 @@ onMounted(async () => {
     }
   })
 
-  const cChamp = createClient(); clients.push(cChamp)
-  subscribeToChannel(cChamp, '/topic/battle/champion-reveal', (data) => {
+  subscribeToChannel(cPhase, '/topic/battle/champion-reveal', (data) => {
     if (data.dismiss) {
       championReveal.value = null
     } else {

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -25,6 +25,9 @@ const rightScore = ref(0)
 const currentWinner = ref(-2)
 const battleJudges  = ref([])
 
+// Champion reveal overlay
+const championReveal = ref(null)   // null | { genreName, championName }
+
 // Judge panel visibility: true = off-screen (idle/battle), false = visible (score revealed)
 const hideJudgeDecision = ref(true)
 
@@ -269,6 +272,15 @@ onMounted(async () => {
     }
   })
 
+  const cChamp = createClient(); clients.push(cChamp)
+  subscribeToChannel(cChamp, '/topic/battle/champion-reveal', (data) => {
+    if (data.dismiss) {
+      championReveal.value = null
+    } else {
+      championReveal.value = { genreName: data.genreName, championName: data.championName }
+    }
+  })
+
   if (!isSmoke.value) {
     battleJudges.value = await getBattleJudges()
     const res = await getCurrentBattlePair()
@@ -301,6 +313,19 @@ onUnmounted(() => {
     :class="{ 'stage-shake': stageShaking }"
     :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
   >
+    <!-- ── Champion Reveal Overlay ─────────────────── -->
+    <Transition name="champ-reveal">
+      <div v-if="championReveal" class="champ-overlay">
+        <div class="champ-overlay-bg"></div>
+        <div class="champ-overlay-content">
+          <div class="champ-genre-tag">{{ championReveal.genreName }} · Final</div>
+          <div class="champ-label">CHAMPION</div>
+          <div class="champ-name-slam">{{ championReveal.championName }}</div>
+          <div class="champ-gold-bar"></div>
+        </div>
+      </div>
+    </Transition>
+
     <!-- Screen-reader live region -->
     <div class="sr-only" role="status" aria-live="assertive" aria-atomic="true">
       <template v-if="currentWinner === 0">{{ leftName }} wins!</template>
@@ -1114,6 +1139,74 @@ body.transparent-page #app {
 }
 
 /* (borderRotate removed — judge card no longer uses rotating glow border) */
+
+/* ── Champion Reveal Overlay ────────────────────────────── */
+.champ-overlay {
+  position: absolute; inset: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: center;
+  background: #060818;
+}
+.champ-overlay-bg {
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(ellipse 60% 50% at 50% 55%, rgba(245,158,11,0.14) 0%, transparent 68%);
+}
+.champ-overlay-content {
+  position: relative; z-index: 1;
+  display: flex; flex-direction: column; align-items: center; gap: 6px;
+  text-align: center;
+}
+.champ-genre-tag {
+  font-family: 'Anton SC', sans-serif; font-size: 9px;
+  letter-spacing: 0.45em; text-transform: uppercase;
+  color: rgba(255,255,255,0.3);
+}
+.champ-label {
+  font-family: 'Anton SC', sans-serif; font-size: 11px;
+  letter-spacing: 0.5em; text-transform: uppercase;
+  color: rgba(245,158,11,0.85);
+}
+.champ-name-slam {
+  font-family: 'Anton SC', sans-serif; font-size: 15vw;
+  letter-spacing: 0.07em; text-transform: uppercase; line-height: 1;
+  color: #fff;
+  text-shadow: 0 0 40px rgba(245,158,11,0.65), 0 0 80px rgba(245,158,11,0.3);
+}
+.champ-gold-bar {
+  width: 180px; height: 2px; margin-top: 6px;
+  background: linear-gradient(90deg, transparent, rgba(245,158,11,0.8), transparent);
+}
+
+/* Transition */
+.champ-reveal-enter-active { transition: opacity 0.3s ease; }
+.champ-reveal-leave-active { transition: opacity 0.25s ease; }
+.champ-reveal-enter-from,
+.champ-reveal-leave-to    { opacity: 0; }
+
+.champ-reveal-enter-active .champ-name-slam {
+  animation: champNameSlam 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.35s both;
+}
+.champ-reveal-enter-active .champ-label {
+  animation: champFadeUp 0.4s ease 0.2s both;
+}
+.champ-reveal-enter-active .champ-genre-tag {
+  animation: champFadeUp 0.4s ease 0.08s both;
+}
+.champ-reveal-enter-active .champ-gold-bar {
+  animation: champBarExpand 0.6s ease 0.65s both;
+}
+
+@keyframes champNameSlam {
+  from { opacity: 0; transform: scale(0.72) translateY(18px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0); }
+}
+@keyframes champFadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes champBarExpand {
+  from { width: 0; opacity: 0; }
+  to   { width: 180px; opacity: 1; }
+}
 
 /* ── Animation utility classes ───────────────────── */
 .slam-in-left  { animation: leftSlamIn  450ms cubic-bezier(0.2, 0, 0.3, 1) both; }

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -67,9 +67,9 @@ const isActiveMatch = (match) => {
          (l === activePair.value.right && r === activePair.value.left)
 }
 
-const slotClass = (match, slot) => {
+const slotClass = (match, slot, isFinal = false) => {
   if (match[2]) {
-    if (match[2] === match[slot]) return 'slot-winner'
+    if (match[2] === match[slot]) return isFinal ? 'slot-winner' : (slot === 0 ? 'slot-winner-left' : 'slot-winner-right')
     if (match[slot]) return 'slot-loser'
     return ''
   }
@@ -78,6 +78,25 @@ const slotClass = (match, slot) => {
   }
   return ''
 }
+
+const slotHeight = computed(() => {
+  const n = topSize.value
+  if (n <= 8)  return '54px'
+  if (n <= 16) return '46px'
+  return '38px'
+})
+const finalSlotHeight = computed(() => {
+  const n = topSize.value
+  if (n <= 8)  return '74px'
+  if (n <= 16) return '66px'
+  return '58px'
+})
+const centerColWidth = computed(() => {
+  const n = topSize.value
+  if (n <= 8)  return '210px'
+  if (n <= 16) return '195px'
+  return '185px'
+})
 
 const formatLabel = (key) => key === 'Top2' ? 'FINAL' : key.replace('Top', 'TOP ')
 
@@ -226,6 +245,11 @@ async function runWinnerAnimation(winnerKey, pending) {
   glowSlotKey.value = null
 
   // Phase 2 — ball travel (5 s)
+  // Bracket update may have arrived during the glow phase — use it as the target
+  if (pending === bracketState.value && pendingBracket.value) {
+    pending = pendingBracket.value
+    pendingBracket.value = null
+  }
   const destKey = findDestSlot(bracketState.value, pending)
   if (destKey) {
     hiddenSlotKey.value = destKey   // hide dest name before applying update
@@ -243,6 +267,12 @@ async function runWinnerAnimation(winnerKey, pending) {
   }
 
   animRunning = false
+
+  // Apply any bracket update that arrived while we were animating and wasn't consumed
+  if (pendingBracket.value) {
+    bracketState.value = pendingBracket.value
+    pendingBracket.value = null
+  }
 }
 
 function getActiveMatchInfo() {
@@ -272,6 +302,8 @@ onMounted(async () => {
       if (animRunning) {
         pendingBracket.value = newState   // defer until animation finishes
       } else {
+        // Clear any stale deferred state from a previous animation cycle
+        pendingBracket.value = null
         // Save snapshot before applying — needed if score arrives after this
         prevBracketUpdate = { state: bracketState.value, timestamp: Date.now() }
         bracketState.value = newState
@@ -355,7 +387,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 </script>
 
 <template>
-  <div class="bracket-root" :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }">
+  <div class="bracket-root" :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor, '--slot-h': slotHeight, '--final-slot-h': finalSlotHeight, '--center-col-w': centerColWidth }">
 
     <!-- ── Scanlines overlay ──────────────────────────── -->
     <div class="scanlines" aria-hidden="true"></div>
@@ -437,7 +469,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[0] || '—' }}</span>
-                  <span v-if="match[2] === match[0] && match[0]" class="win-badge">WIN</span>
+                  <span v-if="match[2] === match[0] && match[0]" class="takes-it-badge">TAKES IT</span>
                 </div>
               </div>
               <div class="match-wrap">
@@ -451,7 +483,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[1] || '—' }}</span>
-                  <span v-if="match[2] === match[1] && match[1]" class="win-badge">WIN</span>
+                  <span v-if="match[2] === match[1] && match[1]" class="takes-it-badge">TAKES IT</span>
                 </div>
               </div>
             </div>
@@ -468,7 +500,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
               class="battler-slot"
               :ref="el => regSlot(el, 'Top2', 0, 0)"
               :class="[
-                slotClass(finalMatch, 0),
+                slotClass(finalMatch, 0, true),
                 glowSlotKey  === 'Top2-0-0' ? 'slot-glow'   : '',
                 hiddenSlotKey === 'Top2-0-0' ? 'name-hidden' : '',
               ]"
@@ -481,7 +513,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
               class="battler-slot"
               :ref="el => regSlot(el, 'Top2', 0, 1)"
               :class="[
-                slotClass(finalMatch, 1),
+                slotClass(finalMatch, 1, true),
                 glowSlotKey  === 'Top2-0-1' ? 'slot-glow'   : '',
                 hiddenSlotKey === 'Top2-0-1' ? 'name-hidden' : '',
               ]"
@@ -514,7 +546,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[0] || '—' }}</span>
-                  <span v-if="match[2] === match[0] && match[0]" class="win-badge">WIN</span>
+                  <span v-if="match[2] === match[0] && match[0]" class="takes-it-badge">TAKES IT</span>
                 </div>
               </div>
               <div class="match-wrap">
@@ -528,7 +560,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[1] || '—' }}</span>
-                  <span v-if="match[2] === match[1] && match[1]" class="win-badge">WIN</span>
+                  <span v-if="match[2] === match[1] && match[1]" class="takes-it-badge">TAKES IT</span>
                 </div>
               </div>
             </div>
@@ -584,9 +616,11 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   --c-champ:      #f59e0b;
   --left-color:   #dc2626;
   --right-color:  #2563eb;
-  --col-gap:      24px;
-  --header-h:     52px;
-  --slot-h:       38px;
+  --col-gap:       24px;
+  --header-h:      52px;
+  --slot-h:        38px;
+  --final-slot-h:  58px;
+  --center-col-w:  185px;
 }
 
 /* ── Root ─────────────────────────────────────────────── */
@@ -751,18 +785,38 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .slot-active-right .battler-name {
   color: color-mix(in srgb, var(--right-color) 80%, #fff) !important;
 }
+/* Final winner — gold */
 .slot-winner {
   background: rgba(245,158,11,0.15) !important;
   border-color: rgba(245,158,11,0.45) !important;
   box-shadow: 0 0 18px rgba(245,158,11,0.25) !important;
 }
 .slot-winner .battler-name { color: #fde68a; }
+
+/* Non-final winner — keep their side color */
+.slot-winner-left {
+  background: color-mix(in srgb, var(--left-color) 20%, transparent) !important;
+  border-color: color-mix(in srgb, var(--left-color) 55%, transparent) !important;
+  box-shadow: 0 0 14px color-mix(in srgb, var(--left-color) 25%, transparent) !important;
+}
+.slot-winner-left .battler-name {
+  color: color-mix(in srgb, var(--left-color) 85%, #fff) !important;
+}
+.slot-winner-right {
+  background: color-mix(in srgb, var(--right-color) 20%, transparent) !important;
+  border-color: color-mix(in srgb, var(--right-color) 55%, transparent) !important;
+  box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 25%, transparent) !important;
+}
+.slot-winner-right .battler-name {
+  color: color-mix(in srgb, var(--right-color) 85%, #fff) !important;
+}
+
 .slot-loser { background: rgba(255,255,255,0.02) !important; border-color: rgba(255,255,255,0.03) !important; opacity: 0.42; }
 .slot-loser  .battler-name { color: var(--c-lose-text); }
 
 .battler-name {
   font-family: 'Anton SC', sans-serif;
-  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;
   color: var(--c-text); opacity: 0.88;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center;
   display: inline-block; transform: skewX(4deg);
@@ -774,9 +828,18 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   display: inline-flex; align-items: center; justify-content: center;
   transform: skewX(5deg); flex-shrink: 0;
   background: rgba(245,158,11,0.22); border: 1px solid rgba(245,158,11,0.5);
-  color: #fbbf24; font-size: 8px; font-weight: 900; font-family: 'Inter', sans-serif;
-  letter-spacing: 0.12em; padding: 1px 5px; border-radius: 2px;
+  color: #fbbf24; font-size: 9px; font-weight: 900; font-family: 'Inter', sans-serif;
+  letter-spacing: 0.12em; padding: 2px 6px; border-radius: 2px;
   clip-path: polygon(3px 0%, 100% 0%, calc(100% - 3px) 100%, 0% 100%);
+}
+.takes-it-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  transform: skewX(5deg); flex-shrink: 0;
+  background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.2);
+  color: rgba(255,255,255,0.6); font-size: 8px; font-weight: 700; font-family: 'Inter', sans-serif;
+  letter-spacing: 0.10em; padding: 1px 5px; border-radius: 2px;
+  clip-path: polygon(3px 0%, 100% 0%, calc(100% - 3px) 100%, 0% 100%);
+  white-space: nowrap;
 }
 
 /* ── Winner glow animation ────────────────────────────── */
@@ -793,9 +856,11 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .slot-glow .battler-name { color: #fde68a; opacity: 1; }
 
 /* ── Center column ────────────────────────────────────── */
-.center-col { flex-shrink: 0; width: 170px; display: flex; flex-direction: column; }
+.center-col { flex-shrink: 0; width: var(--center-col-w, 185px); display: flex; flex-direction: column; }
 .final-area { flex: 1; display: flex; flex-direction: column; align-items: stretch; justify-content: center; gap: 6px; min-height: 0; }
 .final-match { display: flex; flex-direction: column; gap: 6px; }
+.final-match .battler-slot { height: var(--final-slot-h, 58px); }
+.final-match .battler-name { font-size: 17px; letter-spacing: 0.06em; }
 .final-match.match-active .battler-slot {
   border-color: rgba(255,255,255,0.3);
   box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 0 16px rgba(255,255,255,0.1);
@@ -803,7 +868,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .final-vs {
   text-align: center;
   font-family: 'Anton SC', sans-serif;
-  font-size: 9px; letter-spacing: 0.32em;
+  font-size: 11px; letter-spacing: 0.32em;
   color: rgba(255,255,255,0.3); opacity: 0.38;
 }
 

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -288,6 +288,9 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 <template>
   <div class="bracket-root">
 
+    <!-- ── Scanlines overlay ──────────────────────────── -->
+    <div class="scanlines" aria-hidden="true"></div>
+
     <!-- ── Header ─────────────────────────────────────── -->
     <header class="bracket-header">
       <div class="header-brand">
@@ -497,106 +500,135 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 <style scoped>
 /* ── Theme tokens ─────────────────────────────────────── */
 .bracket-root {
-  --c-bg:         #0f172a;
-  --c-surface:    #1e293b;
+  --c-bg:         #060818;
+  --c-surface:    rgba(255,255,255,0.04);
   --c-border:     rgba(255,255,255,0.08);
-  --c-border-act: #06b6d4;
-  --c-text:       #f8fafc;
-  --c-muted:      rgba(255,255,255,0.35);
-  --c-accent:     #06b6d4;
-  --c-win-bg:     rgba(6,182,212,0.1);
-  --c-lose-text:  rgba(255,255,255,0.2);
-  --c-connector:  rgba(255,255,255,0.2);
+  --c-border-act: rgba(255,255,255,0.35);
+  --c-text:       #f0f0f0;
+  --c-muted:      rgba(255,255,255,0.28);
+  --c-accent:     rgba(255,255,255,0.55);
+  --c-win-bg:     rgba(245,158,11,0.15);
+  --c-lose-text:  rgba(255,255,255,0.16);
+  --c-connector:  rgba(255,255,255,0.12);
   --c-champ-bg:   rgba(245,158,11,0.1);
   --c-champ:      #f59e0b;
+  --left-color:   #dc2626;
+  --right-color:  #2563eb;
   --col-gap:      24px;
-  --header-h:     48px;
-  --slot-h:       34px;
-}
-:global([data-theme="light"]) .bracket-root {
-  --c-bg:         #f1f5f9;
-  --c-surface:    #ffffff;
-  --c-border:     rgba(0,0,0,0.1);
-  --c-border-act: #0891b2;
-  --c-text:       #0f172a;
-  --c-muted:      rgba(0,0,0,0.35);
-  --c-accent:     #0891b2;
-  --c-win-bg:     rgba(8,145,178,0.08);
-  --c-lose-text:  rgba(0,0,0,0.25);
-  --c-connector:  rgba(0,0,0,0.18);
-  --c-champ-bg:   rgba(245,158,11,0.08);
-  --c-champ:      #d97706;
+  --header-h:     52px;
+  --slot-h:       38px;
 }
 
 /* ── Root ─────────────────────────────────────────────── */
 .bracket-root {
-  height: 100dvh; background: var(--c-bg);
+  height: 100dvh;
+  background:
+    radial-gradient(ellipse 50vw 55vh at 5% 8%,  rgba(255,255,255,0.04) 0%, transparent 70%),
+    radial-gradient(ellipse 45vw 50vh at 95% 92%, rgba(245,158,11,0.06) 0%, transparent 70%),
+    #060818;
   display: flex; flex-direction: column;
   font-family: 'Inter', sans-serif; color: var(--c-text);
-  overflow: hidden;
+  overflow: hidden; position: relative;
+}
+
+/* ── Scanlines overlay ───────────────────────────────── */
+.scanlines {
+  position: absolute; inset: 0;
+  z-index: 100; pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px, transparent 3px,
+    rgba(0,0,0,0.045) 3px, rgba(0,0,0,0.045) 4px
+  );
 }
 
 /* ── Header ───────────────────────────────────────────── */
 .bracket-header {
   flex-shrink: 0; height: var(--header-h);
   display: flex; align-items: center; justify-content: space-between;
-  padding: 0 20px; background: var(--c-surface);
-  border-bottom: 1px solid var(--c-border);
+  padding: 0 20px;
+  background: linear-gradient(135deg, rgba(6,8,20,0.98) 0%, rgba(8,10,26,0.95) 100%);
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  position: relative; z-index: 10;
 }
-.header-brand { display: flex; align-items: center; gap: 8px; }
+.header-brand { display: flex; align-items: center; gap: 10px; }
 .brand-dot {
   width: 6px; height: 6px; border-radius: 50%;
-  background: var(--c-accent); box-shadow: 0 0 8px var(--c-accent);
+  background: var(--c-accent);
+  box-shadow: 0 0 10px rgba(255,255,255,0.5), 0 0 22px rgba(255,255,255,0.2);
   animation: dotPulse 2s ease-in-out infinite;
 }
-.brand-title { font-family: 'Anton SC', sans-serif; font-size: 13px; letter-spacing: 0.3em; color: var(--c-muted); }
-.active-pill {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 12px; font-weight: 600; color: var(--c-accent);
-  background: var(--c-win-bg); border: 1px solid rgba(6,182,212,0.25);
-  border-radius: 999px; padding: 3px 12px;
+.brand-title {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px; letter-spacing: 0.38em;
+  color: rgba(255,255,255,0.42);
+  text-transform: uppercase;
 }
-.pill-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--c-accent); animation: dotPulse 1s ease-in-out infinite; }
-.vs-sep { color: var(--c-muted); font-weight: 400; }
+.active-pill {
+  display: flex; align-items: center; gap: 8px;
+  font-family: 'Anton SC', sans-serif;
+  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: rgba(255,255,255,0.75);
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 2px; padding: 4px 16px 4px 12px;
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+}
+.pill-dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: rgba(255,255,255,0.7); box-shadow: 0 0 6px rgba(255,255,255,0.5);
+  animation: dotPulse 1s ease-in-out infinite;
+}
+.vs-sep { color: rgba(255,255,255,0.2); font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 400; }
 
 /* ── Empty / Smoke ────────────────────────────────────── */
-.empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; }
-.empty-icon { font-size: 36px; }
-.empty-title { font-family: 'Outfit', sans-serif; font-size: 18px; font-weight: 700; color: var(--c-muted); }
-.empty-sub   { font-size: 13px; color: var(--c-muted); opacity: 0.7; }
+.empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; }
+.empty-icon  { font-size: 36px; opacity: 0.45; }
+.empty-title { font-family: 'Anton SC', sans-serif; font-size: 18px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--c-muted); }
+.empty-sub   { font-size: 12px; color: var(--c-muted); opacity: 0.5; }
 
-.smoke-wrap  { flex: 1; display: flex; flex-direction: column; align-items: center; padding: 24px; overflow-y: auto; }
-.smoke-list  { width: 100%; max-width: 420px; display: flex; flex-direction: column; gap: 8px; }
-.smoke-slot  { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-radius: 12px; background: var(--c-surface); border: 1px solid var(--c-border); }
-.smoke-active{ background: var(--c-win-bg); border-color: rgba(6,182,212,0.3); }
-.smoke-next  { border-color: var(--c-connector); }
-.smoke-pos   { font-family: 'Source Code Pro', monospace; font-size: 12px; color: var(--c-muted); width: 18px; }
-.smoke-name  { flex: 1; font-size: 14px; font-weight: 600; color: var(--c-text); }
-.smoke-score { font-family: 'Source Code Pro', monospace; font-size: 13px; font-weight: 700; color: var(--c-accent); }
-.smoke-badge { font-size: 9px; font-weight: 700; letter-spacing: 0.15em; padding: 2px 7px; border-radius: 999px; background: var(--c-win-bg); color: var(--c-accent); border: 1px solid rgba(6,182,212,0.25); }
-.smoke-badge-next { background: var(--c-border); color: var(--c-muted); border-color: var(--c-border); }
+.smoke-wrap { flex: 1; display: flex; flex-direction: column; align-items: center; padding: 24px; overflow-y: auto; }
+.smoke-list { width: 100%; max-width: 420px; display: flex; flex-direction: column; gap: 8px; }
+.smoke-slot {
+  display: flex; align-items: center; gap: 10px; padding: 10px 16px;
+  background: var(--c-surface); border: 1px solid var(--c-border);
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+}
+.smoke-active { background: rgba(255,255,255,0.07); border-color: rgba(255,255,255,0.25); }
+.smoke-next   { border-color: rgba(255,255,255,0.1); }
+.smoke-pos    { font-family: 'Anton SC', sans-serif; font-size: 11px; color: var(--c-muted); width: 18px; letter-spacing: 0.08em; }
+.smoke-name   { flex: 1; font-family: 'Anton SC', sans-serif; font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--c-text); }
+.smoke-score  { font-family: 'Anton SC', sans-serif; font-size: 13px; color: rgba(255,255,255,0.65); letter-spacing: 0.05em; }
+.smoke-badge  {
+  font-family: 'Anton SC', sans-serif; font-size: 8px; letter-spacing: 0.2em;
+  padding: 2px 9px; background: var(--c-win-bg); color: rgba(255,255,255,0.65);
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+}
+.smoke-badge-next { background: var(--c-surface); color: var(--c-muted); }
 
 /* ── Round label ──────────────────────────────────────── */
 .round-label {
-  flex-shrink: 0; font-family: 'Outfit', sans-serif; font-size: 10px;
-  font-weight: 700; letter-spacing: 0.18em; color: var(--c-accent);
-  text-align: center; padding: 6px 0; opacity: 0.75;
+  flex-shrink: 0;
+  font-family: 'Anton SC', sans-serif;
+  font-size: 9px; letter-spacing: 0.3em;
+  color: rgba(255,255,255,0.38); text-align: center;
+  padding: 6px 0; opacity: 0.52;
+  text-transform: uppercase;
 }
 .mb-4 { margin-bottom: 16px; }
 
 /* ── Bracket layout ───────────────────────────────────── */
-.bracket-area  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); padding: 8px 16px 12px; overflow: hidden; min-height: 0; }
+.bracket-area  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); padding: 8px 16px 12px; overflow: hidden; min-height: 0; position: relative; z-index: 1; }
 .bracket-half  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); min-width: 0; }
 .round-col     { flex: 1; display: flex; flex-direction: column; min-width: 0; position: relative; }
 .matches-col   { flex: 1; display: flex; flex-direction: column; min-height: 0; }
 
-/* Each match = one pair-group. flex:1 → outer rounds shorter, inner rounds taller. */
 .pair-group {
   flex: 1; display: flex; flex-direction: column; position: relative;
   min-height: calc(var(--slot-h) * 2 + 16px);
 }
 
-/* Bracket arm — left side extends RIGHT */
+/* Connector arms */
 .bracket-left .pair-group::after {
   content: ''; position: absolute;
   right: calc(-1 * var(--col-gap)); top: 25%; height: 50%; width: var(--col-gap);
@@ -605,7 +637,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   border-bottom: 1px solid var(--c-connector);
   pointer-events: none; z-index: 1;
 }
-/* Bracket arm — right side extends LEFT */
 .bracket-right .pair-group::after {
   content: ''; position: absolute;
   left: calc(-1 * var(--col-gap)); top: 25%; height: 50%; width: var(--col-gap);
@@ -614,6 +645,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   border-bottom: 1px solid var(--c-connector);
   pointer-events: none; z-index: 1;
 }
+.match-active.pair-group::after { border-color: rgba(255,255,255,0.3); }
 
 .match-wrap { flex: 1; display: flex; align-items: center; padding: 0 2px; }
 
@@ -621,26 +653,41 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .battler-slot {
   width: 100%; height: var(--slot-h);
   display: flex; align-items: center; justify-content: center; gap: 6px;
-  padding: 0 8px;
-  background: var(--c-surface); border: 1px solid var(--c-border); border-radius: 7px;
-  transition: background 0.25s, border-color 0.25s;
+  padding: 0 10px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 2px;
+  transform: skewX(-4deg);
+  transition: background 0.25s, border-color 0.25s, box-shadow 0.25s;
 }
 .match-active .battler-slot {
-  border-color: var(--c-border-act);
-  box-shadow: 0 0 0 1px rgba(6,182,212,0.12), 0 1px 10px rgba(6,182,212,0.10);
+  background: rgba(255,255,255,0.05);
+  border-color: rgba(255,255,255,0.18);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 0 14px rgba(255,255,255,0.08);
 }
-.slot-winner { background: var(--c-win-bg); border-color: rgba(6,182,212,0.4) !important; }
-.slot-winner .battler-name { color: var(--c-accent); font-weight: 700; }
-.slot-loser .battler-name  { color: var(--c-lose-text); text-decoration: line-through; }
+.slot-winner {
+  background: rgba(245,158,11,0.15) !important;
+  border-color: rgba(245,158,11,0.45) !important;
+  box-shadow: 0 0 18px rgba(245,158,11,0.25) !important;
+}
+.slot-winner .battler-name { color: #fde68a; }
+.slot-loser { background: rgba(255,255,255,0.02) !important; border-color: rgba(255,255,255,0.03) !important; opacity: 0.42; }
+.slot-loser  .battler-name { color: var(--c-lose-text); }
 
 .battler-name {
-  font-size: 12px; font-weight: 600; color: var(--c-text); opacity: 0.85;
+  font-family: 'Anton SC', sans-serif;
+  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--c-text); opacity: 0.88;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center;
+  display: inline-block; transform: skewX(4deg);
   transition: opacity 1s ease;
 }
 .name-hidden .battler-name { opacity: 0; transition: none; }
 
-.crown-icon { font-size: 12px; color: var(--c-champ); flex-shrink: 0; }
+.crown-icon {
+  font-size: 11px; color: var(--c-champ); flex-shrink: 0;
+  display: inline-block; transform: skewX(4deg);
+}
 
 /* ── Winner glow animation ────────────────────────────── */
 .slot-glow {
@@ -648,57 +695,94 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   z-index: 10; position: relative;
 }
 @keyframes slotGlow {
-  0%   { background: var(--c-surface);       border-color: var(--c-border);  box-shadow: none; }
-  20%  { background: rgba(6,182,212,0.22);   border-color: var(--c-accent);  box-shadow: 0 0 0 2px rgba(6,182,212,0.4), 0 0 18px rgba(6,182,212,0.65), 0 0 36px rgba(6,182,212,0.3); }
-  70%  { background: rgba(6,182,212,0.16);   border-color: var(--c-accent);  box-shadow: 0 0 0 2px rgba(6,182,212,0.3), 0 0 14px rgba(6,182,212,0.5),  0 0 28px rgba(6,182,212,0.2); }
-  100% { background: var(--c-surface);       border-color: var(--c-border);  box-shadow: none; }
+  0%   { background: var(--c-surface);        border-color: var(--c-border);         box-shadow: none; }
+  20%  { background: rgba(245,158,11,0.28);   border-color: rgba(245,158,11,0.8);    box-shadow: 0 0 0 2px rgba(245,158,11,0.35), 0 0 22px rgba(245,158,11,0.7), 0 0 44px rgba(245,158,11,0.3); }
+  70%  { background: rgba(245,158,11,0.18);   border-color: rgba(245,158,11,0.55);   box-shadow: 0 0 0 2px rgba(245,158,11,0.25), 0 0 16px rgba(245,158,11,0.5), 0 0 32px rgba(245,158,11,0.18); }
+  100% { background: var(--c-surface);        border-color: var(--c-border);         box-shadow: none; }
 }
-.slot-glow .battler-name { color: var(--c-accent); opacity: 1; }
+.slot-glow .battler-name { color: #fde68a; opacity: 1; }
 
 /* ── Center column ────────────────────────────────────── */
 .center-col { flex-shrink: 0; width: 170px; display: flex; flex-direction: column; }
 .final-area { flex: 1; display: flex; flex-direction: column; align-items: stretch; justify-content: center; gap: 6px; min-height: 0; }
 .final-match { display: flex; flex-direction: column; gap: 6px; }
-.final-match.match-active .battler-slot { border-color: var(--c-border-act); box-shadow: 0 0 0 1px rgba(6,182,212,0.12), 0 1px 10px rgba(6,182,212,0.10); }
-.final-vs { text-align: center; font-size: 8px; font-weight: 700; letter-spacing: 0.15em; color: var(--c-muted); }
+.final-match.match-active .battler-slot {
+  border-color: rgba(255,255,255,0.3);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 0 16px rgba(255,255,255,0.1);
+}
+.final-vs {
+  text-align: center;
+  font-family: 'Anton SC', sans-serif;
+  font-size: 9px; letter-spacing: 0.32em;
+  color: rgba(255,255,255,0.3); opacity: 0.38;
+}
 
 /* ── Champion card ────────────────────────────────────── */
-.champion-card { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 10px 14px; border-radius: 12px; background: var(--c-champ-bg); border: 1px solid rgba(245,158,11,0.25); }
-.champ-icon { font-size: 14px; color: var(--c-champ); }
-.champ-name { font-family: 'Outfit', sans-serif; font-size: 13px; font-weight: 700; color: var(--c-champ); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.champion-card {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 10px 14px;
+  background: var(--c-champ-bg);
+  border: 1px solid rgba(245,158,11,0.22);
+  border-radius: 2px;
+  transform: skewX(-4deg);
+  box-shadow: 0 0 24px rgba(245,158,11,0.22);
+}
+.champ-icon {
+  font-size: 14px; color: var(--c-champ); flex-shrink: 0;
+  display: inline-block; transform: skewX(4deg);
+  filter: drop-shadow(0 0 8px rgba(245,158,11,0.9));
+}
+.champ-name {
+  font-family: 'Anton SC', sans-serif; font-size: 13px;
+  color: var(--c-champ); letter-spacing: 0.08em; text-transform: uppercase;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  display: inline-block; transform: skewX(4deg);
+}
 
 /* ── LED Ticker ───────────────────────────────────────── */
-.ticker-bar   { flex-shrink: 0; height: 30px; display: flex; align-items: stretch; background: #080f1e; border-top: 1px solid var(--c-border); overflow: hidden; }
-.ticker-label { flex-shrink: 0; display: flex; align-items: center; gap: 6px; padding: 0 14px; background: var(--c-accent); font-family: 'Anton SC', sans-serif; font-size: 10px; letter-spacing: 0.2em; color: #080f1e; z-index: 1; }
-.ticker-dot   { width: 5px; height: 5px; border-radius: 50%; background: #080f1e; animation: dotPulse 1s ease-in-out infinite; }
+.ticker-bar {
+  flex-shrink: 0; height: 30px;
+  display: flex; align-items: stretch;
+  background: #030610;
+  border-top: 1px solid rgba(255,255,255,0.07);
+  overflow: hidden; position: relative; z-index: 10;
+}
+.ticker-label {
+  flex-shrink: 0; display: flex; align-items: center; gap: 6px;
+  padding: 0 18px 0 14px;
+  background: rgba(255,255,255,0.9);
+  font-family: 'Anton SC', sans-serif;
+  font-size: 10px; letter-spacing: 0.25em;
+  color: #060818; z-index: 1;
+  clip-path: polygon(0% 0%, calc(100% - 10px) 0%, 100% 50%, calc(100% - 10px) 100%, 0% 100%);
+}
+.ticker-dot   { width: 5px; height: 5px; border-radius: 50%; background: #030610; animation: dotPulse 1s ease-in-out infinite; }
 .ticker-track { flex: 1; overflow: hidden; position: relative; mask-image: linear-gradient(to right, transparent 0%, black 3%, black 97%, transparent 100%); }
 .ticker-reel  { display: inline-flex; align-items: center; white-space: nowrap; height: 100%; animation: tickerScroll calc(var(--item-count, 4) * 8s) linear infinite; }
-.ticker-item  { display: inline-flex; align-items: center; gap: 8px; padding: 0 6px; font-family: 'Source Code Pro', monospace; }
-.ticker-tag   { font-size: 9px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: var(--c-muted); opacity: 0.7; }
-.ticker-now   .ticker-tag  { color: var(--c-accent); opacity: 1; }
-.ticker-next  .ticker-tag  { color: rgba(249,115,22,0.85); }
-.ticker-genre .ticker-tag  { color: rgba(167,139,250,0.85); }
-.ticker-text  { font-size: 11px; font-weight: 700; letter-spacing: 0.06em; color: var(--c-text); }
-.ticker-now   .ticker-text { color: var(--c-accent); }
+.ticker-item  { display: inline-flex; align-items: center; gap: 8px; padding: 0 6px; }
+.ticker-tag   { font-family: 'Anton SC', sans-serif; font-size: 8px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--c-muted); opacity: 0.62; }
+.ticker-now   .ticker-tag  { color: rgba(255,255,255,0.85); opacity: 1; }
+.ticker-next  .ticker-tag  { color: rgba(249,115,22,0.85); opacity: 1; }
+.ticker-genre .ticker-tag  { color: rgba(167,139,250,0.85); opacity: 1; }
+.ticker-text  { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; letter-spacing: 0.04em; color: var(--c-text); }
+.ticker-now   .ticker-text { color: rgba(255,255,255,0.85); }
 .ticker-next  .ticker-text { color: rgba(249,115,22,0.9); }
 .ticker-genre .ticker-text { color: rgba(167,139,250,0.9); }
-.ticker-sep   { font-size: 7px; color: var(--c-muted); opacity: 0.3; padding: 0 16px; }
+.ticker-sep   { font-size: 7px; color: var(--c-muted); opacity: 0.22; padding: 0 16px; }
 
-/* ── Travelling ball (rendered via Teleport, position:fixed) ── */
+/* ── Travelling ball ─────────────────────────────────── */
 :global(.anim-ball) {
   position: fixed;
-  width: 12px; height: 12px;
-  border-radius: 50%;
-  background: radial-gradient(circle, #ffffff 0%, #06b6d4 55%, transparent 100%);
-  box-shadow: 0 0 6px #06b6d4, 0 0 14px #06b6d4, 0 0 28px rgba(6,182,212,0.6);
-  pointer-events: none;
-  z-index: 9999;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: radial-gradient(circle, #ffffff 0%, rgba(245,158,11,0.9) 55%, transparent 100%);
+  box-shadow: 0 0 6px rgba(245,158,11,0.9), 0 0 14px rgba(245,158,11,0.7), 0 0 28px rgba(245,158,11,0.4);
+  pointer-events: none; z-index: 9999;
 }
 
 /* ── Animations ───────────────────────────────────────── */
 @keyframes dotPulse {
   0%, 100% { opacity: 1; transform: scale(1); }
-  50%       { opacity: 0.4; transform: scale(0.7); }
+  50%       { opacity: 0.32; transform: scale(0.62); }
 }
 @keyframes tickerScroll {
   0%   { transform: translateX(0); }

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -1,9 +1,10 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
-import { getBracketState } from '@/utils/api'
+import { getBracketState, getOverlayConfig } from '@/utils/api'
 import { createClient } from '@/utils/websocket'
 
 const bracketState   = ref(null)
+const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
 const activePair     = ref(null)
 const currentGenre   = ref(null)
 let   wsClient       = null
@@ -67,10 +68,17 @@ const isActiveMatch = (match) => {
          (l === activePair.value.right && r === activePair.value.left)
 }
 
-const slotClass = (match, slot) => ({
-  'slot-winner': match[2] && match[2] === match[slot],
-  'slot-loser':  match[2] && match[2] !== match[slot] && match[slot],
-})
+const slotClass = (match, slot) => {
+  if (match[2]) {
+    if (match[2] === match[slot]) return 'slot-winner'
+    if (match[slot]) return 'slot-loser'
+    return ''
+  }
+  if (isActiveMatch(match) && match[slot]) {
+    return slot === 0 ? 'slot-active-left' : 'slot-active-right'
+  }
+  return ''
+}
 
 const formatLabel = (key) => key === 'Top2' ? 'FINAL' : key.replace('Top', 'TOP ')
 
@@ -209,6 +217,9 @@ onMounted(async () => {
   const state = await getBracketState()
   if (state && (state.topSize || state.rounds)) bracketState.value = state
 
+  const cfg = await getOverlayConfig()
+  if (cfg) overlayConfig.value = cfg
+
   wsClient = createClient()
   wsClient.onConnect = () => {
 
@@ -235,6 +246,11 @@ onMounted(async () => {
     wsClient.subscribe('/topic/battle/genre', (msg) => {
       const data = JSON.parse(msg.body)
       currentGenre.value = data.genre ?? data.message ?? null
+    })
+
+    wsClient.subscribe('/topic/battle/overlay-config', (msg) => {
+      const cfg = JSON.parse(msg.body)
+      overlayConfig.value = cfg
     })
 
     wsClient.subscribe('/topic/battle/score', (msg) => {
@@ -286,7 +302,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 </script>
 
 <template>
-  <div class="bracket-root">
+  <div class="bracket-root" :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }">
 
     <!-- ── Scanlines overlay ──────────────────────────── -->
     <div class="scanlines" aria-hidden="true"></div>
@@ -355,7 +371,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[0] || '—' }}</span>
-                  <i v-if="match[2] === match[0] && match[0]" class="pi pi-crown crown-icon"></i>
+                  <span v-if="match[2] === match[0] && match[0]" class="win-badge">WIN</span>
                 </div>
               </div>
               <div class="match-wrap">
@@ -369,7 +385,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[1] || '—' }}</span>
-                  <i v-if="match[2] === match[1] && match[1]" class="pi pi-crown crown-icon"></i>
+                  <span v-if="match[2] === match[1] && match[1]" class="win-badge">WIN</span>
                 </div>
               </div>
             </div>
@@ -392,7 +408,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
               ]"
             >
               <span class="battler-name">{{ finalMatch[0] || '—' }}</span>
-              <i v-if="finalMatch[2] === finalMatch[0] && finalMatch[0]" class="pi pi-crown crown-icon"></i>
+              <span v-if="finalMatch[2] === finalMatch[0] && finalMatch[0]" class="win-badge">WIN</span>
             </div>
             <div class="final-vs">VS</div>
             <div
@@ -405,12 +421,8 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
               ]"
             >
               <span class="battler-name">{{ finalMatch[1] || '—' }}</span>
-              <i v-if="finalMatch[2] === finalMatch[1] && finalMatch[1]" class="pi pi-crown crown-icon"></i>
+              <span v-if="finalMatch[2] === finalMatch[1] && finalMatch[1]" class="win-badge">WIN</span>
             </div>
-          </div>
-          <div v-if="champion" class="champion-card">
-            <i class="pi pi-crown champ-icon"></i>
-            <span class="champ-name">{{ champion }}</span>
           </div>
         </div>
       </div>
@@ -436,7 +448,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[0] || '—' }}</span>
-                  <i v-if="match[2] === match[0] && match[0]" class="pi pi-crown crown-icon"></i>
+                  <span v-if="match[2] === match[0] && match[0]" class="win-badge">WIN</span>
                 </div>
               </div>
               <div class="match-wrap">
@@ -450,7 +462,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
                   ]"
                 >
                   <span class="battler-name">{{ match[1] || '—' }}</span>
-                  <i v-if="match[2] === match[1] && match[1]" class="pi pi-crown crown-icon"></i>
+                  <span v-if="match[2] === match[1] && match[1]" class="win-badge">WIN</span>
                 </div>
               </div>
             </div>
@@ -665,6 +677,22 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   border-color: rgba(255,255,255,0.18);
   box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 0 14px rgba(255,255,255,0.08);
 }
+.slot-active-left {
+  background: color-mix(in srgb, var(--left-color) 18%, transparent) !important;
+  border-color: color-mix(in srgb, var(--left-color) 50%, transparent) !important;
+  box-shadow: 0 0 16px color-mix(in srgb, var(--left-color) 28%, transparent) !important;
+}
+.slot-active-left .battler-name {
+  color: color-mix(in srgb, var(--left-color) 80%, #fff) !important;
+}
+.slot-active-right {
+  background: color-mix(in srgb, var(--right-color) 18%, transparent) !important;
+  border-color: color-mix(in srgb, var(--right-color) 50%, transparent) !important;
+  box-shadow: 0 0 16px color-mix(in srgb, var(--right-color) 28%, transparent) !important;
+}
+.slot-active-right .battler-name {
+  color: color-mix(in srgb, var(--right-color) 80%, #fff) !important;
+}
 .slot-winner {
   background: rgba(245,158,11,0.15) !important;
   border-color: rgba(245,158,11,0.45) !important;
@@ -684,9 +712,13 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 }
 .name-hidden .battler-name { opacity: 0; transition: none; }
 
-.crown-icon {
-  font-size: 11px; color: var(--c-champ); flex-shrink: 0;
-  display: inline-block; transform: skewX(4deg);
+.win-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  transform: skewX(5deg); flex-shrink: 0;
+  background: rgba(245,158,11,0.22); border: 1px solid rgba(245,158,11,0.5);
+  color: #fbbf24; font-size: 8px; font-weight: 900; font-family: 'Inter', sans-serif;
+  letter-spacing: 0.12em; padding: 1px 5px; border-radius: 2px;
+  clip-path: polygon(3px 0%, 100% 0%, calc(100% - 3px) 100%, 0% 100%);
 }
 
 /* ── Winner glow animation ────────────────────────────── */
@@ -715,28 +747,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   font-family: 'Anton SC', sans-serif;
   font-size: 9px; letter-spacing: 0.32em;
   color: rgba(255,255,255,0.3); opacity: 0.38;
-}
-
-/* ── Champion card ────────────────────────────────────── */
-.champion-card {
-  display: flex; align-items: center; justify-content: center; gap: 8px;
-  padding: 10px 14px;
-  background: var(--c-champ-bg);
-  border: 1px solid rgba(245,158,11,0.22);
-  border-radius: 2px;
-  transform: skewX(-4deg);
-  box-shadow: 0 0 24px rgba(245,158,11,0.22);
-}
-.champ-icon {
-  font-size: 14px; color: var(--c-champ); flex-shrink: 0;
-  display: inline-block; transform: skewX(4deg);
-  filter: drop-shadow(0 0 8px rgba(245,158,11,0.9));
-}
-.champ-name {
-  font-family: 'Anton SC', sans-serif; font-size: 13px;
-  color: var(--c-champ); letter-spacing: 0.08em; text-transform: uppercase;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  display: inline-block; transform: skewX(4deg);
 }
 
 /* ── LED Ticker ───────────────────────────────────────── */

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -5,6 +5,7 @@ import { createClient } from '@/utils/websocket'
 
 const bracketState   = ref(null)
 const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+const championReveal = ref(null)   // null = hidden; { genreName, championName } = showing
 const activePair     = ref(null)
 const currentGenre   = ref(null)
 let   wsClient       = null
@@ -296,6 +297,15 @@ onMounted(async () => {
       overlayConfig.value = cfg
     })
 
+    wsClient.subscribe('/topic/battle/champion-reveal', (msg) => {
+      const data = JSON.parse(msg.body)
+      if (data.dismiss) {
+        championReveal.value = null
+      } else {
+        championReveal.value = { genreName: data.genreName, championName: data.championName }
+      }
+    })
+
     wsClient.subscribe('/topic/battle/score', (msg) => {
       const data = JSON.parse(msg.body)
       if (data.message !== 0 && data.message !== 1) return
@@ -349,6 +359,19 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 
     <!-- ── Scanlines overlay ──────────────────────────── -->
     <div class="scanlines" aria-hidden="true"></div>
+
+    <!-- ── Champion Reveal Overlay ──────────────────────── -->
+    <Transition name="champ-reveal">
+      <div v-if="championReveal" class="champ-overlay">
+        <div class="champ-overlay-bg"></div>
+        <div class="champ-overlay-content">
+          <div class="champ-genre-tag">{{ championReveal.genreName }} · Final</div>
+          <div class="champ-label">CHAMPION</div>
+          <div class="champ-name-slam">{{ championReveal.championName }}</div>
+          <div class="champ-gold-bar"></div>
+        </div>
+      </div>
+    </Transition>
 
     <!-- ── Header ─────────────────────────────────────── -->
     <header class="bracket-header">
@@ -814,6 +837,74 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .ticker-next  .ticker-text { color: rgba(249,115,22,0.9); }
 .ticker-genre .ticker-text { color: rgba(167,139,250,0.9); }
 .ticker-sep   { font-size: 7px; color: var(--c-muted); opacity: 0.22; padding: 0 16px; }
+
+/* ── Champion Reveal Overlay ────────────────────────────── */
+.champ-overlay {
+  position: absolute; inset: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: center;
+  background: #060818;
+}
+.champ-overlay-bg {
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(ellipse 60% 50% at 50% 55%, rgba(245,158,11,0.14) 0%, transparent 68%);
+}
+.champ-overlay-content {
+  position: relative; z-index: 1;
+  display: flex; flex-direction: column; align-items: center; gap: 6px;
+  text-align: center;
+}
+.champ-genre-tag {
+  font-family: 'Anton SC', sans-serif; font-size: 9px;
+  letter-spacing: 0.45em; text-transform: uppercase;
+  color: rgba(255,255,255,0.3);
+}
+.champ-label {
+  font-family: 'Anton SC', sans-serif; font-size: 11px;
+  letter-spacing: 0.5em; text-transform: uppercase;
+  color: rgba(245,158,11,0.85);
+}
+.champ-name-slam {
+  font-family: 'Anton SC', sans-serif; font-size: 58px;
+  letter-spacing: 0.07em; text-transform: uppercase; line-height: 1;
+  color: #fff;
+  text-shadow: 0 0 40px rgba(245,158,11,0.65), 0 0 80px rgba(245,158,11,0.3);
+}
+.champ-gold-bar {
+  width: 180px; height: 2px; margin-top: 6px;
+  background: linear-gradient(90deg, transparent, rgba(245,158,11,0.8), transparent);
+}
+
+/* Transition */
+.champ-reveal-enter-active { transition: opacity 0.3s ease; }
+.champ-reveal-leave-active { transition: opacity 0.25s ease; }
+.champ-reveal-enter-from,
+.champ-reveal-leave-to    { opacity: 0; }
+
+.champ-reveal-enter-active .champ-name-slam {
+  animation: champNameSlam 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.35s both;
+}
+.champ-reveal-enter-active .champ-label {
+  animation: champFadeUp 0.4s ease 0.2s both;
+}
+.champ-reveal-enter-active .champ-genre-tag {
+  animation: champFadeUp 0.4s ease 0.08s both;
+}
+.champ-reveal-enter-active .champ-gold-bar {
+  animation: champBarExpand 0.6s ease 0.65s both;
+}
+
+@keyframes champNameSlam {
+  from { opacity: 0; transform: scale(0.72) translateY(18px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0); }
+}
+@keyframes champFadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes champBarExpand {
+  from { width: 0; opacity: 0; }
+  to   { width: 180px; opacity: 1; }
+}
 
 /* ── Animations ───────────────────────────────────────── */
 @keyframes dotPulse {

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -13,8 +13,6 @@ let   wsClient       = null
 const pendingBracket  = ref(null)
 const glowSlotKey     = ref(null)   // "roundKey-matchIdx-slot" → glow effect
 const hiddenSlotKey   = ref(null)   // dest slot name hidden until ball arrives
-const ballVisible     = ref(false)
-const ballOrigin      = ref({ x: 0, y: 0 })
 let   animRunning     = false
 // Saves the bracket state that existed BEFORE the most recent bracket update.
 // Used when the bracket WebSocket message arrives before the score message.
@@ -133,46 +131,91 @@ function findDestSlot(oldS, newS) {
 }
 
 async function travelBall(winnerKey, destKey) {
-  const winEl = slotEls[winnerKey]
+  const winEl  = slotEls[winnerKey]
+  const destEl = destKey ? slotEls[destKey] : null
   if (!winEl) return
 
-  const wr    = winEl.getBoundingClientRect()
-  const pg    = winEl.closest('.pair-group')
-  const pgR   = pg?.getBoundingClientRect()
-  const COL_GAP = 24
+  const bracketEl = document.querySelector('.bracket-area')
+  if (!bracketEl) return
+  const bRect  = bracketEl.getBoundingClientRect()
+  const wRect  = winEl.getBoundingClientRect()
 
-  // Determine side by comparing slot center to viewport center
-  const isLeft = (wr.left + wr.right) / 2 < window.innerWidth / 2
+  // ── Phase 1: Ring burst on source slot ──────────────────────────
+  const ring = document.createElement('div')
+  ring.style.cssText = `
+    position: absolute;
+    left: ${wRect.left - bRect.left}px;
+    top:  ${wRect.top  - bRect.top}px;
+    width:  ${wRect.width}px;
+    height: ${wRect.height}px;
+    border: 2px solid rgba(245,158,11,0.9);
+    border-radius: 1px;
+    box-shadow: 0 0 20px rgba(245,158,11,0.6);
+    pointer-events: none;
+    z-index: 20;
+    transform: skewX(-4deg);
+  `
+  bracketEl.style.position = 'relative'
+  bracketEl.appendChild(ring)
 
-  const startX = isLeft ? wr.right      : wr.left
-  const startY = wr.top + wr.height / 2
-  const midY   = pgR ? pgR.top + pgR.height / 2 : startY
-  const armX   = isLeft ? startX + COL_GAP : startX - COL_GAP
+  await ring.animate(
+    [{ transform: 'skewX(-4deg) scale(1)', opacity: 1 },
+     { transform: 'skewX(-4deg) scale(1.65)', opacity: 0 }],
+    { duration: 380, easing: 'ease-out', fill: 'forwards' }
+  ).finished
+  ring.remove()
 
-  let endX = armX, endY = midY
-  if (destKey && slotEls[destKey]) {
-    const dr = slotEls[destKey].getBoundingClientRect()
-    endX = dr.left + dr.width / 2
-    endY = dr.top  + dr.height / 2
-  }
+  if (!destEl) return
 
-  // Place ball origin at start position (ball is 12×12, center offset 6px)
-  ballOrigin.value = { x: startX - 6, y: startY - 6 }
-  ballVisible.value = true
-  await nextTick()
+  const dRect = destEl.getBoundingClientRect()
 
-  const ballEl = document.querySelector('.anim-ball')
-  if (!ballEl) { ballVisible.value = false; return }
+  // ── Phase 2: Lightning streak ────────────────────────────────────
+  const srcCenterX = wRect.left  + wRect.width  / 2 - bRect.left
+  const srcCenterY = wRect.top   + wRect.height / 2 - bRect.top
+  const dstCenterX = dRect.left  + dRect.width  / 2 - bRect.left
+  const dstCenterY = dRect.top   + dRect.height / 2 - bRect.top
 
-  // Path: start → arm edge (horizontal) → midpoint (vertical) → destination
-  await ballEl.animate([
-    { transform: 'translate(0px, 0px)',                                          offset: 0    },
-    { transform: `translate(${armX - startX}px, 0px)`,                          offset: 0.15 },
-    { transform: `translate(${armX - startX}px, ${midY - startY}px)`,           offset: 0.50 },
-    { transform: `translate(${endX - startX}px, ${endY - startY}px)`,           offset: 1.00 },
-  ], { duration: 5000, easing: 'ease-in-out', fill: 'forwards' }).finished
+  const dx = dstCenterX - srcCenterX
+  const dy = dstCenterY - srcCenterY
+  const length = Math.sqrt(dx * dx + dy * dy)
+  const angle  = Math.atan2(dy, dx) * (180 / Math.PI)
 
-  ballVisible.value = false
+  const streak = document.createElement('div')
+  streak.style.cssText = `
+    position: absolute;
+    left:   ${srcCenterX}px;
+    top:    ${srcCenterY - 2}px;
+    width:  0;
+    height: 3px;
+    transform-origin: left center;
+    transform: rotate(${angle}deg);
+    background: linear-gradient(90deg, rgba(245,158,11,0.2) 0%, rgba(245,158,11,0.95) 55%, #fff 100%);
+    border-radius: 2px;
+    box-shadow: 0 0 8px rgba(245,158,11,0.7);
+    pointer-events: none;
+    z-index: 20;
+  `
+  bracketEl.appendChild(streak)
+
+  await streak.animate(
+    [{ width: '0px' }, { width: `${length}px` }],
+    { duration: 200, easing: 'ease-in', fill: 'forwards' }
+  ).finished
+
+  await streak.animate(
+    [{ opacity: 1 }, { opacity: 0 }],
+    { duration: 140, easing: 'linear', fill: 'forwards' }
+  ).finished
+  streak.remove()
+
+  // ── Phase 3: Destination slot ignites ───────────────────────────
+  destEl.style.transition = 'none'
+  destEl.style.boxShadow  = '0 0 40px rgba(245,158,11,0.9), 0 0 80px rgba(245,158,11,0.4)'
+  await sleep(60)
+  destEl.style.transition = 'box-shadow 0.45s ease-out'
+  destEl.style.boxShadow  = ''
+  await sleep(450)
+  destEl.style.transition = ''
 }
 
 async function runWinnerAnimation(winnerKey, pending) {
@@ -499,14 +542,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 
   </div>
 
-  <!-- ── Travelling ball (outside bracket-root to avoid overflow clipping) ── -->
-  <Teleport to="body">
-    <div
-      v-if="ballVisible"
-      class="anim-ball"
-      :style="{ left: ballOrigin.x + 'px', top: ballOrigin.y + 'px' }"
-    ></div>
-  </Teleport>
 </template>
 
 <style scoped>
@@ -779,15 +814,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .ticker-next  .ticker-text { color: rgba(249,115,22,0.9); }
 .ticker-genre .ticker-text { color: rgba(167,139,250,0.9); }
 .ticker-sep   { font-size: 7px; color: var(--c-muted); opacity: 0.22; padding: 0 16px; }
-
-/* ── Travelling ball ─────────────────────────────────── */
-:global(.anim-ball) {
-  position: fixed;
-  width: 12px; height: 12px; border-radius: 50%;
-  background: radial-gradient(circle, #ffffff 0%, rgba(245,158,11,0.9) 55%, transparent 100%);
-  box-shadow: 0 0 6px rgba(245,158,11,0.9), 0 0 14px rgba(245,158,11,0.7), 0 0 28px rgba(245,158,11,0.4);
-  pointer-events: none; z-index: 9999;
-}
 
 /* ── Animations ───────────────────────────────────────── */
 @keyframes dotPulse {

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -39,7 +39,6 @@ const roundKeys = computed(() => {
 
 const sideRoundKeys  = computed(() => roundKeys.value.filter(k => k !== 'Top2'))
 const finalMatch     = computed(() => bracketState.value?.rounds?.Top2?.[0] ?? null)
-const champion       = computed(() => finalMatch.value?.[2] ?? null)
 const rightRoundKeys = computed(() => [...sideRoundKeys.value].reverse())
 
 const smokeList = computed(() => {

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -113,9 +113,14 @@ public class BattleController {
 
     @PostMapping("/score")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
-    public ResponseEntity<?> setBattleScore(){
-        Integer code = battleService.setScoreService();
-        if(code == -2){
+    public ResponseEntity<?> setBattleScore(@RequestBody(required = false) com.example.BES.dtos.battle.SetBattleScoreDto dto){
+        boolean isFinal = dto != null && dto.isFinal();
+        Integer code = battleService.setScoreService(isFinal);
+        if(code == -3){
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                Map.of("message", "Tie not allowed in the final match")
+            );
+        }else if(code == -2){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
                 Map.of("message", "No judge found")
             );

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.BES.dtos.battle.ChampionRevealDto;
 import com.example.BES.dtos.battle.DeleteImageDto;
 import com.example.BES.dtos.battle.SetBattleModeDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
@@ -38,6 +39,7 @@ import com.example.BES.dtos.battle.SetBattlePhaseDto;
 import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
 import com.example.BES.dtos.battle.SetOverlayConfigDto;
+import com.example.BES.dtos.battle.SetBattleScoreDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
 import com.example.BES.dtos.battle.SetVoteDto;
 import com.example.BES.services.BattleService;
@@ -113,40 +115,46 @@ public class BattleController {
 
     @PostMapping("/score")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
-    public ResponseEntity<?> setBattleScore(@RequestBody(required = false) com.example.BES.dtos.battle.SetBattleScoreDto dto){
+    public ResponseEntity<?> setBattleScore(@RequestBody(required = false) SetBattleScoreDto dto){
         boolean isFinal = dto != null && dto.isFinal();
         Integer code = battleService.setScoreService(isFinal);
-        if(code == -3){
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                Map.of("message", "Tie not allowed in the final match")
-            );
-        }else if(code == -2){
+        if(code == -2){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
                 Map.of("message", "No judge found")
             );
+        }else if(code == -3){
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                Map.of("message", "Tie in final match — revote required", "tie", true)
+            );
         }else if(code == -1){
-            return ResponseEntity.ok(
-                Map.of("message", "Its a tie",
-                "winner", -1)
-            );
+            return ResponseEntity.ok(Map.of("message", "Its a tie", "winner", -1));
+        }else if(code == 0){
+            return ResponseEntity.ok(Map.of(
+                "message", "Left side get one point",
+                "winner", 0,
+                "current score", battleService.getCurrentPair().getLeftBattler().getScore()
+            ));
+        }else {
+            return ResponseEntity.ok(Map.of(
+                "message", "Right side get one point",
+                "winner", 1,
+                "current score", battleService.getCurrentPair().getRightBattler().getScore()
+            ));
         }
-        else if(code == 0){
-            return ResponseEntity.ok(
-                Map.of(
-                    "message", "Left side get one point",
-                    "winner", 0,
-                    "current score", battleService.getCurrentPair().getLeftBattler().getScore()
-                )
-            );
-        }
-        else {
-            return ResponseEntity.ok(
-                Map.of(
-                    "message", "Right side get one point",
-                    "winner", 1,
-                    "current score", battleService.getCurrentPair().getRightBattler().getScore())
-            );
-        }
+    }
+
+    @PostMapping("/revote")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> revote(){
+        battleService.resetJudgeVotesService();
+        return ResponseEntity.ok(Map.of("message", "Judge votes reset"));
+    }
+
+    @PostMapping("/champion-reveal")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> championReveal(@RequestBody ChampionRevealDto dto){
+        battleService.broadcastChampionReveal(dto);
+        return ResponseEntity.ok(Map.of("message", "Champion reveal broadcast"));
     }
 
     @GetMapping("/judges")

--- a/BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java
@@ -1,0 +1,11 @@
+package com.example.BES.dtos.battle;
+
+public class ChampionRevealDto {
+    private String genreName;
+    private String championName;
+    private boolean dismiss;
+
+    public String getGenreName()    { return genreName; }
+    public String getChampionName() { return championName; }
+    public boolean isDismiss()      { return dismiss; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java
@@ -1,0 +1,6 @@
+package com.example.BES.dtos.battle;
+
+public class SetBattleScoreDto {
+    private boolean isFinal;
+    public boolean isFinal() { return isFinal; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java
@@ -1,6 +1,9 @@
 package com.example.BES.dtos.battle;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class SetBattleScoreDto {
+    @JsonProperty("isFinal")
     private boolean isFinal;
     public boolean isFinal() { return isFinal; }
 }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -92,7 +92,7 @@ public class BattleService {
         messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
     }
 
-    public Integer setScoreService(){
+    public Integer setScoreService(boolean isFinal){
         // Broadcast the score here
         // This is where we reveal the judge decision on the screen
         // After that we add the point
@@ -105,6 +105,7 @@ public class BattleService {
             score.add(judge.getVote());
         }
         if(Collections.frequency(score, 0) == Collections.frequency(score, 1)){
+            if (isFinal) return -3;   // final tie — blocked, do not broadcast
             res = -1;
         }else if(Collections.frequency(score, 0) > Collections.frequency(score, 1)){
             currentPair.getLeftBattler().setScore(currentPair.leftBattler.getScore() + 1);

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+import com.example.BES.dtos.battle.ChampionRevealDto;
 import com.example.BES.dtos.battle.SetBattleModeDto;
 import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
@@ -243,6 +244,25 @@ public class BattleService {
         newConfig.put("rightColor", dto.getRightColor());
         overlayConfig = newConfig;
         messagingTemplate.convertAndSend("/topic/battle/overlay-config", newConfig);
+    }
+
+    public void resetJudgeVotesService() {
+        for (BattleJudge judge : judges) {
+            judge.setVote(-3);
+        }
+        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+    }
+
+    public void broadcastChampionReveal(ChampionRevealDto dto) {
+        if (dto.isDismiss()) {
+            messagingTemplate.convertAndSend("/topic/battle/champion-reveal",
+                Map.of("dismiss", true));
+        } else {
+            messagingTemplate.convertAndSend("/topic/battle/champion-reveal",
+                Map.of("dismiss", false,
+                       "genreName",     dto.getGenreName()     != null ? dto.getGenreName()     : "",
+                       "championName",  dto.getChampionName()  != null ? dto.getChampionName()  : ""));
+        }
     }
 
     public class BattleJudge {

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -248,7 +248,7 @@ public class BattleService {
 
     public void resetJudgeVotesService() {
         for (BattleJudge judge : judges) {
-            judge.setVote(-3);
+            judge.setVote(-1);
         }
         messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
     }

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -238,7 +238,7 @@ class BattleServiceTest {
     }
 
     @Test
-    void resetJudgeVotes_setsAllVotesToMinusThreeAndBroadcasts() {
+    void resetJudgeVotes_setsAllVotesToMinusOneAndBroadcasts() {
         Judge j = new Judge();
         j.setJudgeId(5L);
         j.setName("Alex");
@@ -255,7 +255,7 @@ class BattleServiceTest {
 
         service.resetJudgeVotesService();
 
-        assertThat(service.getJudges().get(0).getVote()).isEqualTo(-3);
+        assertThat(service.getJudges().get(0).getVote()).isEqualTo(-1);
         verify(messagingTemplate, atLeastOnce()).convertAndSend(
             eq("/topic/battle/judges"), any(Map.class));
     }

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -73,6 +73,7 @@ class BattleServiceTest {
     void setScore_finalTie_returnsMinusThreeToSignalBlock() {
         // empty judges → tie, isFinal=true → returns -3 (blocked)
         assertThat(service.setScoreService(true)).isEqualTo(-3);
+        verify(messagingTemplate, never()).convertAndSend(eq("/topic/battle/score"), any(Map.class));
     }
 
     @Test

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.BES.services;
 
+import com.example.BES.dtos.battle.ChampionRevealDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
 import com.example.BES.dtos.battle.SetOverlayConfigDto;
@@ -232,6 +233,44 @@ class BattleServiceTest {
 
         verify(messagingTemplate).convertAndSend(
             eq("/topic/battle/overlay-config"),
+            any(Map.class)
+        );
+    }
+
+    @Test
+    void resetJudgeVotes_setsAllVotesToMinusThreeAndBroadcasts() {
+        Judge j = new Judge();
+        j.setJudgeId(5L);
+        j.setName("Alex");
+        when(judgeService.getJudgeById(5L)).thenReturn(j);
+
+        SetJudgeDto addDto = mock(SetJudgeDto.class);
+        when(addDto.getId()).thenReturn(5L);
+        service.setBattleJudgeService(addDto);
+
+        SetVoteDto voteDto = mock(SetVoteDto.class);
+        when(voteDto.getId()).thenReturn(5L);
+        when(voteDto.getVote()).thenReturn(0);
+        service.setVoteService(voteDto);
+
+        service.resetJudgeVotesService();
+
+        assertThat(service.getJudges().get(0).getVote()).isEqualTo(-3);
+        verify(messagingTemplate, atLeastOnce()).convertAndSend(
+            eq("/topic/battle/judges"), any(Map.class));
+    }
+
+    @Test
+    void broadcastChampionReveal_sendsToCorrectTopic() {
+        ChampionRevealDto dto = mock(ChampionRevealDto.class);
+        when(dto.getGenreName()).thenReturn("B-Boy/B-Girl");
+        when(dto.getChampionName()).thenReturn("PULSE");
+        when(dto.isDismiss()).thenReturn(false);
+
+        service.broadcastChampionReveal(dto);
+
+        verify(messagingTemplate).convertAndSend(
+            eq("/topic/battle/champion-reveal"),
             any(Map.class)
         );
     }

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -66,7 +66,39 @@ class BattleServiceTest {
     @Test
     void setScore_returnsMinusOneWhenNoJudges() {
         // Empty judges list: score list is empty, frequency(0)==frequency(1) → tie → returns -1
-        assertThat(service.setScoreService()).isEqualTo(-1);
+        assertThat(service.setScoreService(false)).isEqualTo(-1);
+    }
+
+    @Test
+    void setScore_finalTie_returnsMinusThreeToSignalBlock() {
+        // empty judges → tie, isFinal=true → returns -3 (blocked)
+        assertThat(service.setScoreService(true)).isEqualTo(-3);
+    }
+
+    @Test
+    void setScore_nonFinalTie_returnsMinusOne() {
+        // empty judges → tie, isFinal=false → normal tie return -1
+        assertThat(service.setScoreService(false)).isEqualTo(-1);
+    }
+
+    @Test
+    void setScore_finalWinner_returnsZeroAndTransitionsToREVEALED() {
+        Judge j = new Judge();
+        j.setJudgeId(10L);
+        j.setName("Judge_final");
+        when(judgeService.getJudgeById(10L)).thenReturn(j);
+
+        SetJudgeDto jDto = mock(SetJudgeDto.class);
+        when(jDto.getId()).thenReturn(10L);
+        service.setBattleJudgeService(jDto);
+
+        SetVoteDto vDto = mock(SetVoteDto.class);
+        when(vDto.getId()).thenReturn(10L);
+        when(vDto.getVote()).thenReturn(0);
+        service.setVoteService(vDto);
+
+        assertThat(service.setScoreService(true)).isEqualTo(0);
+        assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
     }
 
     @Test
@@ -85,7 +117,7 @@ class BattleServiceTest {
         when(vDto.getVote()).thenReturn(0); // vote for left
         service.setVoteService(vDto);
 
-        Integer result = service.setScoreService();
+        Integer result = service.setScoreService(false);
 
         assertThat(result).isEqualTo(0);
         assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
@@ -107,7 +139,7 @@ class BattleServiceTest {
         when(vDto.getVote()).thenReturn(1); // vote for right
         service.setVoteService(vDto);
 
-        assertThat(service.setScoreService()).isEqualTo(1);
+        assertThat(service.setScoreService(false)).isEqualTo(1);
         assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
     }
 

--- a/docs/superpowers/plans/2026-05-28-bracket-visual-enhancements.md
+++ b/docs/superpowers/plans/2026-05-28-bracket-visual-enhancements.md
@@ -1,0 +1,1663 @@
+# Bracket Visual Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add color theming, a bolder advance animation, champion reveal, and final-match tie prevention to the live bracket system.
+
+**Architecture:** Backend adds three new endpoints (score isFinal check, revote, champion-reveal) and two new DTOs. Frontend adds overlay-config subscription to BracketVisualization, rewrites the advance animation, adds champion-reveal overlays to both BracketVisualization and BattleOverlay, and adds tie/reveal controls to BattleControl.
+
+**Tech Stack:** Vue 3 `<script setup>`, Spring Boot, STOMP WebSocket, CSS `color-mix()`, Web Animations API.
+
+---
+
+## File Map
+
+| File | What changes |
+|---|---|
+| `BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java` | **New** — `{ isFinal: boolean }` |
+| `BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java` | **New** — `{ genreName, championName, dismiss }` |
+| `BES/src/main/java/com/example/BES/services/BattleService.java` | `setScoreService(boolean isFinal)`, `resetJudgeVotesService()`, `broadcastChampionReveal(dto)` |
+| `BES/src/main/java/com/example/BES/controllers/BattleController.java` | Score endpoint accepts optional body; new `/revote` and `/champion-reveal` endpoints |
+| `BES/src/test/java/com/example/BES/services/BattleServiceTest.java` | New tests for isFinal tie block, resetJudgeVotes, championReveal |
+| `BES-frontend/src/utils/api.js` | Update `setBattleScore(isFinal)`, add `resetBattleVotes()`, `revealChampion(genreName, championName)`, `dismissChampionReveal()` |
+| `BES-frontend/src/views/BattleControl.vue` | Final tie warning + START REVOTE; REVEAL CHAMPION / DISMISS buttons |
+| `BES-frontend/src/views/BracketVisualization.vue` | Cyan → white, overlay config subscription, slot color theming, WIN badge, advance animation rewrite, champion reveal overlay |
+| `BES-frontend/src/views/BattleOverlay.vue` | Champion reveal overlay subscription + animation |
+
+---
+
+## Task 1: New backend DTOs
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java`
+- Create: `BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java`
+
+- [ ] **Step 1: Create SetBattleScoreDto**
+
+```java
+// BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java
+package com.example.BES.dtos.battle;
+
+public class SetBattleScoreDto {
+    private boolean isFinal;
+    public boolean isFinal() { return isFinal; }
+}
+```
+
+- [ ] **Step 2: Create ChampionRevealDto**
+
+```java
+// BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java
+package com.example.BES.dtos.battle;
+
+public class ChampionRevealDto {
+    private String genreName;
+    private String championName;
+    private boolean dismiss;
+
+    public String getGenreName()    { return genreName; }
+    public String getChampionName() { return championName; }
+    public boolean isDismiss()      { return dismiss; }
+}
+```
+
+- [ ] **Step 3: Compile check**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw clean compile -q
+```
+Expected: BUILD SUCCESS with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java \
+        BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java
+git commit -m "feat(battle): add SetBattleScoreDto and ChampionRevealDto"
+```
+
+---
+
+## Task 2: BattleService — isFinal tie blocking
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/BattleService.java`
+- Modify: `BES/src/test/java/com/example/BES/services/BattleServiceTest.java`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `BattleServiceTest.java` after the existing `setScore_returnsMinusOneWhenNoJudges` test:
+
+```java
+@Test
+void setScore_finalTie_returnsMinusTwoToSignalBlock() {
+    // empty judges → tie, isFinal=true → returns -2 (blocked)
+    assertThat(service.setScoreService(true)).isEqualTo(-2);
+}
+
+@Test
+void setScore_nonFinalTie_returnsMinusOne() {
+    // empty judges → tie, isFinal=false → normal tie return -1
+    assertThat(service.setScoreService(false)).isEqualTo(-1);
+}
+
+@Test
+void setScore_finalWinner_returnsZeroAndTransitionsToREVEALED() {
+    Judge j = new Judge();
+    j.setJudgeId(10L);
+    j.setName("Judge_final");
+    when(judgeService.getJudgeById(10L)).thenReturn(j);
+
+    SetJudgeDto jDto = mock(SetJudgeDto.class);
+    when(jDto.getId()).thenReturn(10L);
+    service.setBattleJudgeService(jDto);
+
+    SetVoteDto vDto = mock(SetVoteDto.class);
+    when(vDto.getId()).thenReturn(10L);
+    when(vDto.getVote()).thenReturn(0);
+    service.setVoteService(vDto);
+
+    assertThat(service.setScoreService(true)).isEqualTo(0);
+    assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw test -Dtest=BattleServiceTest -pl . -q 2>&1 | tail -20
+```
+Expected: compilation error (method `setScoreService(boolean)` doesn't exist yet).
+
+- [ ] **Step 3: Update setScoreService to accept isFinal**
+
+In `BattleService.java`, replace the `setScoreService()` signature and add the tie-block logic. Find the existing method:
+
+```java
+public Integer setScoreService(){
+    // Broadcast the score here
+    // This is where we reveal the judge decision on the screen
+    // After that we add the point
+    List<Integer> score = new ArrayList<>();
+    Integer res = -100;
+    if(judges.size() == 0){
+        res = -2;
+    }
+    for (BattleJudge judge : judges) {
+        score.add(judge.getVote());
+    }
+    if(Collections.frequency(score, 0) == Collections.frequency(score, 1)){
+        res = -1;
+    }else if(Collections.frequency(score, 0) > Collections.frequency(score, 1)){
+        currentPair.getLeftBattler().setScore(currentPair.leftBattler.getScore() + 1);
+        res = 0;
+    }else{
+        currentPair.getRightBattler().setScore(currentPair.rightBattler.getScore() + 1);
+        res = 1;
+    }
+    messagingTemplate.convertAndSend("/topic/battle/score",
+        Map.of(
+            "message", res,
+            "left", currentPair.getLeftBattler().getScore(),
+            "right", currentPair.getRightBattler().getScore()
+        ));
+    // Auto-transition: winner → REVEALED, tie → stay VOTING
+    if (res == 0 || res == 1) {
+        battlePhase = "REVEALED";
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+    }
+    return res;
+}
+```
+
+Replace with:
+
+```java
+public Integer setScoreService(boolean isFinal){
+    List<Integer> score = new ArrayList<>();
+    Integer res = -100;
+    if(judges.size() == 0){
+        res = -2;
+    }
+    for (BattleJudge judge : judges) {
+        score.add(judge.getVote());
+    }
+    if(Collections.frequency(score, 0) == Collections.frequency(score, 1)){
+        // Final match tie is blocked — return -2 (same as "no judges") to signal the controller
+        if (isFinal) return -2;
+        res = -1;
+    }else if(Collections.frequency(score, 0) > Collections.frequency(score, 1)){
+        currentPair.getLeftBattler().setScore(currentPair.leftBattler.getScore() + 1);
+        res = 0;
+    }else{
+        currentPair.getRightBattler().setScore(currentPair.rightBattler.getScore() + 1);
+        res = 1;
+    }
+    messagingTemplate.convertAndSend("/topic/battle/score",
+        Map.of(
+            "message", res,
+            "left", currentPair.getLeftBattler().getScore(),
+            "right", currentPair.getRightBattler().getScore()
+        ));
+    if (res == 0 || res == 1) {
+        battlePhase = "REVEALED";
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+    }
+    return res;
+}
+```
+
+> **Note on -2 reuse:** The existing `setScoreService()` already returns `-2` for "no judges found" and the controller maps that to 404. The new final-tie case also returns `-2` from the service, but the controller will distinguish it by checking the HTTP status it sends back. The controller in the next task will handle this with a 409 response for the `isFinal=true` + tie case specifically. We avoid adding a new return code value to keep the change minimal.
+
+Actually, to avoid ambiguity between "no judges" and "final tie blocked", use a distinct return value. Replace `if (isFinal) return -2;` with `if (isFinal) return -3;` — we use -3 here specifically for "final tie blocked" in the service, and the controller maps it to 409.
+
+Full corrected step (replace the service method as above but with `-3` for the final tie case):
+
+```java
+if(Collections.frequency(score, 0) == Collections.frequency(score, 1)){
+    if (isFinal) return -3;   // final tie — blocked, do not broadcast
+    res = -1;
+}
+```
+
+- [ ] **Step 4: Fix the test to match the -3 return value**
+
+Update the test added in Step 1:
+```java
+@Test
+void setScore_finalTie_returnsMinusThreeToSignalBlock() {
+    assertThat(service.setScoreService(true)).isEqualTo(-3);
+}
+```
+
+- [ ] **Step 5: Update existing tests that call setScoreService() with no args**
+
+The three existing tests call `service.setScoreService()` (no args). Update them to pass `false` (non-final):
+- `setScore_returnsMinusOneWhenNoJudges` → `service.setScoreService(false)` — but wait, no judges means score list is empty → `frequency(0,0) == frequency(1,0)` → tie → but `isFinal=false` → returns `-1`. Wait, but the original test checks `== -1`. That's wrong: with no judges the original code returns `-2` (the `if(judges.size() == 0)` branch sets `res = -2`). Let me re-read...
+
+Looking again: with `judges.size() == 0`, `res = -2`, then the for loop adds nothing to score (empty list), then `frequency(0)==frequency(1)` is both 0 so they're equal → `res = -1`. So the `-2` set earlier gets overwritten to `-1`. That's existing behavior.
+
+So with the new code, when `judges.size() == 0` and `isFinal=false`: returns `-1`. When `judges.size() == 0` and `isFinal=true`: returns `-3`.
+
+Update the three existing tests:
+```java
+// setScore_returnsMinusOneWhenNoJudges
+assertThat(service.setScoreService(false)).isEqualTo(-1);
+
+// setScore_leftWins_...
+Integer result = service.setScoreService(false);
+
+// setScore_rightWins_...
+assertThat(service.setScoreService(false)).isEqualTo(1);
+```
+
+- [ ] **Step 6: Run tests — verify they pass**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw test -Dtest=BattleServiceTest -pl . -q 2>&1 | tail -20
+```
+Expected: `Tests run: N, Failures: 0, Errors: 0`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/BattleService.java \
+        BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+git commit -m "feat(battle): block final match tie in setScoreService"
+```
+
+---
+
+## Task 3: BattleService — resetJudgeVotesService + broadcastChampionReveal
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/BattleService.java`
+- Modify: `BES/src/test/java/com/example/BES/services/BattleServiceTest.java`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `BattleServiceTest.java`:
+
+```java
+@Test
+void resetJudgeVotes_setsAllVotesToMinusThreeAndBroadcasts() {
+    Judge j = new Judge();
+    j.setJudgeId(5L);
+    j.setName("Alex");
+    when(judgeService.getJudgeById(5L)).thenReturn(j);
+
+    SetJudgeDto addDto = mock(SetJudgeDto.class);
+    when(addDto.getId()).thenReturn(5L);
+    service.setBattleJudgeService(addDto);
+
+    SetVoteDto voteDto = mock(SetVoteDto.class);
+    when(voteDto.getId()).thenReturn(5L);
+    when(voteDto.getVote()).thenReturn(0);
+    service.setVoteService(voteDto);
+
+    service.resetJudgeVotesService();
+
+    assertThat(service.getJudges().get(0).getVote()).isEqualTo(-3);
+    verify(messagingTemplate, atLeastOnce()).convertAndSend(
+        eq("/topic/battle/judges"), any(Map.class));
+}
+
+@Test
+void broadcastChampionReveal_sendsToCorrectTopic() {
+    ChampionRevealDto dto = mock(ChampionRevealDto.class);
+    when(dto.getGenreName()).thenReturn("B-Boy/B-Girl");
+    when(dto.getChampionName()).thenReturn("PULSE");
+    when(dto.isDismiss()).thenReturn(false);
+
+    service.broadcastChampionReveal(dto);
+
+    verify(messagingTemplate).convertAndSend(
+        eq("/topic/battle/champion-reveal"),
+        any(Map.class)
+    );
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw test -Dtest=BattleServiceTest -pl . -q 2>&1 | tail -10
+```
+Expected: compilation errors for missing methods.
+
+- [ ] **Step 3: Add resetJudgeVotesService and broadcastChampionReveal to BattleService**
+
+Add these two methods to `BattleService.java` (after the existing `setOverlayConfigService` method, before the inner classes):
+
+```java
+public void resetJudgeVotesService() {
+    for (BattleJudge judge : judges) {
+        judge.setVote(-3);
+        messagingTemplate.convertAndSend(
+            "/topic/battle/vote/" + judge.getId(),
+            Map.of("vote", -3, "judge", judge.getId())
+        );
+    }
+    messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+}
+
+public void broadcastChampionReveal(ChampionRevealDto dto) {
+    if (dto.isDismiss()) {
+        messagingTemplate.convertAndSend("/topic/battle/champion-reveal",
+            Map.of("dismiss", true));
+    } else {
+        messagingTemplate.convertAndSend("/topic/battle/champion-reveal",
+            Map.of("dismiss", false,
+                   "genreName", dto.getGenreName() != null ? dto.getGenreName() : "",
+                   "championName", dto.getChampionName() != null ? dto.getChampionName() : ""));
+    }
+}
+```
+
+Also add the import at the top of the file:
+```java
+import com.example.BES.dtos.battle.ChampionRevealDto;
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw test -Dtest=BattleServiceTest -pl . -q 2>&1 | tail -10
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/BattleService.java \
+        BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+git commit -m "feat(battle): add resetJudgeVotes and broadcastChampionReveal to BattleService"
+```
+
+---
+
+## Task 4: BattleController — update score endpoint + add revote + champion-reveal
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/controllers/BattleController.java`
+
+- [ ] **Step 1: Add import for new DTOs**
+
+At the top of `BattleController.java`, add to the existing import block:
+```java
+import com.example.BES.dtos.battle.SetBattleScoreDto;
+import com.example.BES.dtos.battle.ChampionRevealDto;
+```
+
+- [ ] **Step 2: Update the score endpoint**
+
+Find the existing `setBattleScore()` method:
+```java
+@PostMapping("/score")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> setBattleScore(){
+    Integer code = battleService.setScoreService();
+```
+
+Replace it with:
+```java
+@PostMapping("/score")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> setBattleScore(
+        @RequestBody(required = false) SetBattleScoreDto dto){
+    boolean isFinal = dto != null && dto.isFinal();
+    Integer code = battleService.setScoreService(isFinal);
+    if(code == -2){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+            Map.of("message", "No judge found")
+        );
+    }else if(code == -3){
+        // Final match tie — blocked
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(
+            Map.of("message", "Tie in final match — revote required", "tie", true)
+        );
+    }else if(code == -1){
+        return ResponseEntity.ok(
+            Map.of("message", "Its a tie",
+            "winner", -1)
+        );
+    }
+    else if(code == 0){
+        return ResponseEntity.ok(
+            Map.of(
+                "message", "Left side get one point",
+                "winner", 0,
+                "current score", battleService.getCurrentPair().getLeftBattler().getScore()
+            )
+        );
+    }
+    else {
+        return ResponseEntity.ok(
+            Map.of(
+                "message", "Right side get one point",
+                "winner", 1,
+                "current score", battleService.getCurrentPair().getRightBattler().getScore())
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Add revote endpoint**
+
+Add after the score endpoint:
+```java
+@PostMapping("/revote")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> revote(){
+    battleService.resetJudgeVotesService();
+    return ResponseEntity.ok(Map.of("message", "Judge votes reset"));
+}
+```
+
+- [ ] **Step 4: Add champion-reveal endpoint**
+
+Add after the revote endpoint (before the closing brace of the class):
+```java
+@PostMapping("/champion-reveal")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> championReveal(@RequestBody ChampionRevealDto dto){
+    battleService.broadcastChampionReveal(dto);
+    return ResponseEntity.ok(Map.of("message", "Champion reveal broadcast"));
+}
+```
+
+- [ ] **Step 5: Compile + run full test suite**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw clean test -q 2>&1 | tail -15
+```
+Expected: BUILD SUCCESS, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/controllers/BattleController.java
+git commit -m "feat(battle): update score endpoint for isFinal; add revote and champion-reveal endpoints"
+```
+
+---
+
+## Task 5: Frontend API — new functions
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js`
+
+- [ ] **Step 1: Update setBattleScore to accept isFinal**
+
+Find the existing `setBattleScore` function:
+```js
+export const setBattleScore = async() =>{
+  try{
+    return await fetch(`${domain}/api/v1/battle/score`,{
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    })
+  }catch(e){
+    console.log(e)
+    return null
+  }
+}
+```
+
+Replace with:
+```js
+export const setBattleScore = async (isFinal = false) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/score`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isFinal })
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+```
+
+- [ ] **Step 2: Add resetBattleVotes, revealChampion, dismissChampionReveal**
+
+Add after the `setBattleScore` function:
+
+```js
+export const resetBattleVotes = async () => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/revote`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const revealChampion = async (genreName, championName) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/champion-reveal`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ genreName, championName, dismiss: false })
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const dismissChampionReveal = async () => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/champion-reveal`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dismiss: true })
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat(api): add setBattleScore isFinal, resetBattleVotes, revealChampion, dismissChampionReveal"
+```
+
+---
+
+## Task 6: BattleControl — final tie warning + revote
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue`
+
+- [ ] **Step 1: Add imports and new refs**
+
+In `BattleControl.vue`, add `resetBattleVotes` to the existing import from `@/utils/api`:
+```js
+import { addBattleJudge, battleJudgeVote, getBattleJudges, getBattlePhase, getOverlayConfig,
+         getParticipantScore, getPickupCrews, removeBattleJudge, resetBattleVotes,
+         setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig,
+         updateSmokeList, uploadImage } from '@/utils/api'
+```
+
+Add two new refs after `const showResetConfirm = ref(false)`:
+```js
+const finalTieBlocked = ref(false)  // true when final match returned a tie
+```
+
+- [ ] **Step 2: Update submitGetScore to pass isFinal and handle 409**
+
+Find the `submitGetScore` function. It currently calls `const res = await setBattleScore()`. Update the standard (non-smoke) branch:
+
+Find this section inside `submitGetScore`:
+```js
+  const left = currentBattle?.value[1][currentBattle?.value[0]][0]
+  const right = currentBattle?.value[1][currentBattle?.value[0]][1]
+  if (left === "" || right === "") return
+  const res = await setBattleScore()
+  const data = await res.json()
+  currentWinner.value = Number(data.winner)
+  if (data.winner === 1 || data.winner === 0) { setWinner(currentTop.value, currentRound.value, data.winner) }
+```
+
+Replace with:
+```js
+  const left = currentBattle?.value[1][currentBattle?.value[0]][0]
+  const right = currentBattle?.value[1][currentBattle?.value[0]][1]
+  if (left === "" || right === "") return
+  const isFinal = !isSmoke.value && currentTop.value === 'Top2'
+  const res = await setBattleScore(isFinal)
+  if (res?.status === 409) {
+    // Final match tie — block progression, require revote
+    finalTieBlocked.value = true
+    return
+  }
+  const data = await res.json()
+  finalTieBlocked.value = false
+  currentWinner.value = Number(data.winner)
+  if (data.winner === 1 || data.winner === 0) { setWinner(currentTop.value, currentRound.value, data.winner) }
+```
+
+- [ ] **Step 3: Add startRevote function**
+
+Add after `submitGetScore`:
+```js
+const startRevote = async () => {
+  await resetBattleVotes()
+  finalTieBlocked.value = false
+  currentWinner.value = -2
+}
+```
+
+- [ ] **Step 4: Add tie warning + revote button to template**
+
+Find the winner announcement div in the template (around line 976):
+```html
+      <!-- Winner announcement -->
+      <div
+        class="px-4 py-3 rounded-xl text-center text-sm font-semibold mb-4"
+```
+
+Add the tie warning block immediately **before** this div:
+```html
+      <!-- Final tie warning -->
+      <div
+        v-if="finalTieBlocked"
+        class="px-4 py-3 rounded-xl text-sm font-semibold mb-4 flex items-center justify-between gap-3
+               bg-amber-500/10 border border-amber-500/40 text-amber-400"
+      >
+        <span><i class="pi pi-exclamation-triangle mr-2"></i>TIE in Final — Revote required</span>
+        <button
+          @click="startRevote"
+          class="flex-shrink-0 px-3 py-1.5 rounded-lg bg-amber-500/20 border border-amber-500/40
+                 text-amber-400 text-xs font-bold hover:bg-amber-500/30 transition-all"
+        >START REVOTE</button>
+      </div>
+```
+
+- [ ] **Step 5: Frontend build check**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run build 2>&1 | tail -20
+```
+Expected: build completes with no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat(battle-control): final tie detection and revote UI"
+```
+
+---
+
+## Task 7: BattleControl — champion reveal button
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue`
+
+- [ ] **Step 1: Add imports and state**
+
+Add `revealChampion` and `dismissChampionReveal` to the api import line (extending what was added in Task 6):
+```js
+import { ..., revealChampion, dismissChampionReveal } from '@/utils/api'
+```
+
+Add a new ref after `finalTieBlocked`:
+```js
+const revealActive = ref(false)
+```
+
+- [ ] **Step 2: Add computed for current genre's champion**
+
+Add after `uniqueGenres` computed:
+```js
+const currentGenreChampion = computed(() => {
+  if (isSmoke.value) return null
+  return rounds.value['Top2']?.[0]?.[2] ?? null
+})
+```
+
+- [ ] **Step 3: Add revealChampionForGenre and dismissReveal functions**
+
+Add after `startRevote`:
+```js
+const revealChampionForGenre = async () => {
+  if (!currentGenreChampion.value) return
+  await revealChampion(selectedGenre.value, currentGenreChampion.value)
+  revealActive.value = true
+}
+
+const dismissReveal = async () => {
+  await dismissChampionReveal()
+  revealActive.value = false
+}
+```
+
+- [ ] **Step 4: Add REVEAL CHAMPION / DISMISS button to template**
+
+Find the Reset Bracket button in the action buttons section (around line 1081):
+```html
+        <button
+          @click="showResetConfirm = true"
+          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-red-200 bg-surface-800
+                 text-sm font-semibold text-red-400 hover:bg-red-950 transition-all"
+        >
+```
+
+Add the champion reveal button **immediately before** the Reset Bracket button:
+```html
+        <!-- Champion Reveal -->
+        <button
+          v-if="currentGenreChampion && !revealActive"
+          @click="revealChampionForGenre"
+          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-amber-500/40 bg-amber-500/10
+                 text-sm font-semibold text-amber-400 hover:bg-amber-500/20 transition-all"
+        >
+          <i class="pi pi-star text-xs"></i>
+          Reveal Champion
+        </button>
+        <button
+          v-if="revealActive"
+          @click="dismissReveal"
+          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
+                 text-sm font-semibold text-content-secondary hover:bg-surface-700 transition-all"
+        >
+          <i class="pi pi-times text-xs"></i>
+          Dismiss Reveal
+        </button>
+```
+
+- [ ] **Step 5: Reset revealActive when genre changes**
+
+In the `watch(selectedGenre, ...)` handler, add `revealActive.value = false` at the start of the handler. Find:
+```js
+watch(selectedGenre, async (newVal) => {
+```
+
+Add inside the handler (at the very top of the callback body):
+```js
+  revealActive.value = false
+```
+
+- [ ] **Step 6: Build check**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run build 2>&1 | tail -10
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat(battle-control): add Reveal Champion / Dismiss button per genre"
+```
+
+---
+
+## Task 8: BracketVisualization — CSS cleanup (cyan → white/silver)
+
+**Files:**
+- Modify: `BES-frontend/src/views/BracketVisualization.vue`
+
+- [ ] **Step 1: Update CSS custom properties block**
+
+Find the `.bracket-root` vars block (lines 501–518):
+```css
+.bracket-root {
+  --c-bg:         #060818;
+  --c-surface:    rgba(255,255,255,0.045);
+  --c-border:     rgba(255,255,255,0.07);
+  --c-border-act: #06b6d4;
+  --c-text:       #f0f0f0;
+  --c-muted:      rgba(255,255,255,0.28);
+  --c-accent:     #06b6d4;
+  --c-win-bg:     rgba(6,182,212,0.13);
+  --c-lose-text:  rgba(255,255,255,0.16);
+  --c-connector:  rgba(6,182,212,0.2);
+  --c-champ-bg:   rgba(245,158,11,0.1);
+  --c-champ:      #f59e0b;
+  --col-gap:      24px;
+  --header-h:     52px;
+  --slot-h:       38px;
+}
+```
+
+Replace with:
+```css
+.bracket-root {
+  --c-bg:         #060818;
+  --c-surface:    rgba(255,255,255,0.04);
+  --c-border:     rgba(255,255,255,0.08);
+  --c-border-act: rgba(255,255,255,0.35);
+  --c-text:       #f0f0f0;
+  --c-muted:      rgba(255,255,255,0.28);
+  --c-accent:     rgba(255,255,255,0.55);
+  --c-win-bg:     rgba(245,158,11,0.15);
+  --c-lose-text:  rgba(255,255,255,0.16);
+  --c-connector:  rgba(255,255,255,0.12);
+  --c-champ-bg:   rgba(245,158,11,0.1);
+  --c-champ:      #f59e0b;
+  --left-color:   #dc2626;
+  --right-color:  #2563eb;
+  --col-gap:      24px;
+  --header-h:     52px;
+  --slot-h:       38px;
+}
+```
+
+- [ ] **Step 2: Update bracket-root background gradient (remove cyan radial)**
+
+Find:
+```css
+  background:
+    radial-gradient(ellipse 50vw 55vh at 5% 8%,  rgba(6,182,212,0.07)  0%, transparent 70%),
+    radial-gradient(ellipse 45vw 50vh at 95% 92%, rgba(245,158,11,0.05) 0%, transparent 70%),
+    #060818;
+```
+
+Replace with:
+```css
+  background:
+    radial-gradient(ellipse 50vw 55vh at 5% 8%,  rgba(255,255,255,0.04) 0%, transparent 70%),
+    radial-gradient(ellipse 45vw 50vh at 95% 92%, rgba(245,158,11,0.06) 0%, transparent 70%),
+    #060818;
+```
+
+- [ ] **Step 3: Update header border and active-pill (remove cyan)**
+
+Find:
+```css
+  border-bottom: 1px solid rgba(6,182,212,0.12);
+```
+Replace with:
+```css
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+```
+
+Find the `.brand-dot` rule:
+```css
+.brand-dot {
+  ...
+  background: var(--c-accent);
+  box-shadow: 0 0 10px var(--c-accent), 0 0 22px rgba(6,182,212,0.45);
+```
+Replace `box-shadow` line with:
+```css
+  box-shadow: 0 0 10px rgba(255,255,255,0.5), 0 0 22px rgba(255,255,255,0.2);
+```
+
+Find `.active-pill`:
+```css
+  color: var(--c-accent);
+  background: rgba(6,182,212,0.08);
+  border: 1px solid rgba(6,182,212,0.22);
+```
+Replace with:
+```css
+  color: rgba(255,255,255,0.75);
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.18);
+```
+
+Find `.pill-dot`:
+```css
+  background: var(--c-accent); box-shadow: 0 0 6px var(--c-accent);
+```
+Replace with:
+```css
+  background: rgba(255,255,255,0.7); box-shadow: 0 0 6px rgba(255,255,255,0.5);
+```
+
+- [ ] **Step 4: Update smoke slot active color**
+
+Find:
+```css
+.smoke-active { background: var(--c-win-bg); border-color: rgba(6,182,212,0.3); }
+```
+Replace with:
+```css
+.smoke-active { background: rgba(255,255,255,0.07); border-color: rgba(255,255,255,0.25); }
+```
+
+Find `.smoke-score` and `.smoke-badge`:
+```css
+.smoke-score  { ... color: var(--c-accent); ... }
+.smoke-badge  { ... background: var(--c-win-bg); color: var(--c-accent); ... }
+```
+Replace `var(--c-accent)` usages with `rgba(255,255,255,0.65)` in both rules.
+
+- [ ] **Step 5: Update .round-label, .match-active connector, .final-match active, and .final-vs**
+
+`.round-label`: find `color: var(--c-accent);` → replace with `color: rgba(255,255,255,0.38);`
+
+`.match-active.pair-group::after`: find `border-color: rgba(6,182,212,0.45);` → replace with `border-color: rgba(255,255,255,0.3);`
+
+`.final-match.match-active .battler-slot`: find `border-color: rgba(6,182,212,0.42); box-shadow: 0 0 0 1px rgba(6,182,212,0.12), 0 0 16px rgba(6,182,212,0.18);` → replace with `border-color: rgba(255,255,255,0.3); box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 0 16px rgba(255,255,255,0.1);`
+
+`.final-vs`: find `color: var(--c-accent);` → replace with `color: rgba(255,255,255,0.3);`
+
+- [ ] **Step 6: Update slot winner/active states and anim-ball**
+
+Find `.match-active .battler-slot`:
+```css
+.match-active .battler-slot {
+  background: var(--c-win-bg);
+  border-color: rgba(6,182,212,0.38);
+  box-shadow: 0 0 0 1px rgba(6,182,212,0.1), 0 0 14px rgba(6,182,212,0.14);
+}
+```
+Replace with (active match slots now use color theming — see Task 9):
+```css
+.match-active .battler-slot {
+  background: rgba(255,255,255,0.05);
+  border-color: rgba(255,255,255,0.18);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 0 14px rgba(255,255,255,0.08);
+}
+```
+
+Find `.slot-winner` (still cyan):
+```css
+.slot-winner {
+  background: rgba(6,182,212,0.17) !important;
+  border-color: rgba(6,182,212,0.48) !important;
+  box-shadow: 0 0 16px rgba(6,182,212,0.28) !important;
+}
+.slot-winner .battler-name { color: var(--c-accent); }
+```
+Replace with:
+```css
+.slot-winner {
+  background: rgba(245,158,11,0.15) !important;
+  border-color: rgba(245,158,11,0.45) !important;
+  box-shadow: 0 0 18px rgba(245,158,11,0.25) !important;
+}
+.slot-winner .battler-name { color: #fde68a; }
+```
+
+Find `.slot-loser .battler-name`:
+```css
+.slot-loser  .battler-name { color: var(--c-lose-text); text-decoration: line-through; }
+```
+Replace with (remove strikethrough, just dim):
+```css
+.slot-loser  .battler-name { color: var(--c-lose-text); }
+```
+
+Also update `.slot-loser` opacity:
+Find `.slot-loser`:
+```css
+.slot-loser  { background: rgba(255,255,255,0.02) !important; border-color: rgba(255,255,255,0.03) !important; }
+```
+Replace with:
+```css
+.slot-loser { background: rgba(255,255,255,0.02) !important; border-color: rgba(255,255,255,0.03) !important; opacity: 0.42; }
+```
+
+Find `.slot-glow` keyframes — replace cyan glow with gold glow:
+```css
+@keyframes slotGlow {
+  0%   { background: var(--c-surface);       border-color: var(--c-border);  box-shadow: none; }
+  20%  { background: rgba(6,182,212,0.30);   border-color: var(--c-accent);  box-shadow: 0 0 0 2px rgba(6,182,212,0.38), 0 0 22px rgba(6,182,212,0.75), 0 0 44px rgba(6,182,212,0.35); }
+  70%  { background: rgba(6,182,212,0.20);   border-color: var(--c-accent);  box-shadow: 0 0 0 2px rgba(6,182,212,0.28), 0 0 16px rgba(6,182,212,0.58), 0 0 32px rgba(6,182,212,0.22); }
+  100% { background: var(--c-surface);       border-color: var(--c-border);  box-shadow: none; }
+}
+.slot-glow .battler-name { color: var(--c-accent); opacity: 1; }
+```
+Replace with:
+```css
+@keyframes slotGlow {
+  0%   { background: var(--c-surface);        border-color: var(--c-border);             box-shadow: none; }
+  20%  { background: rgba(245,158,11,0.28);   border-color: rgba(245,158,11,0.8);        box-shadow: 0 0 0 2px rgba(245,158,11,0.35), 0 0 22px rgba(245,158,11,0.7), 0 0 44px rgba(245,158,11,0.3); }
+  70%  { background: rgba(245,158,11,0.18);   border-color: rgba(245,158,11,0.55);       box-shadow: 0 0 0 2px rgba(245,158,11,0.25), 0 0 16px rgba(245,158,11,0.5), 0 0 32px rgba(245,158,11,0.18); }
+  100% { background: var(--c-surface);        border-color: var(--c-border);             box-shadow: none; }
+}
+.slot-glow .battler-name { color: #fde68a; opacity: 1; }
+```
+
+Find `:global(.anim-ball)`:
+```css
+:global(.anim-ball) {
+  ...
+  background: radial-gradient(circle, #ffffff 0%, #06b6d4 55%, transparent 100%);
+  box-shadow: 0 0 6px #06b6d4, 0 0 14px #06b6d4, 0 0 28px rgba(6,182,212,0.6);
+```
+Replace with:
+```css
+:global(.anim-ball) {
+  position: fixed;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: radial-gradient(circle, #ffffff 0%, rgba(245,158,11,0.9) 55%, transparent 100%);
+  box-shadow: 0 0 6px rgba(245,158,11,0.9), 0 0 14px rgba(245,158,11,0.7), 0 0 28px rgba(245,158,11,0.4);
+  pointer-events: none; z-index: 9999;
+}
+```
+
+- [ ] **Step 7: Update ticker bar (remove cyan)**
+
+Find `.ticker-bar`:
+```css
+  border-top: 1px solid rgba(6,182,212,0.1);
+```
+Replace with:
+```css
+  border-top: 1px solid rgba(255,255,255,0.07);
+```
+
+Find `.ticker-label`:
+```css
+  background: var(--c-accent);
+  ...
+  color: #030610;
+```
+Replace with:
+```css
+  background: rgba(255,255,255,0.9);
+  ...
+  color: #060818;
+```
+
+Find `.ticker-now .ticker-tag` and `.ticker-now .ticker-text`:
+```css
+.ticker-now   .ticker-tag  { color: var(--c-accent); opacity: 1; }
+...
+.ticker-now   .ticker-text { color: var(--c-accent); }
+```
+Replace both `var(--c-accent)` with `rgba(255,255,255,0.85)`.
+
+- [ ] **Step 8: Build check**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run build 2>&1 | tail -10
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add BES-frontend/src/views/BracketVisualization.vue
+git commit -m "style(bracket): remove all cyan, replace with white/silver neutral"
+```
+
+---
+
+## Task 9: BracketVisualization — overlay config + slot color theming + WIN badge
+
+**Files:**
+- Modify: `BES-frontend/src/views/BracketVisualization.vue`
+
+- [ ] **Step 1: Add overlayConfig ref and getOverlayConfig import**
+
+In `<script setup>`, update the import line:
+```js
+import { getBracketState, getOverlayConfig } from '@/utils/api'
+```
+
+Add a new ref after `const bracketState = ref(null)`:
+```js
+const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+```
+
+- [ ] **Step 2: Subscribe to overlay-config in onMounted**
+
+Inside the `wsClient.onConnect` callback, add a new subscription after the existing ones:
+```js
+    wsClient.subscribe('/topic/battle/overlay-config', (msg) => {
+      const cfg = JSON.parse(msg.body)
+      overlayConfig.value = cfg
+    })
+```
+
+Also in `onMounted`, after `const state = await getBracketState()`, fetch the initial config:
+```js
+  const cfg = await getOverlayConfig()
+  if (cfg) overlayConfig.value = cfg
+```
+
+- [ ] **Step 3: Bind CSS vars to bracket-root in template**
+
+Find the root div in the template:
+```html
+  <div class="bracket-root">
+```
+
+Replace with:
+```html
+  <div class="bracket-root" :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }">
+```
+
+- [ ] **Step 4: Update slotClass computed to add active-left / active-right**
+
+Find the existing `slotClass` function:
+```js
+const slotClass = (match, slot) => ({
+  'slot-winner': match[2] && match[2] === match[slot],
+  'slot-loser':  match[2] && match[2] !== match[slot] && match[slot],
+})
+```
+
+Replace with:
+```js
+const slotClass = (match, slot) => {
+  if (match[2]) {
+    if (match[2] === match[slot]) return 'slot-winner'
+    if (match[slot]) return 'slot-loser'
+    return ''
+  }
+  if (isActiveMatch(match) && match[slot]) {
+    return slot === 0 ? 'slot-active-left' : 'slot-active-right'
+  }
+  return ''
+}
+```
+
+- [ ] **Step 5: Add slot-active-left / slot-active-right CSS classes**
+
+Find the existing `.match-active .battler-slot` rule (updated in Task 8) and add these two new rules immediately after it:
+
+```css
+.slot-active-left {
+  background: color-mix(in srgb, var(--left-color) 18%, transparent) !important;
+  border-color: color-mix(in srgb, var(--left-color) 50%, transparent) !important;
+  box-shadow: 0 0 16px color-mix(in srgb, var(--left-color) 28%, transparent) !important;
+}
+.slot-active-left .battler-name {
+  color: color-mix(in srgb, var(--left-color) 80%, #fff) !important;
+}
+.slot-active-right {
+  background: color-mix(in srgb, var(--right-color) 18%, transparent) !important;
+  border-color: color-mix(in srgb, var(--right-color) 50%, transparent) !important;
+  box-shadow: 0 0 16px color-mix(in srgb, var(--right-color) 28%, transparent) !important;
+}
+.slot-active-right .battler-name {
+  color: color-mix(in srgb, var(--right-color) 80%, #fff) !important;
+}
+```
+
+- [ ] **Step 6: Replace crown icon with WIN badge in template**
+
+The crown icon `<i v-if="match[2] === match[slot] && match[slot]" class="pi pi-crown crown-icon"></i>` appears in multiple places. Replace every occurrence with the WIN badge span.
+
+There are 6 locations (left half slot 0, slot 1; center final slot 0, slot 1; right half slot 0, slot 1). For every instance of:
+```html
+                  <i v-if="match[2] === match[0] && match[0]" class="pi pi-crown crown-icon"></i>
+```
+Replace with:
+```html
+                  <span v-if="match[2] === match[0] && match[0]" class="win-badge">WIN</span>
+```
+
+And every instance of:
+```html
+                  <i v-if="match[2] === match[1] && match[1]" class="pi pi-crown crown-icon"></i>
+```
+Replace with:
+```html
+                  <span v-if="match[2] === match[1] && match[1]" class="win-badge">WIN</span>
+```
+
+Do the same for the center column final match slot 0 and slot 1 (same pattern).
+
+- [ ] **Step 7: Add WIN badge CSS + remove old crown CSS**
+
+Find and remove:
+```css
+.crown-icon {
+  font-size: 11px; color: var(--c-champ); flex-shrink: 0;
+  display: inline-block; transform: skewX(4deg);
+}
+```
+
+Add in its place:
+```css
+.win-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  transform: skewX(5deg); flex-shrink: 0;
+  background: rgba(245,158,11,0.22); border: 1px solid rgba(245,158,11,0.5);
+  color: #fbbf24; font-size: 8px; font-weight: 900; font-family: 'Inter', sans-serif;
+  letter-spacing: 0.12em; padding: 1px 5px; border-radius: 2px;
+  clip-path: polygon(3px 0%, 100% 0%, calc(100% - 3px) 100%, 0% 100%);
+}
+```
+
+Also remove `.champ-icon` and `.champion-card` and `.champ-name` styles since the champion card below the final is no longer needed (the champion reveal overlay replaces it). The `v-if="champion"` champion card in the template at line 411 can also be removed:
+```html
+          <div v-if="champion" class="champion-card">
+            <i class="pi pi-crown champ-icon"></i>
+            <span class="champ-name">{{ champion }}</span>
+          </div>
+```
+Remove this block entirely.
+
+- [ ] **Step 8: Build check**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run build 2>&1 | tail -10
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add BES-frontend/src/views/BracketVisualization.vue
+git commit -m "feat(bracket): overlay config subscription, slot color theming, WIN badge"
+```
+
+---
+
+## Task 10: BracketVisualization — rewrite advance animation
+
+**Files:**
+- Modify: `BES-frontend/src/views/BracketVisualization.vue`
+
+The existing animation uses a travelling ball. We replace it with: ring burst on source slot → lightning streak across gap → destination slot ignites.
+
+- [ ] **Step 1: Replace the travelBall function**
+
+Find the `travelBall` function (lines 127–168) and the `ballVisible`/`ballOrigin` refs and the `anim-ball` Teleport at the bottom of the template. Replace all of this.
+
+First, **remove** these refs:
+```js
+const ballVisible     = ref(false)
+const ballOrigin      = ref({ x: 0, y: 0 })
+```
+
+Replace with:
+```js
+const animLayers = ref([])   // absolutely-positioned animation elements rendered over bracket
+```
+
+**Remove** the existing `travelBall` function entirely (lines 127–168).
+
+**Add** the new `travelBall` function in its place:
+
+```js
+async function travelBall(winnerKey, destKey) {
+  const winEl  = slotEls[winnerKey]
+  const destEl = destKey ? slotEls[destKey] : null
+  if (!winEl) return
+
+  const bracketEl = document.querySelector('.bracket-area')
+  if (!bracketEl) return
+  const bRect  = bracketEl.getBoundingClientRect()
+  const wRect  = winEl.getBoundingClientRect()
+
+  // ── Phase 1: Ring burst on source slot ──────────────────────────
+  const ring = document.createElement('div')
+  ring.style.cssText = `
+    position: absolute;
+    left: ${wRect.left - bRect.left}px;
+    top:  ${wRect.top  - bRect.top}px;
+    width:  ${wRect.width}px;
+    height: ${wRect.height}px;
+    border: 2px solid rgba(245,158,11,0.9);
+    border-radius: 1px;
+    box-shadow: 0 0 20px rgba(245,158,11,0.6);
+    pointer-events: none;
+    z-index: 20;
+    transform: skewX(-4deg);
+  `
+  bracketEl.style.position = 'relative'
+  bracketEl.appendChild(ring)
+
+  await ring.animate(
+    [{ transform: 'skewX(-4deg) scale(1)', opacity: 1 },
+     { transform: 'skewX(-4deg) scale(1.65)', opacity: 0 }],
+    { duration: 380, easing: 'ease-out', fill: 'forwards' }
+  ).finished
+  ring.remove()
+
+  if (!destEl) return
+
+  const dRect = destEl.getBoundingClientRect()
+
+  // ── Phase 2: Lightning streak ────────────────────────────────────
+  const srcCenterX = wRect.left  + wRect.width / 2  - bRect.left
+  const srcCenterY = wRect.top   + wRect.height / 2 - bRect.top
+  const dstCenterX = dRect.left  + dRect.width / 2  - bRect.left
+  const dstCenterY = dRect.top   + dRect.height / 2 - bRect.top
+
+  const dx = dstCenterX - srcCenterX
+  const dy = dstCenterY - srcCenterY
+  const length = Math.sqrt(dx * dx + dy * dy)
+  const angle  = Math.atan2(dy, dx) * (180 / Math.PI)
+
+  const streak = document.createElement('div')
+  streak.style.cssText = `
+    position: absolute;
+    left:   ${srcCenterX}px;
+    top:    ${srcCenterY - 2}px;
+    width:  0;
+    height: 3px;
+    transform-origin: left center;
+    transform: rotate(${angle}deg);
+    background: linear-gradient(90deg, rgba(245,158,11,0.2) 0%, rgba(245,158,11,0.95) 55%, #fff 100%);
+    border-radius: 2px;
+    box-shadow: 0 0 8px rgba(245,158,11,0.7);
+    pointer-events: none;
+    z-index: 20;
+  `
+  bracketEl.appendChild(streak)
+
+  await streak.animate(
+    [{ width: '0px' }, { width: `${length}px` }],
+    { duration: 200, easing: 'ease-in', fill: 'forwards' }
+  ).finished
+
+  await streak.animate(
+    [{ opacity: 1 }, { opacity: 0 }],
+    { duration: 140, easing: 'linear', fill: 'forwards' }
+  ).finished
+  streak.remove()
+
+  // ── Phase 3: Destination slot ignites ───────────────────────────
+  destEl.style.transition = 'none'
+  destEl.style.boxShadow  = '0 0 40px rgba(245,158,11,0.9), 0 0 80px rgba(245,158,11,0.4)'
+  await sleep(60)
+  destEl.style.transition = 'box-shadow 0.45s ease-out'
+  destEl.style.boxShadow  = ''
+  await sleep(450)
+  destEl.style.transition = ''
+}
+```
+
+- [ ] **Step 2: Remove the Teleport anim-ball from template**
+
+Find and remove from the template (below the closing `</div>` of `bracket-root`):
+```html
+  <!-- ── Travelling ball (outside bracket-root to avoid overflow clipping) ── -->
+  <Teleport to="body">
+    <div
+      v-if="ballVisible"
+      class="anim-ball"
+      :style="{ left: ballOrigin.x + 'px', top: ballOrigin.y + 'px' }"
+    ></div>
+  </Teleport>
+```
+
+- [ ] **Step 3: Remove the :global(.anim-ball) CSS**
+
+Find and remove:
+```css
+/* ── Travelling ball ─────────────────────────────── */
+:global(.anim-ball) {
+  position: fixed;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: radial-gradient(circle, #ffffff 0%, rgba(245,158,11,0.9) 55%, transparent 100%);
+  box-shadow: 0 0 6px rgba(245,158,11,0.9), 0 0 14px rgba(245,158,11,0.7), 0 0 28px rgba(245,158,11,0.4);
+  pointer-events: none; z-index: 9999;
+}
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run build 2>&1 | tail -10
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/BracketVisualization.vue
+git commit -m "feat(bracket): rewrite advance animation (ring burst + lightning streak)"
+```
+
+---
+
+## Task 11: Champion reveal overlay — BracketVisualization + BattleOverlay
+
+**Files:**
+- Modify: `BES-frontend/src/views/BracketVisualization.vue`
+- Modify: `BES-frontend/src/views/BattleOverlay.vue`
+
+### BracketVisualization
+
+- [ ] **Step 1: Add championReveal ref and WebSocket subscription**
+
+In `<script setup>`, add after `overlayConfig`:
+```js
+const championReveal = ref(null)   // null = no reveal; { genreName, championName } = showing
+```
+
+In `wsClient.onConnect`, add subscription:
+```js
+    wsClient.subscribe('/topic/battle/champion-reveal', (msg) => {
+      const data = JSON.parse(msg.body)
+      if (data.dismiss) {
+        championReveal.value = null
+      } else {
+        championReveal.value = { genreName: data.genreName, championName: data.championName }
+      }
+    })
+```
+
+- [ ] **Step 2: Add champion reveal overlay to template**
+
+Inside `.bracket-root`, add immediately after the `<div class="scanlines">` line:
+```html
+    <!-- ── Champion Reveal Overlay ──────────────────── -->
+    <Transition name="champ-reveal">
+      <div v-if="championReveal" class="champ-overlay">
+        <div class="champ-overlay-bg"></div>
+        <div class="champ-overlay-content">
+          <div class="champ-genre-tag">{{ championReveal.genreName }} · Final</div>
+          <div class="champ-label">Champion</div>
+          <div class="champ-name-slam">{{ championReveal.championName }}</div>
+          <div class="champ-gold-bar"></div>
+        </div>
+      </div>
+    </Transition>
+```
+
+- [ ] **Step 3: Add champion reveal CSS**
+
+Add to the `<style scoped>` section (before the `@keyframes` block):
+```css
+/* ── Champion Reveal Overlay ────────────────────────── */
+.champ-overlay {
+  position: absolute; inset: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: center;
+  background: #060818;
+}
+.champ-overlay-bg {
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(ellipse 60% 50% at 50% 55%, rgba(245,158,11,0.14) 0%, transparent 68%);
+}
+.champ-overlay-content {
+  position: relative; z-index: 1;
+  display: flex; flex-direction: column; align-items: center; gap: 6px;
+  text-align: center;
+}
+.champ-genre-tag {
+  font-family: 'Anton SC', sans-serif; font-size: 9px;
+  letter-spacing: 0.45em; text-transform: uppercase;
+  color: rgba(255,255,255,0.3);
+}
+.champ-label {
+  font-family: 'Anton SC', sans-serif; font-size: 11px;
+  letter-spacing: 0.5em; text-transform: uppercase;
+  color: rgba(245,158,11,0.85);
+}
+.champ-name-slam {
+  font-family: 'Anton SC', sans-serif; font-size: 58px;
+  letter-spacing: 0.07em; text-transform: uppercase; line-height: 1;
+  color: #fff;
+  text-shadow: 0 0 40px rgba(245,158,11,0.65), 0 0 80px rgba(245,158,11,0.3);
+}
+.champ-gold-bar {
+  width: 180px; height: 2px; margin-top: 6px;
+  background: linear-gradient(90deg, transparent, rgba(245,158,11,0.8), transparent);
+}
+
+/* Transition */
+.champ-reveal-enter-active { transition: opacity 0.3s ease; }
+.champ-reveal-leave-active { transition: opacity 0.25s ease; }
+.champ-reveal-enter-from,
+.champ-reveal-leave-to    { opacity: 0; }
+
+.champ-reveal-enter-active .champ-name-slam {
+  animation: champNameSlam 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.35s both;
+}
+.champ-reveal-enter-active .champ-label {
+  animation: champFadeUp 0.4s ease 0.2s both;
+}
+.champ-reveal-enter-active .champ-genre-tag {
+  animation: champFadeUp 0.4s ease 0.08s both;
+}
+.champ-reveal-enter-active .champ-gold-bar {
+  animation: champBarExpand 0.6s ease 0.65s both;
+}
+
+@keyframes champNameSlam {
+  from { opacity: 0; transform: scale(0.72) translateY(18px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0); }
+}
+@keyframes champFadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes champBarExpand {
+  from { width: 0; opacity: 0; }
+  to   { width: 180px; opacity: 1; }
+}
+```
+
+### BattleOverlay
+
+- [ ] **Step 4: Add championReveal ref and subscription to BattleOverlay**
+
+In `BattleOverlay.vue`, in `<script setup>`, add after `const glitching = ref(false)`:
+```js
+const championReveal = ref(null)   // null | { genreName, championName }
+```
+
+In the WebSocket subscription setup area (wherever other subscriptions are added in `onMounted`), add:
+```js
+    subscribeToChannel(wsClient, '/topic/battle/champion-reveal', (msg) => {
+      if (msg.dismiss) {
+        championReveal.value = null
+      } else {
+        championReveal.value = { genreName: msg.genreName, championName: msg.championName }
+      }
+    })
+```
+
+Note: BattleOverlay uses `subscribeToChannel` (not `wsClient.subscribe` directly). The message object `msg` in `subscribeToChannel` callbacks may already be parsed — check the websocket utility to confirm. If it's a raw STOMP frame, use `JSON.parse(msg.body)` instead of `msg` directly. Check: `grep -n 'subscribeToChannel' /Users/bennylim/Documents/BES/BES-frontend/src/utils/websocket.js` before implementing to confirm the callback signature.
+
+- [ ] **Step 5: Add champion reveal overlay to BattleOverlay template**
+
+Find the root container div in BattleOverlay (the outermost `<div>` in `<template>`). Add the overlay as the first child:
+```html
+    <!-- ── Champion Reveal Overlay ─────────────────── -->
+    <Transition name="champ-reveal">
+      <div v-if="championReveal" class="champ-overlay">
+        <div class="champ-overlay-bg"></div>
+        <div class="champ-overlay-content">
+          <div class="champ-genre-tag">{{ championReveal.genreName }} · Final</div>
+          <div class="champ-label">Champion</div>
+          <div class="champ-name-slam">{{ championReveal.championName }}</div>
+          <div class="champ-gold-bar"></div>
+        </div>
+      </div>
+    </Transition>
+```
+
+- [ ] **Step 6: Add champion reveal CSS to BattleOverlay**
+
+Add the same CSS block from Step 3 to `BattleOverlay.vue`'s `<style scoped>`, but with a larger name font size to suit the full-screen overlay:
+
+Use `font-size: 15vw` for `.champ-name-slam` instead of `58px`, so it scales with screen width on the stream.
+
+The rest of the CSS is identical to Step 3.
+
+- [ ] **Step 7: Build check**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run build 2>&1 | tail -10
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add BES-frontend/src/views/BracketVisualization.vue \
+        BES-frontend/src/views/BattleOverlay.vue
+git commit -m "feat(bracket): champion reveal overlay on BracketVisualization and BattleOverlay"
+```
+
+---
+
+## Task 12: Docker rebuild + smoke test
+
+**Files:** None (build verification)
+
+- [ ] **Step 1: Backend compile + test**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw clean test -q 2>&1 | tail -10
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 2: Frontend production build**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES-frontend && npm run build 2>&1 | tail -10
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Rebuild affected Docker containers**
+
+```bash
+cd /Users/bennylim/Documents/BES
+docker compose stop frontend backend
+docker compose rm -f frontend backend
+docker compose build --no-cache frontend backend
+docker compose up -d
+```
+
+- [ ] **Step 4: Verify containers are running**
+
+```bash
+docker compose ps
+```
+Expected: all services `Up`.
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:80
+```
+Expected: 200.
+
+```bash
+curl -s http://localhost:5050/actuator/health
+```
+Expected: `{"status":"UP"}`.
+
+- [ ] **Step 5: Manual smoke tests**
+
+Test each feature:
+
+1. **Color theming** — Open BattleControl, set overlay config (e.g. orange left, blue right), start a battle. Open BracketVisualization — confirm active slots show the configured colors.
+
+2. **Winner badge** — Reveal a result. Confirm the winning slot shows a gold WIN badge (not a crown icon). Confirm the losing slot is dimmed with no strikethrough.
+
+3. **Advance animation** — After a result, confirm: ring expands from winner slot, lightning streak travels to destination, destination slot ignites.
+
+4. **Final tie block** — Set up a final match, set judges to equal votes (tie). Click Get Score. Confirm BattleControl shows the amber "TIE in Final — Revote required" warning and a START REVOTE button. Confirm the overlay/bracket didn't change. Click START REVOTE — confirm warning clears and voting is open again.
+
+5. **Champion reveal** — Complete a final match with a winner. In BattleControl, confirm "Reveal Champion" button appears. Click it — confirm BracketVisualization and BattleOverlay both show the full-screen name slam. Click Dismiss — confirm overlay clears and bracket is visible with WIN badge. Re-click Reveal Champion to confirm it can be retriggered.
+
+---
+
+## Task 13: Final commit
+
+- [ ] **Step 1: Run full backend test suite one last time**
+
+```bash
+cd /Users/bennylim/Documents/BES/BES && ./mvnw test -q 2>&1 | tail -10
+```
+Expected: all tests pass.
+
+- [ ] **Step 2: Final commit if any loose files remain**
+
+```bash
+git status
+```
+If any modified files remain unstaged, stage and commit them with an appropriate message.

--- a/docs/superpowers/specs/2026-05-27-bracket-visual-enhancements-design.md
+++ b/docs/superpowers/specs/2026-05-27-bracket-visual-enhancements-design.md
@@ -98,6 +98,7 @@ Displayed as an absolutely-positioned overlay over the bracket/overlay content:
 - Organiser can run all finals first, then reveal champions one by one at the end
 - The bracket stores the winner in `bracketState` (localStorage + backend) — no re-voting required; reveal is a pure display trigger
 - Only one genre reveal can be active at a time — triggering a second genre's reveal automatically dismisses the previous one
+- The reveal can be re-triggered at any time after dismissing — "REVEAL CHAMPION" is available again immediately once dismissed, so the organiser can replay it for the crowd or projector as needed
 
 ### BattleControl UI change
 
@@ -117,6 +118,51 @@ Backend: new endpoint `POST /api/v1/battle/champion-reveal` accepting `{ genreId
 
 ---
 
+## 4. Final Match Tie Prevention
+
+### Rule
+
+A tie result is not permitted in the final match of any genre. Non-final matches (e.g. semi-finals) can proceed normally with tie-breaker logic as they do today.
+
+### Detection
+
+When the organiser clicks **REVEAL** (transitions the final match from VOTING → REVEALED) in BattleControl, the backend checks vote totals. If the result is a tie:
+- The phase transition to REVEALED is **blocked** — the match stays in VOTING
+- The backend returns an error response indicating a tie
+- **No update is broadcast to the overlay or BracketVisualization** — both screens remain unchanged
+
+### Organiser notification
+
+BattleControl shows a prominent inline warning on that genre's final match row:
+
+> **TIE — Revote required.** Judges must vote again.
+
+With a **"START REVOTE"** button. Pressing it:
+1. Resets all judge votes for the final match (backend clears existing votes)
+2. Match remains in VOTING phase
+3. BattleJudge screens reset to allow judges to vote again (existing WebSocket broadcast of the VOTING phase state handles this)
+4. The tie warning is cleared from BattleControl once the revote starts
+
+### Overlay isolation
+
+During the tie and revote period, `BattleOverlay.vue` and `BracketVisualization.vue` are **not notified**. They continue showing the VOTING state as normal — the audience sees nothing unusual on the projector/stream. Only the organiser's BattleControl view shows the tie warning.
+
+### New backend changes
+
+- `POST /api/v1/battle/reveal` (or equivalent phase-transition endpoint): if the match is a final and the vote is tied, return `HTTP 409` with body `{ error: "TIE", matchId }` instead of advancing the phase
+- `POST /api/v1/battle/revote` (new): accepts `{ matchId }`, clears all judge votes for that match, keeps phase as VOTING, broadcasts updated VOTING state to judges
+- "Final match" is determined by match position in the bracket — the match with no subsequent round is the final
+
+### Files impacted (addition to section below)
+
+| File | Change |
+|---|---|
+| `BES-frontend/src/views/BattleControl.vue` | Detect 409 on reveal, show tie warning + START REVOTE button |
+| `BES/src/main/java/com/example/BES/controllers/BattleController.java` | Return 409 on tied final; new `POST /api/v1/battle/revote` endpoint |
+| `BES/src/main/java/com/example/BES/services/` | Tie detection logic; vote reset logic for revote |
+
+---
+
 ## Files Changed
 
 | File | Change |
@@ -132,6 +178,8 @@ Backend: new endpoint `POST /api/v1/battle/champion-reveal` accepting `{ genreId
 
 ## Out of Scope
 
-- No changes to voting logic, bracket seeding, or match state machine
-- No database schema changes (champion reveal is ephemeral)
-- No changes to BattleJudge, Chart, or other battle views
+- Tie prevention applies to the **final match only** — semi-finals and earlier rounds are unaffected
+- No changes to bracket seeding
+- No database schema changes (champion reveal is ephemeral; revote reuses existing vote storage)
+- No changes to BattleJudge view itself — it resets automatically when VOTING phase is rebroadcast
+- No changes to Chart or other battle views

--- a/docs/superpowers/specs/2026-05-27-bracket-visual-enhancements-design.md
+++ b/docs/superpowers/specs/2026-05-27-bracket-visual-enhancements-design.md
@@ -1,0 +1,137 @@
+# Bracket Visual Enhancements — Design Spec
+
+**Date:** 2026-05-27
+**Branch:** feature/battle-judge-redesign
+**Scope:** BracketVisualization.vue, BattleOverlay.vue, BattleControl.vue
+
+---
+
+## Overview
+
+Three layered visual enhancements to the live bracket system:
+
+1. **Color theming** — bracket slots use the overlay config's `leftColor`/`rightColor`, with gold for winners
+2. **Advance animation** — bolder, more dramatic animation when a winner moves to the next round slot
+3. **Champion reveal** — a triggered full-screen announcement for each genre's champion, dismissible from BattleControl
+
+---
+
+## 1. Color Theming
+
+### Behavior
+
+| Slot state | Visual |
+|---|---|
+| Active match, left side | `leftColor` from overlay config (background + border + glow) |
+| Active match, right side | `rightColor` from overlay config |
+| Won this round (result locked) | Gold — `rgba(245,158,11,…)` — regardless of which side they were on |
+| Lost this round | Dimmed to ~40% opacity, no strikethrough, no extra label |
+| Advancing to next round (before that match is active) | Resets to `leftColor` or `rightColor` based on their new position in the next match |
+| Upcoming / not yet seeded | Neutral dark — `rgba(255,255,255,0.04)` border |
+
+### Winner indicator
+
+A small parallelogram **WIN** badge chip rendered to the right of the name, inside the slot. Styled as:
+- Background: `rgba(245,158,11,0.25)`
+- Border: `1px solid rgba(245,158,11,0.5)`
+- Text: `#fbbf24`, `font-family: Inter`, `font-size: 9px`, `font-weight: 900`, `letter-spacing: 0.12em`
+- Shape: `clip-path: polygon(3px 0%, 100% 0%, calc(100%-3px) 100%, 0% 100%)` — parallelogram
+- Counter-skewed `skewX(5deg)` to sit upright inside the slot's `skewX(-5deg)` transform
+
+### Color source
+
+- `BracketVisualization.vue` subscribes to `/topic/battle/overlay-config` (same as `BattleOverlay.vue`)
+- On mount, calls `getOverlayConfig()` to get initial config
+- Stores as `overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })`
+- CSS custom properties `--left-color` and `--right-color` applied to `.bracket-root` so slot styles can inherit
+
+### Cyan removal
+
+All existing `#06b6d4` cyan in `BracketVisualization.vue` is replaced with white/silver neutral (`rgba(255,255,255,…)`) — ticker labels, round headers, connectors, any accent elements.
+
+---
+
+## 2. Advance Animation
+
+Triggered when `bracketState` updates and a winner advances to a new slot in the next round.
+
+### Sequence
+
+1. **Ring burst on source slot** — an expanding ring `border` animates outward from the winning slot and fades out (`scale(1) → scale(1.6)`, `opacity: 1 → 0`, duration ~400ms). Gold color.
+2. **Lightning streak** — a horizontal gold `div` expands left-to-right across the gap between source and destination slots (`width: 0 → full gap`, duration ~180ms). Gradient: `transparent → rgba(245,158,11,0.9) → #fff`.
+3. **Streak fades** — streak opacity transitions to 0 (~150ms after reaching full width).
+4. **Destination slot ignites** — destination slot transitions to the battler's new position color (left or right config color) with a brief `box-shadow` flash (~400ms settling).
+
+### Implementation notes
+
+- Source and destination slot positions are found via `getBoundingClientRect()` relative to the bracket container
+- The ring and streak `div`s are absolutely positioned inside the bracket container, removed after animation completes
+- Animation is non-blocking (does not delay state updates)
+- If the next round slot is not yet visible (e.g. waiting for the other semi to finish), the animation still plays to the slot's position — the slot just remains "pending" until the other battler is seeded
+
+---
+
+## 3. Champion Reveal
+
+### Trigger flow
+
+1. Organiser clicks **"REVEAL CHAMPION"** for a specific genre in `BattleControl.vue`
+2. Backend (or direct WebSocket broadcast) emits a new event: `champion-reveal` on topic `/topic/battle/champion-reveal`
+3. Payload: `{ genreId, genreName, championName }`
+4. Both `BracketVisualization.vue` and `BattleOverlay.vue` subscribe to this topic and show the reveal animation
+5. Organiser clicks **"DISMISS"** (same area in BattleControl) — emits `champion-dismiss` on `/topic/battle/champion-reveal` with `{ dismiss: true }`
+6. Both screens clear the overlay; bracket is fully visible again with the final match showing the WIN badge on the champion's slot
+
+### Animation (Option 1 — Full-screen name slam)
+
+Displayed as an absolutely-positioned overlay over the bracket/overlay content:
+
+1. **Background darkens** — overlay fades in (`opacity: 0 → 1`, 300ms), background `#060818` with a radial gold glow `radial-gradient(ellipse 60% 50% at 50% 55%, rgba(245,158,11,0.12) 0%, transparent 70%)`
+2. **Genre label** — appears top-center, fade + slide up (`opacity: 0 → 1, translateY(10px) → 0`, delay 100ms)
+3. **"CHAMPION" label** — gold tint, fade + slide up, delay 250ms
+4. **Name slams in** — Anton SC, large (~52px on bracket, larger on overlay), `scale(0.7) translateY(20px) → scale(1) translateY(0)` with `cubic-bezier(0.175, 0.885, 0.32, 1.275)` (overshoot bounce), delay 400ms. White text with `text-shadow: 0 0 40px rgba(245,158,11,0.6), 0 0 80px rgba(245,158,11,0.3)`
+5. **Gold underbar** — a thin horizontal line expands to 200px width beneath the name, delay 700ms
+
+### Multi-genre workflow
+
+- Each genre has its own "REVEAL CHAMPION" / "DISMISS" button in BattleControl
+- Organiser can run all finals first, then reveal champions one by one at the end
+- The bracket stores the winner in `bracketState` (localStorage + backend) — no re-voting required; reveal is a pure display trigger
+- Only one genre reveal can be active at a time — triggering a second genre's reveal automatically dismisses the previous one
+
+### BattleControl UI change
+
+In the genre list within BattleControl, each genre row that has a completed final match gets:
+- **"REVEAL CHAMPION"** button — enabled only when the final match has a winner
+- Changes to **"DISMISS"** while a reveal is active for that genre
+- Button style: same as other BattleControl action buttons (dark pill, not a prominent CTA — this is a behind-the-scenes control)
+
+### New WebSocket event
+
+| Direction | Topic | Payload |
+|---|---|---|
+| Server → clients | `/topic/battle/champion-reveal` | `{ genreId, genreName, championName, dismiss: false }` |
+| Server → clients | `/topic/battle/champion-reveal` | `{ dismiss: true }` |
+
+Backend: new endpoint `POST /api/v1/battle/champion-reveal` accepting `{ genreId, dismiss }`. Backend looks up the winner from bracket state if `dismiss: false`, broadcasts the event. No persistence needed — purely ephemeral display state.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `BES-frontend/src/views/BracketVisualization.vue` | Overlay config subscription, color theming, cyan removal, advance animation, champion reveal overlay |
+| `BES-frontend/src/views/BattleOverlay.vue` | Champion reveal overlay (subscribe + animation) |
+| `BES-frontend/src/views/BattleControl.vue` | "REVEAL CHAMPION" / "DISMISS" buttons per genre |
+| `BES-frontend/src/utils/api.js` | `revealChampion(genreId)` and `dismissChampion()` fetch functions |
+| `BES/src/main/java/com/example/BES/controllers/BattleController.java` | New `POST /api/v1/battle/champion-reveal` endpoint |
+| `BES/src/main/java/com/example/BES/services/` | Logic to look up bracket winner and broadcast via WebSocket |
+
+---
+
+## Out of Scope
+
+- No changes to voting logic, bracket seeding, or match state machine
+- No database schema changes (champion reveal is ephemeral)
+- No changes to BattleJudge, Chart, or other battle views


### PR DESCRIPTION
## Summary

- **Bracket visual enhancements**: bigger name fonts, larger slots for Top8/Top16, final match slot taller/wider than side slots, non-final winners keep their left/right color (not gold) with a silver "TAKES IT" badge, gold "WIN" badge reserved for the final match winner
- **Bracket animation bug fix (revote)**: three-part fix for stale \`pendingBracket\` state — clear stale pending on idle bracket update, pick up late-arriving bracket during glow phase, apply unconsumed pending after animation cycle ends
- **BattleOverlay race condition fix (\`animToken\`)**: non-reactive counter incremented on every new pair (LOCKED phase or \`updateBattlePair\`); \`updateScore\` captures token at start and aborts if it changes, preventing stale winner-side animations from a previous pair's score sequence
- **BattleOverlay transition fix**: removed \`else\` branch in \`updateBattlePair\` that fired \`leftReset\`/\`rightReset\` when \`currentWinner === -2\`, which was causing both panels to animate out and appear as a winner announcement on the new pair
- **Per-genre judge isolation fix**: switching genres now correctly restores each genre's independent judge set — removes are sent sequentially to avoid \`ConcurrentModificationException\` on the backend's shared \`ArrayList\`, a fresh \`getBattleJudges()\` fetch occurs before saving so state is never stale, and a \`judgeSyncing\` lock prevents concurrent calls from rapid switching; backend \`judges\` list changed to \`Collections.synchronizedList\` with guarded iteration

## Test plan

- [x] Run through a full battle with revotes: confirm winner animation plays correctly for the revoted pair and no stale previous-pair animation fires
- [x] Rapidly click "Get Score" then "Next" multiple times: confirm no winner-side animation or judge panel replays on the new pair
- [x] Verify bracket slot sizing: Top8/Top16 slots are visibly larger than Top32; final match slot is taller/wider than side slots
- [x] Verify non-final winners display "TAKES IT" silver badge and retain their left/right color; final match winner displays gold "WIN" badge
- [x] Add judges to genre1 (e.g. j1, j2) and genre2 (e.g. j1 only), switch back and forth several times: confirm each genre consistently shows only its own judges with no cross-contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)