### PR TITLE
feat: CI concurrency groups + agent dispatch brief model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   backend-build:
     name: Backend / Build


### PR DESCRIPTION
## Summary

### CI — concurrency groups
- Added `concurrency: group: ci-${{ github.head_ref || github.ref_name }}` with `cancel-in-progress: true`
- Push CI fires immediately for fast feedback; when a PR opens/updates it cancels the stale push run automatically
- No double billing, PR report still posts, no loss of early warning

### Agent dispatch — master brief model
- Bumps `.agent-dispatch` submodule to new brief-based workflow
- **Before:** native Claude wrote N task files, each pasting CLAUDE.md sections + per-task context → expensive and redundant
- **After:** native Claude writes one `BRIEF-{id}.md` (~15–30 lines, behaviour-only). Container reads `CLAUDE.md` itself, decomposes internally, implements, tests, commits, then emits a `SUMMARY-{id}.md`
- Native Claude reviews the summary (commits + diff + test output) in one pass instead of N spec-review subagent loops
- Brief format: Goal + Constraints (non-obvious only) + Done Criteria + Test Command — no source pasting

## Test plan
- [ ] Push to a feature branch → CI starts
- [ ] Open a PR from that branch → previous push run is cancelled, PR run starts fresh
- [ ] Verify PR report comment still posts when PR run completes
- [ ] Verify `BRIEF-{id}.md` → container runs → `SUMMARY-{id}.md` is written with commits + diff sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)