### PR TITLE
feat: UI polish — judge scoring cards, feedback, timer, global typography

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -214,8 +214,9 @@ onUnmounted(() => {
               leave-to-class="opacity-0 translate-y-1"
             >
               <div v-if="eventMenuOpen"
-                class="absolute right-0 top-full mt-2 w-52 z-50 bg-surface-800 border border-[rgba(255,255,255,0.07)] shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden relative"
-                style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)">
+                class="absolute right-0 top-full mt-2 w-52 z-50 bg-surface-800 border border-[rgba(255,255,255,0.07)] shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden"
+                style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
+                @click.stop>
                 <div class="corner-bar-tl"></div>
                 <div class="px-3 py-2.5 border-b border-[rgba(255,255,255,0.07)]">
                   <p class="type-label text-content-muted mb-0.5">Current Event</p>

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue'
-import { logout, whoami } from './utils/api'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { logout, whoami, getAppConfig } from './utils/api'
+import { createClient, deactivateClient, subscribeToChannel } from './utils/websocket'
 import { useAuthStore } from './utils/auth'
 import ActionDoneModal from './views/ActionDoneModal.vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -12,6 +13,9 @@ const modalTitle   = ref('')
 const modalMessage = ref('')
 const showModal    = ref(false)
 const isOpen       = ref(false)
+
+const accentServer = ref('#ffffff')
+const wsAccentClient = ref(null)
 
 const authStore = useAuthStore()
 
@@ -92,6 +96,11 @@ function applyTheme(t) {
   localStorage.setItem('bes-theme', t)
 }
 
+function applyAccent(color) {
+  accentServer.value = color
+  document.documentElement.style.setProperty('--accent-server', color)
+}
+
 function toggleTheme() {
   const html = document.documentElement
   html.classList.add('theme-transition')
@@ -115,66 +124,84 @@ onMounted(async () => {
   } catch {
     // not authenticated — ok
   }
+  try {
+    const cfg = await getAppConfig()
+    if (cfg?.accentColor) applyAccent(cfg.accentColor)
+  } catch {
+    // server not ready — keep default
+  }
+  const c = createClient()
+  wsAccentClient.value = c
+  subscribeToChannel(c, '/topic/app-config', (msg) => {
+    if (msg?.accentColor) applyAccent(msg.accentColor)
+  })
+})
+
+onUnmounted(() => {
+  deactivateClient(wsAccentClient.value)
 })
 </script>
 
 <template>
-  <!-- ─────────────────────────────────────────
-       Navigation Bar
-  ───────────────────────────────────────── -->
+  <!-- Global scanlines overlay -->
+  <div
+    class="scanlines fixed inset-0 z-[9999] pointer-events-none"
+    style="background: repeating-linear-gradient(to bottom, transparent 0px, transparent 3px, rgba(0,0,0,0.045) 3px, rgba(0,0,0,0.045) 4px);"
+    aria-hidden="true"
+  ></div>
+
   <nav
     v-if="!hideNav"
-    class="fixed top-0 left-0 w-full z-40
-           bg-surface-900/90 backdrop-blur-lg
-           border-b border-surface-600/30
-           shadow-[0_1px_20px_rgba(0,0,0,0.5)]
-           transition-all duration-300"
+    class="fixed top-0 left-0 w-full z-40 bg-surface-900/95 border-b border-[rgba(255,255,255,0.07)] transition-all duration-300"
   >
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-[auto_1fr_auto] items-center h-16 gap-4">
 
-        <!-- Left: Logo -->
-        <router-link to="/" class="flex items-center gap-2 group flex-shrink-0">
-          <div class="w-8 h-8 rounded-lg bg-primary-500 text-white flex items-center justify-center font-anton text-xl group-hover:scale-105 transition-transform duration-200"
-            style="box-shadow: 0 0 12px rgba(6,182,212,0.4);">B</div>
-          <span class="font-anton text-2xl text-content-primary tracking-wide translate-y-[2px]">BES</span>
+        <!-- Left: BES wordmark + glowing dot -->
+        <router-link to="/" class="flex items-center gap-2.5 group flex-shrink-0">
+          <div class="glow-dot"></div>
+          <span class="type-body text-[18px] tracking-[0.12em] text-content-primary">BES</span>
         </router-link>
 
-        <!-- Center: Primary nav -->
-        <div class="hidden md:flex items-center justify-center gap-1">
+        <!-- Center: Primary nav as parallelogram chips -->
+        <div class="hidden md:flex items-center justify-center gap-2">
           <router-link to="/" v-slot="{ isActive }">
-            <span class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer"
-              :class="isActive ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]' : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'">
-              <i class="pi pi-home text-xs"></i> Home
-            </span>
+            <span
+              class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
+              :class="isActive
+                ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
+                : 'text-content-muted hover:text-content-primary'"
+            >Home</span>
           </router-link>
           <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
-            <span class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer"
-              :class="isActive ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]' : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'">
-              <i class="pi pi-calendar text-xs"></i> Events
-            </span>
+            <span
+              class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
+              :class="isActive
+                ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
+                : 'text-content-muted hover:text-content-primary'"
+            >Events</span>
           </router-link>
           <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
-            <span class="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer"
-              :class="isActive ? 'bg-primary-600 text-white shadow-[0_0_12px_rgba(6,182,212,0.3)]' : 'text-content-muted hover:text-content-primary hover:bg-surface-700/60'">
-              <i class="pi pi-cog text-xs"></i> Admin
-            </span>
+            <span
+              class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
+              :class="isActive
+                ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
+                : 'text-content-muted hover:text-content-primary'"
+            >Admin</span>
           </router-link>
         </div>
 
-        <!-- Right: Event chip + utilities -->
+        <!-- Right: event chip + role + theme + logout -->
         <div class="hidden md:flex items-center gap-2">
 
           <!-- Active event dropdown -->
           <div v-if="isAuthenticated && activeEvent" class="relative">
-            <button @click="eventMenuOpen = !eventMenuOpen"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full
-                     bg-surface-700 border border-surface-600 text-content-secondary
-                     text-xs font-medium hover:bg-surface-600 hover:border-primary-500/50
-                     hover:text-primary-400 transition-all duration-200 max-w-[180px]">
-              <i class="pi pi-calendar-clock text-xs flex-shrink-0"></i>
+            <button
+              @click="eventMenuOpen = !eventMenuOpen"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[200px]"
+            >
               <span class="truncate">{{ activeEvent.name }}</span>
-              <i class="pi pi-chevron-down text-xs flex-shrink-0 opacity-60 transition-transform duration-200"
+              <i class="pi pi-chevron-down text-[10px] flex-shrink-0 opacity-50 transition-transform duration-200"
                  :class="eventMenuOpen ? 'rotate-180' : ''"></i>
             </button>
 
@@ -187,42 +214,44 @@ onMounted(async () => {
               leave-to-class="opacity-0 translate-y-1"
             >
               <div v-if="eventMenuOpen"
-                class="absolute right-0 top-full mt-2 w-48 z-50 bg-surface-800 border border-surface-600/60 rounded-xl shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden">
-                <div class="px-3 py-2.5 border-b border-surface-700/60">
-                  <p class="text-[10px] font-bold uppercase tracking-widest text-content-muted mb-0.5">Current Event</p>
-                  <p class="text-sm font-semibold text-content-primary truncate">{{ activeEvent.name }}</p>
+                class="absolute right-0 top-full mt-2 w-52 z-50 bg-surface-800 border border-[rgba(255,255,255,0.07)] shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden relative"
+                style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)">
+                <div class="corner-bar-tl"></div>
+                <div class="px-3 py-2.5 border-b border-[rgba(255,255,255,0.07)]">
+                  <p class="type-label text-content-muted mb-0.5">Current Event</p>
+                  <p class="type-body text-content-primary truncate">{{ activeEvent.name }}</p>
                 </div>
                 <div class="py-1">
                   <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
                     @click="goToEventDetails"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-                    <i class="pi pi-info-circle text-xs w-4"></i> Event Details
+                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                    Event Details
                   </button>
                   <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
                     @click="goToSection('Audition List')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-                    <i class="pi pi-list text-xs w-4"></i> Audition
+                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                    Audition
                   </button>
                   <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
                     @click="goToSection('Update Event Details')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-                    <i class="pi pi-users text-xs w-4"></i> Participants
+                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                    Participants
                   </button>
                   <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'"
                     @click="goToSection('Score')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-                    <i class="pi pi-chart-bar text-xs w-4"></i> Scoreboard
+                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                    Scoreboard
                   </button>
                   <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
                     @click="goToSection('Battle Control')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-                    <i class="pi pi-bolt text-xs w-4"></i> Battle
+                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                    Battle
                   </button>
                 </div>
-                <div class="border-t border-surface-700/60 py-1">
+                <div class="border-t border-[rgba(255,255,255,0.07)] py-1">
                   <button @click="changeEvent"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-content-muted hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-                    <i class="pi pi-refresh text-xs w-4"></i> Change Event
+                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                    Change Event
                   </button>
                 </div>
               </div>
@@ -230,43 +259,41 @@ onMounted(async () => {
             <div v-if="eventMenuOpen" class="fixed inset-0 z-40" @click="eventMenuOpen = false"></div>
           </div>
 
-          <!-- Divider -->
-          <div v-if="isAuthenticated" class="h-5 w-px bg-surface-600/60"></div>
+          <div v-if="isAuthenticated" class="h-4 w-px bg-[rgba(255,255,255,0.12)]"></div>
 
           <!-- Role badge -->
           <span v-if="isAuthenticated && roleDisplay"
-            class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-surface-700 text-content-secondary border border-surface-600">
+            class="badge-neutral type-label px-2 py-0.5">
             {{ roleDisplay.label }}
           </span>
 
           <!-- Theme toggle -->
           <button @click="toggleTheme"
-            class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-content-muted hover:text-content-primary hover:bg-surface-700 transition-all duration-200">
+            class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
             <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
           </button>
 
           <router-link v-if="!isAuthenticated" to="/login">
-            <span class="px-4 py-2 rounded-lg text-sm font-semibold text-white bg-primary-500 hover:bg-primary-600 transition-colors shadow-sm cursor-pointer btn-glow">Login</span>
+            <span class="px-4 py-1.5 para-chip type-label text-surface-900 bg-accent cursor-pointer">Login</span>
           </router-link>
 
           <button v-if="isAuthenticated"
             @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
-            class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200"
-            title="Logout">
+            class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200">
             <i class="pi pi-sign-out text-sm"></i>
           </button>
         </div>
 
         <!-- Mobile Hamburger -->
         <button @click="isOpen = !isOpen"
-          class="md:hidden inline-flex items-center justify-center w-9 h-9 rounded-lg text-content-muted hover:text-content-primary hover:bg-surface-700 transition-colors focus:outline-none">
+          class="md:hidden inline-flex items-center justify-center w-9 h-9 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-colors focus:outline-none">
           <i class="pi text-lg" :class="isOpen ? 'pi-times' : 'pi-bars'"></i>
         </button>
 
       </div>
     </div>
 
-    <!-- Mobile Dropdown (slide-down from navbar) -->
+    <!-- Mobile Dropdown -->
     <Transition
       enter-active-class="transition duration-200 ease-out"
       enter-from-class="opacity-0 -translate-y-2"
@@ -275,95 +302,78 @@ onMounted(async () => {
       leave-from-class="opacity-100 translate-y-0"
       leave-to-class="opacity-0 -translate-y-2"
     >
-      <div
-        v-show="isOpen"
-        class="md:hidden border-t border-surface-600/30
-               bg-surface-900/98 backdrop-blur-md shadow-lg"
-      >
-        <!-- Mobile nav links -->
+      <div v-show="isOpen" class="md:hidden border-t border-[rgba(255,255,255,0.07)] bg-surface-900/98">
         <div class="px-3 py-3 space-y-0.5">
           <router-link to="/" v-slot="{ isActive }">
-            <span class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors duration-150 cursor-pointer"
-              :class="isActive ? 'bg-primary-500 text-white' : 'text-content-secondary hover:bg-surface-700/60'">
-              <i class="pi pi-home w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i> Home
+            <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
+              :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
+              Home
             </span>
           </router-link>
-
           <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
-            <span class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors duration-150 cursor-pointer"
-              :class="isActive ? 'bg-primary-500 text-white' : 'text-content-secondary hover:bg-surface-700/60'">
-              <i class="pi pi-calendar w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i> Events
+            <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
+              :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
+              Events
             </span>
           </router-link>
-
           <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
-            <span class="flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors duration-150 cursor-pointer"
-              :class="isActive ? 'bg-primary-500 text-white' : 'text-content-secondary hover:bg-surface-700/60'">
-              <i class="pi pi-cog w-4" :class="isActive ? 'text-white' : 'text-content-muted'"></i> Admin
+            <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
+              :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
+              Admin
             </span>
           </router-link>
 
-          <!-- Current event section (mobile) -->
           <template v-if="isAuthenticated && activeEvent">
-            <div class="px-4 pt-3 pb-1">
-              <p class="text-[10px] font-bold uppercase tracking-widest text-content-muted">Current Event</p>
-              <p class="text-sm font-semibold text-primary-400 truncate">{{ activeEvent.name }}</p>
+            <div class="px-4 pt-3 pb-1 section-rule">
+              <span class="section-rule-label">Current Event — {{ activeEvent.name }}</span>
+              <div class="section-rule-line"></div>
             </div>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-              @click="goToEventDetails"
-              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-              <i class="pi pi-info-circle w-4 text-content-muted"></i> Event Details
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToEventDetails"
+              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+              Event Details
             </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
-              @click="goToSection('Audition List')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-              <i class="pi pi-list w-4 text-content-muted"></i> Audition
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'" @click="goToSection('Audition List')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+              Audition
             </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-              @click="goToSection('Update Event Details')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-              <i class="pi pi-users w-4 text-content-muted"></i> Participants
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToSection('Update Event Details')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+              Participants
             </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'"
-              @click="goToSection('Score')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-              <i class="pi pi-chart-bar w-4 text-content-muted"></i> Scoreboard
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'" @click="goToSection('Score')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+              Scoreboard
             </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-              @click="goToSection('Battle Control')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-secondary hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-              <i class="pi pi-bolt w-4 text-content-muted"></i> Battle
+            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToSection('Battle Control')"
+              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+              Battle
             </button>
             <button @click="changeEvent"
-              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-sm text-content-muted hover:bg-surface-700/60 hover:text-primary-400 transition-colors">
-              <i class="pi pi-refresh w-4"></i> Change Event
+              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-muted hover:text-content-primary transition-colors">
+              Change Event
             </button>
           </template>
         </div>
 
-        <!-- Mobile bottom row -->
-        <div class="px-3 py-3 border-t border-surface-600/30">
+        <div class="px-3 py-3 border-t border-[rgba(255,255,255,0.07)]">
           <div v-if="isAuthenticated" class="flex items-center justify-between">
             <div class="flex items-center gap-2">
-              <span v-if="roleDisplay"
-                class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-surface-700 text-content-secondary border border-surface-600">
-                {{ roleDisplay.label }}
-              </span>
+              <span v-if="roleDisplay" class="badge-neutral type-label">{{ roleDisplay.label }}</span>
               <button @click="toggleTheme"
-                class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-content-muted hover:text-content-primary hover:bg-surface-700 transition-all duration-200">
+                class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
                 <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
               </button>
             </div>
             <button @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
-              class="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-red-400 bg-red-950 hover:bg-red-900 transition-colors cursor-pointer">
-              <i class="pi pi-sign-out"></i> Logout
+              class="flex items-center gap-2 px-4 py-2 type-label text-red-400 bg-red-950 hover:bg-red-900 transition-colors cursor-pointer"
+              style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)">
+              Logout
             </button>
           </div>
           <router-link v-else to="/login">
-            <span class="flex items-center justify-center px-4 py-3 rounded-xl text-sm font-semibold text-white bg-primary-500 hover:bg-primary-600 transition-colors w-full btn-glow">Login</span>
+            <span class="flex items-center justify-center px-4 py-2.5 type-label para-chip text-surface-900 bg-accent w-full cursor-pointer">Login</span>
           </router-link>
         </div>
-
       </div>
     </Transition>
 

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -211,7 +211,7 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
     padding: 0.625rem 1rem;
     font-family: 'Anton SC', sans-serif;
-    font-size: 13px;
+    font-size: 15px;
     letter-spacing: 0.05em;
     text-transform: uppercase;
     color: rgba(255, 255, 255, 0.88);
@@ -243,7 +243,7 @@
   .badge-success   { background: rgba(52,211,153,0.10); color: #34d399; border: 1px solid rgba(52,211,153,0.2); }
   .badge-warning   { background: rgba(245,158,11,0.08); color: #f59e0b; border: 1px solid rgba(245,158,11,0.2); }
   .badge-danger    { background: rgba(239,68,68,0.10);  color: #ef4444; border: 1px solid rgba(239,68,68,0.2); }
-  .badge-neutral   { background: rgba(255,255,255,0.04); color: rgba(255,255,255,0.55); border: 1px solid rgba(255,255,255,0.07); }
+  .badge-neutral   { background: rgba(255,255,255,0.10); color: rgba(255,255,255,0.80); border: 1px solid rgba(255,255,255,0.20); }
 
   /* Icon wrapper */
   .icon-wrap { }
@@ -280,7 +280,7 @@
 
   .stat-value {
     font-family: 'Anton SC', sans-serif;
-    font-size: 42px;
+    font-size: 48px;
     letter-spacing: 0.02em;
     color: #ffffff;
     line-height: 1;
@@ -289,7 +289,7 @@
 
   .stat-label {
     font-family: 'Anton SC', sans-serif;
-    font-size: 10px;
+    font-size: 12px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
     color: rgba(255,255,255,0.35);
@@ -301,11 +301,44 @@
     clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.07);
+    transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
   }
   .para-chip-sm {
     clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.07);
+    transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+  }
+
+  /* Button-specific interaction states */
+  button.para-chip:hover:not(:disabled),
+  button.para-chip-sm:hover:not(:disabled),
+  a.para-chip:hover,
+  a.para-chip-sm:hover {
+    background: rgba(255, 255, 255, 0.10);
+    border-color: rgba(255, 255, 255, 0.18);
+  }
+  button.para-chip:active:not(:disabled),
+  button.para-chip-sm:active:not(:disabled),
+  a.para-chip:active,
+  a.para-chip-sm:active {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.28);
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.4);
+  }
+  button.para-chip:disabled,
+  button.para-chip-sm:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  /* Filled accent buttons (bg-accent overrides bg, keep hover/active) */
+  button.bg-accent:hover:not(:disabled) {
+    filter: brightness(0.88);
+  }
+  button.bg-accent:active:not(:disabled) {
+    filter: brightness(0.75);
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.35);
   }
 
   /* ── Section rule (label + hairline) ───────────────────────── */
@@ -321,7 +354,7 @@
   }
   .section-rule-label {
     font-family: 'Anton SC', sans-serif;
-    font-size: 10px;
+    font-size: 12px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
     color: rgba(255, 255, 255, 0.28);
@@ -396,7 +429,7 @@
   }
   .type-page-title {
     font-family: 'Anton SC', sans-serif;
-    font-size: 28px;
+    font-size: 32px;
     letter-spacing: 0.06em;
     text-transform: uppercase;
     line-height: 1;
@@ -404,28 +437,28 @@
   }
   .type-section {
     font-family: 'Anton SC', sans-serif;
-    font-size: 13px;
+    font-size: 14px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
     line-height: 1;
   }
   .type-body {
     font-family: 'Anton SC', sans-serif;
-    font-size: 13px;
+    font-size: 15px;
     letter-spacing: 0.05em;
     text-transform: uppercase;
     line-height: 1.1;
   }
   .type-label {
     font-family: 'Anton SC', sans-serif;
-    font-size: 10px;
+    font-size: 12px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
     line-height: 1;
   }
   .type-stat {
     font-family: 'Anton SC', sans-serif;
-    font-size: 42px;
+    font-size: 48px;
     letter-spacing: 0.02em;
     line-height: 1;
   }

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -241,11 +241,11 @@
 
   /* Typography helpers */
   .section-title {
-    @apply text-xl font-heading font-bold text-content-primary tracking-tight;
+    @apply text-xl font-sans font-bold text-content-primary tracking-tight;
   }
 
   .page-title {
-    @apply text-2xl sm:text-3xl font-heading font-extrabold text-content-primary tracking-tight;
+    @apply text-2xl sm:text-3xl font-sans font-extrabold text-content-primary tracking-tight;
   }
 
   .text-muted {
@@ -270,11 +270,21 @@
   }
 
   .stat-value {
-    @apply type-stat tabular-nums;
+    font-family: 'Anton SC', sans-serif;
+    font-size: 42px;
+    letter-spacing: 0.02em;
+    color: #ffffff;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
   }
 
   .stat-label {
-    @apply type-label;
+    font-family: 'Anton SC', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.35);
+    line-height: 1;
   }
 
   /* ── Parallelogram chip (rows, list items, stat boxes) ──────── */

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -146,6 +146,15 @@
     letter-spacing: 0.12em;
     font-size: 0.7rem;
   }
+
+  /* Default colors for type tiers — in @layer base so Tailwind utility classes
+     (text-surface-900, text-white, etc.) from @layer utilities can override them */
+  .type-display    { color: #ffffff; }
+  .type-page-title { color: #f0f0f0; }
+  .type-section    { color: rgba(255,255,255,0.55); }
+  .type-body       { color: rgba(255,255,255,0.75); }
+  .type-label      { color: rgba(255,255,255,0.35); }
+  .type-stat       { color: #ffffff; }
 }
 
 /* ─────────────────────────────────────────
@@ -382,7 +391,6 @@
     font-size: clamp(36px, 5vw, 56px);
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: #ffffff;
     line-height: 1;
     text-shadow: 2px 2px 0 var(--accent-muted);
   }
@@ -391,7 +399,6 @@
     font-size: 28px;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: #f0f0f0;
     line-height: 1;
     text-shadow: 1px 1px 0 var(--accent-muted);
   }
@@ -400,7 +407,6 @@
     font-size: 13px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: rgba(255,255,255,0.55);
     line-height: 1;
   }
   .type-body {
@@ -408,7 +414,6 @@
     font-size: 13px;
     letter-spacing: 0.05em;
     text-transform: uppercase;
-    color: rgba(255,255,255,0.75);
     line-height: 1.1;
   }
   .type-label {
@@ -416,14 +421,12 @@
     font-size: 10px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: rgba(255,255,255,0.35);
     line-height: 1;
   }
   .type-stat {
     font-family: 'Anton SC', sans-serif;
     font-size: 42px;
     letter-spacing: 0.02em;
-    color: #ffffff;
     line-height: 1;
   }
 

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap');
 
 /* Local fonts */
 @font-face {
@@ -43,8 +43,8 @@
 ───────────────────────────────────────── */
 @theme {
   /* Typography */
-  --font-sans:    'Inter', ui-sans-serif, system-ui, sans-serif;
-  --font-heading: 'Outfit', sans-serif;
+  --font-sans:    'Anton SC', sans-serif;
+  --font-body:    'Inter', ui-sans-serif, system-ui, sans-serif;
   --font-eagle:   'EagleHorizonP', sans-serif;
   --font-anton:   'Anton SC', sans-serif;
   --font-source:  'JetBrains Mono', 'Source Code Pro', monospace;
@@ -83,18 +83,33 @@
 }
 
 /* ─────────────────────────────────────────
+   Runtime Accent Color Tokens
+   JS sets --accent-server on <html> (not --accent-color directly).
+   CSS cascades --accent-color from --accent-server.
+   [data-theme="light"] overrides --accent-color via CSS cascade
+   (CSS rules win over inline styles on ancestor elements when
+   the property is set on a different custom property).
+───────────────────────────────────────── */
+:root {
+  --accent-server:  #ffffff;
+  --accent-color:   var(--accent-server);
+  --accent-muted:   color-mix(in srgb, var(--accent-color) 25%, transparent);
+  --accent-subtle:  color-mix(in srgb, var(--accent-color) 7%, transparent);
+}
+
+/* ─────────────────────────────────────────
    Global Resets & Base
 ───────────────────────────────────────── */
 @layer base {
   body {
-    @apply font-sans bg-surface-950 text-content-primary antialiased leading-relaxed min-h-screen;
+    @apply font-sans bg-surface-950 text-content-primary antialiased leading-tight min-h-screen;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     scrollbar-gutter: stable;
   }
 
   h1, h2, h3, h4, h5, h6 {
-    @apply font-heading font-bold tracking-tight text-content-primary;
+    @apply font-sans tracking-wide uppercase text-content-primary;
   }
 
   *,
@@ -116,9 +131,8 @@
 
   /* Global focus-visible ring */
   *:focus-visible {
-    outline: 2px solid rgba(229, 57, 53, 0.6);
+    outline: 2px solid var(--accent-muted);
     outline-offset: 2px;
-    border-radius: 4px;
   }
 
   /* Tabular numerals for stat numbers */
@@ -144,19 +158,29 @@
     @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8;
   }
 
+  /* ── Accent token utilities ─────────────────────────────────── */
+  .text-accent   { color: var(--accent-color); }
+  .bg-accent     { background: var(--accent-color); }
+  .border-accent { border-color: var(--accent-color); }
+  .glow-accent   { box-shadow: 0 0 14px var(--accent-muted); }
+
   /* Cards */
   .card {
-    @apply bg-surface-800 rounded-2xl border border-surface-700;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.5), 0 4px 16px rgba(0,0,0,0.4);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
   }
 
   .card-hover {
-    @apply bg-surface-800 rounded-2xl border border-surface-700 transition-all duration-200;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.5), 0 4px 16px rgba(0,0,0,0.4);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+    transition: background 0.2s, border-color 0.2s;
   }
   .card-hover:hover {
-    @apply bg-surface-700 border-surface-600;
-    box-shadow: 0 0 0 1px rgba(229,57,53,0.15), 0 4px 24px rgba(229,57,53,0.08);
+    background: rgba(255, 255, 255, 0.06);
+    border-color: var(--accent-muted);
+    box-shadow: 0 0 14px var(--accent-muted);
   }
 
   /* Glassmorphism (use sparingly) */
@@ -172,10 +196,25 @@
 
   /* Inputs */
   .input-base {
-    @apply w-full rounded-xl border border-surface-600 bg-surface-900 px-4 py-2.5
-           text-sm text-content-primary shadow-sm placeholder:text-content-disabled
-           focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500
-           transition-all duration-200;
+    width: 100%;
+    clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 0.625rem 1rem;
+    font-family: 'Anton SC', sans-serif;
+    font-size: 13px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.88);
+  }
+  .input-base::placeholder {
+    color: rgba(255, 255, 255, 0.25);
+    letter-spacing: 0.1em;
+  }
+  .input-base:focus {
+    outline: none;
+    border-color: var(--accent-muted);
+    box-shadow: 0 0 8px var(--accent-subtle);
   }
 
   /* Badges / Pills — each class is fully self-contained (Tailwind v4 forbids @apply of custom classes) */
@@ -186,15 +225,16 @@
   .badge-warning,
   .badge-danger,
   .badge-neutral {
-    @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold;
+    @apply inline-flex items-center px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider;
+    clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
   }
 
-  .badge-primary   { @apply bg-primary-100  text-primary-400 border border-primary-200/30; }
-  .badge-secondary { @apply bg-accent-100   text-accent-500;   }  /* accent = orange; medal/ranking use only */
-  .badge-success   { @apply bg-surface-700  text-teal-300   border border-teal-900/30; }
-  .badge-warning   { @apply bg-surface-700  text-amber-300  border border-amber-900/30; }
-  .badge-danger    { @apply bg-surface-700  text-rose-300   border border-rose-900/30; }
-  .badge-neutral   { @apply bg-surface-700  text-content-secondary border border-surface-600; }
+  .badge-primary   { background: rgba(255,255,255,0.08); color: var(--accent-color); border: 1px solid var(--accent-muted); }
+  .badge-secondary { @apply bg-accent-100 text-accent-500; }
+  .badge-success   { background: rgba(52,211,153,0.10); color: #34d399; border: 1px solid rgba(52,211,153,0.2); }
+  .badge-warning   { background: rgba(245,158,11,0.08); color: #f59e0b; border: 1px solid rgba(245,158,11,0.2); }
+  .badge-danger    { background: rgba(239,68,68,0.10);  color: #ef4444; border: 1px solid rgba(239,68,68,0.2); }
+  .badge-neutral   { background: rgba(255,255,255,0.04); color: rgba(255,255,255,0.55); border: 1px solid rgba(255,255,255,0.07); }
 
   /* Icon wrapper */
   .icon-wrap { }
@@ -223,17 +263,158 @@
 
   /* Stat cards */
   .stat-card {
-    @apply bg-surface-800 rounded-2xl border border-surface-700
-           flex flex-col items-center justify-center p-5 text-center gap-1;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.5), 0 4px 16px rgba(0,0,0,0.4);
+    clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    @apply flex flex-col items-center justify-center p-5 text-center gap-1 relative;
   }
 
   .stat-value {
-    @apply text-3xl font-source font-extrabold text-content-primary tabular-nums;
+    @apply type-stat tabular-nums;
   }
 
   .stat-label {
-    @apply text-xs font-medium text-content-muted uppercase tracking-wider;
+    @apply type-label;
+  }
+
+  /* ── Parallelogram chip (rows, list items, stat boxes) ──────── */
+  .para-chip {
+    clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+  }
+  .para-chip-sm {
+    clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+  }
+
+  /* ── Section rule (label + hairline) ───────────────────────── */
+  .section-rule {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .section-rule-line {
+    flex: 1;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.07);
+  }
+  .section-rule-label {
+    font-family: 'Anton SC', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.28);
+    white-space: nowrap;
+  }
+
+  /* ── Corner accent bars (panels, modals) ───────────────────── */
+  .corner-bar-tl {
+    position: absolute; top: 0; left: 0;
+    width: 2px; height: 28%;
+    background: linear-gradient(to bottom, var(--accent-color), transparent);
+    pointer-events: none;
+  }
+  .corner-bar-bl {
+    position: absolute; bottom: 0; left: 0;
+    height: 2px; width: 30%;
+    background: linear-gradient(to right, var(--accent-color), transparent);
+    pointer-events: none;
+  }
+
+  /* ── Color bleed (page root only) ──────────────────────────── */
+  .color-bleed {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background:
+      radial-gradient(ellipse 50% 45% at 0% 100%, var(--accent-subtle), transparent 70%),
+      radial-gradient(ellipse 40% 40% at 100% 100%, color-mix(in srgb, var(--accent-color) 4%, transparent), transparent 70%);
+  }
+
+  /* ── Glowing status dot ─────────────────────────────────────── */
+  .glow-dot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--accent-color);
+    box-shadow: 0 0 8px var(--accent-muted);
+    flex-shrink: 0;
+  }
+
+  /* ── Semantic state chips (left border + dot) ───────────────── */
+  .semantic-chip-error {
+    border-left: 3px solid #ef4444;
+    border-top: 1px solid rgba(239,68,68,0.2);
+    border-right: 1px solid rgba(239,68,68,0.2);
+    border-bottom: 1px solid rgba(239,68,68,0.2);
+    background: rgba(239,68,68,0.10);
+    border-radius: 0;
+  }
+  .semantic-chip-warning {
+    border-left: 3px solid #f59e0b;
+    border-top: 1px solid rgba(245,158,11,0.2);
+    border-right: 1px solid rgba(245,158,11,0.2);
+    border-bottom: 1px solid rgba(245,158,11,0.2);
+    background: rgba(245,158,11,0.08);
+  }
+  .semantic-chip-success {
+    border-left: 3px solid #34d399;
+    border-top: 1px solid rgba(52,211,153,0.2);
+    border-right: 1px solid rgba(52,211,153,0.2);
+    border-bottom: 1px solid rgba(52,211,153,0.2);
+    background: rgba(52,211,153,0.08);
+  }
+
+  /* ── Typography tier utilities ──────────────────────────────── */
+  .type-display {
+    font-family: 'Anton SC', sans-serif;
+    font-size: clamp(36px, 5vw, 56px);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #ffffff;
+    line-height: 1;
+    text-shadow: 2px 2px 0 var(--accent-muted);
+  }
+  .type-page-title {
+    font-family: 'Anton SC', sans-serif;
+    font-size: 28px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #f0f0f0;
+    line-height: 1;
+    text-shadow: 1px 1px 0 var(--accent-muted);
+  }
+  .type-section {
+    font-family: 'Anton SC', sans-serif;
+    font-size: 13px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.55);
+    line-height: 1;
+  }
+  .type-body {
+    font-family: 'Anton SC', sans-serif;
+    font-size: 13px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.75);
+    line-height: 1.1;
+  }
+  .type-label {
+    font-family: 'Anton SC', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.35);
+    line-height: 1;
+  }
+  .type-stat {
+    font-family: 'Anton SC', sans-serif;
+    font-size: 42px;
+    letter-spacing: 0.02em;
+    color: #ffffff;
+    line-height: 1;
   }
 
   /* Divider */
@@ -524,6 +705,9 @@ html.theme-transition *::after {
   --color-content-muted:     #757575;
   --color-content-disabled:  #b0b0b0;
 
+  /* Accent — CSS wins because JS only sets --accent-server (see :root block above) */
+  --accent-color: rgba(0, 0, 0, 0.78);
+
   /* Primary tints — light red tints for hover/bg */
   --color-primary-50:  #fff5f5;
   --color-primary-100: #ffeded;
@@ -614,6 +798,45 @@ html.theme-transition *::after {
 /* Scrollbar — light */
 [data-theme="light"] ::-webkit-scrollbar-thumb       { background: #e2e2e2; }
 [data-theme="light"] ::-webkit-scrollbar-thumb:hover { background: #c8c8c8; }
+
+/* Parallelogram chip surfaces on light */
+[data-theme="light"] .para-chip,
+[data-theme="light"] .para-chip-sm {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .card,
+[data-theme="light"] .card-hover {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 4px 16px rgba(0,0,0,0.04) !important;
+}
+[data-theme="light"] .card-hover:hover { border-color: var(--accent-muted); }
+
+[data-theme="light"] .section-rule-line { background: rgba(0, 0, 0, 0.1); }
+[data-theme="light"] .section-rule-label { color: rgba(0, 0, 0, 0.35); }
+
+[data-theme="light"] .badge-neutral {
+  background: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.55);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .scanlines { opacity: 0.5; }
+[data-theme="light"] .color-bleed { display: none; }
+
+[data-theme="light"] .corner-bar-tl,
+[data-theme="light"] .corner-bar-bl {
+  background: linear-gradient(to bottom, rgba(0,0,0,0.4), transparent);
+}
+
+[data-theme="light"] .type-display    { color: #0d0d0d; text-shadow: 2px 2px 0 rgba(0,0,0,0.08); }
+[data-theme="light"] .type-page-title { color: #1a1a1a; text-shadow: 1px 1px 0 rgba(0,0,0,0.06); }
+[data-theme="light"] .type-section    { color: rgba(0,0,0,0.55); }
+[data-theme="light"] .type-body       { color: rgba(0,0,0,0.75); }
+[data-theme="light"] .type-label      { color: rgba(0,0,0,0.40); }
+[data-theme="light"] .type-stat       { color: #0d0d0d; }
 
 /* ─────────────────────────────────────────
    Page Transitions (must be outside @layer so Tailwind does not purge them)

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -88,17 +88,17 @@ const swipeHint = computed(() => {
         <div
           v-for="({ slots, roundNumber }, uIdx) in visibleRounds"
           :key="roundNumber"
-          class="queue-item rounded-xl border overflow-hidden flex-shrink-0"
+          class="queue-item para-chip-sm overflow-hidden flex-shrink-0"
           :class="uIdx === visibleRounds.length - 1 ? 'border-white/15 bg-white/5' : 'border-white/5 bg-transparent'"
           :style="{ opacity: uIdx === visibleRounds.length - 1 ? '1' : uIdx === visibleRounds.length - 2 ? '0.5' : uIdx === visibleRounds.length - 3 ? '0.3' : '0.15' }"
         >
           <div class="flex items-center justify-between px-2 py-1">
-            <span class="text-[10px] font-bold uppercase tracking-widest text-white/30">
+            <span class="type-label text-content-muted">
               Round {{ roundNumber }}
             </span>
             <span
               v-if="uIdx === visibleRounds.length - 1"
-              class="text-[10px] px-2 py-0.5 rounded-full bg-white/10 text-white/50 border border-white/10 font-bold uppercase tracking-wider"
+              class="badge-neutral type-label"
             >Up Next</span>
           </div>
           <div class="px-2 pb-1.5">
@@ -107,8 +107,8 @@ const swipeHint = computed(() => {
                 #{{ slot.auditionNumber }} — Not Registered
               </div>
               <div v-else class="flex items-center gap-2 flex-wrap">
-                <span class="font-anton text-xl" :class="uIdx === visibleRounds.length - 1 ? 'text-white/60' : 'text-white/25'">#{{ slot.auditionNumber }}</span>
-                <span class="font-heading font-bold text-sm" :class="uIdx === visibleRounds.length - 1 ? 'text-white/70' : 'text-white/30'" style="text-transform: uppercase; letter-spacing: 0.05em;">{{ slot.participantName }}</span>
+                <span class="type-stat text-[22px]" :class="uIdx === visibleRounds.length - 1 ? 'text-content-primary' : 'text-content-muted'">#{{ slot.auditionNumber }}</span>
+                <span class="type-body" :class="uIdx === visibleRounds.length - 1 ? 'text-content-primary' : 'text-content-muted'">{{ slot.participantName }}</span>
                 <span v-if="mode === 'PAIR' && sIdx === 0" class="text-white/20 text-xs">&amp;</span>
               </div>
             </template>
@@ -119,7 +119,7 @@ const swipeHint = computed(() => {
         v-if="hiddenRoundsCount > 0"
         class="flex-shrink-0 text-center pb-1"
       >
-        <span class="text-[10px] text-white/15 font-bold uppercase tracking-widest">+{{ hiddenRoundsCount }} more rounds</span>
+        <span class="type-label text-content-muted">+{{ hiddenRoundsCount }} more rounds</span>
       </div>
     </div>
 
@@ -146,15 +146,16 @@ const swipeHint = computed(() => {
             @touchstart.passive="onTouchStart"
             @touchmove.passive="onTouchMove"
             @touchend="onTouchEnd"
-            class="rounded-2xl border border-white/20 bg-white/5 select-none touch-pan-y"
+            class="card-hover p-0 relative select-none touch-pan-y"
             style="box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 8px 32px rgba(0,0,0,0.6);"
           >
+            <div class="corner-bar-tl"></div>
             <div class="flex items-center justify-between px-3 pt-2 pb-1.5 border-b border-white/8">
               <div class="flex items-center gap-2">
-                <span class="w-2 h-2 rounded-full bg-white animate-pulse inline-block"></span>
-                <span class="text-[10px] font-bold uppercase tracking-widest text-white/50">Now on Stage</span>
+                <span class="glow-dot"></span>
+                <span class="type-label text-content-muted">Now on Stage</span>
               </div>
-              <span class="text-[10px] text-white/25 font-bold uppercase tracking-widest">
+              <span class="type-label text-content-muted">
                 Rd {{ currentRound }} / {{ totalRounds }}
               </span>
             </div>
@@ -166,17 +167,17 @@ const swipeHint = computed(() => {
                 <div v-else>
                   <div v-if="mode === 'PAIR' && sIdx > 0" class="text-white/20 text-sm my-1 pl-1">&amp;</div>
                   <div class="flex items-baseline gap-2">
-                    <span class="font-anton text-white/40" style="font-size: 2rem;">#{{ slot.auditionNumber }}</span>
-                    <span class="font-anton text-white leading-tight" style="font-size: clamp(1.5rem, 6vw, 2.8rem); text-transform: uppercase; letter-spacing: 0.05em;">{{ slot.participantName }}</span>
+                    <span class="type-stat" style="font-size: 2rem;">#{{ slot.auditionNumber }}</span>
+                    <span class="type-body text-content-primary" style="font-size: clamp(1.5rem, 6vw, 2.8rem);">{{ slot.participantName }}</span>
                   </div>
                   <div v-if="slot.judgeName" class="text-xs text-white/25 mt-0.5 pl-1">{{ slot.judgeName }}</div>
                 </div>
               </template>
             </div>
             <div class="flex items-center justify-between px-4 pb-1.5">
-              <span class="text-[8px] text-white/12 tracking-wider">← Prev</span>
-              <span class="text-[8px] text-white/12">swipe</span>
-              <span class="text-[8px] text-white/12 tracking-wider">Next →</span>
+              <span class="type-label text-content-muted">← Prev</span>
+              <span class="type-label text-content-muted">swipe</span>
+              <span class="type-label text-content-muted">Next →</span>
             </div>
           </div>
         </Transition>
@@ -184,7 +185,7 @@ const swipeHint = computed(() => {
     </div>
 
     <!-- ── Timer at bottom (thumb reach) ── -->
-    <div class="emcee-timer px-3 pb-3 pt-2 border-t border-white/5">
+    <div class="emcee-timer px-3 pb-3 pt-2">
       <Timer />
     </div>
 

--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -42,19 +42,16 @@ const actions = [
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
   >
-    <!-- ── Header card (always visible, fixed height) ── -->
+    <!-- ── Header card (always visible) ── -->
     <div
-      class="bg-surface-800 border border-surface-600/50 border-l-[4px] border-l-primary-500
-             transition-all duration-150 cursor-pointer"
-      :class="isHovered || props.expanded
-        ? 'rounded-t-2xl border-b-transparent shadow-[0_0_0_1px_rgba(6,182,212,0.2)]'
-        : 'rounded-2xl'"
+      class="card-hover p-4 cursor-pointer relative"
       @click.stop="emit('toggle')"
     >
-      <div class="flex items-center gap-3 px-4 py-4">
-        <h3 class="font-heading font-bold text-sm text-content-primary leading-snug line-clamp-2 flex-1">
+      <div class="corner-bar-tl"></div>
+      <div class="flex items-center gap-3">
+        <div class="type-body flex-1 line-clamp-2">
           {{ props.buttonName }}
-        </h3>
+        </div>
 
         <!-- Access code (admin only) -->
         <div v-if="props.accessCode !== null" class="flex items-center gap-1.5 flex-shrink-0" @click.stop>
@@ -66,26 +63,29 @@ const actions = [
               @mousedown.stop="codeVisible = true" @mouseup.stop="codeVisible = false"
               @mouseleave.stop="codeVisible = false" @touchstart.prevent.stop="codeVisible = true"
               @touchend.stop="codeVisible = false"
-              class="text-content-muted hover:text-primary-400 transition-colors select-none touch-none"
+              class="text-content-muted hover:text-accent transition-colors select-none touch-none"
             ><i class="pi pi-eye text-xs"></i></button>
-            <button @click.stop="startEdit" class="text-content-muted hover:text-primary-400 transition-colors"
+            <button @click.stop="startEdit" class="text-content-muted hover:text-accent transition-colors"
             ><i class="pi pi-pencil text-xs"></i></button>
           </template>
           <template v-else>
             <input v-model="newCode" type="text" inputmode="numeric" maxlength="4" @click.stop
-              class="w-14 px-1.5 py-0.5 rounded border border-primary-400 bg-surface-900 font-source text-xs tracking-widest text-center text-content-primary focus:outline-none"
+              class="w-14 px-1.5 py-0.5 border border-[color:var(--accent-muted)] bg-surface-900 font-source text-xs tracking-widest text-center text-content-primary focus:outline-none"
+              style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
             />
             <button @click.stop="saveCode" :disabled="saving"
-              class="text-xs px-1.5 py-0.5 rounded bg-primary-600 text-white hover:bg-primary-700 transition-colors"
+              class="text-xs px-1.5 py-0.5 bg-accent text-surface-900 transition-colors"
+              style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
             >{{ saving ? '…' : 'Save' }}</button>
             <button @click.stop="cancelEdit"
-              class="text-xs px-1.5 py-0.5 rounded border border-surface-600 text-content-secondary hover:bg-surface-700 transition-colors"
+              class="text-xs px-1.5 py-0.5 border border-surface-600 text-content-secondary hover:bg-surface-700 transition-colors"
+              style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
             >✕</button>
           </template>
         </div>
 
         <i class="pi pi-chevron-down text-xs text-surface-500 transition-all duration-200 flex-shrink-0"
-           :class="isHovered || props.expanded ? 'text-primary-400 rotate-180' : ''"></i>
+           :class="isHovered || props.expanded ? 'text-accent rotate-180' : ''"></i>
       </div>
     </div>
 
@@ -100,22 +100,20 @@ const actions = [
     >
       <div
         v-if="isHovered || props.expanded"
-        class="absolute top-full left-0 right-0 z-20
-               bg-surface-800 border border-t-0 border-primary-500/40
-               border-l-[4px] border-l-primary-500 rounded-b-2xl overflow-hidden
-               shadow-[0_8px_24px_rgba(0,0,0,0.5)]"
+        class="absolute top-full left-0 right-0 z-20 bg-surface-800 border border-[rgba(255,255,255,0.07)] overflow-hidden shadow-[0_8px_24px_rgba(0,0,0,0.5)]"
+        style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
         @click.stop="emit('toggle')"
       >
-        <div class="grid grid-cols-5 divide-x divide-surface-700/60">
+        <div class="grid grid-cols-5">
           <button
             v-for="action in actions"
             :key="action.key"
             @click.stop="emit(action.key)"
             class="flex flex-col items-center gap-1.5 py-3.5 text-content-muted
-                   hover:text-primary-400 hover:bg-primary-500/10 transition-all duration-150"
+                   hover:text-accent hover:bg-[rgba(255,255,255,0.04)] transition-all duration-150"
           >
-            <i class="pi text-base" :class="action.icon"></i>
-            <span class="text-[9px] font-bold uppercase tracking-wide leading-none">{{ action.label }}</span>
+            <i class="pi text-base text-accent" :class="action.icon"></i>
+            <span class="type-label">{{ action.label }}</span>
           </button>
         </div>
       </div>

--- a/BES-frontend/src/components/FeedbackPopout.vue
+++ b/BES-frontend/src/components/FeedbackPopout.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { ref, watch } from 'vue'
-import ReusableButton from '@/components/ReusableButton.vue'
 
 const props = defineProps({
   visible:          { type: Boolean, default: false },
@@ -36,22 +35,7 @@ function handleSave() {
   })
 }
 
-// Color scheme: index 0 (Strengths) → emerald, index 1 (Areas to Improve) → amber, rest → cyan
-function chipColors(groupIndex, isSelected) {
-  if (groupIndex === 0) {
-    return isSelected
-      ? 'bg-emerald-500 text-white border-emerald-500'
-      : 'bg-surface-700 text-surface-300 border-surface-600 hover:border-emerald-500/60 hover:text-emerald-300'
-  }
-  if (groupIndex === 1) {
-    return isSelected
-      ? 'bg-amber-500 text-white border-amber-500'
-      : 'bg-surface-700 text-surface-300 border-surface-600 hover:border-amber-500/60 hover:text-amber-300'
-  }
-  return isSelected
-    ? 'bg-primary-600 text-white border-primary-600'
-    : 'bg-surface-700 text-surface-300 border-surface-600 hover:border-primary-500/60 hover:text-primary-300'
-}
+
 </script>
 
 <template>
@@ -103,7 +87,7 @@ function chipColors(groupIndex, isSelected) {
         <!-- Tag Groups -->
         <div class="flex-1 space-y-4 mb-4">
           <div
-            v-for="(group, groupIndex) in tagGroups"
+            v-for="group in tagGroups"
             :key="group.id"
             v-show="group.tags?.length"
           >

--- a/BES-frontend/src/components/FeedbackPopout.vue
+++ b/BES-frontend/src/components/FeedbackPopout.vue
@@ -116,11 +116,15 @@ function chipColors(groupIndex, isSelected) {
                 v-for="tag in group.tags"
                 :key="tag.id"
                 @click="toggleTag(tag.id)"
-                class="transition-all duration-150 active:scale-95"
+                class="para-chip-sm type-label inline-flex items-center gap-1.5 px-2.5 py-1 transition-all duration-150"
                 :class="selectedTagIds.has(tag.id)
-                  ? 'bg-accent para-chip-sm type-label text-surface-900'
-                  : 'badge-neutral type-label'"
+                  ? 'text-accent border-[color:var(--accent-color)]'
+                  : 'text-content-primary border-white/20 hover:border-white/40'"
+                :style="selectedTagIds.has(tag.id)
+                  ? { background: 'var(--accent-muted)', boxShadow: '0 0 8px var(--accent-muted)' }
+                  : {}"
               >
+                <i v-if="selectedTagIds.has(tag.id)" class="pi pi-check" style="font-size: 10px;" />
                 {{ tag.label }}
               </button>
             </div>

--- a/BES-frontend/src/components/FeedbackPopout.vue
+++ b/BES-frontend/src/components/FeedbackPopout.vue
@@ -75,48 +75,51 @@ function chipColors(groupIndex, isSelected) {
 
       <!-- Sheet / Modal -->
       <div
-        class="relative w-full sm:max-w-lg max-h-[85vh] overflow-y-auto
-               bg-surface-800 rounded-t-2xl sm:rounded-2xl shadow-2xl
-               border border-surface-600/40 animate-scale-in flex flex-col"
+        class="card-hover p-4 relative w-full sm:max-w-lg max-h-[85vh] overflow-y-auto flex flex-col"
       >
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
         <!-- Header -->
-        <div class="flex items-center justify-between px-5 pt-5 pb-3 flex-shrink-0">
+        <div class="flex items-center justify-between flex-shrink-0 mb-3">
           <div>
-            <p class="text-xs font-medium text-surface-400 uppercase tracking-wider mb-0.5">Leave Feedback</p>
+            <p class="type-label text-content-muted mb-0.5">Leave Feedback</p>
             <div class="flex items-center gap-2">
-              <span class="text-xs font-source text-primary-400 bg-primary-900/40 px-2 py-0.5 rounded-full">
+              <span class="badge-neutral type-label">
                 #{{ participant?.auditionNumber }}
               </span>
-              <h3 class="text-base font-heading font-bold text-content-primary">
+              <span class="type-body text-content-primary">
                 {{ participant?.participantName }}
-              </h3>
+              </span>
             </div>
           </div>
           <button
             @click="emit('close')"
-            class="p-1.5 rounded-lg text-surface-400 hover:text-content-primary hover:bg-surface-700 transition-colors"
+            class="p-1.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-colors"
           >
             <i class="pi pi-times text-sm" />
           </button>
         </div>
 
         <!-- Tag Groups -->
-        <div class="px-5 pb-3 flex-1 space-y-4">
+        <div class="flex-1 space-y-4 mb-4">
           <div
             v-for="(group, groupIndex) in tagGroups"
             :key="group.id"
             v-show="group.tags?.length"
           >
-            <p class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">
-              {{ group.name }}
-            </p>
+            <div class="section-rule mb-2">
+              <span class="section-rule-label">{{ group.name }}</span>
+              <div class="section-rule-line"></div>
+            </div>
             <div class="flex flex-wrap gap-2">
               <button
                 v-for="tag in group.tags"
                 :key="tag.id"
                 @click="toggleTag(tag.id)"
-                class="px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-150 active:scale-95"
-                :class="chipColors(groupIndex, selectedTagIds.has(tag.id))"
+                class="transition-all duration-150 active:scale-95"
+                :class="selectedTagIds.has(tag.id)
+                  ? 'bg-accent para-chip-sm type-label text-surface-900'
+                  : 'badge-neutral type-label'"
               >
                 {{ tag.label }}
               </button>
@@ -125,29 +128,29 @@ function chipColors(groupIndex, isSelected) {
 
           <!-- Optional note -->
           <div>
-            <p class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">
-              Optional Note
-            </p>
+            <div class="section-rule mb-2">
+              <span class="section-rule-label">Optional Note</span>
+              <div class="section-rule-line"></div>
+            </div>
             <textarea
               v-model="note"
               rows="2"
               placeholder="Optional note for this dancer…"
-              class="w-full bg-surface-700 border border-surface-600 rounded-xl px-3 py-2
-                     text-sm text-content-primary placeholder-surface-400 resize-none
-                     focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500
-                     transition-colors"
+              class="input-base resize-none"
             />
           </div>
         </div>
 
         <!-- Footer -->
-        <div class="px-5 pb-5 pt-2 flex gap-3 flex-shrink-0">
-          <div class="flex-1">
-            <ReusableButton buttonName="Skip" variant="outline" @onClick="emit('close')" />
-          </div>
-          <div class="flex-1">
-            <ReusableButton buttonName="Save Feedback" variant="primary" @onClick="handleSave" />
-          </div>
+        <div class="flex gap-3 flex-shrink-0">
+          <button
+            @click="emit('close')"
+            class="flex-1 py-2 para-chip type-label text-content-muted hover:text-content-primary transition-all"
+          >Skip</button>
+          <button
+            @click="handleSave"
+            class="flex-1 py-2 bg-accent para-chip type-label text-surface-900 transition-all"
+          >Save Feedback</button>
         </div>
       </div>
     </div>

--- a/BES-frontend/src/components/MiniScoreMenu.vue
+++ b/BES-frontend/src/components/MiniScoreMenu.vue
@@ -46,21 +46,17 @@ const moveTo = (index) => {
         v-for="(card, idx) in props.cards"
         :key="idx"
         @click="moveTo(idx)"
-        class="flex items-center justify-between p-3 rounded-xl border border-surface-600/50
-               bg-surface-700/50 text-left hover:bg-surface-600/60 hover:border-primary-500/40
-               active:bg-surface-600 transition-all duration-150"
+        class="para-chip-sm p-2 type-label text-content-muted hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-150 text-left"
       >
-        <div>
-          <div class="text-sm font-semibold text-content-primary">
-            #{{ card.auditionNumber }} · {{ card.participantName }}
-          </div>
+        <div class="flex items-center gap-2 w-full">
+          <span class="type-body text-content-primary truncate flex-1">#{{ card.auditionNumber }} · {{ card.participantName }}</span>
+          <span
+            class="type-stat text-[16px] flex-shrink-0"
+            :class="card.score === 0 ? 'text-content-muted' : 'text-accent'"
+          >
+            {{ card.score === 0 ? '—' : card.score }}
+          </span>
         </div>
-        <span
-          class="text-sm font-bold ml-2 flex-shrink-0"
-          :class="card.score === 0 ? 'text-red-400' : 'text-primary-400'"
-        >
-          {{ card.score === 0 ? '—' : card.score }}
-        </span>
       </button>
     </div>
   </ActionDoneModal>

--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -180,12 +180,12 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
                 >#{{ card.auditionNumber }}</span>
                 <div class="flex-1 min-w-0">
                   <div
-                    class="type-body leading-tight truncate"
+                    class="type-body text-[22px] leading-tight truncate"
                     :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx) ? 'text-content-primary' : 'text-content-muted'"
                   >{{ card.participantName }}</div>
                   <div
                     v-if="card.score > 0"
-                    class="text-[10px] font-source tabular-nums mt-0.5"
+                    class="text-[18px] font-source tabular-nums mt-0.5"
                     :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx) ? 'text-amber-400/60' : 'text-white/20'"
                   >{{ card.score }}</div>
                 </div>
@@ -202,21 +202,23 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
 
               <!-- Info column -->
               <div class="pair-card-info">
-                <!-- Score display -->
-                <div class="flex items-center justify-between mb-2">
-                  <div>
-                    <div class="type-label text-content-muted mb-0.5">
-                      {{ hasCriteria ? 'AVG' : 'SCORE' }}
-                    </div>
-                    <div
-                      class="type-stat"
-                      :class="activeCard.score === 0 ? 'text-content-muted' : 'text-accent'"
-                    >{{ activeCard.score === 0 ? '—' : activeCard.score }}</div>
+
+                <!-- Score — grows to fill space and centers -->
+                <div class="pair-card-score-area">
+                  <div class="type-label text-content-muted mb-0.5">
+                    {{ hasCriteria ? 'AVG' : 'SCORE' }}
                   </div>
-                  <!-- Feedback button -->
+                  <div
+                    class="type-stat"
+                    :class="activeCard.score === 0 ? 'text-content-muted' : 'text-accent'"
+                  >{{ activeCard.score === 0 ? '—' : activeCard.score }}</div>
+                </div>
+
+                <!-- Feedback button -->
+                <div class="flex justify-center mb-2">
                   <button
                     @click.stop="emit('open-feedback', activeCard)"
-                    class="flex items-center gap-1.5 px-2.5 py-1.5 para-chip-sm type-label transition-all duration-150 active:scale-95"
+                    class="flex items-center gap-1.5 px-2.5 py-1.5 para-chip-sm type-label transition-all duration-150"
                     :class="feedbackData?.get(activeCard.auditionNumber)
                       ? 'text-green-400 border-green-500/35'
                       : 'text-content-muted hover:text-content-primary'"
@@ -230,21 +232,23 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
                 <!-- Feedback preview -->
                 <div
                   v-if="feedbackData?.get(activeCard.auditionNumber)"
-                  class="mb-2 p-2 rounded-xl border border-white/6 bg-white/[0.02]"
+                  class="mb-2 p-2 border border-white/15 bg-white/[0.08]"
+                  style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
                 >
                   <div v-if="feedbackData.get(activeCard.auditionNumber).tagLabels?.length" class="flex flex-wrap gap-1.5 mb-1">
                     <span
                       v-for="tag in feedbackData.get(activeCard.auditionNumber).tagLabels"
                       :key="tag.id"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 border border-amber-500/20"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 type-label bg-white/[0.12] text-content-primary border border-white/20"
+                      style="clip-path: polygon(3px 0%,100% 0%,calc(100% - 3px) 100%,0% 100%)"
                     >
                       {{ tag.label }}
-                      <button @click.stop="emit('remove-tag', { auditionNumber: activeCard.auditionNumber, tagId: tag.id })" class="text-amber-400/40 hover:text-red-400 transition-colors">
+                      <button @click.stop="emit('remove-tag', { auditionNumber: activeCard.auditionNumber, tagId: tag.id })" class="text-content-muted hover:text-content-primary transition-colors">
                         <i class="pi pi-times text-[9px]" />
                       </button>
                     </span>
                   </div>
-                  <div v-if="feedbackData.get(activeCard.auditionNumber).note" class="text-xs text-white/35 line-clamp-2">
+                  <div v-if="feedbackData.get(activeCard.auditionNumber).note" class="text-xs text-white/65 line-clamp-2">
                     {{ feedbackData.get(activeCard.auditionNumber).note }}
                   </div>
                 </div>
@@ -258,19 +262,19 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
                       @click="setActiveCriterion(activeCard.auditionNumber, criterion.name)"
                       class="flex-shrink-0 flex items-center gap-1 px-3 py-1.5 text-xs font-bold border-b-2 transition-all duration-150 -mb-px"
                       :class="getActiveCriterion(activeCard.auditionNumber) === criterion.name
-                        ? 'border-amber-400 text-amber-400'
+                        ? 'border-[color:var(--accent-color)] text-accent'
                         : 'border-transparent text-white/25 hover:text-white/50'"
                     >
                       {{ criterion.name }}
-                      <span v-if="criteriaScore(activeCard, criterion.name) > 0" class="font-source tabular-nums text-amber-300/60 text-[10px]">
+                      <span v-if="criteriaScore(activeCard, criterion.name) > 0" class="font-source tabular-nums text-accent/60 text-[10px]">
                         {{ criteriaScore(activeCard, criterion.name) }}
                       </span>
                     </button>
                   </div>
                   <template v-for="criterion in criteria" :key="criterion.id">
                     <div v-if="getActiveCriterion(activeCard.auditionNumber) === criterion.name" class="flex items-center justify-between mb-2">
-                      <span class="text-[9px] font-bold text-white/25 uppercase tracking-widest">{{ criterion.name }}<span v-if="criterion.weight != null" class="text-amber-400/40 ml-1">×{{ criterion.weight }}</span></span>
-                      <span class="font-anton text-2xl tabular-nums" :class="criteriaScore(activeCard, criterion.name) === 0 ? 'text-white/15' : 'text-amber-400'">
+                      <span class="text-[9px] font-bold text-white/25 uppercase tracking-widest">{{ criterion.name }}<span v-if="criterion.weight != null" class="text-accent/40 ml-1">×{{ criterion.weight }}</span></span>
+                      <span class="type-stat text-2xl tabular-nums" :class="criteriaScore(activeCard, criterion.name) === 0 ? 'text-white/15' : 'text-accent'">
                         {{ criteriaScore(activeCard, criterion.name) === 0 ? '—' : criteriaScore(activeCard, criterion.name) }}
                       </span>
                     </div>
@@ -411,7 +415,20 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
     display: grid;
     grid-template-columns: 1fr 1fr;
     column-gap: 16px;
-    align-items: start;
+    align-items: stretch;
+  }
+  .pair-card-info {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+  .pair-card-score-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
   }
 }
 </style>

--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -139,19 +139,20 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
         style="width: 100%; scroll-snap-stop: always;"
       >
         <div
-          class="rounded-2xl border p-3 transition-all duration-200"
-          :class="[isActivePair(pairIdx) ? 'bg-surface-800 border-amber-500/25' : 'bg-surface-900 border-white/5 opacity-40']"
+          class="card-hover p-2 relative transition-all duration-200"
+          :class="[isActivePair(pairIdx) ? 'border-[color:var(--accent-muted)]' : 'border-white/5 opacity-40']"
           :style="isActivePair(pairIdx)
-            ? { boxShadow: '0 0 0 1px rgba(245,158,11,0.12), 0 8px 32px rgba(0,0,0,0.7)' }
+            ? { boxShadow: '0 0 0 1px var(--accent-muted), 0 8px 32px rgba(0,0,0,0.7)' }
             : {}"
         >
 
           <!-- Round label -->
           <div class="flex items-center justify-between mb-3 px-1">
-            <span class="text-[9px] font-bold text-white/25 uppercase tracking-widest">
+            <div class="corner-bar-tl"></div>
+            <span class="type-label text-content-muted">
               Round {{ pairIdx + 1 }} of {{ pairs.length }}
             </span>
-            <span v-if="pairIdx === pairs.length - 1" class="text-[9px] px-2 py-0.5 rounded-full bg-white/8 text-white/35 border border-white/10 font-bold uppercase tracking-wider">Last</span>
+            <span v-if="pairIdx === pairs.length - 1" class="badge-neutral type-label">Last</span>
           </div>
 
           <!-- ── Participant selector tabs ── -->
@@ -160,7 +161,7 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
               <!-- Placeholder tab -->
               <div
                 v-if="card._placeholder"
-                class="flex-1 flex items-center justify-center px-3 py-2 rounded-xl border border-dashed border-amber-500/20 bg-amber-500/4"
+                class="flex-1 flex items-center justify-center px-3 py-2 para-chip-sm border-dashed border-amber-500/20"
               >
                 <span class="text-xs text-amber-400/40 italic">#{{ card.auditionNumber }} Empty</span>
               </div>
@@ -168,19 +169,19 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
               <button
                 v-else
                 @click="activeParticipantNum = card.auditionNumber"
-                class="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl border transition-all duration-150 active:scale-98 text-left"
+                class="flex-1 flex items-center gap-2 px-3 py-2 para-chip-sm transition-all duration-150 active:scale-98 text-left"
                 :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx)
-                  ? 'border-amber-500/40 bg-amber-500/12'
-                  : 'border-white/8 bg-white/3 opacity-60'"
+                  ? 'text-accent border-[color:var(--accent-muted)]'
+                  : 'text-content-muted opacity-60'"
               >
                 <span
-                  class="font-anton text-xl leading-none flex-shrink-0"
-                  :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx) ? 'text-amber-400' : 'text-white/30'"
+                  class="type-stat text-[22px] flex-shrink-0"
+                  :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx) ? 'text-accent' : 'text-content-muted'"
                 >#{{ card.auditionNumber }}</span>
                 <div class="flex-1 min-w-0">
                   <div
-                    class="font-heading font-bold text-sm leading-tight truncate"
-                    :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx) ? 'text-white' : 'text-white/35'"
+                    class="type-body leading-tight truncate"
+                    :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx) ? 'text-content-primary' : 'text-content-muted'"
                   >{{ card.participantName }}</div>
                   <div
                     v-if="card.score > 0"
@@ -204,22 +205,21 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
                 <!-- Score display -->
                 <div class="flex items-center justify-between mb-2">
                   <div>
-                    <div class="text-[9px] font-bold text-white/25 uppercase tracking-widest mb-0.5">
+                    <div class="type-label text-content-muted mb-0.5">
                       {{ hasCriteria ? 'AVG' : 'SCORE' }}
                     </div>
                     <div
-                      class="font-anton tabular-nums leading-none"
-                      style="font-size: 3rem;"
-                      :class="activeCard.score === 0 ? 'text-white/15' : 'text-amber-400'"
+                      class="type-stat"
+                      :class="activeCard.score === 0 ? 'text-content-muted' : 'text-accent'"
                     >{{ activeCard.score === 0 ? '—' : activeCard.score }}</div>
                   </div>
                   <!-- Feedback button -->
                   <button
                     @click.stop="emit('open-feedback', activeCard)"
-                    class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-bold border transition-all duration-150 active:scale-95"
+                    class="flex items-center gap-1.5 px-2.5 py-1.5 para-chip-sm type-label transition-all duration-150 active:scale-95"
                     :class="feedbackData?.get(activeCard.auditionNumber)
-                      ? 'bg-green-500/15 border-green-500/35 text-green-400'
-                      : 'bg-white/4 border-white/10 text-white/35 hover:text-white/60 hover:border-white/20'"
+                      ? 'text-green-400 border-green-500/35'
+                      : 'text-content-muted hover:text-content-primary'"
                   >
                     <i class="pi pi-comment text-xs" />
                     {{ feedbackData?.get(activeCard.auditionNumber) ? 'Edit' : 'Feedback' }}
@@ -383,20 +383,17 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
     >
       <button
         @click="emit('reset')"
-        class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-bold border transition-all duration-150 active:scale-95"
-        style="clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%); border-color: rgba(255,255,255,0.10); color: rgba(255,255,255,0.35); background: transparent;"
+        class="flex items-center gap-1.5 px-4 py-2.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-all duration-150 active:scale-95"
       ><i class="pi pi-undo text-xs"></i> Reset</button>
 
       <button
         @click="emit('jump')"
-        class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-bold border transition-all duration-150 active:scale-95"
-        style="clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%); border-color: rgba(255,255,255,0.10); color: rgba(255,255,255,0.35); background: transparent;"
+        class="flex items-center gap-1.5 px-4 py-2.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-all duration-150 active:scale-95"
       ><i class="pi pi-search text-xs"></i> Go To</button>
 
       <button
         @click="emit('submit')"
-        class="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-sm font-bold transition-all duration-150 active:scale-[0.98]"
-        style="clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%); background: rgb(245,158,11); color: #000;"
+        class="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-accent para-chip type-label text-surface-900 transition-all duration-150 active:scale-[0.98]"
       ><i class="pi pi-send text-xs"></i> Submit All</button>
 
       <div v-if="hasCriteria && aggregateDisplay !== null" class="text-xs font-bold text-amber-400/40 ml-1 shrink-0 font-source tabular-nums">

--- a/BES-frontend/src/components/ReusableDropdown.vue
+++ b/BES-frontend/src/components/ReusableDropdown.vue
@@ -25,16 +25,9 @@ if (!currentSelected.value && props.options.length > 0) {
 
         <!-- Trigger Button -->
         <ListboxButton
-          class="w-full flex items-center justify-between rounded-xl border bg-surface-800 px-4 py-2.5
-                 text-left text-sm shadow-sm
-                 hover:border-primary-400
-                 focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500
-                 transition-all duration-200"
+          class="w-full flex items-center justify-between para-chip type-label transition-all duration-200"
           :class="[
-            open
-              ? 'border-primary-500 ring-2 ring-primary-500/30'
-              : 'border-surface-600',
-            currentSelected ? 'text-content-primary' : 'text-content-disabled'
+            currentSelected ? 'text-accent' : 'text-content-muted'
           ]"
         >
           <span class="truncate">{{ currentSelected || placeholder }}</span>
@@ -48,17 +41,14 @@ if (!currentSelected.value && props.options.length > 0) {
         <!-- Options List -->
         <Transition
           enter-active-class="transition duration-150 ease-out"
-          enter-from-class="opacity-0 -translate-y-2 scale-95"
-          enter-to-class="opacity-100 translate-y-0 scale-100"
+          enter-from-class="opacity-0 -translate-y-2"
+          enter-to-class="opacity-100 translate-y-0"
           leave-active-class="transition duration-100 ease-in"
-          leave-from-class="opacity-100 translate-y-0 scale-100"
-          leave-to-class="opacity-0 -translate-y-2 scale-95"
+          leave-from-class="opacity-100 translate-y-0"
+          leave-to-class="opacity-0 -translate-y-2"
         >
           <ListboxOptions
-            class="absolute z-50 mt-1.5 max-h-60 w-full overflow-auto
-                   rounded-xl border border-surface-600 bg-surface-800
-                   shadow-xl shadow-black/40
-                   py-1 focus:outline-none"
+            class="absolute z-50 mt-1.5 max-h-60 w-full overflow-auto card-hover py-1 focus:outline-none"
           >
             <ListboxOption
               v-for="option in props.options"
@@ -68,15 +58,15 @@ if (!currentSelected.value && props.options.length > 0) {
             >
               <li
                 class="flex items-center justify-between px-4 py-2.5
-                       cursor-pointer text-sm select-none
+                       cursor-pointer type-body select-none
                        transition-colors duration-100"
                 :class="[
-                  active   ? 'bg-primary-100 text-primary-400' : 'text-content-secondary',
-                  selected ? 'font-semibold' : 'font-normal'
+                  active   ? 'text-accent bg-[rgba(255,255,255,0.04)]' : 'text-content-secondary',
+                  selected ? 'text-accent' : ''
                 ]"
               >
                 {{ option }}
-                <i v-if="selected" class="pi pi-check text-primary-400 text-xs flex-shrink-0"></i>
+                <i v-if="selected" class="pi pi-check text-accent text-xs flex-shrink-0"></i>
               </li>
             </ListboxOption>
           </ListboxOptions>

--- a/BES-frontend/src/components/ScoringCriteriaModal.vue
+++ b/BES-frontend/src/components/ScoringCriteriaModal.vue
@@ -150,17 +150,19 @@ const applyToAllGenres = async () => {
         <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="close" />
 
         <!-- Panel -->
-        <div class="relative w-full max-w-xl bg-surface-800 rounded-2xl border border-surface-600/50 shadow-2xl flex flex-col max-h-[85vh]">
+        <div class="card-hover p-6 relative w-full max-w-xl flex flex-col max-h-[85vh]">
+          <div class="corner-bar-tl"></div>
+          <div class="corner-bar-bl"></div>
 
           <!-- Header -->
-          <div class="flex items-center justify-between px-5 py-4 border-b border-surface-700/50 flex-shrink-0">
+          <div class="flex items-center justify-between flex-shrink-0 mb-4">
             <div>
-              <h2 class="font-heading font-bold text-content-primary text-base">Scoring Criteria</h2>
-              <p class="text-xs text-content-muted mt-0.5">Define what judges score on. Leave empty for a single 0–10 score.</p>
+              <p class="type-page-title" style="font-size: 18px;">Scoring Criteria</p>
+              <p class="type-label text-content-muted mt-0.5">Define what judges score on. Leave empty for a single 0–10 score.</p>
             </div>
             <button
               @click="close"
-              class="p-2 rounded-lg text-surface-400 hover:text-content-primary hover:bg-surface-700 transition-colors"
+              class="p-1.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-colors"
             >
               <i class="pi pi-times text-sm" />
             </button>
@@ -172,10 +174,10 @@ const applyToAllGenres = async () => {
               v-for="tab in allTabs"
               :key="tab"
               @click="activeTab = tab"
-              class="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all duration-150"
+              class="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label transition-all duration-150"
               :class="activeTab === tab
-                ? 'bg-primary-600 text-white border-primary-600'
-                : 'bg-surface-700/60 border-surface-600/50 text-surface-300 hover:border-primary-500/50 hover:text-primary-300'"
+                ? 'bg-accent text-surface-900 border-accent'
+                : 'text-content-muted hover:text-content-primary'"
             >
               <i v-if="tab === 'event-level'" class="pi pi-globe text-[10px]" />
               {{ tab === 'event-level' ? 'Event Default' : tab }}
@@ -212,30 +214,30 @@ const applyToAllGenres = async () => {
               <div
                 v-for="c in activeCriteria"
                 :key="c.id"
-                class="rounded-xl border border-surface-600/50 overflow-hidden"
+                class="card-hover p-3 relative"
               >
                 <!-- View row -->
                 <div
                   v-if="editingId !== c.id"
-                  class="flex items-center justify-between px-3 py-2.5 bg-surface-700/40"
+                  class="flex items-center justify-between"
                 >
                   <div class="flex items-center gap-2 flex-1 min-w-0">
                     <span class="text-sm font-semibold text-content-primary truncate">{{ c.name }}</span>
-                    <span v-if="c.weight != null" class="text-xs px-1.5 py-0.5 rounded bg-primary-500/15 text-primary-400 border border-primary-500/20 shrink-0">
+                    <span v-if="c.weight != null" class="badge-neutral type-label shrink-0">
                       ×{{ c.weight }}
                     </span>
                   </div>
                   <div class="flex items-center gap-1 ml-2 shrink-0">
                     <button
                       @click="startEdit(c)"
-                      class="p-1.5 rounded-lg text-surface-400 hover:text-primary-400 hover:bg-primary-500/10 transition-colors"
+                      class="p-1.5 para-chip-sm type-label text-content-muted hover:text-accent transition-colors"
                       title="Edit"
                     >
                       <i class="pi pi-pencil text-xs" />
                     </button>
                     <button
                       @click="remove(c.id)"
-                      class="p-1.5 rounded-lg text-surface-400 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                      class="p-1.5 para-chip-sm type-label text-content-muted hover:text-red-400 transition-colors"
                       title="Delete"
                     >
                       <i class="pi pi-times text-xs" />
@@ -244,37 +246,33 @@ const applyToAllGenres = async () => {
                 </div>
 
                 <!-- Edit row -->
-                <div v-else class="px-3 py-2.5 bg-surface-700/60 space-y-2">
+                <div v-else class="space-y-2">
                   <div class="flex gap-2">
                     <input
                       v-model="editName"
                       placeholder="Criterion name"
-                      class="flex-1 bg-surface-700 border border-surface-600 rounded-lg px-3 py-1.5 text-sm text-content-primary
-                             placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+                      class="flex-1 input-base"
                       @keydown.enter="saveEdit"
                       @keydown.escape="cancelEdit"
                     />
                     <input
                       v-model="editWeight"
                       type="number" min="0" step="0.5" placeholder="Weight"
-                      class="w-24 bg-surface-700 border border-surface-600 rounded-lg px-3 py-1.5 text-sm text-content-primary
-                             placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+                      class="w-24 input-base"
                     />
                   </div>
                   <div class="flex gap-2">
                     <button
                       @click="saveEdit"
                       :disabled="editSaving || !editName.trim()"
-                      class="flex-1 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-semibold
-                             hover:bg-primary-500 active:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+                      class="flex-1 py-1.5 bg-accent para-chip type-label text-surface-900 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
                     >
                       <i v-if="editSaving" class="pi pi-spin pi-spinner mr-1" />
                       Save
                     </button>
                     <button
                       @click="cancelEdit"
-                      class="px-3 py-1.5 rounded-lg border border-surface-600 bg-surface-700 text-xs text-content-muted
-                             hover:border-surface-500 hover:bg-surface-600 transition-all"
+                      class="px-3 py-1.5 para-chip type-label border-accent text-content-muted hover:text-content-primary transition-all"
                     >
                       Cancel
                     </button>
@@ -284,37 +282,33 @@ const applyToAllGenres = async () => {
             </template>
 
             <!-- Add form -->
-            <div v-if="showAdd" class="bg-surface-700/40 border border-surface-600/50 rounded-xl p-3 space-y-2">
+            <div v-if="showAdd" class="card-hover p-3 space-y-2">
               <div class="flex gap-2">
                 <input
                   v-model="newName"
                   placeholder="Criterion name (e.g. Musicality)"
-                  class="flex-1 bg-surface-700 border border-surface-600 rounded-lg px-3 py-1.5 text-sm text-content-primary
-                         placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+                  class="flex-1 input-base"
                   @keydown.enter="add"
                   @keydown.escape="cancelAdd"
                 />
                 <input
                   v-model="newWeight"
                   type="number" min="0" step="0.5" placeholder="Weight"
-                  class="w-24 bg-surface-700 border border-surface-600 rounded-lg px-3 py-1.5 text-sm text-content-primary
-                         placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+                  class="w-24 input-base"
                 />
               </div>
               <div class="flex gap-2">
                 <button
                   @click="add"
                   :disabled="saving || !newName.trim()"
-                  class="flex-1 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-semibold
-                         hover:bg-primary-500 active:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+                  class="flex-1 py-1.5 bg-accent para-chip type-label text-surface-900 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
                 >
                   <i v-if="saving" class="pi pi-spin pi-spinner mr-1" />
                   Add
                 </button>
                 <button
                   @click="cancelAdd"
-                  class="px-3 py-1.5 rounded-lg border border-surface-600 bg-surface-700 text-xs text-content-muted
-                         hover:border-surface-500 hover:bg-surface-600 transition-all"
+                  class="px-3 py-1.5 para-chip type-label border-accent text-content-muted hover:text-content-primary transition-all"
                 >
                   Cancel
                 </button>
@@ -323,12 +317,11 @@ const applyToAllGenres = async () => {
           </div>
 
           <!-- Footer actions -->
-          <div class="px-5 py-4 border-t border-surface-700/50 flex items-center gap-2 flex-shrink-0">
+          <div class="flex items-center gap-2 flex-shrink-0 pt-4 border-t border-[rgba(255,255,255,0.07)]">
             <button
               v-if="!showAdd"
               @click="showAdd = true"
-              class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-dashed border-surface-600
-                     text-xs text-content-muted hover:border-primary-500/50 hover:text-primary-400 transition-all duration-150"
+              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent text-content-muted hover:text-accent transition-all duration-150"
             >
               <i class="pi pi-plus text-xs" />
               Add Criterion
@@ -341,8 +334,7 @@ const applyToAllGenres = async () => {
               v-if="activeTab !== 'event-level' && genres.length > 1"
               @click="applyToAllGenres"
               :disabled="applyingAll || activeCriteria.length === 0"
-              class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-surface-600 bg-surface-700/60
-                     text-xs text-content-muted hover:border-primary-500/50 hover:text-primary-400
+              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent text-content-muted hover:text-accent
                      disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
               title="Copy these criteria to all other genres and Event Default"
             >

--- a/BES-frontend/src/components/ScoringCriteriaPanel.vue
+++ b/BES-frontend/src/components/ScoringCriteriaPanel.vue
@@ -64,18 +64,19 @@ const remove = async (id) => {
       <div
         v-for="c in criteria"
         :key="c.id"
-        class="flex items-center justify-between px-3 py-2 rounded-xl bg-surface-700/60 border border-surface-600/50"
+        class="card-hover p-3 relative"
       >
+        <div class="corner-bar-tl"></div>
         <div class="flex items-center gap-2 flex-1 min-w-0">
           <span class="text-sm font-semibold text-content-primary truncate">{{ c.name }}</span>
           <span class="text-xs text-content-muted shrink-0">max {{ c.maxScore }}</span>
-          <span v-if="c.weight != null" class="text-xs px-1.5 py-0.5 rounded bg-primary-500/15 text-primary-400 border border-primary-500/20 shrink-0">
+          <span v-if="c.weight != null" class="badge-neutral type-label shrink-0">
             ×{{ c.weight }}
           </span>
         </div>
         <button
           @click="remove(c.id)"
-          class="ml-2 p-1 rounded-lg text-surface-400 hover:text-red-400 hover:bg-red-500/10 transition-colors shrink-0"
+          class="ml-2 p-1 para-chip-sm type-label text-content-muted hover:text-red-400 transition-colors shrink-0"
           title="Remove criterion"
         >
           <i class="pi pi-times text-xs" />
@@ -84,12 +85,11 @@ const remove = async (id) => {
     </div>
 
     <!-- Add form -->
-    <div v-if="showAddForm" class="bg-surface-700/40 border border-surface-600/50 rounded-xl p-3 mb-3 space-y-2">
+    <div v-if="showAddForm" class="card-hover p-3 mb-3 space-y-2">
       <input
         v-model="newName"
         placeholder="Criterion name (e.g. Musicality)"
-        class="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-2 text-sm text-content-primary
-               placeholder-surface-400 focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+        class="w-full input-base"
         @keydown.enter="add"
       />
       <div class="grid grid-cols-2 gap-2">
@@ -98,8 +98,7 @@ const remove = async (id) => {
           <input
             v-model="newMaxScore"
             type="number" min="1" max="100" step="1"
-            class="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-1.5 text-sm text-content-primary
-                   focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+            class="w-full input-base"
           />
         </div>
         <div>
@@ -107,8 +106,7 @@ const remove = async (id) => {
           <input
             v-model="newWeight"
             type="number" min="0" step="0.5" placeholder="—"
-            class="w-full bg-surface-700 border border-surface-600 rounded-lg px-3 py-1.5 text-sm text-content-primary
-                   placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+            class="w-full input-base"
           />
         </div>
       </div>
@@ -116,16 +114,14 @@ const remove = async (id) => {
         <button
           @click="add"
           :disabled="saving || !newName.trim()"
-          class="flex-1 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-semibold
-                 hover:bg-primary-500 active:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+          class="flex-1 py-1.5 bg-accent para-chip type-label text-surface-900 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
         >
           <i v-if="saving" class="pi pi-spin pi-spinner mr-1" />
           Add
         </button>
         <button
           @click="showAddForm = false; newName = ''; newMaxScore = 10; newWeight = null"
-          class="px-3 py-1.5 rounded-lg border border-surface-600 bg-surface-700 text-xs text-content-muted
-                 hover:border-surface-500 hover:bg-surface-600 transition-all"
+          class="px-3 py-1.5 para-chip type-label border-accent text-content-muted hover:text-content-primary transition-all"
         >
           Cancel
         </button>
@@ -136,8 +132,7 @@ const remove = async (id) => {
     <button
       v-if="!showAddForm"
       @click="showAddForm = true"
-      class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-dashed border-surface-600
-             text-xs text-content-muted hover:border-primary-500/50 hover:text-primary-400 transition-all duration-150"
+      class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent text-content-muted hover:text-accent transition-all duration-150"
     >
       <i class="pi pi-plus text-xs" />
       Add Criterion

--- a/BES-frontend/src/components/SwipeableCardsV2.vue
+++ b/BES-frontend/src/components/SwipeableCardsV2.vue
@@ -139,10 +139,10 @@ onMounted(observeCards)
               <!-- Feedback button -->
               <button
                 @click.stop="emit('open-feedback', card)"
-                class="mb-2 flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-bold border transition-all duration-150 active:scale-95"
+                class="mb-2 flex items-center gap-1.5 px-2.5 py-1.5 para-chip-sm type-label transition-all duration-150 active:scale-95"
                 :class="feedbackData?.get(card.auditionNumber)
-                  ? 'bg-green-500/15 border-green-500/35 text-green-400'
-                  : 'bg-white/4 border-white/10 text-white/35 hover:text-white/60 hover:border-white/20'"
+                  ? 'text-green-400 border-green-500/35'
+                  : 'text-content-muted hover:text-content-primary'"
               >
                 <i class="pi pi-comment text-xs" />
                 {{ feedbackData?.get(card.auditionNumber) ? 'Edit Feedback' : 'Feedback' }}
@@ -315,20 +315,17 @@ onMounted(observeCards)
     >
       <button
         @click="emit('reset')"
-        class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-bold border transition-all duration-150 active:scale-95"
-        style="clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%); border-color: rgba(255,255,255,0.10); color: rgba(255,255,255,0.35); background: transparent;"
+        class="flex items-center gap-1.5 px-4 py-2.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-all duration-150 active:scale-95"
       ><i class="pi pi-undo text-xs"></i> Reset</button>
 
       <button
         @click="emit('jump')"
-        class="flex items-center gap-1.5 px-4 py-2.5 text-sm font-bold border transition-all duration-150 active:scale-95"
-        style="clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%); border-color: rgba(255,255,255,0.10); color: rgba(255,255,255,0.35); background: transparent;"
+        class="flex items-center gap-1.5 px-4 py-2.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-all duration-150 active:scale-95"
       ><i class="pi pi-search text-xs"></i> Go To</button>
 
       <button
         @click="emit('submit')"
-        class="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-sm font-bold transition-all duration-150 active:scale-[0.98]"
-        style="clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%); background: rgb(245,158,11); color: #000;"
+        class="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-accent para-chip type-label text-surface-900 transition-all duration-150 active:scale-[0.98]"
       ><i class="pi pi-send text-xs"></i> Submit All</button>
 
       <div v-if="hasCriteria && aggregateDisplay !== null" class="text-xs font-bold text-amber-400/40 ml-1 shrink-0 font-source tabular-nums">

--- a/BES-frontend/src/components/SwipeableCardsV2.vue
+++ b/BES-frontend/src/components/SwipeableCardsV2.vue
@@ -106,10 +106,10 @@ onMounted(observeCards)
       >
         <!-- Score card -->
         <div
-          class="rounded-2xl border p-3 transition-all duration-200"
-          :class="[idx === currentIndex ? 'bg-surface-800 border-amber-500/25' : 'bg-surface-900 border-white/5 opacity-40']"
+          class="card-hover p-3 relative transition-all duration-200"
+          :class="[idx === currentIndex ? 'border-[color:var(--accent-muted)]' : 'border-white/5 opacity-40']"
           :style="idx === currentIndex
-            ? { boxShadow: '0 0 0 1px rgba(245,158,11,0.12), 0 8px 32px rgba(0,0,0,0.7)' }
+            ? { boxShadow: '0 0 0 1px var(--accent-muted), 0 8px 32px rgba(0,0,0,0.7)' }
             : {}"
         >
           <div class="score-card-body">
@@ -118,55 +118,56 @@ onMounted(observeCards)
             <div class="score-card-info">
 
               <!-- Participant header -->
-              <div class="flex items-start justify-between mb-2">
-                <div>
-                  <span class="font-anton text-amber-400 leading-none block" style="font-size: 2.8rem;">#{{ card.auditionNumber }}</span>
-                  <div class="font-heading font-bold text-xl text-white leading-tight mt-0.5">{{ card.participantName }}</div>
-                </div>
-                <!-- Score display -->
-                <div class="text-right flex-shrink-0 ml-3">
-                  <div class="text-[9px] font-bold text-white/25 uppercase tracking-widest mb-0.5">
-                    {{ hasCriteria ? 'AVG' : 'SCORE' }}
-                  </div>
-                  <div
-                    class="font-anton tabular-nums leading-none"
-                    style="font-size: 3.5rem;"
-                    :class="card.score === 0 ? 'text-white/20' : 'text-amber-400'"
-                  >{{ card.score === 0 ? '—' : card.score }}</div>
-                </div>
+              <div class="text-center mb-2">
+                <span class="type-stat text-accent leading-none block" style="font-size: 2.8rem;">#{{ card.auditionNumber }}</span>
+                <div class="type-body text-content-primary text-xl leading-tight mt-0.5">{{ card.participantName }}</div>
+              </div>
+
+              <!-- Score — grows to fill remaining space and centers -->
+              <div class="score-card-score-area">
+                <div class="type-label text-content-muted mb-0.5">{{ hasCriteria ? 'AVG' : 'SCORE' }}</div>
+                <div
+                  class="type-stat tabular-nums leading-none"
+                  style="font-size: 3.5rem;"
+                  :class="card.score === 0 ? 'text-white/20' : 'text-accent'"
+                >{{ card.score === 0 ? '—' : card.score }}</div>
               </div>
 
               <!-- Feedback button -->
-              <button
-                @click.stop="emit('open-feedback', card)"
-                class="mb-2 flex items-center gap-1.5 px-2.5 py-1.5 para-chip-sm type-label transition-all duration-150 active:scale-95"
-                :class="feedbackData?.get(card.auditionNumber)
-                  ? 'text-green-400 border-green-500/35'
-                  : 'text-content-muted hover:text-content-primary'"
-              >
-                <i class="pi pi-comment text-xs" />
-                {{ feedbackData?.get(card.auditionNumber) ? 'Edit Feedback' : 'Feedback' }}
-                <span v-if="feedbackData?.get(card.auditionNumber)" class="ml-1 w-1.5 h-1.5 rounded-full bg-green-400 inline-block"></span>
-              </button>
+              <div class="flex justify-center mb-2">
+                <button
+                  @click.stop="emit('open-feedback', card)"
+                  class="flex items-center gap-1.5 px-2.5 py-1.5 para-chip-sm type-label transition-all duration-150"
+                  :class="feedbackData?.get(card.auditionNumber)
+                    ? 'text-green-400 border-green-500/35'
+                    : 'text-content-muted hover:text-content-primary'"
+                >
+                  <i class="pi pi-comment text-xs" />
+                  {{ feedbackData?.get(card.auditionNumber) ? 'Edit' : 'Feedback' }}
+                  <span v-if="feedbackData?.get(card.auditionNumber)" class="ml-1 w-1.5 h-1.5 rounded-full bg-green-400 inline-block"></span>
+                </button>
+              </div>
 
               <!-- Feedback tag preview -->
               <div
                 v-if="feedbackData?.get(card.auditionNumber)"
-                class="mb-2 p-2 rounded-xl border border-white/6 bg-white/[0.02]"
+                class="mb-2 p-2 border border-white/15 bg-white/[0.08]"
+                style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
               >
                 <div v-if="feedbackData.get(card.auditionNumber).tagLabels?.length" class="flex flex-wrap gap-1.5 mb-1">
                   <span
                     v-for="tag in feedbackData.get(card.auditionNumber).tagLabels"
                     :key="tag.id"
-                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 border border-amber-500/20"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 type-label bg-white/[0.12] text-content-primary border border-white/20"
+                    style="clip-path: polygon(3px 0%,100% 0%,calc(100% - 3px) 100%,0% 100%)"
                   >
                     {{ tag.label }}
-                    <button @click.stop="emit('remove-tag', { auditionNumber: card.auditionNumber, tagId: tag.id })" class="text-amber-400/40 hover:text-red-400 transition-colors">
+                    <button @click.stop="emit('remove-tag', { auditionNumber: card.auditionNumber, tagId: tag.id })" class="text-content-muted hover:text-content-primary transition-colors">
                       <i class="pi pi-times text-[9px]" />
                     </button>
                   </span>
                 </div>
-                <div v-if="feedbackData.get(card.auditionNumber).note" class="text-xs text-white/35 line-clamp-2">
+                <div v-if="feedbackData.get(card.auditionNumber).note" class="text-xs text-white/65 line-clamp-2">
                   {{ feedbackData.get(card.auditionNumber).note }}
                 </div>
               </div>
@@ -181,19 +182,19 @@ onMounted(observeCards)
                     @click="setActiveCriterion(idx, criterion.name)"
                     class="flex-shrink-0 flex items-center gap-1 px-3 py-1.5 text-xs font-bold border-b-2 transition-all duration-150 -mb-px"
                     :class="getActiveCriterion(idx) === criterion.name
-                      ? 'border-amber-400 text-amber-400'
+                      ? 'border-[color:var(--accent-color)] text-accent'
                       : 'border-transparent text-white/25 hover:text-white/50'"
                   >
                     {{ criterion.name }}
-                    <span v-if="criteriaScore(card, criterion.name) > 0" class="font-source tabular-nums text-amber-300/60 text-[10px]">
+                    <span v-if="criteriaScore(card, criterion.name) > 0" class="font-source tabular-nums text-accent/60 text-[10px]">
                       {{ criteriaScore(card, criterion.name) }}
                     </span>
                   </button>
                 </div>
                 <template v-for="criterion in criteria" :key="criterion.id">
                   <div v-if="getActiveCriterion(idx) === criterion.name" class="flex items-center justify-between mb-2">
-                    <span class="text-[9px] font-bold text-white/25 uppercase tracking-widest">{{ criterion.name }}<span v-if="criterion.weight != null" class="text-amber-400/40 ml-1">×{{ criterion.weight }}</span></span>
-                    <span class="font-anton text-2xl tabular-nums" :class="criteriaScore(card, criterion.name) === 0 ? 'text-white/15' : 'text-amber-400'">
+                    <span class="text-[9px] font-bold text-white/25 uppercase tracking-widest">{{ criterion.name }}<span v-if="criterion.weight != null" class="text-accent/40 ml-1">×{{ criterion.weight }}</span></span>
+                    <span class="type-stat text-2xl tabular-nums" :class="criteriaScore(card, criterion.name) === 0 ? 'text-white/15' : 'text-accent'">
                       {{ criteriaScore(card, criterion.name) === 0 ? '—' : criteriaScore(card, criterion.name) }}
                     </span>
                   </div>
@@ -343,7 +344,20 @@ onMounted(observeCards)
     display: grid;
     grid-template-columns: 1fr 1fr;
     column-gap: 16px;
-    align-items: start;
+    align-items: stretch;
+  }
+  .score-card-info {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+  .score-card-score-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
   }
 }
 </style>

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -67,6 +67,7 @@ onBeforeUnmount(() => {
     <div class="text-center leading-none">
       <div
         class="type-stat transition-colors duration-300"
+        style="font-size: clamp(4rem, 14vh, 8rem); line-height: 1;"
         :class="{
           'text-red-500 animate-pulse': isNearEnd,
           'text-content-muted':         isFinished && !isNearEnd,
@@ -89,27 +90,27 @@ onBeforeUnmount(() => {
     </div>
 
     <!-- Controls -->
-    <div class="flex items-center gap-1 flex-wrap justify-center">
+    <div class="flex items-center gap-2 flex-wrap justify-center">
       <button
         @click="toggleMode"
-        class="para-chip-sm type-label transition-all duration-150 active:scale-95"
+        class="para-chip px-4 py-3 type-body transition-all duration-150 active:scale-95"
         :class="countUp
           ? 'text-accent border-[color:var(--accent-muted)]'
           : 'text-content-muted hover:text-content-primary'"
       >
-        <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-0.5 text-[9px]"></i>
-        {{ countUp ? 'Up' : 'Dn' }}
+        <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-1 text-xs"></i>
+        {{ countUp ? 'Up' : 'Down' }}
       </button>
-      <div class="w-px h-5 bg-white/12"></div>
+      <div class="w-px h-8 bg-white/12"></div>
       <button
         v-for="t in [30, 45, 60, 90]"
         :key="t"
         @click="startTimer(t)"
-        class="para-chip-sm type-label transition-all duration-150 active:scale-95"
+        class="para-chip px-4 py-3 type-body transition-all duration-150 active:scale-95"
         :class="selectedTime === t && isRunning
           ? 'text-accent border-[color:var(--accent-muted)]'
           : 'text-content-muted hover:text-content-primary'"
-      >{{ t }}</button>
+      >{{ t }}s</button>
     </div>
   </div>
 </template>

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -64,27 +64,25 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="flex flex-col items-center gap-1 select-none">
-    <!-- Anton SC number -->
     <div class="text-center leading-none">
       <div
-        class="font-anton tabular-nums transition-colors duration-300"
-        style="font-size: clamp(4rem, 15vw, 6rem);"
+        class="type-stat transition-colors duration-300"
         :class="{
           'text-red-500 animate-pulse': isNearEnd,
-          'text-white/40':              isFinished && !isNearEnd,
+          'text-content-muted':         isFinished && !isNearEnd,
           'text-green-400':             countUp && !isNearEnd && !isFinished,
-          'text-white':                 !isNearEnd && !isFinished && !countUp,
+          'text-content-primary':       !isNearEnd && !isFinished && !countUp,
         }"
       >{{ displayTime }}</div>
-      <div class="text-[10px] text-white/20 uppercase tracking-widest">
+      <div class="type-label text-content-muted">
         {{ selectedTime > 0 ? `OF ${selectedTime}S` : 'SECONDS' }}
       </div>
     </div>
 
     <!-- Progress bar -->
-    <div class="w-full max-w-xs h-px bg-white/8 rounded-full overflow-hidden">
+    <div class="w-full max-w-xs h-px bg-white/8 overflow-hidden">
       <div
-        class="h-full rounded-full transition-all duration-1000"
+        class="h-full transition-all duration-1000"
         :class="isNearEnd ? 'bg-red-500' : countUp ? 'bg-green-400' : 'bg-white/50'"
         :style="{ width: progressPct + '%' }"
       ></div>
@@ -94,10 +92,10 @@ onBeforeUnmount(() => {
     <div class="flex items-center gap-1 flex-wrap justify-center">
       <button
         @click="toggleMode"
-        class="px-3 py-1.5 rounded-lg text-xs font-bold border transition-all duration-150 active:scale-95"
+        class="para-chip-sm type-label transition-all duration-150 active:scale-95"
         :class="countUp
-          ? 'bg-white/15 border-white/30 text-white'
-          : 'bg-transparent border-white/15 text-white/40 hover:border-white/30 hover:text-white/60'"
+          ? 'text-accent border-[color:var(--accent-muted)]'
+          : 'text-content-muted hover:text-content-primary'"
       >
         <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-0.5 text-[9px]"></i>
         {{ countUp ? 'Up' : 'Dn' }}
@@ -107,10 +105,10 @@ onBeforeUnmount(() => {
         v-for="t in [30, 45, 60, 90]"
         :key="t"
         @click="startTimer(t)"
-        class="px-3 py-1.5 rounded-lg text-xs font-bold border transition-all duration-150 active:scale-95"
+        class="para-chip-sm type-label transition-all duration-150 active:scale-95"
         :class="selectedTime === t && isRunning
-          ? 'bg-white/20 border-white/40 text-white'
-          : 'bg-transparent border-white/15 text-white/40 hover:border-white/30 hover:text-white/60'"
+          ? 'text-accent border-[color:var(--accent-muted)]'
+          : 'text-content-muted hover:text-content-primary'"
       >{{ t }}</button>
     </div>
   </div>

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1138,3 +1138,18 @@ export const removeBattleGuest = async (guestId) => {
     console.log(e)
   }
 }
+
+export const getAppConfig = async () => {
+  const res = await fetch('/api/v1/config/app', { credentials: 'include' })
+  return res.json()
+}
+
+export const postAppConfig = async (accentColor) => {
+  const res = await fetch('/api/v1/config/app', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accentColor })
+  })
+  return res.json()
+}

--- a/BES-frontend/src/views/ActionDoneModal.vue
+++ b/BES-frontend/src/views/ActionDoneModal.vue
@@ -22,7 +22,7 @@ defineEmits(['close', 'accept'])
       class="fixed inset-0 z-50 flex items-center justify-center p-4"
     >
       <div
-        class="absolute inset-0 bg-black/60"
+        class="absolute inset-0 bg-black/80 backdrop-blur-sm"
         @click="$emit('close')"
       ></div>
 

--- a/BES-frontend/src/views/ActionDoneModal.vue
+++ b/BES-frontend/src/views/ActionDoneModal.vue
@@ -1,24 +1,14 @@
 <script setup>
-import ReusableButton from '@/components/ReusableButton.vue'
-
-const props = defineProps({
+defineProps({
   show:    { type: Boolean, default: false },
   title:   { type: String,  default: 'Notification' },
-  variant: { type: String,  default: 'info' }  // info | success | error | warning
+  variant: { type: String,  default: 'info' }
 })
 
 defineEmits(['close', 'accept'])
-
-const iconConfig = {
-  info:    { icon: 'pi-info-circle',         color: 'text-primary-400',   bg: 'bg-primary-100'  },
-  success: { icon: 'pi-check-circle',         color: 'text-emerald-400',   bg: 'bg-emerald-950'  },
-  error:   { icon: 'pi-times-circle',         color: 'text-red-400',       bg: 'bg-red-950'      },
-  warning: { icon: 'pi-exclamation-triangle', color: 'text-amber-400',     bg: 'bg-amber-950'    },
-}
 </script>
 
 <template>
-  <!-- Overlay fade -->
   <Transition
     enter-active-class="transition duration-200 ease-out"
     enter-from-class="opacity-0"
@@ -31,62 +21,43 @@ const iconConfig = {
       v-if="show"
       class="fixed inset-0 z-50 flex items-center justify-center p-4"
     >
-      <!-- Backdrop -->
       <div
-        class="absolute inset-0 bg-surface-950/80 backdrop-blur-sm"
+        class="absolute inset-0 bg-black/60"
         @click="$emit('close')"
       ></div>
 
-      <!-- Card (scale-in on mount) -->
       <div
-        class="relative w-full max-w-md max-h-[90vh] overflow-y-auto
-               bg-surface-800 rounded-2xl shadow-2xl border border-surface-600/40
-               animate-scale-in"
+        class="card-hover p-8 relative max-w-sm w-full mx-4"
       >
-        <!-- Header -->
-        <div class="flex items-start justify-between px-6 pt-6 pb-4">
-          <div class="flex items-center gap-3">
-            <div
-              class="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center"
-              :class="iconConfig[props.variant]?.bg ?? iconConfig.info.bg"
-            >
-              <i
-                class="pi text-xl"
-                :class="[
-                  iconConfig[props.variant]?.icon  ?? iconConfig.info.icon,
-                  iconConfig[props.variant]?.color ?? iconConfig.info.color
-                ]"
-              ></i>
-            </div>
-            <h3 class="text-lg font-heading font-bold text-content-primary leading-snug">
-              {{ title }}
-            </h3>
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
+
+        <div
+          v-if="variant === 'warning'"
+          class="semantic-chip-warning p-4 mb-4 flex items-start gap-3"
+        >
+          <div class="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0 mt-1" style="box-shadow: 0 0 6px rgba(245,158,11,0.8)"></div>
+          <slot></slot>
+        </div>
+        <div
+          v-else-if="variant === 'error'"
+          class="semantic-chip-error p-4 mb-4 flex items-start gap-3"
+        >
+          <div class="w-2 h-2 rounded-full bg-red-400 flex-shrink-0 mt-1" style="box-shadow: 0 0 6px rgba(239,68,68,0.8)"></div>
+          <slot></slot>
+        </div>
+        <template v-else>
+          <p class="type-page-title mb-2">{{ title }}</p>
+          <div class="type-body text-content-muted mb-6">
+            <slot></slot>
           </div>
+        </template>
 
-          <button
-            @click="$emit('close')"
-            class="flex-shrink-0 ml-4 p-1.5 rounded-lg text-content-muted
-                   hover:text-content-secondary hover:bg-surface-700
-                   transition-colors duration-150"
-          >
-            <i class="pi pi-times text-sm"></i>
-          </button>
-        </div>
-
-        <!-- Body -->
-        <div class="px-6 pb-2 text-content-secondary text-sm leading-relaxed whitespace-pre-line">
-          <slot />
-        </div>
-
-        <!-- Footer -->
-        <div class="px-6 py-5">
-          <ReusableButton
-            buttonName="Got it"
-            @onClick="$emit('accept')"
-          />
-        </div>
+        <button
+          @click="$emit('accept')"
+          class="bg-accent para-chip type-label text-surface-900 px-6 py-2 w-full"
+        >OK</button>
       </div>
-
     </div>
   </Transition>
 </template>

--- a/BES-frontend/src/views/ActionDoneModal.vue
+++ b/BES-frontend/src/views/ActionDoneModal.vue
@@ -32,26 +32,25 @@ defineEmits(['close', 'accept'])
         <div class="corner-bar-tl"></div>
         <div class="corner-bar-bl"></div>
 
+        <p class="type-page-title mb-4">{{ title }}</p>
+
         <div
           v-if="variant === 'warning'"
-          class="semantic-chip-warning p-4 mb-4 flex items-start gap-3"
+          class="semantic-chip-warning p-4 mb-6 flex items-start gap-3"
         >
-          <div class="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0 mt-1" style="box-shadow: 0 0 6px rgba(245,158,11,0.8)"></div>
+          <div class="w-2 h-2 rounded-full flex-shrink-0 mt-1" style="background:#f59e0b;box-shadow:0 0 6px rgba(245,158,11,0.8)"></div>
           <slot></slot>
         </div>
         <div
           v-else-if="variant === 'error'"
-          class="semantic-chip-error p-4 mb-4 flex items-start gap-3"
+          class="semantic-chip-error p-4 mb-6 flex items-start gap-3"
         >
-          <div class="w-2 h-2 rounded-full bg-red-400 flex-shrink-0 mt-1" style="box-shadow: 0 0 6px rgba(239,68,68,0.8)"></div>
+          <div class="w-2 h-2 rounded-full flex-shrink-0 mt-1" style="background:#f87171;box-shadow:0 0 6px rgba(239,68,68,0.8)"></div>
           <slot></slot>
         </div>
-        <template v-else>
-          <p class="type-page-title mb-2">{{ title }}</p>
-          <div class="type-body text-content-muted mb-6">
-            <slot></slot>
-          </div>
-        </template>
+        <div v-else class="type-body text-content-muted mb-6">
+          <slot></slot>
+        </div>
 
         <button
           @click="$emit('accept')"

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -3,7 +3,7 @@ import { addGenre, deleteGenre, deleteImage, deleteScore, getAllImages, updateGe
 import { checkInputNull } from '@/utils/utils';
 import { onMounted, ref } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { fetchAllEvents, fetchAllGenres } from '@/utils/api';
+import { fetchAllEvents, fetchAllGenres, getAppConfig, postAppConfig } from '@/utils/api';
 import UpdateFieldForm from '@/components/UpdateFieldForm.vue';
 
 const addGenreInput = ref('');
@@ -51,6 +51,10 @@ const feedbackGroups = ref([])
 const addGroupInput = ref('')
 const addTagInputs = ref({})  // { [groupId]: string }
 const dynamicHandler = ref(() => {})
+
+const accentInput = ref('#ffffff')
+const activeTab = ref('genres')
+const tabs = ref(['genres', 'scores', 'feedback', 'images', 'theme'])
 
 const confirmResetScore = (id, title, message) => {
   modalTitle.value = title
@@ -140,252 +144,255 @@ const submitDeleteTag = async (tagId) => {
   }
 }
 
+const saveAccent = async () => {
+  await postAppConfig(accentInput.value)
+}
+
 onMounted(async () => {
   genres.value = await fetchAllGenres() ?? []
   events.value = await fetchAllEvents() ?? []
   images.value = await getAllImages() ?? []
   feedbackGroups.value = await getFeedbackGroups() ?? []
+  const cfg = await getAppConfig()
+  accentInput.value = cfg?.accentColor ?? '#ffffff'
 })
 </script>
 
 <template>
-  <div class="page-container space-y-8">
+  <div class="page-container relative">
+    <div class="color-bleed"></div>
+    <div class="relative z-10 space-y-8">
 
-    <!-- Page header -->
-    <div>
-      <h1 class="page-title">Admin</h1>
-      <p class="text-muted mt-1">Manage genres, events, and system settings</p>
-    </div>
-
-    <!-- Genres section -->
-    <section class="card p-6">
-      <div class="flex items-center gap-3 mb-6">
-        <div class="w-8 h-8 rounded-xl bg-primary-100 flex items-center justify-center">
-          <i class="pi pi-tag text-primary-400 text-sm"></i>
-        </div>
-        <h2 class="font-heading font-bold text-content-secondary text-lg">Genres</h2>
-        <span class="badge-neutral text-xs">{{ genres.length }}</span>
+      <!-- Page header -->
+      <div>
+        <div class="type-page-title">Admin</div>
       </div>
 
-      <!-- Add genre -->
-      <div class="flex gap-3 mb-5">
-        <input
-          v-model="addGenreInput"
-          type="text"
-          placeholder="Genre name…"
-          class="input-base flex-1 max-w-xs"
-          @keyup.enter="submitAddGenre"
-        />
+      <!-- Section tabs -->
+      <div class="flex flex-wrap gap-2">
         <button
-          @click="submitAddGenre"
-          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl bg-primary-600 text-white text-sm
-                 font-semibold hover:bg-primary-700 transition-all duration-200 shadow-sm"
-        >
-          <i class="pi pi-plus text-xs"></i>
-          Add Genre
-        </button>
+          v-for="tab in tabs"
+          :key="tab"
+          @click="activeTab = tab"
+          class="para-chip-sm type-label px-3 py-1.5 transition-all duration-150"
+          :class="activeTab === tab ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
+        >{{ tab }}</button>
       </div>
 
-      <!-- Genre list -->
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
-        <div
-          v-for="g in genres"
-          :key="g.id"
-          class="flex items-center justify-between px-3 py-2.5 rounded-xl border border-surface-600 bg-surface-800 hover:border-surface-500 transition-all"
-        >
-          <button
-            @click="selectId(g.id, 'genre')"
-            class="text-sm font-medium text-content-secondary hover:text-primary-400 text-left truncate flex-1 transition-colors"
+      <!-- ── Genres ──────────────────────────────────────────── -->
+      <div v-if="activeTab === 'genres'">
+        <div class="section-rule mb-4">
+          <span class="section-rule-label">Genres</span>
+          <span class="badge-neutral type-label px-2 py-0.5">{{ genres.length }}</span>
+          <div class="section-rule-line"></div>
+        </div>
+
+        <div class="flex gap-3 mb-5">
+          <input
+            v-model="addGenreInput"
+            type="text"
+            placeholder="Genre name…"
+            class="input-base flex-1 max-w-xs"
+            @keyup.enter="submitAddGenre"
+          />
+          <button @click="submitAddGenre" class="bg-accent para-chip-sm type-label text-surface-900 px-4 py-2">Add Genre</button>
+        </div>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2">
+          <div
+            v-for="g in genres"
+            :key="g.id"
+            class="card-hover p-3 relative flex items-center justify-between"
           >
-            {{ g.genreName }}
-          </button>
-          <button
-            @click="confirmRemoveGenre(g.id, 'Remove Genre?', `Are you sure you want to remove ${g.genreName}?`)"
-            class="ml-2 flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center
-                   text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
-          >
-            <i class="pi pi-times text-xs"></i>
-          </button>
-        </div>
-        <div v-if="genres.length === 0" class="col-span-full text-sm text-content-muted py-4">
-          No genres added yet
-        </div>
-      </div>
-    </section>
-
-    <!-- Reset Scores section -->
-    <section class="card p-6">
-      <div class="flex items-center gap-3 mb-6">
-        <div class="w-8 h-8 rounded-xl bg-red-950 flex items-center justify-center">
-          <i class="pi pi-trash text-red-400 text-sm"></i>
-        </div>
-        <div>
-          <h2 class="font-heading font-bold text-content-secondary text-lg">Reset Scores</h2>
-          <p class="text-xs text-content-muted">Permanently removes all scores for an event</p>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
-        <div
-          v-for="e in events"
-          :key="e.id"
-          class="flex items-center justify-between px-3 py-2.5 rounded-xl border border-surface-600 bg-surface-800"
-        >
-          <span class="text-sm font-medium text-content-secondary truncate flex-1">{{ e.name }}</span>
-          <button
-            @click="confirmResetScore(e.id, 'Reset Scores?', `This will permanently delete all scores for ${e.name}.`)"
-            class="ml-2 flex-shrink-0 px-2 py-1 rounded-lg text-xs font-semibold text-red-400
-                   hover:bg-red-950 transition-all"
-          >
-            Reset
-          </button>
-        </div>
-      </div>
-    </section>
-
-    <!-- Feedback Tags section -->
-    <section class="card p-6">
-      <div class="flex items-center gap-3 mb-6">
-        <div class="w-8 h-8 rounded-xl bg-primary-100 flex items-center justify-center">
-          <i class="pi pi-comment text-primary-400 text-sm"></i>
-        </div>
-        <h2 class="font-heading font-bold text-content-secondary text-lg">Feedback Tags</h2>
-        <span class="badge-neutral text-xs">{{ feedbackGroups.length }} groups</span>
-      </div>
-
-      <!-- Add group -->
-      <div class="flex gap-3 mb-6">
-        <input
-          v-model="addGroupInput"
-          type="text"
-          placeholder="New group name…"
-          class="input-base flex-1 max-w-xs"
-          @keyup.enter="submitAddGroup"
-        />
-        <button
-          @click="submitAddGroup"
-          class="flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium
-                 bg-primary-600 text-white hover:bg-primary-700 transition-colors"
-        >
-          <i class="pi pi-plus text-xs"></i>
-          Add Group
-        </button>
-      </div>
-
-      <!-- Groups list -->
-      <div class="space-y-5">
-        <div
-          v-for="group in feedbackGroups"
-          :key="group.id"
-          class="border border-surface-600/50 rounded-xl p-4 bg-surface-700/20"
-        >
-          <!-- Group header -->
-          <div class="flex items-center justify-between mb-3">
-            <h3 class="text-sm font-semibold text-content-primary">{{ group.name }}</h3>
+            <div class="corner-bar-tl"></div>
             <button
-              @click="submitDeleteGroup(group.id)"
-              class="w-6 h-6 rounded-full flex items-center justify-center
-                     text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
-              title="Delete group"
+              @click="selectId(g.id, 'genre')"
+              class="type-body text-content-secondary hover:text-accent text-left truncate flex-1 transition-colors"
+            >
+              {{ g.genreName }}
+            </button>
+            <button
+              @click="confirmRemoveGenre(g.id, 'Remove Genre?', `Are you sure you want to remove ${g.genreName}?`)"
+              class="ml-2 flex-shrink-0 w-6 h-6 flex items-center justify-center text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
             >
               <i class="pi pi-times text-xs"></i>
             </button>
           </div>
-
-          <!-- Tags -->
-          <div class="flex flex-wrap gap-2 mb-3">
-            <div
-              v-for="tag in group.tags"
-              :key="tag.id"
-              class="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
-                     bg-surface-600/60 border border-surface-500/50 text-content-secondary"
-            >
-              {{ tag.label }}
-              <button
-                @click="submitDeleteTag(tag.id)"
-                class="text-surface-400 hover:text-red-400 transition-colors leading-none"
-              >
-                <i class="pi pi-times" style="font-size: 0.6rem"></i>
-              </button>
-            </div>
-            <p v-if="!group.tags?.length" class="text-xs text-content-muted py-1">No tags yet</p>
+          <div v-if="genres.length === 0" class="col-span-full type-label text-content-muted py-4">
+            No genres added yet
           </div>
+        </div>
+      </div>
 
-          <!-- Add tag input -->
-          <div class="flex gap-2">
-            <input
-              v-model="addTagInputs[group.id]"
-              type="text"
-              :placeholder="`Add tag to ${group.name}…`"
-              class="input-base flex-1 text-sm py-1.5"
-              @keyup.enter="submitAddTag(group.id)"
-            />
+      <!-- ── Reset Scores ───────────────────────────────────── -->
+      <div v-if="activeTab === 'scores'">
+        <div class="section-rule mb-4">
+          <span class="section-rule-label">Reset Scores</span>
+          <div class="section-rule-line"></div>
+        </div>
+        <p class="type-label text-content-muted mb-4">Permanently removes all scores for an event.</p>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+          <div
+            v-for="e in events"
+            :key="e.id"
+            class="card-hover p-3 relative flex items-center justify-between"
+          >
+            <div class="corner-bar-tl"></div>
+            <span class="type-body text-content-secondary truncate flex-1">{{ e.name }}</span>
             <button
-              @click="submitAddTag(group.id)"
-              class="px-3 py-1.5 rounded-xl text-xs font-medium
-                     bg-surface-600 text-content-secondary hover:bg-surface-500 transition-colors"
+              @click="confirmResetScore(e.id, 'Reset Scores?', `This will permanently delete all scores for ${e.name}.`)"
+              class="ml-2 flex-shrink-0 para-chip-sm type-label px-2 py-1 text-red-400 hover:bg-red-950 transition-all"
             >
-              <i class="pi pi-plus text-xs"></i>
+              Reset
             </button>
           </div>
         </div>
-
-        <p v-if="feedbackGroups.length === 0" class="text-sm text-content-muted py-2">
-          No groups configured. Create groups above, then add tags to each.
-        </p>
       </div>
-    </section>
 
-    <!-- Images section -->
-    <section class="card p-6">
-      <div class="flex items-center gap-3 mb-6">
-        <div class="icon-wrap w-8 h-8 rounded-xl bg-surface-700 flex items-center justify-center">
-          <i class="pi pi-image text-content-muted text-sm"></i>
+      <!-- ── Feedback Tags ──────────────────────────────────── -->
+      <div v-if="activeTab === 'feedback'">
+        <div class="section-rule mb-4">
+          <span class="section-rule-label">Feedback Tags</span>
+          <span class="badge-neutral type-label px-2 py-0.5">{{ feedbackGroups.length }} groups</span>
+          <div class="section-rule-line"></div>
         </div>
-        <h2 class="font-heading font-bold text-content-secondary text-lg">Uploaded Images</h2>
-        <span class="badge-neutral text-xs">{{ images.length }}</span>
-      </div>
 
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
-        <div
-          v-for="img in images"
-          :key="img"
-          class="flex items-center justify-between px-3 py-2.5 rounded-xl border border-surface-600 bg-surface-800"
-        >
-          <span class="text-sm text-content-secondary truncate flex-1">{{ img }}</span>
-          <button
-            @click="confirmRemoveImage(img, `Delete ${img}?`, 'Are you sure you want to delete this image?')"
-            class="ml-2 flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center
-                   text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
+        <div class="flex gap-3 mb-6">
+          <input
+            v-model="addGroupInput"
+            type="text"
+            placeholder="New group name…"
+            class="input-base flex-1 max-w-xs"
+            @keyup.enter="submitAddGroup"
+          />
+          <button @click="submitAddGroup" class="bg-accent para-chip-sm type-label text-surface-900 px-4 py-2">Add Group</button>
+        </div>
+
+        <div class="space-y-5">
+          <div
+            v-for="group in feedbackGroups"
+            :key="group.id"
+            class="card-hover p-4 relative"
           >
-            <i class="pi pi-times text-xs"></i>
-          </button>
-        </div>
-        <div v-if="images.length === 0" class="col-span-full text-sm text-content-muted py-4">
-          No images uploaded
+            <div class="corner-bar-tl"></div>
+            <div class="flex items-center justify-between mb-3">
+              <span class="type-body text-content-primary">{{ group.name }}</span>
+              <button
+                @click="submitDeleteGroup(group.id)"
+                class="w-6 h-6 flex items-center justify-center text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
+                title="Delete group"
+              >
+                <i class="pi pi-times text-xs"></i>
+              </button>
+            </div>
+
+            <div class="flex flex-wrap gap-2 mb-3">
+              <div
+                v-for="tag in group.tags"
+                :key="tag.id"
+                class="para-chip-sm px-3 py-1 type-label text-content-secondary flex items-center gap-1.5"
+              >
+                {{ tag.label }}
+                <button
+                  @click="submitDeleteTag(tag.id)"
+                  class="text-content-muted hover:text-red-400 transition-colors leading-none"
+                >
+                  <i class="pi pi-times" style="font-size: 0.6rem"></i>
+                </button>
+              </div>
+              <p v-if="!group.tags?.length" class="type-label text-content-muted py-1">No tags yet</p>
+            </div>
+
+            <div class="flex gap-2">
+              <input
+                v-model="addTagInputs[group.id]"
+                type="text"
+                :placeholder="`Add tag to ${group.name}…`"
+                class="input-base flex-1 text-sm py-1.5"
+                @keyup.enter="submitAddTag(group.id)"
+              />
+              <button
+                @click="submitAddTag(group.id)"
+                class="para-chip-sm type-label px-3 py-1.5 text-content-secondary hover:text-content-primary transition-colors"
+              >
+                <i class="pi pi-plus text-xs"></i>
+              </button>
+            </div>
+          </div>
+
+          <p v-if="feedbackGroups.length === 0" class="type-label text-content-muted py-2">
+            No groups configured. Create groups above, then add tags to each.
+          </p>
         </div>
       </div>
-    </section>
 
+      <!-- ── Uploaded Images ────────────────────────────────── -->
+      <div v-if="activeTab === 'images'">
+        <div class="section-rule mb-4">
+          <span class="section-rule-label">Uploaded Images</span>
+          <span class="badge-neutral type-label px-2 py-0.5">{{ images.length }}</span>
+          <div class="section-rule-line"></div>
+        </div>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+          <div
+            v-for="img in images"
+            :key="img"
+            class="card-hover p-3 relative flex items-center justify-between"
+          >
+            <div class="corner-bar-tl"></div>
+            <span class="type-body text-content-secondary truncate flex-1">{{ img }}</span>
+            <button
+              @click="confirmRemoveImage(img, `Delete ${img}?`, 'Are you sure you want to delete this image?')"
+              class="ml-2 flex-shrink-0 w-6 h-6 flex items-center justify-center text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
+            >
+              <i class="pi pi-times text-xs"></i>
+            </button>
+          </div>
+          <div v-if="images.length === 0" class="col-span-full type-label text-content-muted py-4">
+            No images uploaded
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Theme Config ───────────────────────────────────── -->
+      <div v-if="activeTab === 'theme'">
+        <div class="section-rule mb-6">
+          <span class="section-rule-label">Accent Color</span>
+          <div class="section-rule-line"></div>
+        </div>
+        <div class="card-hover p-6 relative">
+          <div class="corner-bar-tl"></div>
+          <p class="type-label text-content-muted mb-4">Sets the global accent color for all connected clients in real-time.</p>
+          <div class="flex items-center gap-4">
+            <input type="color" v-model="accentInput" class="w-12 h-10 cursor-pointer bg-transparent border-0" />
+            <span class="type-body text-accent">{{ accentInput }}</span>
+            <button @click="saveAccent" class="bg-accent para-chip type-label text-surface-900 px-4 py-2">Apply</button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <ActionDoneModal
+      :show="showModal"
+      :title="modalTitle"
+      :variant="modalVariant"
+      @accept="() => { dynamicHandler() }"
+      @close="() => { showModal = false }"
+    >
+      <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+    </ActionDoneModal>
+
+    <UpdateFieldForm
+      :show="showUpdateModal"
+      :title="updateModalTitle"
+      :type="updateType"
+      @close="showUpdateModal = false"
+      @submitUpdate="submitUpdate"
+    >
+      {{ updateModalMessage }}
+    </UpdateFieldForm>
   </div>
-
-  <ActionDoneModal
-    :show="showModal"
-    :title="modalTitle"
-    :variant="modalVariant"
-    @accept="() => { dynamicHandler() }"
-    @close="() => { showModal = false }"
-  >
-    <p class="text-content-secondary leading-relaxed">{{ modalMessage }}</p>
-  </ActionDoneModal>
-
-  <UpdateFieldForm
-    :show="showUpdateModal"
-    :title="updateModalTitle"
-    :type="updateType"
-    @close="showUpdateModal = false"
-    @submitUpdate="submitUpdate"
-  >
-    {{ updateModalMessage }}
-  </UpdateFieldForm>
 </template>

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -482,7 +482,7 @@ onMounted(async () => {
       leave-from-class="opacity-100 translate-y-0"
       leave-to-class="opacity-0 -translate-y-2"
     >
-      <div v-if="showFilters || !hasActiveSession" class="card p-5" :class="hasActiveSession ? 'fixed left-0 right-0 z-40 mx-4' : 'mb-6'" :style="hasActiveSession ? { top: '138px', boxShadow: '0 0 0 1px rgba(255,255,255,0.05), 0 20px 60px rgba(0,0,0,0.8)' } : {}">
+      <div v-if="showFilters || !hasActiveSession" class="card p-5" :class="hasActiveSession ? 'fixed left-0 right-0 z-40 mx-4' : 'mb-6'" :style="hasActiveSession ? { top: '138px', background: '#1a1a1a', borderColor: 'rgba(255,255,255,0.12)', boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 20px 60px rgba(0,0,0,0.9)', clipPath: 'none' } : { clipPath: 'none' }">
         <div class="flex flex-wrap items-center gap-3">
           <!-- Event name -->
           <span class="type-body text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -431,27 +431,26 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="page-container" :style="hasActiveSession ? { display: 'flex', flexDirection: 'column', height: 'calc(100dvh - 64px)', overflow: 'hidden', padding: '8px 16px' } : {}">
+  <div class="page-container relative" :style="hasActiveSession ? { display: 'flex', flexDirection: 'column', height: 'calc(100dvh - 64px)', overflow: 'hidden', padding: '8px 16px' } : {}">
+    <div class="color-bleed"></div>
 
     <!-- Context bar (active session: genre + role both selected) -->
     <div
       v-if="hasActiveSession"
-      class="flex items-center justify-between px-4 py-2.5 mb-4 rounded-xl border border-white/8 flex-shrink-0"
-      style="background: #060818;"
+      class="para-chip px-4 py-2.5 mb-4 flex-shrink-0 flex items-center justify-between"
     >
-      <div class="flex items-center gap-2 text-sm font-bold text-white/60 flex-wrap">
-        <span class="font-heading text-white/80">{{ selectedEvent }}</span>
-        <span class="text-white/15">·</span>
+      <div class="flex items-center gap-2 type-label text-content-muted flex-wrap">
+        <span class="text-accent">{{ selectedEvent }}</span>
+        <span class="text-content-muted opacity-30">·</span>
         <span>{{ selectedGenre }}</span>
-        <span class="text-white/15">·</span>
-        <span class="uppercase text-xs tracking-widest">{{ judgingMode }}</span>
-        <span class="text-white/15">·</span>
+        <span class="text-content-muted opacity-30">·</span>
+        <span class="uppercase tracking-widest">{{ judgingMode }}</span>
+        <span class="text-content-muted opacity-30">·</span>
         <span>{{ selectedRole }}</span>
       </div>
       <button
         @click="showFilters = !showFilters"
-        class="p-1.5 rounded-lg border transition-all active:scale-95"
-        :class="showFilters ? 'border-white/30 text-white/70 bg-white/10' : 'border-white/10 text-white/30 hover:border-white/25 hover:text-white/60'"
+        class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-all"
       >
         <i class="pi pi-sliders-h text-xs"></i>
       </button>
@@ -460,17 +459,14 @@ onMounted(async () => {
     <!-- Page header (no active session yet) -->
     <div v-else class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
       <div>
-        <h1 class="page-title">Audition List</h1>
-        <p class="text-muted mt-1">
+        <div class="type-page-title mb-1">Audition List</div>
+        <p class="type-label text-content-muted">
           {{ selectedRole === 'Judge' ? 'Score participants for your genre' : 'Track audition progress' }}
         </p>
       </div>
       <button
         @click="showFilters = !showFilters"
-        class="flex items-center gap-2 px-3.5 py-2 rounded-xl border text-sm font-semibold transition-all duration-200 self-start"
-        :class="showFilters
-          ? 'bg-surface-600 text-content-primary border-surface-500'
-          : 'bg-surface-800 text-content-secondary border-surface-600 hover:border-surface-500'"
+        class="para-chip-sm px-3 py-1.5 type-label text-content-muted hover:text-content-primary transition-all duration-200 self-start"
       >
         <i class="pi text-xs" :class="showFilters ? 'pi-filter-slash' : 'pi-filter'"></i>
         Filters
@@ -489,48 +485,48 @@ onMounted(async () => {
       <div v-if="showFilters || !hasActiveSession" class="card p-5" :class="hasActiveSession ? 'fixed left-0 right-0 z-40 mx-4' : 'mb-6'" :style="hasActiveSession ? { top: '138px', boxShadow: '0 0 0 1px rgba(255,255,255,0.05), 0 20px 60px rgba(0,0,0,0.8)' } : {}">
         <div class="flex flex-wrap items-center gap-3">
           <!-- Event name -->
-          <span class="font-heading font-bold text-base text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
+          <span class="type-body text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
           <span class="text-surface-600 select-none">|</span>
 
           <!-- Role toggle -->
-          <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <div class="flex gap-1">
             <button
               v-for="r in roles"
               :key="r"
               @click="selectedRole = r"
-              class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+              class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
               :class="selectedRole === r
-                ? 'bg-surface-600 text-white'
-                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                ? 'text-accent border-[color:var(--accent-muted)]'
+                : 'text-content-muted hover:text-content-primary'"
             >{{ r }}</button>
           </div>
           <span class="text-surface-600 select-none">|</span>
 
           <!-- Genre toggle -->
-          <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <div class="flex gap-1">
             <button
               v-for="g in uniqueGenres"
               :key="g"
               @click="selectedGenre = g"
-              class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+              class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
               :class="selectedGenre === g
-                ? 'bg-surface-600 text-white'
-                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                ? 'text-accent border-[color:var(--accent-muted)]'
+                : 'text-content-muted hover:text-content-primary'"
             >{{ g }}</button>
           </div>
 
           <!-- Type toggle (conditional) -->
           <template v-if="hasTeamAndSoloMix">
             <span class="text-surface-600 select-none">|</span>
-            <div class="flex rounded-xl overflow-hidden border border-surface-600">
+            <div class="flex gap-1">
               <button
                 v-for="t in ['Teams', 'Solo']"
                 :key="t"
                 @click="selectedEntryType = t"
-                class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+                class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
                 :class="selectedEntryType === t
-                  ? 'bg-surface-600 text-white'
-                  : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                  ? 'text-accent border-[color:var(--accent-muted)]'
+                  : 'text-content-muted hover:text-content-primary'"
               >{{ t }}</button>
             </div>
           </template>
@@ -538,15 +534,15 @@ onMounted(async () => {
           <!-- Judging mode toggle (admin only) -->
           <template v-if="isAdmin && selectedEvent">
             <span class="text-surface-600 select-none">|</span>
-            <div class="flex rounded-xl overflow-hidden border border-surface-600">
+            <div class="flex gap-1">
               <button
                 v-for="m in ['SOLO', 'PAIR']"
                 :key="m"
                 @click="judgingMode = m; setJudgingMode(selectedEvent, m)"
-                class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+                class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
                 :class="judgingMode === m
-                  ? 'bg-surface-600 text-white'
-                  : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                  ? 'text-accent border-[color:var(--accent-muted)]'
+                  : 'text-content-muted hover:text-content-primary'"
               >{{ m }}</button>
             </div>
           </template>
@@ -567,21 +563,25 @@ onMounted(async () => {
     <!-- No judges banner -->
     <div
       v-if="noJudgesConfigured"
-      class="flex items-center gap-3 px-4 py-3 mb-4 rounded-xl border border-amber-800/40 bg-amber-950/30 text-sm flex-shrink-0"
+      class="semantic-chip-warning flex items-center gap-3 px-4 py-3 mb-4 flex-shrink-0"
     >
-      <i class="pi pi-exclamation-triangle text-amber-400 text-sm flex-shrink-0"></i>
-      <span class="text-amber-200/80">
-        No judges configured for <strong class="text-amber-200">{{ selectedEvent }}</strong>.
+      <div class="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0" style="box-shadow: 0 0 6px rgba(245,158,11,0.8)"></div>
+      <span class="type-label text-amber-300/90">
+        No judges configured for <span class="text-amber-200">{{ selectedEvent }}</span>.
       </span>
       <RouterLink
         :to="`/events/${selectedEvent}`"
-        class="ml-auto flex-shrink-0 text-xs font-semibold text-primary-400 hover:text-primary-300 underline underline-offset-2 transition-colors"
+        class="ml-auto flex-shrink-0 type-label text-accent underline underline-offset-2 transition-colors"
       >
-        Add judges in Event Details →
+        Add judges →
       </RouterLink>
     </div>
 
     <!-- Emcee view: Timer + round view -->
+    <div class="section-rule mb-4">
+      <span class="section-rule-label">Participants</span>
+      <div class="section-rule-line"></div>
+    </div>
     <div class="flex-1 min-h-0" style="overflow: hidden;">
     <template v-if="selectedRole === 'Emcee' && filteredParticipantsForEmceeView.length > 0">
       <EmceeRoundView
@@ -627,11 +627,11 @@ onMounted(async () => {
       v-else-if="selectedRole && selectedGenre && filteredParticipantsForEmceeView.length === 0 && filteredParticipantsForJudge.length === 0"
       class="flex flex-col items-center justify-center h-full text-center"
     >
-      <div class="icon-wrap w-14 h-14 rounded-2xl bg-surface-700 flex items-center justify-center mb-4">
+      <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
         <i class="pi pi-list text-content-muted text-xl"></i>
       </div>
-      <p class="font-heading font-semibold text-content-secondary">No participants found</p>
-      <p class="text-muted text-sm mt-1">Select a different event or genre</p>
+      <p class="type-body text-content-secondary">No participants found</p>
+      <p class="type-label text-content-muted mt-1">Select a different event or genre</p>
     </div>
 
     <!-- No role selected -->
@@ -639,11 +639,11 @@ onMounted(async () => {
       v-else-if="!selectedRole"
       class="flex flex-col items-center justify-center py-24 text-center"
     >
-      <div class="w-14 h-14 rounded-2xl bg-primary-100 flex items-center justify-center mb-4">
-        <i class="pi pi-filter text-primary-400 text-xl"></i>
+      <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
+        <i class="pi pi-filter text-accent text-xl"></i>
       </div>
-      <p class="font-heading font-semibold text-content-secondary">Select your role to begin</p>
-      <p class="text-muted text-sm mt-1">Choose Emcee or Judge in the filter panel above</p>
+      <p class="type-body text-content-secondary">Select your role to begin</p>
+      <p class="type-label text-content-muted mt-1">Choose Emcee or Judge in the filter panel above</p>
     </div>
 
     </div>
@@ -656,7 +656,7 @@ onMounted(async () => {
     @accept="() => { dynamicCallBack() }"
     @close="() => { showModal = false }"
   >
-    <p class="text-content-secondary leading-relaxed">{{ modalMessage }}</p>
+    <p class="type-body text-content-secondary">{{ modalMessage }}</p>
   </ActionDoneModal>
 
   <FeedbackPopout

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -955,12 +955,14 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="page-container space-y-6">
+  <div class="page-container relative">
+    <div class="color-bleed"></div>
+    <div class="relative z-10 space-y-6">
 
     <!-- Page header -->
     <div>
-      <h1 class="page-title">Battle Control</h1>
-      <p class="text-muted mt-1">Manage brackets, rounds, and live voting</p>
+      <div class="type-page-title">Battle Control</div>
+      <p class="type-label text-content-muted mt-1">Manage brackets, rounds, and live voting</p>
     </div>
 
     <!-- Quick access links -->
@@ -969,9 +971,7 @@ onUnmounted(() => {
         href="/battle/overlay"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
-               text-sm font-semibold text-content-secondary hover:border-primary-400 hover:text-primary-400
-               transition-all duration-200"
+        class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
       >
         <i class="pi pi-desktop text-xs"></i>
         Stream Overlay
@@ -981,9 +981,7 @@ onUnmounted(() => {
         href="/battle/overlay?isSmoke=true"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
-               text-sm font-semibold text-content-secondary hover:border-primary-400 hover:text-primary-400
-               transition-all duration-200"
+        class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
       >
         <i class="pi pi-desktop text-xs"></i>
         Smoke Overlay
@@ -993,9 +991,7 @@ onUnmounted(() => {
         href="/battle/judge"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
-               text-sm font-semibold text-content-secondary hover:border-primary-400 hover:text-primary-400
-               transition-all duration-200"
+        class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
       >
         <i class="pi pi-users text-xs"></i>
         Judge View
@@ -1005,9 +1001,7 @@ onUnmounted(() => {
         href="/battle/bracket"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
-               text-sm font-semibold text-content-secondary hover:border-primary-400 hover:text-primary-400
-               transition-all duration-200"
+        class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
       >
         <i class="pi pi-sitemap text-xs"></i>
         Live Bracket
@@ -1023,54 +1017,57 @@ onUnmounted(() => {
         <span class="text-surface-600 select-none">|</span>
 
         <!-- Genre toggle -->
-        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+        <div class="flex flex-wrap gap-2">
           <button
             v-for="g in uniqueGenres"
             :key="g"
             @click="selectedGenre = g"
-            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150"
             :class="selectedGenre === g
-              ? 'bg-primary-600 text-white'
-              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              ? 'text-accent border-[color:var(--accent-muted)]'
+              : 'text-content-muted hover:text-content-primary'"
           >{{ g }}</button>
         </div>
         <span class="text-surface-600 select-none">|</span>
 
         <!-- Format toggle -->
-        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+        <div class="flex flex-wrap gap-2">
           <button
             v-for="s in sizes"
             :key="s"
             @click="topSize = s"
-            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150"
             :class="topSize === s
-              ? 'bg-primary-600 text-white'
-              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              ? 'text-accent border-[color:var(--accent-muted)]'
+              : 'text-content-muted hover:text-content-primary'"
           >{{ s === 7 ? '7 to Smoke' : `Top ${s}` }}</button>
         </div>
       </div>
 
       <!-- Judge management -->
-      <div class="flex flex-wrap items-center gap-3 pt-4 border-t border-surface-600/30">
-        <span class="text-xs font-semibold text-content-muted uppercase tracking-wide whitespace-nowrap">Judges</span>
+      <div class="section-rule mt-4">
+        <span class="section-rule-label">Judges</span>
+        <div class="section-rule-line"></div>
+      </div>
 
-        <!-- Active judge pills -->
-        <div class="flex flex-wrap gap-2">
-          <span
+      <div class="flex flex-wrap items-center gap-3 mt-3">
+        <!-- Active judge slots -->
+        <div class="flex flex-wrap gap-3 flex-1 min-w-0">
+          <div
             v-for="(j, index) in battleJudges?.judges || []"
             :key="index"
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-semibold
-                   text-content-secondary bg-surface-700 border border-surface-600"
+            class="card-hover p-2 relative inline-flex items-center gap-1.5 px-3"
           >
-            {{ j.name }}
+            <div class="corner-bar-tl"></div>
+            <span class="type-body text-content-primary">{{ j.name }}</span>
             <button
               @click="submitRemoveBattleJudge(j.name)"
               class="flex items-center justify-center hover:text-red-400 transition-colors"
             >
               <i class="pi pi-times text-xs"></i>
             </button>
-          </span>
-          <span v-if="!battleJudges?.judges?.length" class="text-xs text-content-muted italic">None added</span>
+          </div>
+          <span v-if="!battleJudges?.judges?.length" class="type-label text-content-muted">None added</span>
         </div>
 
         <!-- Add control pushed to the right -->
@@ -1080,8 +1077,7 @@ onUnmounted(() => {
           </div>
           <button
             @click="submitAddBattleJudge(selectedJudge)"
-            class="flex items-center gap-1.5 px-3.5 py-2 rounded-xl bg-primary-600 text-white text-sm
-                   font-semibold hover:bg-primary-700 transition-all duration-200 whitespace-nowrap"
+            class="bg-accent para-chip-sm px-3 py-1.5 type-label transition-all duration-200 whitespace-nowrap"
           >
             <i class="pi pi-plus text-xs"></i>
             Add
@@ -1148,50 +1144,49 @@ onUnmounted(() => {
     <p v-if="overlayConfigError" class="overlay-config-error">{{ overlayConfigError }}</p>
       </details>
 
-      <div class="h-px bg-surface-600/30 my-4"></div>
+      <div class="section-rule">
+        <span class="section-rule-label">Seeding</span>
+        <div class="section-rule-line"></div>
+      </div>
 
-      <!-- ── Seeding quick-fill ───────────────────────────── -->
-      <div class="flex flex-wrap items-center gap-3 mb-5">
-        <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Seed by</span>
-
+      <div class="flex flex-wrap items-center gap-2 mt-4 mb-5">
         <!-- Pickup crew sort toggle (mixed bracket only) -->
         <template v-if="isMixedBracket">
-          <div class="flex rounded-lg border border-surface-600/60 overflow-hidden text-xs font-semibold">
+          <div class="flex gap-1">
             <button
               @click="crewSortMode = 'leader'"
-              class="px-2.5 py-1.5 transition-all"
-              :class="crewSortMode === 'leader' ? 'bg-primary-600 text-white' : 'bg-surface-800 text-content-muted hover:text-content-primary'"
+              class="para-chip-sm px-2.5 py-1.5 type-label transition-all"
+              :class="crewSortMode === 'leader' ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
               title="Sort pickup crews by their leader's individual audition score"
             >Leader</button>
             <button
               @click="crewSortMode = 'avg'"
-              class="px-2.5 py-1.5 transition-all"
-              :class="crewSortMode === 'avg' ? 'bg-primary-600 text-white' : 'bg-surface-800 text-content-muted hover:text-content-primary'"
+              class="para-chip-sm px-2.5 py-1.5 type-label transition-all"
+              :class="crewSortMode === 'avg' ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
               title="Sort pickup crews by average score of all members"
             >Avg</button>
           </div>
           <span class="text-surface-600 select-none">|</span>
         </template>
 
-        <div class="flex rounded-xl border border-surface-600/60 overflow-hidden text-xs font-semibold">
+        <div class="flex flex-wrap gap-1">
           <button
             @click="autoFillSeeds"
-            class="flex items-center gap-1 px-3 py-1.5 text-content-secondary border-r border-surface-600/60
-                   hover:bg-surface-700 hover:text-content-primary transition-all"
+            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 transition-all"
+            :class="rankAsc ? 'text-content-muted hover:text-content-primary' : 'text-content-muted hover:text-content-primary'"
             :title="rankAsc ? 'Lowest score first' : 'Highest score first'"
           >
             <i :class="rankAsc ? 'pi pi-sort-amount-up' : 'pi pi-sort-amount-down'" class="text-xs"></i>
             By Rank
-            <button
+            <span
               @click.stop="rankAsc = !rankAsc; autoFillSeeds()"
-              class="ml-0.5 px-1 py-0.5 rounded font-mono text-primary-400 hover:bg-primary-500/20 transition-all"
+              class="ml-0.5 px-1 py-0.5 type-label text-accent cursor-pointer"
               :title="rankAsc ? 'Switch to highest first' : 'Switch to lowest first'"
-            >{{ rankAsc ? '↑' : '↓' }}</button>
+            >{{ rankAsc ? '↑' : '↓' }}</span>
           </button>
           <button
             @click="highVsLowFill"
-            class="flex items-center gap-1 px-3 py-1.5 text-content-secondary border-r border-surface-600/60
-                   hover:bg-surface-700 hover:text-content-primary transition-all"
+            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 text-content-muted hover:text-content-primary transition-all"
             title="Pair highest with lowest (1st vs last, 2nd vs 2nd-last...)"
           >
             <i class="pi pi-arrows-v text-xs"></i>
@@ -1199,8 +1194,7 @@ onUnmounted(() => {
           </button>
           <button
             @click="randomFill"
-            class="flex items-center gap-1 px-3 py-1.5 text-content-secondary transition-all"
-            :class="isMixedBracket ? 'border-r border-surface-600/60 hover:bg-surface-700 hover:text-content-primary' : 'hover:bg-surface-700 hover:text-content-primary'"
+            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 text-content-muted hover:text-content-primary transition-all"
             title="Random shuffle"
           >
             <i class="pi pi-refresh text-xs"></i>
@@ -1209,7 +1203,7 @@ onUnmounted(() => {
           <button
             v-if="isMixedBracket"
             @click="splitBracketFill"
-            class="flex items-center gap-1 px-3 py-1.5 text-primary-400 hover:bg-primary-500/10 transition-all"
+            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 text-accent transition-all"
             title="Pre-formed teams on left half, pickup crews on right half"
           >
             <i class="pi pi-table text-xs"></i>
@@ -1218,21 +1212,23 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- ── Battle Guests ──────────────────────────────── -->
-      <div v-if="!isSmoke" class="flex flex-wrap items-start gap-3 mb-5 pt-4 border-t border-surface-600/30">
-        <span class="text-xs font-semibold text-content-muted uppercase tracking-wide whitespace-nowrap pt-1">Guests</span>
+      <div class="section-rule">
+        <span class="section-rule-label">Battle Guests</span>
+        <div class="section-rule-line"></div>
+      </div>
 
-        <!-- Guest pills -->
+      <div v-if="!isSmoke" class="flex flex-wrap items-start gap-3 mt-3 mb-5">
+        <!-- Guest slots -->
         <div class="flex flex-wrap gap-2 flex-1 min-w-0">
           <span
             v-for="g in guestsForCurrentGenre"
             :key="g.id"
-            class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-xl text-xs font-semibold
-                   text-content-secondary bg-surface-700 border border-primary-500/30"
+            class="card-hover p-2 relative inline-flex items-center gap-1.5 px-2.5"
           >
-            <i class="pi pi-star text-primary-400" style="font-size:0.6rem"></i>
-            {{ g.guestName }}
-            <span class="text-surface-500 text-[10px]">→ {{ g.entryRound }}</span>
+            <div class="corner-bar-tl"></div>
+            <i class="pi pi-star text-accent" style="font-size:0.6rem"></i>
+            <span class="type-body text-content-primary">{{ g.guestName }}</span>
+            <span class="type-label text-content-muted">→ {{ g.entryRound }}</span>
             <button
               @click="submitRemoveBattleGuest(g)"
               class="flex items-center justify-center hover:text-red-400 transition-colors ml-0.5"
@@ -1240,7 +1236,7 @@ onUnmounted(() => {
               <i class="pi pi-times text-xs"></i>
             </button>
           </span>
-          <span v-if="!guestsForCurrentGenre.length" class="text-xs text-content-muted italic pt-1">None added</span>
+          <span v-if="!guestsForCurrentGenre.length" class="type-label text-content-muted pt-1">None added</span>
         </div>
 
         <!-- Add guest form pushed to the right -->
@@ -1249,14 +1245,12 @@ onUnmounted(() => {
             v-model="newGuestName"
             type="text"
             placeholder="Guest name"
-            class="w-36 px-2.5 py-1.5 rounded-lg bg-surface-700 border border-surface-600 text-xs font-semibold
-                   text-content-primary placeholder:text-content-muted outline-none focus:border-primary-500/50"
+            class="input-base w-36"
             @keyup.enter="submitAddBattleGuest"
           />
           <select
             v-model="newGuestEntryRound"
-            class="px-2.5 py-1.5 rounded-lg bg-surface-700 border border-surface-600 text-xs font-semibold
-                   text-content-primary outline-none focus:border-primary-500/50 cursor-pointer"
+            class="input-base w-24"
           >
             <option value="" disabled>Round</option>
             <option v-for="r in entryRoundOptions" :key="r" :value="r">{{ r }}</option>
@@ -1264,8 +1258,7 @@ onUnmounted(() => {
           <button
             @click="submitAddBattleGuest"
             :disabled="addingGuest || !newGuestName.trim() || !newGuestEntryRound"
-            class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-600 text-white text-xs
-                   font-semibold hover:bg-primary-700 transition-all disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+            class="bg-accent para-chip-sm px-3 py-1.5 type-label transition-all disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
           >
             <i class="pi pi-plus text-xs"></i>
             Add
@@ -1273,31 +1266,37 @@ onUnmounted(() => {
         </div>
       </div>
 
+      <div class="section-rule">
+        <span class="section-rule-label">Bracket</span>
+        <div class="section-rule-line"></div>
+      </div>
+
       <!-- ── Standard bracket ──────────────────────────── -->
-      <div v-if="Number(topSize) !== 7">
+      <div v-if="Number(topSize) !== 7" class="mt-3">
         <!-- Round tabs -->
-        <div class="flex rounded-xl overflow-hidden border border-surface-600 self-start mb-4 w-fit">
+        <div class="flex flex-wrap gap-1 mb-4">
           <button
             v-for="(size, idx) in roundSizes"
             :key="idx"
             @click="activeRoundIdx = idx"
-            class="px-5 py-2 text-sm font-semibold transition-all duration-150"
+            class="para-chip-sm px-4 py-1.5 type-label transition-all duration-150"
             :class="activeRoundIdx === idx
-              ? 'bg-primary-600 text-white'
-              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              ? 'text-accent border-[color:var(--accent-muted)]'
+              : 'text-content-muted hover:text-content-primary'"
           >Top {{ size }}</button>
         </div>
 
         <!-- Active round matches -->
         <template v-for="(size, idx) in roundSizes" :key="idx">
-          <div v-if="activeRoundIdx === idx" class="bg-surface-900/60 rounded-2xl p-4 border border-surface-600/50">
+          <div v-if="activeRoundIdx === idx" class="card p-4">
             <div class="flex flex-col gap-2 mb-3">
               <!-- Match card: horizontal Left VS Right layout -->
               <div
                 v-for="(match, mIdx) in rounds[`Top${size}`]"
                 :key="mIdx"
-                class="rounded-lg border border-surface-600/40 bg-surface-800/50 overflow-hidden flex items-stretch min-h-[44px]"
+                class="card-hover p-3 relative flex items-stretch min-h-[44px]"
               >
+                <div class="corner-bar-tl"></div>
                 <!-- Slot 0 — left -->
                 <div
                   class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
@@ -1317,10 +1316,10 @@ onUnmounted(() => {
                     draggable="true"
                     @dragstart="(e) => onDragStart(`Top${size}`, mIdx, 0, e)"
                     @dragend="onDragEnd"
-                    class="flex-1 min-w-0 text-xs font-semibold truncate select-none cursor-grab active:cursor-grabbing"
+                    class="flex-1 min-w-0 type-body truncate select-none cursor-grab active:cursor-grabbing"
                     :class="match[2] === match[0] && match[0] ? 'text-emerald-400' : 'text-content-primary'"
                   >{{ match[0] }}</div>
-                  <span v-else class="flex-1 text-xs text-surface-600/60 italic">Drop here</span>
+                  <span v-else class="flex-1 type-body text-surface-600/60 italic">Drop here</span>
                   <button v-if="match[0]" @click="clearSlot(`Top${size}`, mIdx, 0)" class="flex-shrink-0 px-0.5 text-surface-600 hover:text-red-400 transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
                   <button
                     :disabled="!match[0]"
@@ -1354,10 +1353,10 @@ onUnmounted(() => {
                     draggable="true"
                     @dragstart="(e) => onDragStart(`Top${size}`, mIdx, 1, e)"
                     @dragend="onDragEnd"
-                    class="flex-1 min-w-0 text-xs font-semibold truncate select-none cursor-grab active:cursor-grabbing"
+                    class="flex-1 min-w-0 type-body truncate select-none cursor-grab active:cursor-grabbing"
                     :class="match[2] === match[1] && match[1] ? 'text-emerald-400' : 'text-content-primary'"
                   >{{ match[1] }}</div>
-                  <span v-else class="flex-1 text-xs text-surface-600/60 italic">Drop here</span>
+                  <span v-else class="flex-1 type-body text-surface-600/60 italic">Drop here</span>
                   <button v-if="match[1]" @click="clearSlot(`Top${size}`, mIdx, 1)" class="flex-shrink-0 px-0.5 text-surface-600 hover:text-red-400 transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
                   <button
                     :disabled="!match[1]"
@@ -1371,8 +1370,7 @@ onUnmounted(() => {
 
             <button
               @click="initiateBattlePair(`Top${size}`, rounds[`Top${size}`])"
-              class="w-full py-2 rounded-xl bg-primary-600 text-white text-xs font-bold
-                     hover:bg-primary-700 active:bg-primary-800 transition-all duration-200"
+              class="w-full py-2 bg-accent para-chip type-label transition-all duration-200"
             >
               <i class="pi pi-play text-xs mr-1.5"></i>
               Start Round
@@ -1382,26 +1380,29 @@ onUnmounted(() => {
       </div>
 
       <!-- ── 7 to Smoke bracket ──────────────────────────── -->
-      <div v-else class="bg-surface-900/60 rounded-2xl p-4 border border-surface-600/50">
-        <div class="text-xs font-bold text-primary-400 uppercase tracking-widest mb-3">7 to Smoke — Queue</div>
+      <div v-else class="mt-3">
+        <div class="section-rule mb-4">
+          <span class="section-rule-label">7 to Smoke — Queue</span>
+          <div class="section-rule-line"></div>
+        </div>
 
         <!-- Queue: ordered chips, populated by fill buttons above -->
         <div v-if="Array.isArray(rounds) && rounds.some(r => r.name)" class="flex flex-wrap gap-2 mb-4">
           <div
             v-for="(match, mIdx) in rounds"
             :key="mIdx"
-            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-surface-600/40 bg-surface-800/50 text-sm font-semibold text-content-secondary"
+            class="card-hover p-2 relative flex items-center gap-1.5 px-3"
           >
-            <span class="text-xs font-source text-primary-400 font-bold">{{ mIdx + 1 }}</span>
-            <span>{{ match.name || '—' }}</span>
+            <div class="corner-bar-tl"></div>
+            <span class="type-label text-accent">{{ mIdx + 1 }}</span>
+            <span class="type-body text-content-primary">{{ match.name || '—' }}</span>
           </div>
         </div>
-        <p v-else class="text-xs text-content-muted mb-4">Use the Seed by buttons above to fill the queue.</p>
+        <p v-else class="type-body text-content-muted mb-4">Use the Seed by buttons above to fill the queue.</p>
 
         <button
           @click="initiateBattlePair(0, 0)"
-          class="w-full py-2 rounded-xl bg-primary-600 text-white text-xs font-bold
-                 hover:bg-primary-700 transition-all duration-200"
+          class="w-full py-2 bg-accent para-chip type-label transition-all duration-200"
         >
           <i class="pi pi-play text-xs mr-1.5"></i>
           Start Round
@@ -1412,18 +1413,18 @@ onUnmounted(() => {
     <!-- Reset bracket confirmation modal -->
     <Transition name="fade">
       <div v-if="showResetConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-        <div class="bg-surface-800 rounded-2xl border border-surface-600 p-6 max-w-sm w-full mx-4 shadow-xl">
-          <h3 class="font-heading font-bold text-content-primary text-lg mb-2">Reset Bracket?</h3>
-          <p class="text-sm text-content-muted mb-6">This will clear all bracket data and set the battle phase to IDLE. This cannot be undone.</p>
+        <div class="card-hover p-6 max-w-sm w-full mx-4 relative">
+          <div class="corner-bar-tl"></div>
+          <div class="type-page-title text-lg mb-2">Reset Bracket?</div>
+          <p class="type-body text-content-muted mb-6">This will clear all bracket data and set the battle phase to IDLE. This cannot be undone.</p>
           <div class="flex gap-3 justify-end">
             <button
               @click="showResetConfirm = false"
-              class="px-4 py-2 rounded-xl border border-surface-600 bg-surface-700 text-sm font-semibold
-                     text-content-secondary hover:bg-surface-600 transition-all"
+              class="para-chip-sm px-4 py-2 type-label transition-all"
             >Cancel</button>
             <button
               @click="confirmResetBracket"
-              class="px-4 py-2 rounded-xl bg-red-600 text-white text-sm font-semibold hover:bg-red-700 transition-all"
+              class="para-chip-sm px-4 py-2 type-label bg-red-600/20 text-red-400 border-red-500/40 hover:bg-red-600/30 transition-all"
             >Reset</button>
           </div>
         </div>
@@ -1432,91 +1433,111 @@ onUnmounted(() => {
 
     <!-- Live match tracker -->
     <div class="card p-5">
+      <div class="section-rule mb-4">
+        <span class="section-rule-label">Live Match</span>
+        <div class="section-rule-line"></div>
+      </div>
+
       <div class="flex items-center gap-3 mb-4">
-        <h2 class="font-heading font-bold text-content-secondary">Live Match</h2>
-        <span
-          class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold uppercase tracking-wide"
+        <div
+          class="inline-flex items-center gap-2 px-3 py-1.5"
           :class="{
-            'bg-surface-700 text-surface-400': battlePhase === 'IDLE',
-            'bg-amber-500/20 text-amber-400 border border-amber-500/40': battlePhase === 'LOCKED',
-            'bg-primary-500/20 text-primary-400 border border-primary-500/40 animate-pulse': battlePhase === 'VOTING',
-            'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40': battlePhase === 'REVEALED',
+            'semantic-chip-success': battlePhase === 'REVEALED',
+            'semantic-chip-warning': battlePhase === 'LOCKED',
+            'semantic-chip-warning animate-pulse': battlePhase === 'VOTING',
+            'semantic-chip-warning opacity-50': battlePhase === 'IDLE',
           }"
-        >{{ battlePhase }}</span>
+        >
+          <div
+            class="w-2 h-2 rounded-full"
+            :style="battlePhase === 'REVEALED' ? 'background:#34d399;box-shadow:0 0 8px rgba(52,211,153,0.8)' : battlePhase === 'LOCKED' ? 'background:#f59e0b;box-shadow:0 0 8px rgba(245,158,11,0.8)' : battlePhase === 'VOTING' ? 'background:#f59e0b;box-shadow:0 0 8px rgba(245,158,11,0.8)' : 'background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,0.5)'"
+          ></div>
+          <span class="type-body" :class="battlePhase === 'REVEALED' ? 'text-emerald-400' : battlePhase === 'LOCKED' ? 'text-amber-400' : battlePhase === 'VOTING' ? 'text-amber-400' : 'text-gray-400'">{{ battlePhase }}</span>
+        </div>
+      </div>
       </div>
 
       <!-- Final tie warning -->
       <div
         v-if="finalTieBlocked"
-        class="px-4 py-3 rounded-xl text-sm font-semibold mb-4 flex items-center justify-between gap-3
-               bg-amber-500/10 border border-amber-500/40 text-amber-400"
+        class="semantic-chip-warning px-4 py-3 flex items-center justify-between gap-3 mb-4"
       >
-        <span><i class="pi pi-exclamation-triangle mr-2"></i>TIE in Final — Revote required</span>
+        <div class="w-2 h-2 rounded-full" style="background:#f59e0b;box-shadow:0 0 8px rgba(245,158,11,0.8)"></div>
+        <span class="type-body flex-1 text-amber-400"><i class="pi pi-exclamation-triangle mr-2"></i>TIE in Final — Revote required</span>
         <button
           @click="startRevote"
-          class="flex-shrink-0 px-3 py-1.5 rounded-lg bg-amber-500/20 border border-amber-500/40
-                 text-amber-400 text-xs font-bold hover:bg-amber-500/30 transition-all"
+          class="para-chip-sm px-3 py-1.5 type-label text-accent transition-all"
         >START REVOTE</button>
       </div>
 
       <!-- Winner announcement -->
       <div
-        class="px-4 py-3 rounded-xl text-center text-sm font-semibold mb-4"
+        class="px-4 py-3 mb-4"
         :class="{
-          'bg-amber-950 text-amber-400 border border-amber-700/50': winnerVariant === 'ongoing',
-          'bg-amber-950 text-amber-400 border border-amber-700/50': winnerVariant === 'wait',
-          'bg-primary-100 text-primary-400 border border-primary-500/40': winnerVariant === 'winner',
-          'bg-surface-700 text-content-secondary border border-surface-500': winnerVariant === 'tie',
+          'semantic-chip-warning': winnerVariant === 'ongoing',
+          'semantic-chip-warning': winnerVariant === 'wait',
+          'semantic-chip-success': winnerVariant === 'winner',
+          'border-l-3 border-gray-400 bg-gray-500/10': winnerVariant === 'tie',
         }"
       >
-        {{ winnerAnnouncement }}
+        <div
+          class="w-2 h-2 rounded-full mb-1"
+          :class="winnerVariant === 'winner' ? 'bg-emerald-400' : winnerVariant === 'tie' ? 'bg-gray-400' : 'bg-amber-400'"
+          :style="winnerVariant === 'winner' ? 'box-shadow:0 0 8px rgba(52,211,153,0.8)' : winnerVariant === 'tie' ? '' : 'box-shadow:0 0 8px rgba(245,158,11,0.8)'"
+        ></div>
+        <span class="type-body text-content-primary">{{ winnerAnnouncement }}</span>
       </div>
 
       <!-- Match pairs (standard) -->
       <div v-if="!isSmoke" class="grid grid-cols-3 gap-3 mb-4">
-        <div class="card p-4 text-sm">
-          <div class="text-xs font-semibold text-content-muted uppercase tracking-wider mb-2">Previous</div>
+        <div class="stat-card relative">
+          <div class="corner-bar-tl"></div>
+          <span class="type-label text-content-muted mb-1">Previous</span>
           <template v-if="previousBattlePair">
-            <span class="font-bold text-content-secondary">{{ previousBattlePair[0] }}</span>
-            <span class="text-content-muted mx-2">vs</span>
-            <span class="font-bold text-content-secondary">{{ previousBattlePair[1] }}</span>
+            <span class="type-body text-content-secondary block">{{ previousBattlePair[0] }}</span>
+            <span class="type-label text-content-muted">vs</span>
+            <span class="type-body text-content-secondary block">{{ previousBattlePair[1] }}</span>
           </template>
-          <span v-else class="text-content-disabled">—</span>
+          <span v-else class="type-stat text-content-disabled opacity-30">—</span>
         </div>
-        <div class="card p-4 text-sm ring-2 ring-primary-200">
-          <div class="text-xs font-semibold text-primary-500 uppercase tracking-wider mb-2">Current</div>
+        <div class="stat-card relative" style="box-shadow: 0 0 0 1px var(--accent-muted), 0 8px 40px var(--accent-subtle);">
+          <div class="corner-bar-tl"></div>
+          <span class="type-label text-accent mb-1">Current</span>
           <template v-if="currentBattlePair">
-            <span class="font-bold text-content-primary">{{ currentBattlePair[0] }}</span>
-            <span class="text-content-muted mx-2">vs</span>
-            <span class="font-bold text-content-primary">{{ currentBattlePair[1] }}</span>
+            <span class="type-body text-content-primary block">{{ currentBattlePair[0] }}</span>
+            <span class="type-label text-content-muted">vs</span>
+            <span class="type-body text-content-primary block">{{ currentBattlePair[1] }}</span>
           </template>
-          <span v-else class="text-content-disabled">—</span>
+          <span v-else class="type-stat text-content-disabled opacity-30">—</span>
         </div>
-        <div class="card p-4 text-sm">
-          <div class="text-xs font-semibold text-content-muted uppercase tracking-wider mb-2">Next</div>
+        <div class="stat-card relative">
+          <div class="corner-bar-tl"></div>
+          <span class="type-label text-content-muted mb-1">Next</span>
           <template v-if="nextBattlePair">
-            <span class="font-bold text-content-secondary">{{ nextBattlePair[0] }}</span>
-            <span class="text-content-muted mx-2">vs</span>
-            <span class="font-bold text-content-secondary">{{ nextBattlePair[1] }}</span>
+            <span class="type-body text-content-secondary block">{{ nextBattlePair[0] }}</span>
+            <span class="type-label text-content-muted">vs</span>
+            <span class="type-body text-content-secondary block">{{ nextBattlePair[1] }}</span>
           </template>
-          <span v-else class="text-content-disabled">—</span>
+          <span v-else class="type-stat text-content-disabled opacity-30">—</span>
         </div>
       </div>
 
       <!-- Match pairs (smoke) -->
       <div v-else class="grid grid-cols-2 gap-3 mb-4">
-        <div class="card p-4 text-sm ring-2 ring-primary-200">
-          <div class="text-xs font-semibold text-primary-500 uppercase tracking-wider mb-2">Current Match</div>
+        <div class="stat-card relative" style="box-shadow: 0 0 0 1px var(--accent-muted), 0 8px 40px var(--accent-subtle);">
+          <div class="corner-bar-tl"></div>
+          <span class="type-label text-accent mb-1">Current Match</span>
           <template v-if="currentBattlePair">
-            <span class="font-bold text-content-primary">{{ currentBattlePair[0].name }} ({{ currentBattlePair[0].score }})</span>
-            <span class="text-content-muted mx-2">vs</span>
-            <span class="font-bold text-content-primary">{{ currentBattlePair[1].name }} ({{ currentBattlePair[1].score }})</span>
+            <span class="type-body text-content-primary block">{{ currentBattlePair[0].name }} ({{ currentBattlePair[0].score }})</span>
+            <span class="type-label text-content-muted">vs</span>
+            <span class="type-body text-content-primary block">{{ currentBattlePair[1].name }} ({{ currentBattlePair[1].score }})</span>
           </template>
         </div>
-        <div class="card p-4 text-sm">
-          <div class="text-xs font-semibold text-content-muted uppercase tracking-wider mb-2">Queue</div>
-          <span v-if="nextBattlePair" class="text-content-muted">{{ nextBattlePair.map(p => p.name).join(', ') }}</span>
-          <span v-else class="text-content-disabled">—</span>
+        <div class="stat-card relative">
+          <div class="corner-bar-tl"></div>
+          <span class="type-label text-content-muted mb-1">Queue</span>
+          <span v-if="nextBattlePair" class="type-body text-content-secondary block">{{ nextBattlePair.map(p => p.name).join(', ') }}</span>
+          <span v-else class="type-stat text-content-disabled opacity-30">—</span>
         </div>
       </div>
 
@@ -1526,8 +1547,7 @@ onUnmounted(() => {
         <button
           v-if="battlePhase === 'LOCKED'"
           @click="openVoting"
-          class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-primary-600 text-white text-sm
-                 font-semibold hover:bg-primary-700 transition-all shadow-sm"
+          class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
         >
           <i class="pi pi-lock-open text-xs"></i>
           Open Voting
@@ -1537,8 +1557,7 @@ onUnmounted(() => {
         <button
           v-if="showFinalReveal"
           @click="revealChampionForGenre"
-          class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl border border-amber-500/40 bg-amber-500/10
-                 text-sm font-semibold text-amber-400 hover:bg-amber-500/20 transition-all"
+          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
         >
           <i class="pi pi-star text-xs"></i>
           Reveal Champion
@@ -1548,8 +1567,7 @@ onUnmounted(() => {
         <button
           v-else-if="battlePhase === 'VOTING'"
           @click="submitGetScore"
-          class="flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-primary-600 text-white text-sm
-                 font-semibold hover:bg-primary-700 transition-all shadow-sm"
+          class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
         >
           <i class="pi pi-bolt text-xs"></i>
           {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}
@@ -1559,16 +1577,14 @@ onUnmounted(() => {
         <template v-if="battlePhase === 'REVEALED'">
           <button
             @click="prevPair"
-            class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
-                   text-sm font-semibold text-content-secondary hover:border-surface-500 transition-all"
+            class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
           >
             <i class="pi pi-chevron-left text-xs"></i>
             Previous
           </button>
           <button
             @click="nextPair"
-            class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl bg-primary-600 text-white text-sm
-                   font-semibold hover:bg-primary-700 transition-all shadow-sm"
+            class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
           >
             Next
             <i class="pi pi-chevron-right text-xs"></i>
@@ -1579,8 +1595,7 @@ onUnmounted(() => {
         <button
           v-if="currentGenreChampion && !revealActive"
           @click="revealChampionForGenre"
-          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-amber-500/40 bg-amber-500/10
-                 text-sm font-semibold text-amber-400 hover:bg-amber-500/20 transition-all"
+          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
         >
           <i class="pi pi-star text-xs"></i>
           Reveal Champion
@@ -1588,8 +1603,7 @@ onUnmounted(() => {
         <button
           v-if="revealActive"
           @click="dismissReveal"
-          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
-                 text-sm font-semibold text-content-secondary hover:bg-surface-700 transition-all"
+          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
         >
           <i class="pi pi-times text-xs"></i>
           Dismiss Reveal
@@ -1597,8 +1611,7 @@ onUnmounted(() => {
 
         <button
           @click="showResetConfirm = true"
-          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-red-200 bg-surface-800
-                 text-sm font-semibold text-red-400 hover:bg-red-950 transition-all"
+          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 text-red-400 border-red-500/30 transition-all"
         >
           <i class="pi pi-refresh text-xs"></i>
           Reset Bracket
@@ -1606,8 +1619,7 @@ onUnmounted(() => {
 
         <!-- File upload -->
         <label
-          class="flex items-center gap-1.5 px-4 py-2.5 rounded-xl border border-surface-600 bg-surface-800
-                 text-sm font-semibold text-content-secondary hover:border-surface-500 cursor-pointer transition-all"
+          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 cursor-pointer transition-all"
         >
           <i class="pi pi-upload text-xs"></i>
           Upload Images
@@ -1616,33 +1628,31 @@ onUnmounted(() => {
       </div>
 
       <!-- Uploaded images list -->
-      <div v-if="uploadedFiles.length > 0" class="mt-4 pt-4 border-t border-surface-600/30">
-        <div class="flex items-center gap-2 mb-3">
-          <i class="pi pi-images text-content-muted text-sm"></i>
-          <span class="text-sm font-semibold text-content-secondary">Uploaded Images</span>
-          <span class="badge-neutral inline-flex items-center justify-center w-5 h-5 rounded-full bg-surface-700
-                       text-xs font-bold text-content-muted">{{ uploadedFiles.length }}</span>
+      <div v-if="uploadedFiles.length > 0" class="mt-4 pt-4">
+        <div class="section-rule mb-3">
+          <span class="section-rule-label">Uploaded Images</span>
+          <div class="section-rule-line"></div>
         </div>
         <div class="flex flex-wrap gap-2">
           <div
             v-for="(name, idx) in uploadedFiles"
             :key="idx"
-            class="flex items-center gap-2 px-3 py-2 rounded-xl border border-surface-600
-                   bg-surface-900 text-sm text-content-secondary"
+            class="card-hover p-2 relative flex items-center gap-2 px-3"
           >
-            <span class="max-w-[160px] truncate">{{ name }}</span>
+            <div class="corner-bar-tl"></div>
+            <span class="type-body text-content-primary max-w-[160px] truncate">{{ name }}</span>
             <button
               @click="removeUploadedFile(idx)"
-              class="flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full
-                     hover:bg-surface-600 transition-colors"
+              class="flex-shrink-0 w-5 h-5 flex items-center justify-center hover:text-red-400 transition-colors"
             >
-              <i class="pi pi-times text-xs text-content-muted"></i>
+              <i class="pi pi-times text-xs"></i>
             </button>
           </div>
         </div>
       </div>
     </div>
 
+    </div>
   </div>
 </template>
 

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1455,7 +1455,6 @@ onUnmounted(() => {
           <span class="type-body" :class="battlePhase === 'REVEALED' ? 'text-emerald-400' : battlePhase === 'LOCKED' ? 'text-amber-400' : battlePhase === 'VOTING' ? 'text-amber-400' : 'text-gray-400'">{{ battlePhase }}</span>
         </div>
       </div>
-      </div>
 
       <!-- Final tie warning -->
       <div

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -6,7 +6,6 @@ import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenr
 import { setActiveEvent } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
-import ReusableButton from '@/components/ReusableButton.vue';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
 import CreateParticipantForm from '@/components/CreateParticipantForm.vue'
 import ScoringCriteriaModal from '@/components/ScoringCriteriaModal.vue';

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -607,47 +607,41 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="page-container">
+  <div class="page-container relative">
+    <div class="color-bleed"></div>
+    <div class="relative z-10">
 
     <!-- Page header -->
     <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
       <div>
-        <h1 class="page-title">{{ props.eventName }}</h1>
-        <p class="text-muted mt-1">Event overview and participant management</p>
+        <div class="type-page-title mb-1">{{ props.eventName }}</div>
+        <p class="type-label text-content-muted">Event overview and participant management</p>
       </div>
       <div class="flex flex-wrap gap-2 self-start">
         <button
           @click="showWalkInForm = true"
-          class="flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-600 bg-surface-800 text-sm
-                 font-semibold text-content-secondary hover:bg-surface-700 hover:border-surface-500
-                 transition-all duration-200"
+          class="flex items-center gap-2 px-4 py-2 para-chip type-label border-accent"
         >
           <i class="pi pi-user-plus text-sm"></i>
           Add Walk-in
         </button>
         <button
           @click="showAdjustModal = true"
-          class="flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-600 bg-surface-800 text-sm
-                 font-semibold text-content-secondary hover:bg-surface-700 hover:border-surface-500
-                 transition-all duration-200"
+          class="flex items-center gap-2 px-4 py-2 para-chip type-label border-accent"
         >
           <i class="pi pi-sliders-h text-sm"></i>
           Adjust Genres
         </button>
         <button
           @click="openTemplateModal"
-          class="flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-600 bg-surface-800 text-sm
-                 font-semibold text-content-secondary hover:bg-surface-700 hover:border-surface-500
-                 transition-all duration-200"
+          class="flex items-center gap-2 px-4 py-2 para-chip type-label border-accent"
         >
           <i class="pi pi-envelope text-sm"></i>
           Email Template
         </button>
         <RouterLink
           to="/event/audition-number"
-          class="flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-600 bg-surface-800 text-sm
-                 font-semibold text-content-secondary hover:bg-surface-700 hover:border-surface-500
-                 transition-all duration-200"
+          class="flex items-center gap-2 px-4 py-2 para-chip type-label border-accent"
         >
           <i class="pi pi-hashtag text-sm"></i>
           Audition Screen
@@ -655,44 +649,42 @@ onUnmounted(() => {
         <button
           @click="refreshParticipant"
           :disabled="loading"
-          class="flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-600 bg-surface-800 text-sm
-                 font-semibold text-content-secondary hover:bg-surface-700 hover:border-surface-500
-                 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+          class="flex items-center gap-2 px-4 py-2 bg-accent para-chip type-label disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <i class="pi text-sm" :class="loading ? 'pi-spinner pi-spin text-primary-500' : 'pi-cloud-download'"></i>
+          <i class="pi text-sm" :class="loading ? 'pi-spinner pi-spin' : 'pi-cloud-download'"></i>
           {{ loading ? 'Importing…' : 'Import from Sheets' }}
         </button>
       </div>
     </div>
 
     <!-- Tab toggle -->
-    <div class="flex rounded-xl overflow-hidden border border-surface-600 w-fit mb-6">
+    <div class="flex gap-2 mb-6">
       <button
         @click="activeTab = 'setup'"
-        class="px-5 py-2 text-sm font-semibold transition-all duration-150"
+        class="para-chip-sm px-5 py-2 type-label transition-all duration-150"
         :class="activeTab === 'setup'
-          ? 'bg-primary-600 text-white'
-          : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          ? 'text-accent border-accent'
+          : 'text-content-muted hover:text-content-primary'"
       >
         <i class="pi pi-cog text-xs mr-1.5"></i>
         Setup
       </button>
       <button
         @click="activeTab = 'event-day'"
-        class="px-5 py-2 text-sm font-semibold transition-all duration-150"
+        class="para-chip-sm px-5 py-2 type-label transition-all duration-150"
         :class="activeTab === 'event-day'
-          ? 'bg-primary-600 text-white'
-          : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+          ? 'text-accent border-accent'
+          : 'text-content-muted hover:text-content-primary'"
       >
         <i class="pi pi-calendar text-xs mr-1.5"></i>
         Event Day
         <span
           v-if="totalNotShownUp > 0"
-          class="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold bg-amber-500 text-white"
+          class="ml-1.5 inline-flex items-center justify-center badge-warning px-1.5 py-0.5 text-[10px]"
         >{{ totalNotShownUp }}</span>
         <span
           v-else-if="unverifiedParticipants.length > 0 && activeTab !== 'event-day'"
-          class="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] font-bold bg-rose-500 text-white"
+          class="ml-1.5 inline-flex items-center justify-center badge-danger px-1.5 py-0.5 text-[10px]"
         >{{ unverifiedParticipants.length }}</span>
       </button>
     </div>
@@ -702,44 +694,41 @@ onUnmounted(() => {
 
     <!-- Stat strip -->
     <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">
-      <div class="card p-4">
-        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Total</p>
-        <p class="text-2xl font-heading font-extrabold text-content-primary">{{ (totalParticipants || 0) + totalWalkIn }}</p>
+      <div class="stat-card relative">
+        <div class="corner-bar-tl"></div>
+        <div class="type-stat">{{ (totalParticipants || 0) + totalWalkIn }}</div>
+        <div class="type-label">Total</div>
         <div class="flex gap-3 mt-1">
-          <span class="text-xs text-content-muted">Form: <strong class="text-content-secondary">{{ totalParticipants || 0 }}</strong></span>
-          <span class="text-xs text-content-muted">Walk-in: <strong class="text-content-secondary">{{ totalWalkIn }}</strong></span>
+          <span class="type-label text-content-muted">Form: {{ totalParticipants || 0 }}</span>
+          <span class="type-label text-content-muted">Walk-in: {{ totalWalkIn }}</span>
         </div>
       </div>
-      <div class="card p-4">
-        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Pending Verification</p>
-        <p class="text-2xl font-heading font-extrabold" :class="unverifiedParticipants.length > 0 ? 'text-rose-300' : 'text-content-primary'">
-          {{ unverifiedParticipants.length }}
-        </p>
-        <span class="text-xs text-content-muted">{{ totalVerified }} verified</span>
+      <div class="stat-card relative">
+        <div class="corner-bar-tl"></div>
+        <div class="type-stat" :class="unverifiedParticipants.length > 0 ? 'text-red-400' : ''">{{ unverifiedParticipants.length }}</div>
+        <div class="type-label">Pending Verification</div>
+        <div class="type-label text-content-muted mt-1">{{ totalVerified }} verified</div>
       </div>
     </div>
 
     <!-- Unverified (payment pending — DB-driven) -->
-      <div v-if="unverifiedParticipants.length > 0" class="card overflow-hidden panel-danger">
+      <div v-if="unverifiedParticipants.length > 0" class="card-hover p-4 relative">
+        <div class="corner-bar-tl"></div>
         <button
           @click="expandedPeople.has('unverified') ? expandedPeople.delete('unverified') : expandedPeople.add('unverified'); expandedPeople = new Set(expandedPeople)"
           :aria-expanded="expandedPeople.has('unverified')"
           aria-controls="panel-unverified"
-          class="w-full flex items-center justify-between px-5 py-4 bg-surface-900/40 hover:bg-surface-700/60 transition-colors duration-150 text-left"
+          class="w-full flex items-center justify-between text-left"
         >
           <div class="flex items-center gap-3">
-            <div class="icon-wrap w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
-              <i class="pi pi-exclamation-circle text-rose-300 text-xs"></i>
-            </div>
-            <span class="font-heading font-bold text-content-secondary truncate">Awaiting Payment Verification</span>
-            <span class="badge-danger inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-rose-300 border border-rose-900/30">
-              {{ unverifiedParticipants.length }}
-            </span>
+            <i class="pi pi-exclamation-circle text-rose-300 text-xs"></i>
+            <span class="type-body text-content-secondary truncate">Awaiting Payment Verification</span>
+            <span class="badge-danger">{{ unverifiedParticipants.length }}</span>
           </div>
           <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
              :class="{ 'rotate-180': expandedPeople.has('unverified') }"></i>
         </button>
-        <div v-if="expandedPeople.has('unverified')" id="panel-unverified" class="px-5 pb-5 border-t border-surface-600/30 pt-4 shadow-[inset_0_4px_8px_rgba(0,0,0,0.2)]">
+        <div v-if="expandedPeople.has('unverified')" id="panel-unverified" class="mt-4 pt-4 border-t border-surface-600/30">
           <!-- Batch action bar -->
           <div class="flex items-center justify-between mb-3">
             <p class="text-xs text-content-muted flex items-center gap-1.5">
@@ -750,8 +739,7 @@ onUnmounted(() => {
               v-if="selectedUnverified.size > 0"
               @click="handleBatchVerifyPayment"
               :disabled="batchVerifying"
-              class="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-primary-500 text-white text-xs font-semibold
-                     hover:bg-primary-600 active:scale-95 disabled:opacity-50 transition-all"
+              class="bg-accent para-chip-sm px-3 py-1.5 type-label disabled:opacity-50"
             >
               <i class="pi text-xs" :class="batchVerifying ? 'pi-spinner pi-spin' : 'pi-check'"></i>
               {{ batchVerifying ? 'Verifying…' : `Verify Batch (${selectedUnverified.size})` }}
@@ -761,36 +749,33 @@ onUnmounted(() => {
             <div
               v-for="p in unverifiedParticipants"
               :key="p.participantId"
-              class="flex flex-col gap-2 px-3 py-2.5 rounded-xl bg-surface-700/50 border border-l-2 transition-colors"
-              :class="selectedUnverified.has(p.participantId) ? 'border-primary-500/40 bg-primary-100/10 border-l-primary-500' : 'border-surface-600 border-l-rose-800/50'"
+              class="para-chip p-3"
+              :class="selectedUnverified.has(p.participantId) ? 'border-accent' : ''"
             >
-              <!-- Top row: checkbox + name + genres -->
               <div class="flex items-start gap-3">
                 <input
                   type="checkbox"
                   :checked="selectedUnverified.has(p.participantId)"
                   @change="toggleUnverifiedSelect(p.participantId)"
-                  class="checkbox-custom shrink-0 mt-0.5"
+                  class="shrink-0 mt-0.5"
                 />
                 <div class="flex-1 min-w-0">
-                  <span class="text-sm font-semibold text-content-secondary block">{{ p.name }}</span>
+                  <span class="type-body text-content-secondary block">{{ p.name }}</span>
                   <div class="flex flex-wrap gap-1 mt-1">
                     <span
                       v-for="g in p.genres"
                       :key="g"
-                      class="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-surface-900 border border-surface-500/40 text-content-secondary"
+                      class="badge-neutral text-xs"
                     >{{ g }}</span>
                   </div>
                 </div>
               </div>
-              <!-- Bottom row: action buttons -->
-              <div class="flex items-center gap-2 justify-end">
+              <div class="flex items-center gap-2 justify-end mt-2">
                 <a
                   v-if="p.screenshotUrl && /^https?:\/\//.test(p.screenshotUrl)"
                   :href="p.screenshotUrl"
                   target="_blank"
-                  class="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-surface-700 text-content-muted text-xs font-medium
-                         hover:bg-surface-600 border border-surface-600 transition-colors"
+                  class="para-chip-sm px-2.5 py-1 type-label"
                 >
                   <i class="pi pi-image text-xs"></i>
                   View Receipt
@@ -798,9 +783,7 @@ onUnmounted(() => {
                 <button
                   @click="handleVerifyPayment(p)"
                   :disabled="verifyingParticipantId === p.participantId"
-                  class="flex items-center gap-1 px-2.5 py-1 rounded-lg bg-primary-600 text-white text-xs font-semibold
-                         hover:bg-primary-500 hover:scale-[1.03] hover:shadow-[0_0_12px_rgba(34,211,238,0.3)]
-                         active:scale-95 disabled:opacity-50 transition-all duration-150"
+                  class="bg-accent para-chip-sm px-2.5 py-1 type-label disabled:opacity-50"
                 >
                   <i class="pi text-xs" :class="verifyingParticipantId === p.participantId ? 'pi-spinner pi-spin' : 'pi-check'"></i>
                   {{ verifyingParticipantId === p.participantId ? 'Verifying…' : 'Verify Payment' }}
@@ -813,66 +796,59 @@ onUnmounted(() => {
 
 
     <!-- Setup section (when no table exists) -->
-    <div v-if="!tableExist" class="card p-6">
+    <div v-if="!tableExist" class="card-hover p-6 relative">
+      <div class="corner-bar-tl"></div>
       <div class="flex items-center gap-3 mb-6">
-        <div class="icon-wrap w-9 h-9 rounded-xl bg-surface-700 flex items-center justify-center">
-          <i class="pi pi-exclamation-triangle text-amber-300 text-sm"></i>
-        </div>
+        <i class="pi pi-exclamation-triangle text-amber-300 text-sm"></i>
         <div>
-          <h2 class="font-heading font-bold text-content-secondary">Event Setup Required</h2>
-          <p class="text-muted text-sm">No record found for this event. Select genres to initialise.</p>
+          <div class="type-body text-content-secondary">Event Setup Required</div>
+          <p class="type-label text-content-muted">No record found for this event. Select genres to initialise.</p>
         </div>
       </div>
 
-      <div class="mb-6">
-        <label class="block text-sm font-semibold text-content-secondary mb-3">
-          Genres / Categories
-        </label>
-        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
-          <div
-            v-for="g in genreOptions"
-            :key="g.genreName"
-            class="flex flex-col gap-2 px-4 py-3 rounded-xl border transition-all duration-150"
-            :class="createTable.genres.includes(g.genreName)
-              ? 'bg-primary-100 border-primary-300'
-              : 'bg-surface-800 border-surface-600 hover:border-surface-500'"
+      <div class="section-rule mb-4">
+        <span class="section-rule-label">Genres / Categories</span>
+        <div class="section-rule-line"></div>
+      </div>
+
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2 mb-6">
+        <div
+          v-for="g in genreOptions"
+          :key="g.genreName"
+          class="para-chip-sm p-3 transition-all duration-150"
+          :class="createTable.genres.includes(g.genreName) ? 'border-accent' : ''"
+        >
+          <label class="flex items-center gap-2.5 cursor-pointer">
+            <input
+              type="checkbox"
+              :id="g.genreName"
+              :value="g.genreName"
+              v-model="createTable.genres"
+              class="w-4 h-4"
+            />
+            <span class="type-body capitalize">{{ g.genreName }}</span>
+          </label>
+          <select
+            v-if="createTable.genres.includes(g.genreName)"
+            v-model="createTable.genreFormats[g.genreName]"
+            class="input-base text-xs mt-2"
           >
-            <label class="flex items-center gap-2.5 cursor-pointer"
-              :class="createTable.genres.includes(g.genreName) ? 'text-primary-400' : 'text-content-secondary'"
-            >
-              <input
-                type="checkbox"
-                :id="g.genreName"
-                :value="g.genreName"
-                v-model="createTable.genres"
-                class="w-4 h-4 rounded accent-primary-600"
-              />
-              <span class="text-sm font-medium capitalize">{{ g.genreName }}</span>
-            </label>
-            <select
-              v-if="createTable.genres.includes(g.genreName)"
-              v-model="createTable.genreFormats[g.genreName]"
-              class="text-xs px-2 py-1 rounded-lg bg-white/70 border border-primary-300 text-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-500/40 w-full"
-            >
-              <option value="">No format</option>
-              <option v-for="opt in formatOptions" :key="opt" :value="opt">{{ opt }}</option>
-            </select>
-          </div>
+            <option value="">No format</option>
+            <option v-for="opt in formatOptions" :key="opt" :value="opt">{{ opt }}</option>
+          </select>
         </div>
       </div>
 
       <!-- Payment required toggle -->
       <div class="mb-6">
         <label
-          class="flex items-center gap-3 px-4 py-3 rounded-xl border cursor-pointer transition-all duration-150 w-fit"
-          :class="paymentRequired
-            ? 'bg-amber-950 border-amber-300 text-amber-400'
-            : 'bg-surface-800 border-surface-600 text-content-secondary hover:border-surface-500'"
+          class="flex items-center gap-3 px-4 py-3 para-chip cursor-pointer transition-all duration-150 w-fit"
+          :class="paymentRequired ? 'border-accent' : ''"
         >
-          <input type="checkbox" v-model="paymentRequired" class="w-4 h-4 rounded accent-amber-500" />
+          <input type="checkbox" v-model="paymentRequired" class="w-4 h-4" />
           <div>
-            <span class="text-sm font-semibold">Payment Required</span>
-            <p class="text-xs mt-0.5" :class="paymentRequired ? 'text-amber-400' : 'text-content-muted'">
+            <span class="type-body">Payment Required</span>
+            <p class="type-label mt-0.5" :class="paymentRequired ? 'text-amber-400' : 'text-content-muted'">
               {{ paymentRequired ? 'Participants will be placed in an unverified queue until you manually verify payment in-app.' : 'All participants will be auto-verified and emailed immediately on import.' }}
             </p>
           </div>
@@ -880,28 +856,36 @@ onUnmounted(() => {
       </div>
 
       <div class="flex justify-end">
-        <ReusableButton variant="primary" @onClick="onSubmit" :disabled="loading">
-          <template #default>
-            <i class="pi text-xs" :class="loading ? 'pi-spinner pi-spin' : 'pi-database'"></i>
-            {{ loading ? 'Setting up…' : 'Initialise Event' }}
-          </template>
-        </ReusableButton>
+        <button
+          @click="onSubmit"
+          :disabled="loading"
+          class="bg-accent para-chip type-label disabled:opacity-50 px-5 py-2 flex items-center gap-2"
+        >
+          <i class="pi text-xs" :class="loading ? 'pi-spinner pi-spin' : 'pi-database'"></i>
+          {{ loading ? 'Setting up…' : 'Initialise Event' }}
+        </button>
       </div>
     </div>
 
   <!-- Genre Configuration — unified per-genre tabs (participants, format, criteria, judges) -->
-  <div v-if="tableExist && eventGenres.length > 0" class="card overflow-hidden mt-6">
+  <div v-if="tableExist && eventGenres.length > 0" class="card-hover p-4 relative mt-6">
+    <div class="corner-bar-tl"></div>
+
+    <div class="section-rule mb-4">
+      <span class="section-rule-label">Genre Configuration</span>
+      <div class="section-rule-line"></div>
+    </div>
 
     <!-- Genre tab bar -->
-    <div class="flex border-b border-surface-700/50 bg-surface-900/30 overflow-x-auto">
+    <div class="flex flex-wrap gap-2 mb-4">
       <button
         v-for="g in eventGenres"
         :key="g.genreName"
         @click="activeGenreTab = g.genreName"
-        class="px-5 py-3 text-sm font-semibold whitespace-nowrap transition-all duration-150 border-b-2"
+        class="para-chip-sm px-4 py-2 type-label transition-all duration-150"
         :class="activeGenreTab === g.genreName
-          ? 'border-primary-500 text-content-primary bg-surface-800/50'
-          : 'border-transparent text-content-muted hover:text-content-secondary hover:bg-surface-700/30'"
+          ? 'text-accent border-accent'
+          : 'text-content-muted hover:text-content-primary'"
       >
         {{ g.genreName }}
         <span
@@ -935,11 +919,11 @@ onUnmounted(() => {
               <span
                 v-for="p in getUnregistered(normalizeGenreName(g.genreName)).unregistered"
                 :key="p.participantName"
-                class="inline-flex items-center px-2.5 py-1 rounded-full bg-surface-800 text-rose-300 text-xs font-medium border border-rose-300/20 font-source"
+                class="badge-danger font-source"
               >{{ p.participantName }}</span>
             </div>
           </div>
-          <div v-else class="flex items-center gap-2 text-teal-300 text-xs">
+          <div v-else class="flex items-center gap-2 type-body text-emerald-400">
             <i class="pi pi-check-circle"></i>
             <span>All participants registered</span>
           </div>
@@ -951,16 +935,16 @@ onUnmounted(() => {
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
 
           <!-- Battle Format -->
-          <div class="flex flex-col gap-2 p-3 rounded-xl bg-surface-800/60 border border-surface-600/30">
-            <p class="text-xs font-semibold text-content-muted uppercase tracking-wide">Battle Format</p>
+          <div class="flex flex-col gap-2 p-3 para-chip">
+            <p class="type-label text-content-muted">Battle Format</p>
             <template v-if="editingFormatFor !== g.genreName">
               <div class="flex items-center justify-between">
-                <span class="font-source text-sm" :class="g.format ? 'text-primary-400' : 'text-content-muted'">
+                <span class="type-body" :class="g.format ? 'text-accent' : 'text-content-muted'">
                   {{ g.format || 'No format' }}
                 </span>
                 <button
                   @click="startEditFormat(g)"
-                  class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-surface-500 hover:text-content-primary transition-all"
+                  class="para-chip-sm px-2.5 py-1 type-label"
                 ><i class="pi pi-pencil" style="font-size:0.65rem"></i> Edit</button>
               </div>
             </template>
@@ -980,12 +964,12 @@ onUnmounted(() => {
           </div>
 
           <!-- Scoring Criteria -->
-          <div class="flex flex-col gap-2 p-3 rounded-xl bg-surface-800/60 border border-surface-600/30">
+          <div class="flex flex-col gap-2 p-3 para-chip">
             <div class="flex items-center justify-between">
-              <p class="text-xs font-semibold text-content-muted uppercase tracking-wide">Scoring Criteria</p>
+              <p class="type-label text-content-muted">Scoring Criteria</p>
               <button
                 @click="showCriteriaModal = true"
-                class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-primary-500/50 hover:text-primary-400 transition-all whitespace-nowrap"
+                class="para-chip-sm px-2.5 py-1 type-label"
               ><i class="pi pi-sliders-h" style="font-size:0.65rem"></i> Configure</button>
             </div>
             <template v-if="criteriaByGenre[g.genreName]?.length">
@@ -1019,23 +1003,23 @@ onUnmounted(() => {
               <span class="font-heading font-semibold text-content-secondary text-sm flex-1">{{ j.judgeName }}</span>
               <button
                 @click="submitRemoveJudge(j.judgeId)"
-                class="text-xs px-2.5 py-1 rounded-lg border border-surface-600/50 text-content-muted hover:border-red-800/50 hover:text-red-400 transition-all"
+                class="para-chip-sm px-2.5 py-1 type-label"
               >Remove</button>
             </div>
-            <div class="flex items-center gap-2 px-3 py-2 rounded-xl border border-dashed border-surface-600/40 mt-0.5">
+            <div class="flex items-center gap-2 para-chip p-2">
               <input
                 v-model="addJudgeInput"
                 type="text"
                 placeholder="Add judge…"
-                class="flex-1 bg-transparent text-sm text-content-secondary placeholder:text-content-muted focus:outline-none"
+                class="flex-1 bg-transparent type-body placeholder:text-content-muted focus:outline-none"
                 @keyup.enter="submitAddJudge"
               />
               <button
                 @click="submitAddJudge"
-                class="flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-surface-600 text-content-secondary hover:bg-surface-500 transition-colors"
+                class="bg-accent para-chip-sm px-2.5 py-1 type-label"
               ><i class="pi pi-plus" style="font-size:0.65rem"></i> Add</button>
             </div>
-            <p v-if="eventJudges.length === 0" class="text-xs text-content-muted px-1">No judges added yet</p>
+            <p v-if="eventJudges.length === 0" class="type-label text-content-muted px-1">No judges added yet</p>
           </div>
         </div>
 
@@ -1051,56 +1035,53 @@ onUnmounted(() => {
 
     <!-- Stat strip -->
     <div class="grid grid-cols-2 gap-3 mb-6">
-      <div class="card p-4">
-        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Registered</p>
-        <p class="text-2xl font-heading font-extrabold text-content-primary">{{ totalDbRegistered.length }}</p>
-        <span class="text-xs text-content-muted">Have audition numbers</span>
+      <div class="stat-card relative">
+        <div class="corner-bar-tl"></div>
+        <div class="type-stat">{{ totalDbRegistered.length }}</div>
+        <div class="type-label">Registered</div>
+        <div class="type-label text-content-muted mt-1">Have audition numbers</div>
       </div>
-      <div class="card p-4">
-        <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1">Not Shown Up</p>
-        <p class="text-2xl font-heading font-extrabold" :class="totalNotShownUp > 0 ? 'text-amber-300' : 'text-content-primary'">
-          {{ totalNotShownUp }}
-        </p>
-        <span class="text-xs text-content-muted">Verified but no audition number yet</span>
+      <div class="stat-card relative">
+        <div class="corner-bar-tl"></div>
+        <div class="type-stat" :class="totalNotShownUp > 0 ? 'text-amber-400' : ''">{{ totalNotShownUp }}</div>
+        <div class="type-label">Not Shown Up</div>
+        <div class="type-label text-content-muted mt-1">Verified but no audition number yet</div>
       </div>
     </div>
 
     <!-- Not Shown Up panel -->
     <div class="space-y-2 mb-6">
-      <div v-if="notShownUpList.length > 0" class="card overflow-hidden panel-warning">
+      <div v-if="notShownUpList.length > 0" class="card-hover p-4 relative">
+        <div class="corner-bar-tl"></div>
         <button
           @click="expandedPeople.has('notShownUp') ? expandedPeople.delete('notShownUp') : expandedPeople.add('notShownUp'); expandedPeople = new Set(expandedPeople)"
           :aria-expanded="expandedPeople.has('notShownUp')"
-          class="w-full flex items-center justify-between px-5 py-4 bg-surface-900/40 hover:bg-surface-700/60 transition-colors duration-150 text-left"
+          class="w-full flex items-center justify-between text-left"
         >
           <div class="flex items-center gap-3">
-            <div class="icon-wrap w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
-              <i class="pi pi-clock text-amber-300 text-xs"></i>
-            </div>
-            <span class="font-heading font-bold text-content-secondary">Not Shown Up</span>
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-amber-300 border border-amber-900/30">
-              {{ notShownUpList.length }}
-            </span>
+            <i class="pi pi-clock text-amber-300 text-xs"></i>
+            <span class="type-body text-content-secondary">Not Shown Up</span>
+            <span class="badge-warning">{{ notShownUpList.length }}</span>
           </div>
           <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
              :class="{ 'rotate-180': expandedPeople.has('notShownUp') }"></i>
         </button>
-        <div v-if="expandedPeople.has('notShownUp')" class="px-4 pb-4 border-t border-surface-600/30 pt-4">
+        <div v-if="expandedPeople.has('notShownUp')" class="mt-4 pt-4 border-t border-surface-600/30">
           <div class="space-y-2">
             <div
               v-for="p in notShownUpList"
               :key="p.name"
-              class="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-surface-700/50 border border-surface-600"
+              class="para-chip p-3"
             >
               <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-sm font-semibold text-content-secondary">{{ p.name }}</span>
+                <span class="type-body text-content-secondary">{{ p.name }}</span>
               </div>
-              <div class="flex flex-wrap gap-1">
+              <div class="flex flex-wrap gap-1 mt-1">
                 <span v-for="g in p.genres" :key="g"
-                  class="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-surface-800 border border-surface-600 text-content-muted"
+                  class="badge-neutral"
                 >{{ g }}</span>
               </div>
-              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted mt-0.5">
+              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 type-label text-content-muted mt-0.5">
                 <i class="pi pi-users" style="font-size:0.65rem"></i>
                 <span>{{ p.memberNames.join(', ') }}</span>
               </div>
@@ -1108,7 +1089,7 @@ onUnmounted(() => {
           </div>
         </div>
       </div>
-      <p v-else class="text-sm text-teal-300 flex items-center gap-2 px-1">
+      <p v-else class="type-body text-emerald-400 flex items-center gap-2 px-1">
         <i class="pi pi-check-circle"></i> All verified participants have shown up
       </p>
     </div>
@@ -1117,72 +1098,68 @@ onUnmounted(() => {
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
 
       <!-- Check-In card -->
-      <div class="card flex flex-col h-[520px]">
-        <div class="flex items-center justify-between px-5 py-4 border-b border-surface-600/30 shrink-0">
+      <div class="card-hover p-4 relative flex flex-col h-[520px]">
+        <div class="corner-bar-tl"></div>
+        <div class="flex items-center justify-between mb-4 shrink-0">
           <div class="flex items-center gap-3">
-            <div class="w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
-              <i class="pi pi-users text-content-muted text-xs"></i>
-            </div>
-            <span class="font-heading font-bold text-content-secondary">Check-In</span>
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-amber-300 border border-amber-900/30">
-              {{ checkinList.filter(p => !isCheckedIn(p)).length }} pending
-            </span>
+            <i class="pi pi-users text-content-muted text-xs"></i>
+            <span class="type-body text-content-secondary">Check-In</span>
+            <span class="badge-warning">{{ checkinList.filter(p => !isCheckedIn(p)).length }} pending</span>
           </div>
         </div>
-        <div class="flex-1 overflow-y-auto px-4 py-3 space-y-2 min-h-0">
-          <div v-if="loadingCheckinList" class="flex items-center justify-center h-full text-content-muted text-sm">
+        <div class="flex-1 overflow-y-auto space-y-2 min-h-0">
+          <div v-if="loadingCheckinList" class="flex items-center justify-center h-full type-label text-content-muted">
             <i class="pi pi-spinner pi-spin mr-2"></i> Loading…
           </div>
-          <div v-else-if="checkinList.length === 0" class="flex items-center justify-center h-full text-content-muted text-sm">
+          <div v-else-if="checkinList.length === 0" class="flex items-center justify-center h-full type-label text-content-muted">
             No participants found
           </div>
           <template v-else>
             <div v-for="p in sortedCheckinList" :key="p.participantId"
-              class="flex items-center gap-3 px-3 py-2.5 rounded-xl border transition-colors"
-              :class="isCheckedIn(p) ? 'bg-surface-700/30 border-surface-600/20 opacity-50' : 'bg-surface-800 border-surface-600'"
+              class="para-chip p-3 transition-colors"
+              :class="isCheckedIn(p) ? 'opacity-50' : ''"
             >
               <div class="flex-1 min-w-0">
-                <p class="text-sm font-semibold text-content-secondary truncate">{{ p.label }}</p>
+                <p class="type-body text-content-secondary truncate">{{ p.label }}</p>
                 <div class="flex flex-wrap gap-1 mt-0.5">
                   <span v-for="g in p.genres" :key="g.genreName"
-                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs bg-surface-700 border border-surface-600 text-content-muted"
+                    class="badge-neutral"
                   >
                     <span class="capitalize">{{ g.genreName }}</span>
-                    <span v-if="g.auditionNumber !== null" class="font-heading font-extrabold text-primary-400">#{{ g.auditionNumber }}</span>
+                    <span v-if="g.auditionNumber !== null" class="text-accent ml-1">#{{ g.auditionNumber }}</span>
                   </span>
                 </div>
               </div>
-              <button v-if="!isCheckedIn(p)" @click="checkIn(p)" :disabled="checkingInId === p.participantId"
-                class="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-semibold hover:bg-primary-500 active:scale-95 disabled:opacity-50 transition-all"
-              >
-                <i class="pi text-xs" :class="checkingInId === p.participantId ? 'pi-spinner pi-spin' : 'pi-check'"></i>
-                {{ checkingInId === p.participantId ? '…' : 'Check In' }}
-              </button>
-              <i v-else class="pi pi-check-circle text-teal-400 text-sm shrink-0"></i>
+              <div class="flex items-center gap-2 mt-2 justify-end">
+                <button v-if="!isCheckedIn(p)" @click="checkIn(p)" :disabled="checkingInId === p.participantId"
+                  class="bg-accent para-chip-sm px-3 py-1.5 type-label disabled:opacity-50"
+                >
+                  <i class="pi text-xs" :class="checkingInId === p.participantId ? 'pi-spinner pi-spin' : 'pi-check'"></i>
+                  {{ checkingInId === p.participantId ? '…' : 'Check In' }}
+                </button>
+                <i v-else class="pi pi-check-circle text-emerald-400 text-sm"></i>
+              </div>
             </div>
           </template>
         </div>
       </div>
 
       <!-- Registered card -->
-      <div class="card flex flex-col h-[520px]">
-        <div class="flex items-center justify-between px-5 py-4 border-b border-surface-600/30 shrink-0">
+      <div class="card-hover p-4 relative flex flex-col h-[520px]">
+        <div class="corner-bar-tl"></div>
+        <div class="flex items-center justify-between mb-4 shrink-0">
           <div class="flex items-center gap-3">
-            <div class="w-7 h-7 rounded-lg bg-surface-700 flex items-center justify-center shrink-0">
-              <i class="pi pi-check-circle text-teal-400 text-xs"></i>
-            </div>
-            <span class="font-heading font-bold text-content-secondary">Registered</span>
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-surface-700 text-teal-300 border border-teal-900/30">
-              {{ registeredList.length }}
-            </span>
+            <i class="pi pi-check-circle text-emerald-400 text-xs"></i>
+            <span class="type-body text-content-secondary">Registered</span>
+            <span class="badge-success">{{ registeredList.length }}</span>
           </div>
         </div>
-        <div class="px-4 py-3 border-b border-surface-600/20 shrink-0">
+        <div class="mb-4 shrink-0">
           <div class="flex gap-2">
             <div class="relative flex-1">
               <i class="pi pi-search absolute left-3 top-1/2 -translate-y-1/2 text-content-muted text-xs pointer-events-none"></i>
               <input v-model="registeredSearch" type="text" placeholder="Search by name or genre…" autocomplete="off"
-                class="w-full pl-8 pr-8 py-2 rounded-lg border border-surface-600 bg-surface-900 text-sm text-content-primary placeholder-content-muted focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+                class="input-base pl-8 pr-8"
               />
               <button v-if="registeredSearch" @click="registeredSearch = ''"
                 class="absolute right-2.5 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-secondary transition-colors">
@@ -1190,54 +1167,54 @@ onUnmounted(() => {
               </button>
             </div>
             <select v-model="registeredGenreFilter"
-              class="px-3 py-2 rounded-lg border border-surface-600 bg-surface-900 text-sm text-content-secondary focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500 transition-colors"
+              class="input-base w-auto"
             >
               <option value="">All genres</option>
               <option v-for="g in registeredGenreOptions" :key="g" :value="g">{{ g }}</option>
             </select>
           </div>
-          <p v-if="registeredSearch || registeredGenreFilter" class="text-xs text-content-muted mt-2">
+          <p v-if="registeredSearch || registeredGenreFilter" class="type-label text-content-muted mt-2">
             {{ filteredRegisteredList.length }} result{{ filteredRegisteredList.length !== 1 ? 's' : '' }}
           </p>
         </div>
-        <div class="flex-1 overflow-y-auto px-4 py-3 space-y-2 min-h-0">
-          <div v-if="registeredList.length === 0" class="flex items-center justify-center h-full text-content-muted text-sm">
+        <div class="flex-1 overflow-y-auto space-y-2 min-h-0">
+          <div v-if="registeredList.length === 0" class="flex items-center justify-center h-full type-label text-content-muted">
             No registered participants yet
           </div>
-          <div v-else-if="filteredRegisteredList.length === 0" class="flex items-center justify-center h-full text-content-muted text-sm">
+          <div v-else-if="filteredRegisteredList.length === 0" class="flex items-center justify-center h-full type-label text-content-muted">
             No results match your search
           </div>
           <template v-else>
             <div v-for="p in filteredRegisteredList" :key="p.name"
-              class="flex flex-col gap-2 px-3 py-2.5 rounded-xl bg-surface-900 border border-surface-600"
+              class="para-chip p-3"
             >
               <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-sm font-semibold text-content-secondary">{{ p.name }}</span>
-                <span v-if="p.walkin" class="shrink-0 inline-flex px-1.5 py-0.5 rounded text-xs font-medium bg-surface-700 text-content-muted border border-surface-600">walk-in</span>
+                <span class="type-body text-content-secondary">{{ p.name }}</span>
+                <span v-if="p.walkin" class="badge-neutral">walk-in</span>
                 <span v-if="p.walkin && p.referenceCode"
-                  class="relative shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-surface-800 border border-surface-600 cursor-pointer select-none touch-none"
+                  class="relative shrink-0 inline-flex items-center gap-1 px-2 py-0.5 badge-neutral cursor-pointer select-none touch-none"
                   @mousedown="revealingRef = p.name" @mouseup="revealingRef = null" @mouseleave="revealingRef = null"
                   @touchstart.prevent="revealingRef = p.name" @touchend="revealingRef = null" @touchcancel="revealingRef = null"
                 >
                   <i class="pi pi-eye text-content-muted" style="font-size:0.65rem"></i>
                   <span class="text-content-muted">Ref code</span>
                   <span v-if="revealingRef === p.name"
-                    class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-4 py-2.5 rounded-xl bg-surface-700 border border-surface-500 shadow-xl whitespace-nowrap z-50 pointer-events-none"
+                    class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-4 py-2.5 para-chip shadow-xl whitespace-nowrap z-50 pointer-events-none"
                   >
-                    <span class="font-source tracking-widest text-primary-400 text-base font-bold">{{ p.referenceCode }}</span>
+                    <span class="font-source tracking-widest text-accent text-base font-bold">{{ p.referenceCode }}</span>
                     <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-500"></span>
                   </span>
                 </span>
               </div>
-              <div class="flex flex-wrap gap-1.5">
+              <div class="flex flex-wrap gap-1.5 mt-1">
                 <span v-for="e in p.entries" :key="e.genre"
-                  class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-surface-800 border border-primary-200 text-sm"
+                  class="badge-neutral"
                 >
-                  <span class="text-content-muted capitalize text-xs">{{ e.genre }}</span>
-                  <span class="font-heading font-extrabold text-primary-400">#{{ e.auditionNumber }}</span>
+                  <span class="text-content-muted capitalize">{{ e.genre }}</span>
+                  <span class="text-accent ml-1">#{{ e.auditionNumber }}</span>
                 </span>
               </div>
-              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 text-xs text-content-muted">
+              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 type-label text-content-muted mt-0.5">
                 <i class="pi pi-users" style="font-size:0.65rem"></i>
                 <span>{{ p.memberNames.join(', ') }}</span>
               </div>
@@ -1251,6 +1228,7 @@ onUnmounted(() => {
   </template>
   <!-- ── END EVENT DAY TAB ──────────────────────────────────────────────────── -->
 
+  </div><!-- end relative z-10 -->
   </div><!-- end page-container -->
 
   <ActionDoneModal
@@ -1260,7 +1238,7 @@ onUnmounted(() => {
     @accept="handleAccept"
     @close="handleAccept"
   >
-    <p class="text-content-secondary leading-relaxed">{{ modalMessage }}</p>
+    <p class="type-body text-content-secondary">{{ modalMessage }}</p>
   </ActionDoneModal>
 
   <LoadingOverlay v-if="onStartLoading">Loading event data…</LoadingOverlay>

--- a/BES-frontend/src/views/EventSelector.vue
+++ b/BES-frontend/src/views/EventSelector.vue
@@ -62,21 +62,25 @@ const handleSubmit = async () => {
 </script>
 
 <template>
-  <div class="page-container flex items-start justify-center">
-    <div class="w-full max-w-md mt-10">
+  <div class="page-container flex items-start justify-center relative">
+    <div class="color-bleed"></div>
+    <div class="relative z-10 w-full max-w-md mt-10">
       <div class="card p-8">
 
         <!-- Header -->
         <div class="mb-8">
-          <h1 class="font-heading font-bold text-content-primary text-2xl mb-1">Select Event</h1>
-          <p class="text-muted text-sm">Choose the event you are working on today</p>
+          <div class="type-page-title mb-1">Select Event</div>
+          <p class="type-label text-content-muted">{{ events.length }} available</p>
         </div>
 
         <form @submit.prevent="handleSubmit" class="space-y-5">
 
           <!-- Event grid -->
           <div>
-            <label class="block text-sm font-semibold text-content-secondary mb-2">Event</label>
+            <div class="section-rule mb-4">
+              <span class="section-rule-label">Available Events</span>
+              <div class="section-rule-line"></div>
+            </div>
             <div class="grid gap-2" :class="events.length > 4 ? 'grid-cols-2' : 'grid-cols-1'">
               <button
                 v-for="event in events"
@@ -84,59 +88,55 @@ const handleSubmit = async () => {
                 type="button"
                 @click="selectedEventId = event.id; accessCode = ''; error = ''"
                 :class="[
-                  'text-center px-3 py-4 rounded-xl border transition-all duration-150',
-                  selectedEventId === event.id
-                    ? 'border-primary-500 bg-primary-500/15 text-primary-400 font-semibold'
-                    : 'border-surface-600 bg-surface-700 hover:border-primary-500/50 hover:bg-surface-600 text-content-primary'
+                  'card-hover p-5 text-left relative group w-full',
+                  selectedEventId === event.id ? 'border-[color:var(--accent-muted)]' : ''
                 ]"
               >
-                <div class="font-heading font-semibold text-sm leading-snug">{{ event.name }}</div>
+                <div class="corner-bar-tl"></div>
+                <div class="type-body mb-1">{{ event.name }}</div>
                 <div
                   v-if="isAdmin && event.accessCode"
-                  class="font-source text-xs text-content-muted tracking-widest mt-0.5"
+                  class="type-label text-content-muted"
                 >
                   {{ event.accessCode }}
                 </div>
               </button>
             </div>
-            <p v-if="events.length === 0" class="text-sm text-muted mt-2">No events found.</p>
+            <p v-if="events.length === 0" class="type-label text-content-muted mt-2">No events found.</p>
           </div>
 
           <!-- Already verified chip -->
           <div
             v-if="alreadyVerified && !isAdmin"
-            class="flex items-center gap-2 px-3 py-2 rounded-xl bg-emerald-950 border border-emerald-800/50"
+            class="semantic-chip-success flex items-center gap-2 px-3 py-2"
           >
-            <i class="pi pi-check-circle text-emerald-400 text-sm"></i>
-            <span class="text-emerald-400 text-sm font-medium">Already verified — you can proceed directly</span>
+            <div class="w-2 h-2 rounded-full bg-emerald-400 flex-shrink-0" style="box-shadow: 0 0 6px rgba(52,211,153,0.8)"></div>
+            <span class="type-label text-emerald-400">Already verified — you can proceed directly</span>
           </div>
 
           <!-- Access code input (non-admin, not yet verified) -->
           <div v-if="selectedEventId !== null && !isAdmin && !alreadyVerified">
-            <label class="block text-sm font-semibold text-content-secondary mb-2">Access Code</label>
+            <label class="type-label text-content-muted block mb-2">Access Code</label>
             <input
               v-model="accessCode"
               type="text"
               inputmode="numeric"
               maxlength="4"
               placeholder="0000"
-              class="input-base font-source text-2xl tracking-widest text-center"
+              class="input-base text-2xl tracking-widest text-center"
               autocomplete="off"
             />
           </div>
 
           <!-- Error -->
-          <p v-if="error" class="text-sm text-red-400 font-medium">{{ error }}</p>
+          <p v-if="error" class="type-label text-red-400">{{ error }}</p>
 
           <!-- Submit -->
           <button
             type="submit"
             :disabled="isLoading || !selectedEventId"
-            class="w-full py-3 px-6 rounded-xl font-semibold text-sm text-white
-                   bg-primary-600 hover:bg-primary-700 active:scale-95
-                   disabled:opacity-50 disabled:cursor-not-allowed
-                   transition-all duration-200 btn-glow
-                   flex items-center justify-center gap-2"
+            class="w-full py-3 type-body bg-accent text-surface-900 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center gap-2"
+            style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
           >
             <span v-if="isLoading">
               <i class="pi pi-spin pi-spinner mr-2"></i>Verifying…

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -66,15 +66,18 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="page-container">
+  <div class="page-container relative">
+    <div class="color-bleed"></div>
+
+    <div class="relative z-10">
 
     <!-- Page header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
       <div>
-        <h1 class="page-title">Events</h1>
-        <p class="text-muted mt-1">Select an event to manage participants and scores</p>
+        <div class="type-page-title mb-1">Events</div>
+        <p class="type-label text-content-muted">Select an event to manage participants and scores</p>
       </div>
-      <span class="badge-neutral self-start sm:self-auto text-sm px-3 py-1">
+      <span class="badge-neutral type-label self-start sm:self-auto px-3 py-1">
         {{ events.length }} event{{ events.length !== 1 ? 's' : '' }}
       </span>
     </div>
@@ -87,9 +90,14 @@ onMounted(async () => {
       <input
         v-model="search"
         type="text"
-        placeholder="Search events…"
+        placeholder="Search events"
         class="input-base !pl-10"
       />
+    </div>
+
+    <div class="section-rule mb-6">
+      <span class="section-rule-label">All Events</span>
+      <div class="section-rule-line"></div>
     </div>
 
     <!-- Events grid -->
@@ -115,14 +123,15 @@ onMounted(async () => {
 
     <!-- Empty state -->
     <div v-else class="flex flex-col items-center justify-center py-24 text-center">
-      <div class="icon-wrap w-16 h-16 rounded-2xl bg-surface-700 flex items-center justify-center mb-4">
+      <div class="para-chip w-16 h-16 flex items-center justify-center mb-4">
         <i class="pi pi-calendar text-content-muted text-2xl"></i>
       </div>
-      <p class="font-heading font-semibold text-content-secondary text-lg">No events found</p>
-      <p class="text-muted mt-1">
+      <p class="type-body text-content-secondary">No events found</p>
+      <p class="type-label text-content-muted mt-1">
         {{ search ? 'Try a different search term' : 'No events are available yet' }}
       </p>
     </div>
 
+  </div>
   </div>
 </template>

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -51,181 +51,109 @@ const submitLogin = async () => {
 </script>
 
 <template>
-  <div class="min-h-screen flex overflow-hidden">
+  <div class="min-h-screen flex overflow-hidden bg-surface-950 relative">
 
-    <!-- ── Left panel: Brand ───────────────────────────────────────────── -->
-    <div class="hidden lg:flex lg:w-[52%] relative flex-col justify-between p-14 overflow-hidden login-panel">
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
 
-      <!-- CSS-only dot-grid pattern -->
-      <div class="absolute inset-0 login-dots pointer-events-none"></div>
+    <!-- ── Left panel: BES hero ───────────────────────────────── -->
+    <div class="hidden lg:flex lg:w-[52%] relative flex-col justify-between p-14 overflow-hidden">
+      <div class="absolute inset-0 bg-surface-900"></div>
+      <div class="corner-bar-tl" style="height: 40%"></div>
+      <div class="corner-bar-bl" style="width: 40%"></div>
 
-      <!-- Thin gradient separator -->
-      <div class="absolute right-0 top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-primary-500/30 to-transparent"></div>
-
-      <!-- Top: Wordmark -->
-      <div class="relative z-10 flex items-center gap-3">
-        <div class="w-10 h-10 rounded-xl bg-primary-500/20 border border-primary-500/30 flex items-center justify-center">
-          <span class="font-anton text-primary-400 text-xl leading-none">B</span>
-        </div>
-        <span class="font-anton text-white text-2xl tracking-widest">BES</span>
+      <!-- Wordmark -->
+      <div class="relative z-10 flex items-center gap-2.5">
+        <div class="glow-dot"></div>
+        <span class="type-body tracking-[0.12em]">BES</span>
       </div>
 
-      <!-- Centre: Hero text -->
-      <div class="relative z-10 max-w-lg">
-        <h1 class="font-anton text-[clamp(4.5rem,8vw,7rem)] text-white leading-none tracking-wide mb-8">
-          BES
-        </h1>
-        <div class="border-l-4 border-primary-500 pl-5">
-          <p class="font-sans text-lg font-light text-content-secondary leading-relaxed">
-            The all-in-one platform for street dance battle events — from registration to the final round.
-          </p>
+      <!-- Hero -->
+      <div class="relative z-10">
+        <div class="type-display mb-6">BES</div>
+        <div class="section-rule mb-6">
+          <div class="section-rule-line"></div>
         </div>
-
-        <!-- Feature pills -->
+        <p class="type-body text-content-secondary leading-relaxed max-w-md">
+          The all-in-one platform for street dance battle events — registration, judging, real-time battles.
+        </p>
         <div class="flex flex-wrap gap-2 mt-8">
-          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-surface-800/60 text-content-secondary text-xs font-medium border border-surface-600/40">
-            <i class="pi pi-calendar text-primary-400 text-xs"></i> Event Management
-          </span>
-          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-surface-800/60 text-content-secondary text-xs font-medium border border-surface-600/40">
-            <i class="pi pi-list text-primary-400 text-xs"></i> Audition Control
-          </span>
-          <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-surface-800/60 text-content-secondary text-xs font-medium border border-surface-600/40">
-            <i class="pi pi-bolt text-primary-400 text-xs"></i> Battle System
-          </span>
+          <span class="badge-neutral px-3 py-1.5">Event Management</span>
+          <span class="badge-neutral px-3 py-1.5">Audition Control</span>
+          <span class="badge-neutral px-3 py-1.5">Battle System</span>
         </div>
       </div>
 
-      <!-- Bottom: Copyright -->
-      <div class="relative z-10 text-content-disabled text-sm">
-        &copy; {{ new Date().getFullYear() }} BES Platform. All rights reserved.
+      <!-- Footer -->
+      <div class="relative z-10 type-label text-content-muted">
+        &copy; {{ new Date().getFullYear() }} BES Platform
       </div>
     </div>
 
-    <!-- ── Right panel: Form ───────────────────────────────────────────── -->
-    <div class="w-full lg:w-[48%] flex items-center justify-center bg-surface-900 px-8 sm:px-14 lg:px-20 py-12">
-      <div class="w-full max-w-sm animate-fade-in">
+    <!-- ── Right panel: Login form ───────────────────────────── -->
+    <div class="flex-1 flex items-center justify-center p-8 relative z-10">
+      <div class="w-full max-w-sm relative">
+        <!-- Corner bars on form panel -->
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
 
-        <!-- Mobile brand mark -->
-        <div class="lg:hidden flex items-center gap-2 mb-10">
-          <div class="w-9 h-9 rounded-lg bg-primary-600 flex items-center justify-center">
-            <span class="font-anton text-white text-xl leading-none">B</span>
+        <div class="p-8 bg-surface-900 border border-[rgba(255,255,255,0.07)]"
+          style="clip-path: polygon(8px 0%,100% 0%,calc(100% - 8px) 100%,0% 100%)">
+
+          <div class="mb-8">
+            <div class="type-page-title mb-1">Sign In</div>
+            <p class="type-label text-content-muted">Battle Event System</p>
           </div>
-          <span class="font-anton text-content-primary text-2xl tracking-widest">BES</span>
-        </div>
 
-        <!-- Heading -->
-        <div class="mb-8">
-          <h2 class="font-heading font-extrabold text-3xl text-content-primary tracking-tight">
-            Welcome back
-          </h2>
-          <p class="text-content-muted text-sm mt-1.5">
-            Sign in to access your event dashboard
-          </p>
-        </div>
-
-        <!-- Form -->
-        <form @submit.prevent="submitLogin" class="space-y-5">
-
-          <!-- Username -->
-          <div>
-            <label for="username" class="block text-sm font-semibold text-content-secondary mb-1.5">
-              Username
-            </label>
-            <div class="relative">
-              <span class="absolute inset-y-0 left-0 flex items-center pl-3.5 text-content-muted pointer-events-none">
-                <i class="pi pi-user text-sm"></i>
-              </span>
+          <form @submit.prevent="submitLogin" class="space-y-4">
+            <div>
+              <label class="type-label text-content-muted block mb-2">Username</label>
               <input
-                id="username"
-                type="text"
-                placeholder="Enter your username"
                 v-model="username"
+                type="text"
+                placeholder="Username"
+                class="input-base w-full"
                 autocomplete="username"
-                class="w-full pl-10 pr-4 py-3 text-sm rounded-xl border border-surface-600 bg-surface-800
-                       text-content-primary placeholder:text-content-disabled
-                       focus:bg-surface-700 focus:outline-none focus:ring-2 focus:ring-primary-600/30 focus:border-primary-600
-                       transition-all duration-200"
               />
             </div>
-          </div>
-
-          <!-- Password -->
-          <div>
-            <div class="flex justify-between items-center mb-1.5">
-              <label for="password" class="text-sm font-semibold text-content-secondary">Password</label>
-              <a href="#" class="text-xs font-medium text-primary-400 hover:text-primary-300 hover:underline transition-colors">
-                Forgot password?
-              </a>
+            <div>
+              <label class="type-label text-content-muted block mb-2">Password</label>
+              <div class="relative">
+                <input
+                  v-model="password"
+                  :type="showPassword ? 'text' : 'password'"
+                  placeholder="Password"
+                  class="input-base w-full pr-10"
+                  autocomplete="current-password"
+                />
+                <button type="button" @click="showPassword = !showPassword"
+                  class="absolute right-3 top-1/2 -translate-y-1/2 type-label text-content-muted hover:text-content-primary transition-colors">
+                  <i class="pi" :class="showPassword ? 'pi-eye-slash' : 'pi-eye'"></i>
+                </button>
+              </div>
             </div>
-            <div class="relative">
-              <span class="absolute inset-y-0 left-0 flex items-center pl-3.5 text-content-muted pointer-events-none">
-                <i class="pi pi-lock text-sm"></i>
-              </span>
-              <input
-                id="password"
-                :type="showPassword ? 'text' : 'password'"
-                placeholder="Enter your password"
-                v-model="password"
-                autocomplete="current-password"
-                class="w-full pl-10 pr-11 py-3 text-sm rounded-xl border border-surface-600 bg-surface-800
-                       text-content-primary placeholder:text-content-disabled
-                       focus:bg-surface-700 focus:outline-none focus:ring-2 focus:ring-primary-600/30 focus:border-primary-600
-                       transition-all duration-200"
-              />
-              <button
-                type="button"
-                @click="showPassword = !showPassword"
-                class="absolute inset-y-0 right-0 flex items-center pr-3.5 text-content-muted hover:text-content-secondary transition-colors"
-              >
-                <i class="pi text-sm" :class="showPassword ? 'pi-eye-slash' : 'pi-eye'"></i>
-              </button>
-            </div>
-          </div>
 
-          <!-- Submit -->
-          <div class="pt-2">
             <button
               type="submit"
               :disabled="isLoading"
-              class="w-full py-3 px-6 rounded-xl font-semibold text-sm text-white
-                     bg-primary-600 hover:bg-primary-700 active:bg-primary-700
-                     shadow-sm hover:shadow-md
-                     disabled:opacity-60 disabled:cursor-not-allowed
-                     focus:outline-none focus:ring-2 focus:ring-primary-600/40 focus:ring-offset-1 focus:ring-offset-surface-800
-                     transition-all duration-200 active:scale-[0.99] btn-glow
-                     flex items-center justify-center gap-2"
-            >
-              <i v-if="isLoading" class="pi pi-spinner pi-spin text-sm"></i>
-              <span>{{ isLoading ? 'Signing in…' : 'Sign In' }}</span>
+              class="w-full py-3 type-body bg-accent text-surface-900 transition-all duration-200 disabled:opacity-50 mt-2"
+              style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)">
+              {{ isLoading ? 'Signing in...' : 'Sign In' }}
             </button>
-          </div>
-
-        </form>
+          </form>
+        </div>
       </div>
     </div>
 
+    <!-- Error modal -->
+    <ActionDoneModal
+      :show="showModal"
+      :title="modalTitle"
+      :variant="modalVariant"
+      @accept="handleAccept"
+      @close="showModal = false"
+    >
+      <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+    </ActionDoneModal>
   </div>
-
-  <ActionDoneModal
-    :show="showModal"
-    :title="modalTitle"
-    :variant="modalVariant"
-    @accept="handleAccept"
-    @close="handleAccept"
-  >
-    <p class="text-content-secondary leading-relaxed">{{ modalMessage }}</p>
-  </ActionDoneModal>
 </template>
-
-<style scoped>
-/* Dark navy brand panel */
-.login-panel {
-  background-color: #070e1d;
-}
-
-/* Subtle cyan dot grid — pure CSS, no animations */
-.login-dots {
-  background-image: radial-gradient(circle, rgba(6, 182, 212, 0.15) 1px, transparent 1px);
-  background-size: 28px 28px;
-}
-</style>

--- a/BES-frontend/src/views/MainMenu.vue
+++ b/BES-frontend/src/views/MainMenu.vue
@@ -1,225 +1,131 @@
 <script setup>
 import { computed } from 'vue'
 import { useAuthStore } from '@/utils/auth'
-import { useScrollReveal } from '@/utils/useScrollReveal'
 
 const authStore = useAuthStore()
-const { revealRef } = useScrollReveal()
 
 const role = computed(() =>
   authStore.user ? authStore.user['role'][0]['authority'] : ''
 )
 
-const roleLabel = computed(() => {
-  const map = {
-    ROLE_ADMIN:     'Admin',
-    ROLE_ORGANISER: 'Organiser',
-    ROLE_JUDGE:     'Judge',
-    ROLE_EMCEE:     'Emcee',
-  }
-  return map[role.value] ?? 'User'
-})
+const activeEvent = computed(() => authStore.activeEvent)
 
-// Quick action cards per role
-const quickActions = computed(() => {
-  const r = role.value
-  const all = [
-    {
-      icon: 'pi-calendar',
-      title: 'Events',
-      desc: 'Browse and manage dance battle events',
-      route: '/events',
-      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'],
-    },
-    {
-      icon: 'pi-users',
-      title: 'Participants',
-      desc: 'Assign judges and manage participant entries',
-      route: '/event/update-event-details',
-      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'],
-    },
-    {
-      icon: 'pi-chart-bar',
-      title: 'Scoreboard',
-      desc: 'View and compare scores across genres',
-      route: '/event/score',
-      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'],
-    },
-    {
-      icon: 'pi-list',
-      title: 'Audition List',
-      desc: 'Manage auditions, score participants, and run the timer',
-      route: '/event/audition-list',
-      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'],
-    },
-    {
-      icon: 'pi-bolt',
-      title: 'Battle Control',
-      desc: 'Run the bracket, manage rounds and voting',
-      route: '/battle/control',
-      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'],
-    },
-    {
-      icon: 'pi-sitemap',
-      title: 'Crew Formation',
-      desc: 'Form pickup crews from solo auditioners',
-      route: '/event/crew-formation',
-      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'],
-    },
-    {
-      icon: 'pi-thumbs-up',
-      title: 'Battle Judge',
-      desc: 'Cast your vote during live battle rounds',
-      route: '/battle/judge',
-      roles: ['ROLE_JUDGE'],
-    },
-    {
-      icon: 'pi-cog',
-      title: 'Admin',
-      desc: 'Manage judges, genres, and system settings',
-      route: '/admin',
-      roles: ['ROLE_ADMIN'],
-    },
-  ]
-  return all.filter(a => a.roles.includes(r))
+const roleDisplay = computed(() => {
+  const labels = { ROLE_ADMIN: 'Admin', ROLE_ORGANISER: 'Organiser', ROLE_JUDGE: 'Judge', ROLE_EMCEE: 'Emcee' }
+  const label = labels[role.value]
+  return label ? { label } : null
 })
 </script>
 
 <template>
-  <div class="page-container">
+  <div class="page-container relative">
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
 
-    <!-- Welcome header -->
-    <div class="mb-10">
-      <div class="flex items-center gap-2 mb-2">
-        <span class="badge-neutral text-xs px-2.5 py-1">{{ roleLabel }}</span>
+    <div class="relative z-10">
+      <!-- Page header -->
+      <div class="mb-8">
+        <div class="type-page-title mb-1">Home</div>
+        <p class="type-label text-content-muted">{{ roleDisplay?.label ?? 'Welcome' }}</p>
       </div>
-      <h1 class="page-title">Welcome to BES</h1>
-      <p class="text-muted mt-1">Battle Event System — your quick access dashboard</p>
-    </div>
 
-    <!-- Quick action cards with scroll reveal -->
-    <div
-      :ref="revealRef"
-      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-12"
-    >
-      <button
-        v-for="(action, i) in quickActions"
-        :key="action.title"
-        @click="$router.push(action.route)"
-        class="group card-hover text-left p-6 focus:outline-none
-               focus:ring-2 focus:ring-primary-500/30 reveal"
-        :class="`reveal-delay-${Math.min(i + 1, 4)}`"
-      >
-        <!-- Icon -->
-        <div class="w-11 h-11 rounded-xl bg-primary-100 group-hover:bg-primary-200
-                    flex items-center justify-center mb-4 transition-colors duration-200">
-          <i class="pi text-primary-400 text-xl" :class="action.icon"></i>
-        </div>
-        <!-- Text -->
-        <h3 class="font-heading font-bold text-content-primary text-base mb-1">
-          {{ action.title }}
-        </h3>
-        <p class="text-content-muted text-sm leading-relaxed">{{ action.desc }}</p>
-        <!-- Arrow -->
-        <div class="flex items-center gap-1 mt-4 text-primary-400 text-xs font-semibold
-                    opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-          Open <i class="pi pi-arrow-right text-xs"></i>
-        </div>
-      </button>
-    </div>
+      <!-- Quick actions section -->
+      <div class="section-rule mb-6">
+        <span class="section-rule-label">Quick Actions</span>
+        <div class="section-rule-line"></div>
+      </div>
 
-    <!-- How to use — collapsible -->
-    <div class="card overflow-hidden">
-      <details class="group">
-        <summary
-          class="flex items-center justify-between px-6 py-4 cursor-pointer
-                 list-none select-none hover:bg-surface-700/40 transition-colors"
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+        <!-- Events card (Admin / Organiser) -->
+        <router-link
+          v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+          to="/events"
+          class="card-hover p-6 relative cursor-pointer group"
         >
-          <div class="flex items-center gap-2.5">
-            <i class="pi pi-book text-content-muted text-sm"></i>
-            <span class="font-heading font-semibold text-content-secondary text-sm">How to Use</span>
-          </div>
-          <i class="pi pi-chevron-down text-content-muted text-xs
-                    group-open:rotate-180 transition-transform duration-200"></i>
-        </summary>
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-calendar text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Events</div>
+          <p class="type-label text-content-muted">Manage and browse events</p>
+        </router-link>
 
-        <div class="px-6 pb-6 pt-2 border-t border-surface-600/30">
-          <div class="prose prose-sm max-w-none text-content-secondary space-y-6">
+        <!-- Audition List -->
+        <router-link
+          v-if="activeEvent"
+          :to="{ name: 'Audition List' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-list text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Audition</div>
+          <p class="type-label text-content-muted">Score and timer controls</p>
+        </router-link>
 
-            <!-- Before Event Day -->
-            <section>
-              <h2 class="font-heading font-bold text-content-secondary text-base mb-3">Before Event Day</h2>
-              <ol class="list-decimal list-inside space-y-1.5 text-sm text-content-muted">
-                <li>Each folder should contain one response form.</li>
-                <li>Each response should contain at least: <strong class="text-content-secondary">Name, Category/Categories, Email</strong>.</li>
-                <li>Go to <em>Events</em> and choose one.</li>
-                <li>The first table shows participant breakdown for each genre.</li>
-              </ol>
-              <div class="mt-4 pl-4 border-l-2 border-surface-600/30 space-y-3 text-sm">
-                <div>
-                  <p class="font-semibold text-content-secondary mb-1">If there is a record of this event:</p>
-                  <p class="text-content-muted">A table will be shown with participants and categories joined.</p>
-                </div>
-                <div>
-                  <p class="font-semibold text-content-secondary mb-1">Else:</p>
-                  <ol class="list-decimal list-inside space-y-1 text-content-muted">
-                    <li>Choose categories.</li>
-                    <li>Name the judges.</li>
-                    <li>Insert a record in the database.</li>
-                    <li>Refresh the database once you verify payment from Google response.</li>
-                  </ol>
-                </div>
-                <div>
-                  <p class="font-semibold text-content-secondary mb-1">If different judges per category:</p>
-                  <ol class="list-decimal list-inside space-y-1 text-content-muted">
-                    <li>Go to <em>Participants</em>.</li>
-                    <li>Assign judges to each participant and press the update button.</li>
-                  </ol>
-                </div>
-              </div>
-            </section>
+        <!-- Participants (Admin / Organiser) -->
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER')"
+          :to="{ name: 'Update Event Details' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-users text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Participants</div>
+          <p class="type-label text-content-muted">Manage registrations and judges</p>
+        </router-link>
 
-            <!-- On Event Day -->
-            <section>
-              <h2 class="font-heading font-bold text-content-secondary text-base mb-3">On the Event Day</h2>
-              <div class="grid sm:grid-cols-2 gap-4 text-sm">
-                <div class="bg-surface-700/50 rounded-xl p-4">
-                  <p class="font-semibold text-content-secondary mb-2">Event Organiser</p>
-                  <ol class="list-decimal list-inside space-y-1 text-content-muted">
-                    <li>Display <em>Audition Number</em> screen.</li>
-                    <li>Scan QR → audition number + category shown.</li>
-                    <li>Give wrist tag with number.</li>
-                  </ol>
-                </div>
-                <div class="bg-surface-700/50 rounded-xl p-4">
-                  <p class="font-semibold text-content-secondary mb-2">Emcee</p>
-                  <ol class="list-decimal list-inside space-y-1 text-content-muted">
-                    <li>Go to <em>Audition List</em>, update the filter.</li>
-                    <li>Use the timer for countdown.</li>
-                  </ol>
-                </div>
-                <div class="bg-surface-700/50 rounded-xl p-4">
-                  <p class="font-semibold text-content-secondary mb-2">Judge</p>
-                  <ol class="list-decimal list-inside space-y-1 text-content-muted">
-                    <li>Go to <em>Audition List</em>, update the filter.</li>
-                    <li>Ensure <em>Current Judge</em> is selected.</li>
-                    <li>Give score and submit.</li>
-                  </ol>
-                </div>
-                <div class="bg-surface-700/50 rounded-xl p-4">
-                  <p class="font-semibold text-content-secondary mb-2">When Audition Ends</p>
-                  <ol class="list-decimal list-inside space-y-1 text-content-muted">
-                    <li>Go to <em>Scoreboard</em> to get top-n participants.</li>
-                    <li>If judges were assigned, choose <em>By Judge</em>.</li>
-                  </ol>
-                </div>
-              </div>
-            </section>
+        <!-- Scoreboard (Admin / Organiser / Emcee) -->
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE')"
+          :to="{ name: 'Score' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-chart-bar text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Scoreboard</div>
+          <p class="type-label text-content-muted">Live leaderboard</p>
+        </router-link>
 
-          </div>
+        <!-- Battle Control (Admin / Organiser) -->
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER')"
+          :to="{ name: 'Battle Control' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-bolt text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Battle</div>
+          <p class="type-label text-content-muted">Bracket and match control</p>
+        </router-link>
+
+        <!-- Admin (Admin only) -->
+        <router-link
+          v-if="role === 'ROLE_ADMIN'"
+          to="/admin"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-cog text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Admin</div>
+          <p class="type-label text-content-muted">Genres, judges, theme config</p>
+        </router-link>
+
+      </div>
+
+      <!-- No event selected hint -->
+      <div v-if="!activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE')"
+        class="mt-8 p-4 semantic-chip-warning flex items-start gap-3">
+        <div class="w-2 h-2 rounded-full bg-amber-400 box-shadow-[0_0_6px_rgba(245,158,11,0.8)] mt-0.5 flex-shrink-0"></div>
+        <div>
+          <div class="type-body text-amber-400 mb-1">No Active Event</div>
+          <p class="type-label text-content-muted">
+            Select an event to access audition, scoring, and battle features.
+          </p>
+          <router-link :to="{ name: 'EventSelector' }" class="type-label text-accent underline mt-2 inline-block">
+            Select Event →
+          </router-link>
         </div>
-      </details>
-    </div>
+      </div>
 
+    </div>
   </div>
 </template>

--- a/BES-frontend/src/views/Results.vue
+++ b/BES-frontend/src/views/Results.vue
@@ -73,205 +73,240 @@ const groupTags = (tags) => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-surface-900 flex flex-col">
-    <!-- Header -->
-    <header class="border-b border-surface-700/50 bg-surface-900/80 backdrop-blur-sm">
-      <div class="max-w-5xl mx-auto px-4 py-4 flex items-center gap-3">
-        <div class="w-8 h-8 rounded-lg bg-primary-600 flex items-center justify-center flex-shrink-0">
-          <i class="pi pi-star text-white text-sm"></i>
+  <div class="min-h-screen flex overflow-hidden bg-surface-950 relative">
+
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
+
+    <div class="flex-1 flex flex-col lg:flex-row relative z-10">
+
+      <!-- ── Left panel: BES hero (≥md) ────────────────────────────── -->
+      <div class="hidden lg:flex lg:w-[44%] relative flex-col justify-between p-14 overflow-hidden">
+        <div class="absolute inset-0 bg-surface-900"></div>
+        <div class="corner-bar-tl" style="height: 40%"></div>
+        <div class="corner-bar-bl" style="width: 40%"></div>
+
+        <!-- Wordmark -->
+        <div class="relative z-10 flex items-center gap-2.5">
+          <div class="glow-dot"></div>
+          <span class="type-body tracking-[0.12em]">BES</span>
         </div>
-        <div>
-          <p class="font-heading font-bold text-content-primary text-sm leading-none">BES Results Portal</p>
-          <p class="text-xs text-content-muted mt-0.5">Battle Event System</p>
-        </div>
-      </div>
-    </header>
 
-    <main class="flex-1 max-w-5xl w-full mx-auto px-4 py-10">
-
-      <!-- Lookup card -->
-      <div class="card p-6 mb-8 max-w-xl mx-auto">
-        <h1 class="font-heading font-bold text-content-primary text-xl mb-1">View Your Results</h1>
-        <p class="text-sm text-content-muted mb-5">Enter the reference code from your registration email to view your scores and judge feedback.</p>
-
-        <div class="flex gap-3">
-          <div class="flex-1">
-            <input
-              :value="refCode"
-              @input="onInput"
-              placeholder="e.g. AB3K-9XPQ"
-              maxlength="9"
-              class="input-base font-source text-lg tracking-widest uppercase w-full"
-              @keydown.enter="lookup"
-            />
+        <!-- Hero -->
+        <div class="relative z-10">
+          <div class="type-display mb-6">BES</div>
+          <div class="section-rule mb-6">
+            <div class="section-rule-line"></div>
           </div>
-          <button
-            @click="lookup"
-            :disabled="loading || refCode.length !== 9"
-            class="px-5 py-2.5 rounded-xl bg-primary-600 text-white font-semibold text-sm
-                   hover:bg-primary-500 active:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed
-                   transition-all duration-200 flex items-center gap-2 flex-shrink-0"
-          >
-            <i v-if="loading" class="pi pi-spin pi-spinner"></i>
-            <i v-else class="pi pi-search"></i>
-            {{ loading ? 'Looking up…' : 'Look up' }}
-          </button>
+          <p class="type-body text-content-secondary leading-relaxed max-w-md">
+            View your scores, judge feedback, and performance details — all in one place.
+          </p>
+          <div class="flex flex-wrap gap-2 mt-8">
+            <span class="badge-neutral px-3 py-1.5">Scores</span>
+            <span class="badge-neutral px-3 py-1.5">Feedback</span>
+            <span class="badge-neutral px-3 py-1.5">Results</span>
+          </div>
         </div>
 
-        <div
-          v-if="errorMsg"
-          class="mt-4 flex items-start gap-2.5 px-4 py-3 rounded-xl border border-red-500/30 bg-red-500/8"
-        >
-          <i class="pi pi-exclamation-circle text-red-400 mt-0.5 flex-shrink-0"></i>
-          <p class="text-sm text-red-300">{{ errorMsg }}</p>
+        <!-- Footer -->
+        <div class="relative z-10 type-label text-content-muted">
+          &copy; {{ new Date().getFullYear() }} BES Platform
         </div>
       </div>
 
-      <!-- Results -->
-      <template v-if="results">
-        <!-- Participant header -->
-        <div class="flex items-center gap-4 mb-6 max-w-xl mx-auto">
-          <div class="w-12 h-12 rounded-2xl bg-primary-600/20 border border-primary-500/30 flex items-center justify-center flex-shrink-0">
-            <i class="pi pi-user text-primary-400 text-lg"></i>
-          </div>
-          <div>
-            <h2 class="font-heading font-bold text-content-primary text-xl">{{ results.participantName }}</h2>
-            <p class="text-sm text-content-muted">{{ results.eventName }}</p>
-          </div>
-        </div>
+      <!-- ── Right panel: Results lookup ───────────────────────── -->
+      <div class="flex-1 flex flex-col items-center justify-center p-6 sm:p-8 lg:p-14 overflow-y-auto">
+        <div class="w-full max-w-xl">
 
-        <!-- Genre results — row layout, centered when single -->
-        <div
-          :class="results.genres.length === 1
-            ? 'flex justify-center'
-            : 'grid grid-cols-1 sm:grid-cols-2 gap-4'"
-        >
-          <div
-            v-for="genre in results.genres"
-            :key="genre.genreName"
-            class="card p-5"
-            :class="results.genres.length === 1 ? 'w-full max-w-xl' : ''"
-          >
-            <!-- Genre header -->
-            <div class="flex items-center justify-between mb-4">
-              <div class="flex items-center gap-2 flex-wrap">
-                <span class="px-3 py-1 rounded-full bg-primary-500/15 text-primary-400 text-xs font-bold border border-primary-500/25 uppercase tracking-wide">
-                  {{ genre.genreName }}
-                </span>
-                <span
-                  v-if="genre.format"
-                  class="px-2 py-0.5 rounded-full bg-surface-700 text-content-muted text-xs font-source border border-surface-600/60"
+          <!-- Lookup form -->
+          <div class="relative" v-if="!results">
+            <div class="corner-bar-tl"></div>
+            <div class="corner-bar-bl"></div>
+            <div class="p-8 bg-surface-900 border border-[rgba(255,255,255,0.07)]"
+              style="clip-path: polygon(8px 0%,100% 0%,calc(100% - 8px) 100%,0% 100%)">
+
+              <div class="mb-6">
+                <div class="type-page-title mb-1">My Results</div>
+                <p class="type-label text-content-muted">Enter your reference code</p>
+              </div>
+
+              <div class="flex gap-3">
+                <div class="flex-1">
+                  <input
+                    :value="refCode"
+                    @input="onInput"
+                    placeholder="e.g. AB3K-9XPQ"
+                    maxlength="9"
+                    class="input-base w-full"
+                    @keydown.enter="lookup"
+                  />
+                </div>
+                <button
+                  @click="lookup"
+                  :disabled="loading || refCode.length !== 9"
+                  class="px-5 py-2.5 bg-accent text-surface-900 type-body transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2 flex-shrink-0"
+                  style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
                 >
-                  {{ genre.format }}
-                </span>
-                <span v-if="genre.auditionNumber" class="text-xs text-content-muted">
-                  Audition #{{ genre.auditionNumber }}
-                </span>
+                  <i v-if="loading" class="pi pi-spin pi-spinner"></i>
+                  <i v-else class="pi pi-search"></i>
+                  {{ loading ? 'Looking up…' : 'Look up' }}
+                </button>
               </div>
-              <div v-if="genre.scores && genre.scores.length > 0" class="text-right ml-2 flex-shrink-0">
-                <p class="text-xs text-content-muted">Total</p>
-                <p class="font-source font-bold text-primary-400 text-xl">{{ totalScore(genre.scores) }}</p>
+
+              <!-- Error state -->
+              <div
+                v-if="errorMsg"
+                class="mt-4 semantic-chip-error flex items-start gap-3 p-4"
+              >
+                <div class="w-2 h-2 rounded-full bg-red-400 flex-shrink-0 mt-0.5" style="box-shadow: 0 0 6px rgba(239,68,68,0.8)"></div>
+                <p class="type-body text-content-secondary">{{ errorMsg }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Results display -->
+          <template v-if="results">
+            <!-- Participant header -->
+            <div class="mb-8">
+              <div class="type-page-title mb-1">{{ results.participantName }}</div>
+              <div class="section-rule">
+                <span class="section-rule-label">{{ results.eventName }}</span>
+                <div class="section-rule-line"></div>
               </div>
             </div>
 
-            <!-- Scores -->
-            <div v-if="genre.scores && genre.scores.length > 0" class="mb-4">
-              <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-2">Scores</p>
+            <!-- Genre results -->
+            <div
+              :class="results.genres.length === 1
+                ? 'flex justify-center'
+                : 'grid grid-cols-1 sm:grid-cols-2 gap-4'"
+            >
+              <div
+                v-for="genre in results.genres"
+                :key="genre.genreName"
+                class="card-hover p-4 relative"
+                :class="results.genres.length === 1 ? 'w-full max-w-xl' : ''"
+              >
+                <div class="corner-bar-tl"></div>
 
-              <template v-if="isMultiCriteria(genre.scores)">
-                <div class="space-y-3">
-                  <div
-                    v-for="(aspects, judge) in groupScoresByJudge(genre.scores)"
-                    :key="judge"
-                    class="rounded-xl bg-surface-700/50 border border-surface-600/40 px-3 py-2.5"
-                  >
-                    <p class="text-xs font-semibold text-content-muted mb-2">{{ judge }}</p>
-                    <div class="space-y-1">
-                      <div
-                        v-for="(score, aspect) in aspects"
-                        :key="aspect"
-                        class="flex items-center justify-between"
-                      >
-                        <span class="text-xs text-content-secondary">{{ aspect }}</span>
-                        <span class="font-source font-bold text-primary-400 text-sm">{{ score }}</span>
-                      </div>
-                    </div>
+                <!-- Genre header -->
+                <div class="flex items-center justify-between mb-4">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <span class="badge-neutral">{{ genre.genreName }}</span>
+                    <span
+                      v-if="genre.format"
+                      class="badge-neutral"
+                    >{{ genre.format }}</span>
+                    <span v-if="genre.auditionNumber" class="type-label text-content-muted">
+                      #{{ genre.auditionNumber }}
+                    </span>
+                  </div>
+                  <div v-if="genre.scores && genre.scores.length > 0" class="text-right ml-2 flex-shrink-0">
+                    <div class="type-label text-content-muted">Total</div>
+                    <div class="type-stat text-[28px]">{{ totalScore(genre.scores) }}</div>
                   </div>
                 </div>
-              </template>
 
-              <template v-else>
-                <div class="grid grid-cols-2 gap-2">
-                  <div
-                    v-for="score in genre.scores"
-                    :key="score.judgeName"
-                    class="rounded-xl bg-surface-700/50 border border-surface-600/40 px-3 py-2.5"
-                  >
-                    <p class="text-xs text-content-muted truncate">{{ score.judgeName }}</p>
-                    <p class="font-source font-bold text-content-primary text-lg">{{ score.score }}</p>
+                <!-- Scores -->
+                <div v-if="genre.scores && genre.scores.length > 0" class="mb-4">
+                  <div class="section-rule mb-3">
+                    <span class="section-rule-label">Scores</span>
+                    <div class="section-rule-line"></div>
                   </div>
-                </div>
-              </template>
-            </div>
-            <div v-else class="mb-4">
-              <p class="text-sm text-content-muted italic">No scores recorded yet</p>
-            </div>
 
-            <!-- Feedback -->
-            <template v-if="genre.feedback && genre.feedback.length > 0">
-              <div class="border-t border-surface-700/50 pt-4">
-                <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-3">Judge Feedback</p>
-                <div class="space-y-4">
-                  <div
-                    v-for="entry in genre.feedback"
-                    :key="entry.judgeName"
-                    class="rounded-xl border border-surface-600/40 bg-surface-700/20 p-3.5"
-                  >
-                    <p class="text-xs font-bold text-content-secondary mb-2">{{ entry.judgeName }}</p>
-
-                    <template v-if="entry.tags && entry.tags.length > 0">
+                  <template v-if="isMultiCriteria(genre.scores)">
+                    <div class="space-y-3">
                       <div
-                        v-for="(tags, groupName) in groupTags(entry.tags)"
-                        :key="groupName"
-                        class="mb-2"
+                        v-for="(aspects, judge) in groupScoresByJudge(genre.scores)"
+                        :key="judge"
+                        class="para-chip px-3 py-2.5"
                       >
-                        <p class="text-xs text-content-muted mb-1">{{ groupName }}</p>
-                        <div class="flex flex-wrap gap-1.5">
-                          <span
-                            v-for="tag in tags"
-                            :key="tag.label"
-                            class="text-xs px-2.5 py-1 rounded-full font-medium border"
-                            :class="groupName === 'Strengths'
-                              ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30'
-                              : 'bg-amber-500/10 text-amber-400 border-amber-500/30'"
-                          >{{ tag.label }}</span>
+                        <div class="type-body text-content-secondary mb-2">{{ judge }}</div>
+                        <div class="space-y-1">
+                          <div
+                            v-for="(score, aspect) in aspects"
+                            :key="aspect"
+                            class="flex items-center justify-between"
+                          >
+                            <span class="type-label text-content-muted">{{ aspect }}</span>
+                            <span class="type-stat text-[18px]">{{ score }}</span>
+                          </div>
                         </div>
                       </div>
-                    </template>
-
-                    <div v-if="entry.note" class="mt-2 pt-2 border-t border-surface-600/30">
-                      <p class="text-xs text-content-secondary italic">"{{ entry.note }}"</p>
                     </div>
+                  </template>
 
-                    <p
-                      v-if="(!entry.tags || entry.tags.length === 0) && !entry.note"
-                      class="text-xs text-content-muted italic"
-                    >No feedback provided</p>
+                  <template v-else>
+                    <div class="grid grid-cols-2 gap-2">
+                      <div
+                        v-for="score in genre.scores"
+                        :key="score.judgeName"
+                        class="para-chip px-3 py-2.5"
+                      >
+                        <div class="type-label text-content-muted truncate">{{ score.judgeName }}</div>
+                        <div class="type-stat text-[22px]">{{ score.score }}</div>
+                      </div>
+                    </div>
+                  </template>
+                </div>
+                <div v-else class="mb-4">
+                  <p class="type-body text-content-muted">No scores recorded yet</p>
+                </div>
+
+                <!-- Feedback -->
+                <template v-if="genre.feedback && genre.feedback.length > 0">
+                  <div class="pt-4" style="border-top: 1px solid rgba(255,255,255,0.07)">
+                    <div class="section-rule mb-3">
+                      <span class="section-rule-label">Judge Feedback</span>
+                      <div class="section-rule-line"></div>
+                    </div>
+                    <div class="space-y-4">
+                      <div
+                        v-for="entry in genre.feedback"
+                        :key="entry.judgeName"
+                        class="para-chip px-3 py-3"
+                      >
+                        <div class="type-body text-content-secondary mb-2">{{ entry.judgeName }}</div>
+
+                        <template v-if="entry.tags && entry.tags.length > 0">
+                          <div
+                            v-for="(tags, groupName) in groupTags(entry.tags)"
+                            :key="groupName"
+                            class="mb-2"
+                          >
+                            <div class="type-label text-content-muted mb-1">{{ groupName }}</div>
+                            <div class="flex flex-wrap gap-1.5">
+                              <span
+                                v-for="tag in tags"
+                                :key="tag.label"
+                                class="badge-neutral"
+                              >{{ tag.label }}</span>
+                            </div>
+                          </div>
+                        </template>
+
+                        <div v-if="entry.note" class="mt-2 pt-2" style="border-top: 1px solid rgba(255,255,255,0.06)">
+                          <p class="type-body text-content-secondary">"{{ entry.note }}"</p>
+                        </div>
+
+                        <p
+                          v-if="(!entry.tags || entry.tags.length === 0) && !entry.note"
+                          class="type-label text-content-muted"
+                        >No feedback provided</p>
+                      </div>
+                    </div>
                   </div>
+                </template>
+                <div v-else class="pt-4" style="border-top: 1px solid rgba(255,255,255,0.07)">
+                  <p class="type-label text-content-muted">No judge feedback for this genre</p>
                 </div>
               </div>
-            </template>
-            <div v-else class="border-t border-surface-700/50 pt-4">
-              <p class="text-xs text-content-muted italic">No judge feedback for this genre</p>
             </div>
-          </div>
+          </template>
+
         </div>
-      </template>
+      </div>
 
-    </main>
-
-    <footer class="border-t border-surface-700/50 py-4">
-      <p class="text-center text-xs text-content-muted">Battle Event System · Results Portal</p>
-    </footer>
+    </div>
   </div>
 </template>

--- a/BES-frontend/src/views/ResultsQR.vue
+++ b/BES-frontend/src/views/ResultsQR.vue
@@ -36,59 +36,66 @@ const print = () => window.print()
 </script>
 
 <template>
-  <div class="min-h-screen bg-white flex flex-col items-center justify-center p-8 print:p-4">
+  <div class="min-h-screen flex flex-col items-center justify-center p-8 print:p-4 relative bg-surface-950">
 
-    <!-- Loading -->
-    <div v-if="loading" class="flex flex-col items-center gap-3">
-      <i class="pi pi-spin pi-spinner text-4xl text-surface-400"></i>
-      <p class="text-sm text-surface-500">Generating QR code…</p>
-    </div>
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
 
-    <!-- Error -->
-    <div v-else-if="error" class="flex flex-col items-center gap-3 text-center">
-      <i class="pi pi-exclamation-circle text-4xl text-red-400"></i>
-      <p class="text-sm text-surface-600">{{ error }}</p>
-    </div>
+    <div class="relative z-10 w-full max-w-lg flex flex-col items-center">
 
-    <!-- QR Card -->
-    <div v-else class="flex flex-col items-center gap-6 w-full max-w-xs">
-      <!-- BES branding -->
-      <div class="flex items-center gap-2">
-        <div class="w-7 h-7 rounded-lg bg-primary-600 flex items-center justify-center">
-          <i class="pi pi-star text-white text-xs"></i>
+      <!-- Loading -->
+      <div v-if="loading" class="flex flex-col items-center gap-3">
+        <i class="pi pi-spin pi-spinner text-4xl text-content-muted"></i>
+        <p class="type-body text-content-muted">Loading...</p>
+      </div>
+
+      <!-- Error -->
+      <div v-else-if="error" class="semantic-chip-error flex items-start gap-3 p-4 w-full max-w-md">
+        <div class="w-2 h-2 rounded-full bg-red-400 flex-shrink-0 mt-0.5" style="box-shadow: 0 0 6px rgba(239,68,68,0.8)"></div>
+        <p class="type-body text-content-secondary">{{ error }}</p>
+      </div>
+
+      <!-- QR Card -->
+      <div v-else class="flex flex-col items-center gap-6 w-full">
+        <!-- BES branding -->
+        <div class="flex items-center gap-2.5">
+          <div class="glow-dot"></div>
+          <span class="type-body tracking-[0.12em]">BES</span>
         </div>
-        <span class="font-heading font-bold text-surface-700 text-sm">BES Results Portal</span>
-      </div>
 
-      <!-- QR code image -->
-      <div class="rounded-2xl border-2 border-surface-200 p-4 bg-white shadow-sm">
-        <img
-          :src="qrImageUrl"
-          alt="Results QR Code"
-          class="w-64 h-64 block"
-        />
-      </div>
+        <!-- QR code image -->
+        <div class="card-hover p-6 relative">
+          <div class="corner-bar-tl"></div>
+          <div class="corner-bar-bl"></div>
+          <img
+            :src="qrImageUrl"
+            alt="Results QR Code"
+            class="w-64 h-64 block"
+          />
+        </div>
 
-      <!-- Participant info -->
-      <div class="text-center">
-        <p class="font-heading font-bold text-surface-800 text-lg">{{ participantName }}</p>
-        <p class="text-sm text-surface-500 mt-0.5 font-source tracking-widest">{{ refCode }}</p>
-      </div>
+        <!-- Participant info -->
+        <div class="text-center">
+          <div class="type-page-title">{{ participantName }}</div>
+          <p class="type-label text-content-muted mt-1">{{ refCode }}</p>
+        </div>
 
-      <!-- Instructions -->
-      <div class="w-full rounded-xl border border-surface-200 bg-surface-50 px-4 py-3 text-center">
-        <p class="text-xs text-surface-600 font-medium">Scan this QR code to view your scores and feedback</p>
-        <p class="text-xs text-surface-400 mt-1">Results are released by the organiser after all auditions</p>
-      </div>
+        <!-- Instructions -->
+        <div class="para-chip px-5 py-4 text-center w-full max-w-sm">
+          <p class="type-label text-content-muted">Scan this QR code to view your scores and feedback</p>
+          <p class="type-label text-content-muted mt-1 opacity-60">Results are released by the organiser after all auditions</p>
+        </div>
 
-      <!-- Print button (hidden in print) -->
-      <button
-        @click="print"
-        class="print:hidden flex items-center gap-2 px-5 py-2.5 rounded-xl bg-surface-800 text-white text-sm font-semibold hover:bg-surface-700 transition-colors"
-      >
-        <i class="pi pi-print"></i>
-        Print / Save
-      </button>
+        <!-- Print button (hidden in print) -->
+        <button
+          @click="print"
+          class="print:hidden px-5 py-2.5 bg-accent text-surface-900 type-body transition-all duration-200 flex items-center gap-2"
+          style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
+        >
+          <i class="pi pi-print"></i>
+          Print / Save
+        </button>
+      </div>
     </div>
   </div>
 </template>

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -721,7 +721,7 @@ function transformForScore(data) {
                 <tr
                   v-for="row in pagedFinalRows"
                   :key="row.id"
-                  class="bg-surface-800 even:bg-surface-700/40 hover:bg-primary-100/30 transition-colors duration-150"
+                  class="bg-surface-800 even:bg-surface-700/40 hover:bg-accent/5 transition-colors duration-150"
                 >
                   <td class="px-4 py-3 whitespace-nowrap">
                     <span class="text-content-secondary">{{ row.id }}</span>
@@ -729,7 +729,7 @@ function transformForScore(data) {
                   <td class="px-4 py-3 whitespace-nowrap">
                     <button
                       @click="editScore(row.participantName)"
-                      class="text-primary-400 hover:text-primary-300 font-medium hover:underline focus:outline-none"
+                      class="text-accent hover:text-accent/80 font-medium hover:underline focus:outline-none"
                     >{{ row.participantName }}</button>
                   </td>
                   <td class="px-4 py-3 whitespace-nowrap">
@@ -749,7 +749,7 @@ function transformForScore(data) {
                         v-if="topNResult.isMultiAspect"
                         @click="viewBreakdown(row.participantName)"
                         title="View score breakdown"
-                        class="p-1.5 rounded-lg text-content-muted hover:text-primary-400 hover:bg-surface-700 transition-colors"
+                        class="p-1.5 rounded-lg text-content-muted hover:text-accent hover:bg-surface-700 transition-colors"
                       >
                         <i class="pi pi-chart-bar text-sm"></i>
                       </button>
@@ -757,7 +757,7 @@ function transformForScore(data) {
                       <button
                         @click="viewFeedback(row.participantName)"
                         title="View judge feedback"
-                        class="p-1.5 rounded-lg text-content-muted hover:text-primary-400 hover:bg-surface-700 transition-colors"
+                        class="p-1.5 rounded-lg text-content-muted hover:text-accent hover:bg-surface-700 transition-colors"
                       >
                         <i class="pi pi-comment text-sm"></i>
                       </button>
@@ -802,7 +802,7 @@ function transformForScore(data) {
                 @click="tablePage = p"
                 class="w-8 h-8 rounded-lg text-sm font-semibold border transition-all"
                 :class="tablePage === p
-                  ? 'bg-primary-600 text-white border-primary-600'
+                  ? 'bg-accent text-surface-900 border-accent'
                   : 'border-surface-600 bg-surface-800 text-content-secondary hover:bg-surface-700'"
               >{{ p }}</button>
               <button
@@ -918,7 +918,7 @@ function transformForScore(data) {
         <div class="overflow-y-auto px-5 py-4 flex-1">
           <!-- Loading -->
           <div v-if="feedbackLoading" class="flex items-center justify-center py-12">
-            <i class="pi pi-spin pi-spinner text-primary-400 text-2xl"></i>
+            <i class="pi pi-spin pi-spinner text-accent text-2xl"></i>
           </div>
 
           <!-- No feedback empty state -->
@@ -1018,7 +1018,7 @@ function transformForScore(data) {
                 class="flex items-center justify-between px-3 py-2 rounded-lg bg-surface-700/50"
               >
                 <span class="text-sm text-content-secondary">{{ aspect }}</span>
-                <span class="font-source font-bold text-primary-400 text-sm">{{ score }}</span>
+                <span class="font-source font-bold text-accent text-sm">{{ score }}</span>
               </div>
             </div>
           </div>

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -428,13 +428,15 @@ function transformForScore(data) {
 </script>
 
 <template>
-  <div class="page-container">
+  <div class="page-container relative">
+    <div class="color-bleed"></div>
+    <div class="relative z-10">
 
     <!-- Page header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
       <div>
-        <h1 class="page-title">Scoreboard</h1>
-        <p class="text-muted mt-1">View and compare scores across genres and judges</p>
+        <div class="type-page-title mb-1">Scoreboard</div>
+        <p class="type-label text-content-muted">View and compare scores across genres and judges</p>
       </div>
     </div>
 
@@ -442,81 +444,82 @@ function transformForScore(data) {
     <div class="card p-5 mb-6">
       <div class="flex flex-wrap items-center gap-3">
         <!-- Event name -->
-        <span class="font-heading font-bold text-base text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
+        <span class="type-body text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
         <span class="text-surface-600 select-none">|</span>
 
         <!-- Genre toggle -->
-        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+        <div class="flex gap-1">
           <button
             v-for="g in uniqueGenres"
             :key="g"
             @click="selectedGenre = g"
-            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
             :class="selectedGenre === g
-              ? 'bg-primary-600 text-white'
-              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              ? 'text-accent border-[color:var(--accent-muted)]'
+              : 'text-content-muted hover:text-content-primary'"
           >{{ g }}</button>
         </div>
         <span class="text-surface-600 select-none">|</span>
 
         <!-- Group By toggle -->
-        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+        <div class="flex gap-1">
           <button
             v-for="t in tabulationMethod"
             :key="t"
             @click="selectedTabulation = t"
-            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
             :class="selectedTabulation === t
-              ? 'bg-primary-600 text-white'
-              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              ? 'text-accent border-[color:var(--accent-muted)]'
+              : 'text-content-muted hover:text-content-primary'"
           >{{ t }}</button>
         </div>
         <span class="text-surface-600 select-none">|</span>
 
         <!-- Show Top toggle -->
-        <div class="flex rounded-xl overflow-hidden border border-surface-600">
+        <div class="flex gap-1">
           <button
             v-for="n in topNOptions"
             :key="n"
             @click="selectedTopN = n"
-            class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+            class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
             :class="selectedTopN === n
-              ? 'bg-primary-600 text-white'
-              : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              ? 'text-accent border-[color:var(--accent-muted)]'
+              : 'text-content-muted hover:text-content-primary'"
           >{{ n }}</button>
         </div>
 
         <!-- Type toggle (conditional) -->
         <template v-if="hasTeamAndSoloMix">
           <span class="text-surface-600 select-none">|</span>
-          <div class="flex rounded-xl overflow-hidden border border-surface-600">
+          <div class="flex gap-1">
             <button
               v-for="t in ['Teams', 'Solo']"
               :key="t"
               @click="selectedEntryType = t"
-              class="px-3.5 py-1.5 text-sm font-semibold transition-all duration-150"
+              class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
               :class="selectedEntryType === t
-                ? 'bg-primary-600 text-white'
-                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                ? 'text-accent border-[color:var(--accent-muted)]'
+                : 'text-content-muted hover:text-content-primary'"
             >{{ t }}</button>
           </div>
         </template>
       </div>
 
       <!-- Release Results toggle (admin/organiser only) -->
-      <div v-if="isAdminOrOrganiser" class="mt-4 pt-4 border-t border-surface-700/50 flex items-center justify-between">
-        <div>
-          <p class="text-xs font-semibold text-content-muted uppercase tracking-wide">Results Portal</p>
-          <p class="text-xs text-content-muted mt-0.5">
-            {{ resultsReleased ? 'Participants can view their scores and feedback' : 'Results are hidden from participants' }}
-          </p>
-        </div>
+      <div v-if="isAdminOrOrganiser" class="section-rule mt-4 pt-4">
+        <span class="section-rule-label">Results Portal</span>
+        <div class="section-rule-line"></div>
+      </div>
+      <div v-if="isAdminOrOrganiser" class="flex items-center justify-between mt-3">
+        <p class="type-label text-content-muted">
+          {{ resultsReleased ? 'Participants can view their scores and feedback' : 'Results are hidden from participants' }}
+        </p>
         <button
           @click="toggleRelease"
-          class="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold border transition-all duration-200"
+          class="type-label transition-all duration-200"
           :class="resultsReleased
-            ? 'bg-emerald-500/10 border-emerald-500/40 text-emerald-400 hover:bg-emerald-500/15'
-            : 'bg-surface-700/50 border-surface-600/50 text-content-muted hover:border-surface-500 hover:bg-surface-700'"
+            ? 'bg-accent para-chip-sm px-3 py-1.5 text-surface-900'
+            : 'para-chip-sm px-3 py-1.5 border-accent text-content-muted hover:text-content-primary'"
         >
           <i :class="resultsReleased ? 'pi pi-eye' : 'pi pi-eye-slash'"></i>
           {{ resultsReleased ? 'Released' : 'Release Results' }}
@@ -657,42 +660,44 @@ function transformForScore(data) {
           v-if="finalRows.length >= 3"
           class="grid grid-cols-3 gap-4 mb-6"
         >
-          <div class="stat-card p-5 text-center order-1 border-t-2 border-t-content-secondary">
-            <div class="text-2xl font-heading font-extrabold text-content-muted mb-1">2</div>
-            <div class="font-heading font-bold text-content-secondary text-sm leading-tight mb-2">
+          <div class="stat-card relative order-1">
+            <div class="corner-bar-tl"></div>
+            <span class="badge-neutral type-label mb-1">2</span>
+            <div class="type-body text-content-secondary mb-1">
               {{ finalRows[1].participantName }}
             </div>
-            <div class="text-2xl font-source font-extrabold text-content-secondary">
+            <div class="type-stat">
               {{ finalRows[1].totalScore }}
             </div>
           </div>
           <div
-            class="stat-card p-5 text-center order-2 ring-2 ring-primary-500/30 relative border-t-2 border-t-accent-500 animate-float"
-            style="box-shadow: 0 0 0 1px rgba(6,182,212,0.3), 0 8px 40px rgba(6,182,212,0.15);"
+            class="stat-card relative order-2"
+            style="box-shadow: 0 0 0 1px var(--accent-muted), 0 8px 40px var(--accent-subtle);"
           >
-            <div class="absolute -top-3 left-1/2 -translate-x-1/2">
-              <span
-                class="px-2 py-0.5 rounded-full bg-primary-600 text-white text-xs font-bold"
-                style="box-shadow: 0 0 12px rgba(6,182,212,0.5);"
-              >1st</span>
-            </div>
-            <div class="text-2xl font-heading font-extrabold text-primary-400 mb-1">1</div>
-            <div class="font-heading font-bold text-content-primary text-sm leading-tight mb-2">
+            <div class="corner-bar-tl"></div>
+            <span class="badge-neutral type-label mb-1">1</span>
+            <div class="type-body text-content-primary mb-1">
               {{ finalRows[0].participantName }}
             </div>
-            <div class="text-4xl font-source font-extrabold text-primary-400">
+            <div class="type-stat text-accent">
               {{ finalRows[0].totalScore }}
             </div>
           </div>
-          <div class="stat-card p-5 text-center order-3 border-t-2 border-t-accent-700">
-            <div class="text-2xl font-heading font-extrabold text-surface-600 mb-1">3</div>
-            <div class="font-heading font-bold text-content-muted text-sm leading-tight mb-2">
+          <div class="stat-card relative order-3">
+            <div class="corner-bar-tl"></div>
+            <span class="badge-neutral type-label mb-1">3</span>
+            <div class="type-body text-content-muted mb-1">
               {{ finalRows[2].participantName }}
             </div>
-            <div class="text-2xl font-source font-extrabold text-content-muted">
+            <div class="type-stat">
               {{ finalRows[2].totalScore }}
             </div>
           </div>
+        </div>
+
+        <div class="section-rule mb-4 mt-8">
+          <span class="section-rule-label">Full Rankings</span>
+          <div class="section-rule-line"></div>
         </div>
 
         <!-- Full rankings table: custom for admin/organiser, standard for others -->
@@ -827,11 +832,11 @@ function transformForScore(data) {
 
       <!-- Empty state -->
       <div v-else class="flex flex-col items-center justify-center py-20 text-center">
-        <div class="icon-wrap w-14 h-14 rounded-2xl bg-surface-700 flex items-center justify-center mb-4">
+        <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
           <i class="pi pi-chart-bar text-content-muted text-xl"></i>
         </div>
-        <p class="font-heading font-semibold text-content-secondary">No scores yet</p>
-        <p class="text-muted text-sm mt-1">Select an event and genre to view scores</p>
+        <p class="type-body text-content-secondary">No scores yet</p>
+        <p class="type-label text-content-muted mt-1">Select an event and genre to view scores</p>
       </div>
     </template>
 
@@ -843,12 +848,9 @@ function transformForScore(data) {
           :key="judge"
           class="mb-8"
         >
-          <div class="flex items-center gap-3 mb-3">
-            <div class="w-8 h-8 rounded-full bg-surface-600 flex items-center justify-center">
-              <i class="pi pi-user text-content-secondary text-xs"></i>
-            </div>
-            <h2 class="font-heading font-bold text-content-secondary">{{ judge }}</h2>
-            <span class="badge-neutral text-xs">{{ group.rows.length }} participants</span>
+          <div class="section-rule mb-3">
+            <span class="section-rule-label">{{ judge }}</span>
+            <div class="section-rule-line"></div>
           </div>
           <DynamicTable
             @onClick="editScore"
@@ -860,14 +862,15 @@ function transformForScore(data) {
 
       <!-- Empty state -->
       <div v-else class="flex flex-col items-center justify-center py-20 text-center">
-        <div class="icon-wrap w-14 h-14 rounded-2xl bg-surface-700 flex items-center justify-center mb-4">
+        <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
           <i class="pi pi-chart-bar text-content-muted text-xl"></i>
         </div>
-        <p class="font-heading font-semibold text-content-secondary">No scores yet</p>
-        <p class="text-muted text-sm mt-1">Select an event and genre to view scores</p>
+        <p class="type-body text-content-secondary">No scores yet</p>
+        <p class="type-label text-content-muted mt-1">Select an event and genre to view scores</p>
       </div>
     </template>
 
+  </div>
   </div>
 
   <UpdateScoreForm

--- a/BES-frontend/src/views/UpdateEventDetails.vue
+++ b/BES-frontend/src/views/UpdateEventDetails.vue
@@ -110,32 +110,31 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="page-container">
+  <div class="page-container relative">
+  <div class="color-bleed"></div>
+  <div class="relative z-10">
 
     <!-- Page header -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
       <div>
-        <h1 class="page-title">Participants</h1>
-        <p class="text-muted mt-1">Assign judges and manage participant entries</p>
+        <div class="type-page-title mb-1">Participants</div>
+        <p class="type-label text-content-muted">Assign judges and manage participant entries</p>
       </div>
-      <ReusableButton
-        variant="primary"
-        size="sm"
-        @onClick="showCreateNewEntry = true"
+      <button
+        @click="showCreateNewEntry = true"
+        class="bg-accent para-chip type-label text-surface-900 px-4 py-2 flex items-center gap-2"
       >
-        <template #default>
-          <i class="pi pi-plus text-xs"></i>
-          Add Participant
-        </template>
-      </ReusableButton>
+        <i class="pi pi-plus text-xs"></i>
+        Add Participant
+      </button>
     </div>
 
     <!-- Filter bar -->
-    <div class="card p-5 mb-6">
+    <div class="para-chip p-5 mb-6">
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div class="flex flex-col gap-1">
-          <span class="text-xs font-semibold text-content-muted uppercase tracking-wide">Event</span>
-          <span class="badge-neutral text-sm px-3 py-1.5 self-start">{{ selectedEvent }}</span>
+          <span class="type-label text-content-muted">Event</span>
+          <span class="badge-neutral type-body px-3 py-1.5 self-start">{{ selectedEvent }}</span>
         </div>
         <div>
           <ReusableDropdown
@@ -150,14 +149,18 @@ onMounted(async () => {
       <!-- Participant count -->
       <div class="flex items-center gap-2 mt-4 pt-4 border-t border-surface-600/30">
         <i class="pi pi-users text-content-muted text-sm"></i>
-        <span class="text-sm text-content-muted">
-          Showing <strong class="text-content-primary">{{ filteredParticipants.length }}</strong>
-          of <strong class="text-content-primary">{{ participants.length }}</strong> participants
+        <span class="type-label text-content-muted">
+          Showing <span class="text-accent">{{ filteredParticipants.length }}</span>
+          of <span class="text-accent">{{ participants.length }}</span> participants
         </span>
       </div>
     </div>
 
-    <!-- Table -->
+    <div class="section-rule mb-4">
+      <span class="section-rule-label">Participants</span>
+      <div class="section-rule-line"></div>
+    </div>
+
     <div class="mb-6">
       <DynamicTable
         v-if="participants.length > 0"
@@ -175,24 +178,26 @@ onMounted(async () => {
         v-if="participants.length === 0 && selectedEvent"
         class="flex flex-col items-center justify-center py-20 text-center"
       >
-        <div class="icon-wrap w-14 h-14 rounded-2xl bg-surface-700 flex items-center justify-center mb-4">
+        <div class="w-14 h-14 para-chip flex items-center justify-center mb-4">
           <i class="pi pi-users text-content-muted text-xl"></i>
         </div>
-        <p class="font-heading font-semibold text-content-secondary">No participants found</p>
-        <p class="text-muted text-sm mt-1">Select a different event or add a participant</p>
+        <p class="type-body text-content-secondary">No participants found</p>
+        <p class="type-label text-content-muted mt-1">Select a different event or add a participant</p>
       </div>
     </div>
 
     <!-- Save action -->
     <div class="flex justify-end">
-      <ReusableButton variant="primary" @onClick="updateParticipantJudge">
-        <template #default>
-          <i class="pi pi-check text-xs"></i>
-          Save Judge Assignments
-        </template>
-      </ReusableButton>
+      <button
+        @click="updateParticipantJudge"
+        class="bg-accent para-chip type-label text-surface-900 px-5 py-2 flex items-center gap-2"
+      >
+        <i class="pi pi-check text-xs"></i>
+        Save Judge Assignments
+      </button>
     </div>
 
+  </div><!-- end relative z-10 -->
   </div>
 
   <ActionDoneModal
@@ -202,7 +207,7 @@ onMounted(async () => {
     @accept="handleAccept"
     @close="handleAccept"
   >
-    <p class="text-content-secondary leading-relaxed">{{ modalMessage }}</p>
+    <p class="type-body text-content-secondary">{{ modalMessage }}</p>
   </ActionDoneModal>
 
   <CreateParticipantForm

--- a/BES-frontend/src/views/UpdateEventDetails.vue
+++ b/BES-frontend/src/views/UpdateEventDetails.vue
@@ -3,7 +3,6 @@ import DynamicTable from '@/components/DynamicTable.vue';
 import { onMounted, ref, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue'
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import ReusableButton from '@/components/ReusableButton.vue';
 import { getActiveEvent } from '@/utils/auth';
 import CreateParticipantForm from '@/components/CreateParticipantForm.vue';
 const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem("selectedEvent") || "")

--- a/BES/src/main/java/com/example/BES/config/SecurityConfig.java
+++ b/BES/src/main/java/com/example/BES/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/battle/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/results").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/config/app").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                     .formLogin(AbstractHttpConfigurer::disable)

--- a/BES/src/main/java/com/example/BES/controllers/AppConfigController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AppConfigController.java
@@ -1,0 +1,42 @@
+package com.example.BES.controllers;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.example.BES.services.AppConfigService;
+
+@RestController
+@RequestMapping("/api/v1/config")
+public class AppConfigController {
+
+    @Autowired
+    private AppConfigService service;
+
+    @Autowired
+    private SimpMessagingTemplate messaging;
+
+    @GetMapping("/app")
+    public ResponseEntity<Map<String, String>> getAppConfig() {
+        String color = service.getAccentColor();
+        return ResponseEntity.ok(Map.of("accentColor", color));
+    }
+
+    @PostMapping("/app")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String, String>> postAppConfig(@RequestBody Map<String, String> body) {
+        String color = body.get("accentColor");
+        if (color == null || color.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "accentColor is required"));
+        }
+        String saved = service.saveAccentColor(color);
+        messaging.convertAndSend("/topic/app-config", Map.of("accentColor", saved));
+        return ResponseEntity.ok(Map.of("accentColor", saved));
+    }
+}

--- a/BES/src/main/java/com/example/BES/models/AppConfig.java
+++ b/BES/src/main/java/com/example/BES/models/AppConfig.java
@@ -1,0 +1,29 @@
+package com.example.BES.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "app_config")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String key;
+
+    @Column(nullable = false)
+    private String value;
+}

--- a/BES/src/main/java/com/example/BES/respositories/AppConfigRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/AppConfigRepository.java
@@ -1,0 +1,9 @@
+package com.example.BES.respositories;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.BES.models.AppConfig;
+
+public interface AppConfigRepository extends JpaRepository<AppConfig, Long> {
+    Optional<AppConfig> findByKey(String key);
+}

--- a/BES/src/main/java/com/example/BES/services/AppConfigService.java
+++ b/BES/src/main/java/com/example/BES/services/AppConfigService.java
@@ -1,0 +1,30 @@
+package com.example.BES.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import com.example.BES.models.AppConfig;
+import com.example.BES.respositories.AppConfigRepository;
+
+@Service
+public class AppConfigService {
+
+    private static final String ACCENT_KEY = "accentColor";
+    private static final String ACCENT_DEFAULT = "#ffffff";
+
+    @Autowired
+    private AppConfigRepository repo;
+
+    public String getAccentColor() {
+        return repo.findByKey(ACCENT_KEY)
+                   .map(AppConfig::getValue)
+                   .orElse(ACCENT_DEFAULT);
+    }
+
+    public String saveAccentColor(String color) {
+        AppConfig cfg = repo.findByKey(ACCENT_KEY)
+                            .orElse(new AppConfig(null, ACCENT_KEY, ACCENT_DEFAULT));
+        cfg.setValue(color);
+        repo.save(cfg);
+        return color;
+    }
+}

--- a/BES/src/main/resources/application-test.properties
+++ b/BES/src/main/resources/application-test.properties
@@ -1,7 +1,7 @@
 # Test profile: uses H2 in-memory database instead of PostgreSQL
 # Activated via @ActiveProfiles("test") or --spring.profiles.active=test
 
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;NON_KEYWORDS=VALUE
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;NON_KEYWORDS=VALUE,KEY
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=

--- a/BES/src/main/resources/db/migration/V20__add_app_config.sql
+++ b/BES/src/main/resources/db/migration/V20__add_app_config.sql
@@ -1,0 +1,7 @@
+CREATE TABLE app_config (
+    id      BIGSERIAL PRIMARY KEY,
+    key     VARCHAR(100) NOT NULL UNIQUE,
+    value   TEXT         NOT NULL
+);
+
+INSERT INTO app_config (key, value) VALUES ('accentColor', '#ffffff');

--- a/BES/src/test/java/com/example/BES/controllers/AppConfigControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AppConfigControllerIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.example.BES.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class AppConfigControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void getAppConfig_unauthenticated_returnsDefault() throws Exception {
+        mockMvc.perform(get("/api/v1/config/app"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accentColor").value("#ffffff"));
+    }
+
+    @Test
+    public void postAppConfig_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/config/app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accentColor\":\"#ff0000\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    public void postAppConfig_admin_savesColor() throws Exception {
+        mockMvc.perform(post("/api/v1/config/app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accentColor\":\"#06b6d4\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accentColor").value("#06b6d4"));
+
+        mockMvc.perform(get("/api/v1/config/app"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accentColor").value("#06b6d4"));
+    }
+
+    @Test
+    @WithMockUser(username = "organiser", roles = {"ORGANISER"})
+    public void postAppConfig_organiser_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/config/app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accentColor\":\"#ff0000\"}"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,50 +233,80 @@ Scoring only:
 
 ## Frontend Design System
 
-All frontend work must follow this design system consistently across every component and view.
+> **Full spec:** `docs/superpowers/specs/2026-05-30-ui-overhaul-design.md`
+> All frontend work must follow this design system. When adding or updating any UI, read the spec first.
 
-### Color Tokens (defined in `base.css` `@theme`)
-| Role | Token | Hex |
-|------|-------|-----|
-| Primary | `primary-500` | `#e53935` (red) |
-| Primary Dark | `primary-600/700` | `#c62828 / #b71c1c` |
-| Primary Text (dark mode) | `primary-400` | `#f87171` (light red) |
-| Accent | `accent-500` | `#f97316` (orange) |
-| Surface Dark | `surface-900` | `#111111` (near-black) |
-| Surface Card | `surface-800` | `#1a1a1a` |
-| Surface Border | `surface-600/700` | `#2c2c2c / #222222` |
-| Content | `content-primary` | `#f0f0f0` (off-white) |
+### Design Language — Cinematic Battle
 
-### Typography
-| Use | Font | Class |
-|-----|------|-------|
-| Body / UI | Inter | `font-sans` |
-| Headings | Outfit | `font-heading` |
-| Numbers / Code | JetBrains Mono | `font-source` |
-| Display titles | Anton SC | `font-anton` |
+The entire app uses a unified cinematic aesthetic inspired by `BattleOverlay.vue` and `BracketVisualization.vue`. Every screen should feel like part of the same broadcast production system.
 
-### Spacing & Shape
-- Border radius: `rounded-xl` (inputs, cards) · `rounded-2xl` (panels, modals) · `rounded-full` (badges, pills)
-- Card style: `bg-surface-800 rounded-2xl border border-surface-700`
-- Page container: `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8`
-- Navbar height offset: `h-16` (64px)
+**Do NOT change** `BattleOverlay.vue`, `BracketVisualization.vue`, or `Chart.vue` — they already have their own bespoke CSS and are the reference point, not the target.
 
-### Colour Usage Rules (60-30-10)
-- **60% Neutral** — `surface-*` for backgrounds, borders, text hierarchy (true neutral blacks/grays — no blue tinting)
-- **30% Structure** — `surface-800/900` + `content-primary` for nav, headers, dark surfaces
-- **10% Brand** — `primary-*` (red) for ALL interactive elements only
-- **Semantic** — emerald=success, amber=warning, red=error — functional use only, never decorative
-- **Orange `accent-*`** — medals/rankings ONLY; never buttons, nav, or role badges
-- **Button secondary** → `bg-surface-600 text-content-primary` (neutral dark, not orange)
-- **Role badges** → all use `bg-surface-700 text-content-secondary border-surface-600` (label is differentiator)
+### Accent Color (runtime-configurable)
 
-### Interaction States
-- Active nav item: `bg-primary-500 text-white` (filled red pill)
-- Button active: `active:scale-95`
-- Focus ring: `focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500`
-- Row hover: `hover:bg-primary-50` or `hover:bg-surface-700`
+- **CSS custom property:** `--accent-color` — set on `<html>` at runtime via `App.vue`
+- **Dark mode default:** `#ffffff` (white/silver)
+- **Light mode override:** `rgba(0,0,0,0.78)` — set via `[data-theme="light"]` CSS, ignores server value
+- **Derived tokens** (auto-computed in CSS): `--accent-muted` = `color-mix(in srgb, var(--accent-color) 25%, transparent)` · `--accent-subtle` = `color-mix(in srgb, var(--accent-color) 7%, transparent)`
+- **Utility classes:** `.text-accent` · `.bg-accent` · `.border-accent` · `.glow-accent`
+- Admin can change the color globally via `AdminPage.vue` → saved to `AppConfig` DB table → broadcast via `/topic/app-config` WebSocket → all clients update live
+
+### Red (`primary-*`) — Error/Danger ONLY
+
+Red is **no longer a brand color**. It is reserved exclusively for error states, destructive actions, and warning indicators. Never use `primary-*` for buttons, links, nav, or interactive chrome.
+
+### Semantic State Pattern (left border + glowing dot)
+
+All alert banners, warning chips, and status callouts use:
+- **3px solid left border** in the semantic color (red / amber / green)
+- **Subtle tint background** (10–12% opacity)
+- **Glowing dot indicator** (same color with `box-shadow` glow)
+- Never use full solid fills or low-opacity tints alone — both were hard to read
+
+### Typography — Full Anton SC
+
+**Every text element uses Anton SC.** `--font-sans` is `'Anton SC'` (the default body font). Inter is available as `--font-body` but is not used by default. All text is `text-transform: uppercase`. Letter-spacing + opacity provide hierarchy (Anton SC has only one weight).
+
+| Tier | Size | Letter-spacing | Use |
+|------|------|----------------|-----|
+| Display | `clamp(36px,5vw,56px)` | `0.06em` | Page heroes, login |
+| Page title | `28px` | `0.06em` | View `h1` headings |
+| Section header | `13px` | `0.18em` | Group labels + rule line |
+| Body / row | `13px` | `0.05em` | Table rows, cards, form values |
+| Label | `10px` | `0.22em` | Field labels, badges, breadcrumbs |
+| Number / stat | `42px` | `0.02em` | Scores, counts, audition numbers |
+
+Text shadows use `var(--accent-muted)`: Display `2px 2px 0`, Page title `1px 1px 0`, others none.
+
+### Shape — Parallelogram (universal)
+
+All cards, list rows, stat boxes, and badges use **parallelogram clip-path** in both dark and light mode:
+```css
+clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%)
+```
+**No more** `rounded-2xl` cards or `rounded-full` badges. The `.card` and `.badge-*` utilities in `base.css` use this shape.
+
+### Six Cinematic Chrome Elements
+
+| Element | Where | Notes |
+|---------|-------|-------|
+| **Scanlines** | `App.vue` global overlay | Always on; 50% opacity in light mode |
+| **Parallelogram chips** | All cards, rows, badges | Core shape of every UI element |
+| **Corner accent bars** | Panels, modals only | Top-left + bottom-left bars only (not all 4 corners) |
+| **Section rules** | Every section header | Label + `flex:1` hairline — replaces `border-b` dividers |
+| **Color bleed** | Page root only | Radial gradients from bottom corners using `--accent-subtle`; hidden in light mode |
+| **Topbar** | `App.vue` navbar | Anton SC, parallelogram nav chips, glowing dot |
+
+### Surface Scale (unchanged)
+| Token | Value | Use |
+|-------|-------|-----|
+| `surface-900` | `#111111` | Page base |
+| `surface-800` | `#1a1a1a` | Cards, panels |
+| `surface-600` | `#2c2c2c` | Borders, dividers |
+| Chip fill | `rgba(255,255,255,0.04)` | Parallelogram background |
+| Chip border | `rgba(255,255,255,0.07)` | Parallelogram border |
 
 ### Target Audience UX Rules
-- **Judges**: Large touch targets (min 48px), very large font for scores/numbers, minimal steps to complete a score
-- **Emcees**: Clear status badges (scored/unscored), prominent search, always-visible participant count
+- **Judges**: Large touch targets (min 48px), Number/stat tier for scores, minimal steps to submit
+- **Emcees**: Clear status badges, always-visible participant count
 - **Organisers**: Scannable stat cards, collapsible complexity, clear workflow steps

--- a/docs/superpowers/plans/2026-05-30-ui-overhaul.md
+++ b/docs/superpowers/plans/2026-05-30-ui-overhaul.md
@@ -1,0 +1,1953 @@
+# BES UI Overhaul — Cinematic Battle Design Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify every BES screen under the cinematic battle design language — Anton SC typography, `--accent-color` token system, parallelogram shapes, and broadcast chrome — while keeping `BattleOverlay.vue`, `BracketVisualization.vue`, and `Chart.vue` untouched.
+
+**Architecture:** The token layer (`base.css`) is updated first so every downstream view inherits new defaults. `App.vue` gets the cinematic navbar and global scanlines. A new `AppConfig` backend entity stores the accent color and broadcasts changes via WebSocket so all clients update live.
+
+**Tech Stack:** Vue 3 (Composition API), Tailwind v4 (`base.css @theme`), Spring Boot 3, Spring Data JPA, STOMP WebSocket, Flyway (V20 migration), H2 for tests.
+
+**Do NOT change:** `BattleOverlay.vue`, `BracketVisualization.vue`, `Chart.vue`, `BattleJudge.vue`.
+
+---
+
+## File Structure
+
+### New files
+| File | Purpose |
+|------|---------|
+| `BES/src/main/resources/db/migration/V20__add_app_config.sql` | Create `app_config` table with seed row |
+| `BES/src/main/java/com/example/BES/models/AppConfig.java` | JPA entity for key-value app config |
+| `BES/src/main/java/com/example/BES/respositories/AppConfigRepository.java` | Spring Data repo |
+| `BES/src/main/java/com/example/BES/services/AppConfigService.java` | Business logic (get/save accent) |
+| `BES/src/main/java/com/example/BES/controllers/AppConfigController.java` | `GET/POST /api/v1/config/app` |
+| `BES/src/test/java/com/example/BES/controllers/AppConfigControllerIntegrationTest.java` | Integration tests |
+
+### Modified files — Backend
+| File | Change |
+|------|--------|
+| `BES/src/main/java/com/example/BES/config/SecurityConfig.java` | Permit `GET /api/v1/config/app`; restrict `POST` to ADMIN |
+
+### Modified files — Frontend
+| File | Change |
+|------|--------|
+| `BES-frontend/src/assets/base.css` | New token layer, Anton SC, accent tokens, parallelogram utilities |
+| `BES-frontend/src/App.vue` | Cinematic navbar, scanlines, accent fetch + WS subscribe |
+| `BES-frontend/src/utils/api.js` | Add `getAppConfig`, `postAppConfig` |
+| `BES-frontend/src/views/Login.vue` | Display-tier hero, parallelogram form |
+| `BES-frontend/src/views/MainMenu.vue` | Parallelogram quick-action cards, section rules |
+| `BES-frontend/src/views/EventSelector.vue` | Parallelogram event cards, corner bars |
+| `BES-frontend/src/views/Events.vue` | Parallelogram rows, section rules |
+| `BES-frontend/src/components/EventCard.vue` | Parallelogram card shape, corner bars |
+| `BES-frontend/src/views/EventDetails.vue` | Section rules, parallelogram stat boxes |
+| `BES-frontend/src/views/UpdateEventDetails.vue` | Parallelogram rows, semantic chips |
+| `BES-frontend/src/views/AuditionList.vue` | Context bar + filter chips → parallelogram |
+| `BES-frontend/src/views/Score.vue` | Number/stat tier for scores, parallelogram rows |
+| `BES-frontend/src/views/BattleControl.vue` | Section rules, bracket seed slots → parallelogram |
+| `BES-frontend/src/views/AdminPage.vue` | Theme Config section with color picker |
+| `BES-frontend/src/views/Results.vue` | Parallelogram result rows |
+| `BES-frontend/src/views/ResultsQR.vue` | Parallelogram result rows |
+| `BES-frontend/src/components/EmceeRoundView.vue` | Anton SC labels, section rules |
+| `BES-frontend/src/components/FeedbackPopout.vue` | Parallelogram chips, Anton SC |
+| `BES-frontend/src/components/Timer.vue` | Number/stat tier |
+| `BES-frontend/src/components/MiniScoreMenu.vue` | Parallelogram chips |
+| `BES-frontend/src/components/ReusableDropdown.vue` | Parallelogram options |
+| `BES-frontend/src/components/SwipeableCardsV2.vue` | Parallelogram score card |
+| `BES-frontend/src/components/PairScoreCards.vue` | Parallelogram stat layout |
+| `BES-frontend/src/views/ActionDoneModal.vue` | Corner bars on modal, semantic chip variants |
+
+---
+
+## Task 1: base.css — Design Token Foundation
+
+**Files:**
+- Modify: `BES-frontend/src/assets/base.css`
+
+This is the most critical task. Every downstream view inherits from it. Complete it before touching any view.
+
+Key changes to make, section by section:
+
+- [ ] **Step 1: Update Google Fonts import** — Remove Outfit (no longer used); keep Inter and JetBrains Mono.
+
+Replace line 1:
+```css
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap');
+```
+
+- [ ] **Step 2: Update `@theme` typography tokens**
+
+Replace the `/* Typography */` block inside `@theme` (lines ~46-50):
+```css
+/* Typography */
+--font-sans:    'Anton SC', sans-serif;
+--font-body:    'Inter', ui-sans-serif, system-ui, sans-serif;
+--font-eagle:   'EagleHorizonP', sans-serif;
+--font-anton:   'Anton SC', sans-serif;
+--font-source:  'JetBrains Mono', 'Source Code Pro', monospace;
+```
+(`--font-heading` is removed. `--font-body` is Inter, available but not the default.)
+
+- [ ] **Step 3: Add accent CSS custom properties** — Insert after the closing `}` of `@theme`, before the `@layer base` block:
+
+```css
+/* ─────────────────────────────────────────
+   Runtime Accent Color Tokens
+   JS sets --accent-server on <html> (not --accent-color directly).
+   CSS cascades --accent-color from --accent-server.
+   [data-theme="light"] overrides --accent-color via CSS cascade
+   (CSS rules win over inline styles on ancestor elements when
+   the property is set on a different custom property).
+───────────────────────────────────────── */
+:root {
+  --accent-server:  #ffffff;
+  --accent-color:   var(--accent-server);
+  --accent-muted:   color-mix(in srgb, var(--accent-color) 25%, transparent);
+  --accent-subtle:  color-mix(in srgb, var(--accent-color) 7%, transparent);
+}
+```
+
+Then in Step 10, add `--accent-color: rgba(0, 0, 0, 0.78)` to the **existing** `[data-theme="light"]` block — do NOT create a second `[data-theme="light"]` block. There should be exactly one such block in the file.
+```
+
+- [ ] **Step 4: Update `body` base rule** — change `leading-relaxed` to `leading-tight`. Anton SC is a display font; 1.625 line-height creates excessive gaps.
+
+In `@layer base`, replace:
+```css
+@apply font-sans bg-surface-950 text-content-primary antialiased leading-relaxed min-h-screen;
+```
+with:
+```css
+@apply font-sans bg-surface-950 text-content-primary antialiased leading-tight min-h-screen;
+```
+
+- [ ] **Step 5: Update `h1-h6` base rule** — Remove Outfit (`font-heading`); Anton SC is now the default via `font-sans`.
+
+Replace the `h1, h2, h3, h4, h5, h6` block:
+```css
+h1, h2, h3, h4, h5, h6 {
+  @apply font-sans tracking-wide uppercase text-content-primary;
+}
+```
+
+- [ ] **Step 6: Add accent CSS utilities** — Add inside the `@layer utilities` block, after the existing layout utilities:
+
+```css
+/* ── Accent token utilities ─────────────────────────────────── */
+.text-accent   { color: var(--accent-color); }
+.bg-accent     { background: var(--accent-color); }
+.border-accent { border-color: var(--accent-color); }
+.glow-accent   { box-shadow: 0 0 14px var(--accent-muted); }
+```
+
+- [ ] **Step 7: Update `.card` and `.card-hover`** — Replace rounded corners with parallelogram clip-path.
+
+Replace the existing `.card` and `.card-hover` blocks:
+```css
+.card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+}
+
+.card-hover {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  transition: background 0.2s, border-color 0.2s;
+}
+.card-hover:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--accent-muted);
+  box-shadow: 0 0 14px var(--accent-muted);
+}
+```
+
+- [ ] **Step 8: Update `.badge-*`** — Replace `rounded-full` with parallelogram clip-path.
+
+Replace the badge block:
+```css
+.badge,
+.badge-primary,
+.badge-secondary,
+.badge-success,
+.badge-warning,
+.badge-danger,
+.badge-neutral {
+  @apply inline-flex items-center px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+}
+
+.badge-primary   { background: rgba(255,255,255,0.08); color: var(--accent-color); border: 1px solid var(--accent-muted); }
+.badge-secondary { @apply bg-accent-100 text-accent-500; }
+.badge-success   { background: rgba(52,211,153,0.10); color: #34d399; border: 1px solid rgba(52,211,153,0.2); }
+.badge-warning   { background: rgba(245,158,11,0.08); color: #f59e0b; border: 1px solid rgba(245,158,11,0.2); }
+.badge-danger    { background: rgba(239,68,68,0.10);  color: #ef4444; border: 1px solid rgba(239,68,68,0.2); }
+.badge-neutral   { background: rgba(255,255,255,0.04); color: rgba(255,255,255,0.55); border: 1px solid rgba(255,255,255,0.07); }
+```
+
+- [ ] **Step 9: Add cinematic chrome utilities** — Add inside `@layer utilities`:
+
+```css
+/* ── Parallelogram chip (rows, list items, stat boxes) ──────── */
+.para-chip {
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+.para-chip-sm {
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+/* ── Section rule (label + hairline) ───────────────────────── */
+.section-rule {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.section-rule-line {
+  flex: 1;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.07);
+}
+.section-rule-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.28);
+  white-space: nowrap;
+}
+
+/* ── Corner accent bars (panels, modals) ───────────────────── */
+.corner-bar-tl {
+  position: absolute; top: 0; left: 0;
+  width: 2px; height: 28%;
+  background: linear-gradient(to bottom, var(--accent-color), transparent);
+  pointer-events: none;
+}
+.corner-bar-bl {
+  position: absolute; bottom: 0; left: 0;
+  height: 2px; width: 30%;
+  background: linear-gradient(to right, var(--accent-color), transparent);
+  pointer-events: none;
+}
+
+/* ── Color bleed (page root only) ──────────────────────────── */
+.color-bleed {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(ellipse 50% 45% at 0% 100%, var(--accent-subtle), transparent 70%),
+    radial-gradient(ellipse 40% 40% at 100% 100%, color-mix(in srgb, var(--accent-color) 4%, transparent), transparent 70%);
+}
+
+/* ── Glowing status dot ─────────────────────────────────────── */
+.glow-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent-color);
+  box-shadow: 0 0 8px var(--accent-muted);
+  flex-shrink: 0;
+}
+
+/* ── Semantic state chips (left border + dot) ───────────────── */
+.semantic-chip-error {
+  border-left: 3px solid #ef4444;
+  border-top: 1px solid rgba(239,68,68,0.2);
+  border-right: 1px solid rgba(239,68,68,0.2);
+  border-bottom: 1px solid rgba(239,68,68,0.2);
+  background: rgba(239,68,68,0.10);
+  border-radius: 0;
+}
+.semantic-chip-warning {
+  border-left: 3px solid #f59e0b;
+  border-top: 1px solid rgba(245,158,11,0.2);
+  border-right: 1px solid rgba(245,158,11,0.2);
+  border-bottom: 1px solid rgba(245,158,11,0.2);
+  background: rgba(245,158,11,0.08);
+}
+.semantic-chip-success {
+  border-left: 3px solid #34d399;
+  border-top: 1px solid rgba(52,211,153,0.2);
+  border-right: 1px solid rgba(52,211,153,0.2);
+  border-bottom: 1px solid rgba(52,211,153,0.2);
+  background: rgba(52,211,153,0.08);
+}
+
+/* ── Typography tier utilities ──────────────────────────────── */
+.type-display {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(36px, 5vw, 56px);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #ffffff;
+  line-height: 1;
+  text-shadow: 2px 2px 0 var(--accent-muted);
+}
+.type-page-title {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 28px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #f0f0f0;
+  line-height: 1;
+  text-shadow: 1px 1px 0 var(--accent-muted);
+}
+.type-section {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.55);
+  line-height: 1;
+}
+.type-body {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.75);
+  line-height: 1.1;
+}
+.type-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.35);
+  line-height: 1;
+}
+.type-stat {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 42px;
+  letter-spacing: 0.02em;
+  color: #ffffff;
+  line-height: 1;
+}
+```
+
+- [ ] **Step 10: Update `[data-theme="light"]` block** — Two edits to make:
+
+**10a** — Find the existing `[data-theme="light"] { ... }` block (around line 510 in the current file) and add this property inside it, after the existing `--color-content-disabled` line:
+```css
+/* Accent — CSS wins because JS only sets --accent-server (see :root block above) */
+--accent-color: rgba(0, 0, 0, 0.78);
+```
+
+**10b** — After all existing `[data-theme="light"] .class { }` rules at the bottom of the file, append the following new component-specific light-mode rules (following the existing pattern in the file):
+```css
+/* Parallelogram chip surfaces on light */
+[data-theme="light"] .para-chip,
+[data-theme="light"] .para-chip-sm {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .card,
+[data-theme="light"] .card-hover {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 4px 16px rgba(0,0,0,0.04) !important;
+}
+[data-theme="light"] .card-hover:hover { border-color: var(--accent-muted); }
+
+[data-theme="light"] .section-rule-line { background: rgba(0, 0, 0, 0.1); }
+[data-theme="light"] .section-rule-label { color: rgba(0, 0, 0, 0.35); }
+
+[data-theme="light"] .badge-neutral {
+  background: rgba(0, 0, 0, 0.04);
+  color: rgba(0, 0, 0, 0.55);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="light"] .scanlines { opacity: 0.5; }
+[data-theme="light"] .color-bleed { display: none; }
+
+[data-theme="light"] .corner-bar-tl,
+[data-theme="light"] .corner-bar-bl {
+  background: linear-gradient(to bottom, rgba(0,0,0,0.4), transparent);
+}
+
+[data-theme="light"] .type-display    { color: #0d0d0d; text-shadow: 2px 2px 0 rgba(0,0,0,0.08); }
+[data-theme="light"] .type-page-title { color: #1a1a1a; text-shadow: 1px 1px 0 rgba(0,0,0,0.06); }
+[data-theme="light"] .type-section    { color: rgba(0,0,0,0.55); }
+[data-theme="light"] .type-body       { color: rgba(0,0,0,0.75); }
+[data-theme="light"] .type-label      { color: rgba(0,0,0,0.40); }
+[data-theme="light"] .type-stat       { color: #0d0d0d; }
+```
+
+- [ ] **Step 11: Update `.stat-card` and `.stat-value`** — Parallelogram shape; Number/stat tier for value:
+
+Replace the existing `.stat-card` and `.stat-value` blocks:
+```css
+.stat-card {
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  @apply flex flex-col items-center justify-center p-5 text-center gap-1 relative;
+}
+
+.stat-value {
+  @apply type-stat tabular-nums;
+}
+
+.stat-label {
+  @apply type-label;
+}
+```
+
+- [ ] **Step 12: Update `.input-base`** — Anton SC, parallelogram, accent focus ring:
+
+Replace the existing `.input-base`:
+```css
+.input-base {
+  width: 100%;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.625rem 1rem;
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.88);
+}
+.input-base::placeholder {
+  color: rgba(255, 255, 255, 0.25);
+  letter-spacing: 0.1em;
+}
+.input-base:focus {
+  outline: none;
+  border-color: var(--accent-muted);
+  box-shadow: 0 0 8px var(--accent-subtle);
+}
+```
+
+- [ ] **Step 13: Update focus-visible ring** — Use accent color instead of red:
+
+```css
+*:focus-visible {
+  outline: 2px solid var(--accent-muted);
+  outline-offset: 2px;
+}
+```
+
+- [ ] **Step 14: Run dev server and verify basics work**
+
+```bash
+cd BES-frontend && npm run dev
+```
+Open http://localhost:5173. Verify: body font is now Anton SC (all caps), no broken layout.
+
+- [ ] **Step 15: Run tests**
+
+```bash
+cd BES-frontend && npm test
+```
+Expected: all existing tests pass (CSS changes don't affect logic tests).
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add BES-frontend/src/assets/base.css
+git commit -m "style: rewrite base.css with Anton SC, accent tokens, parallelogram utilities"
+```
+
+---
+
+## Task 2: api.js — App Config API helpers
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js`
+
+- [ ] **Step 1: Add `getAppConfig` and `postAppConfig` functions** — Append to the end of `api.js`:
+
+```js
+export const getAppConfig = async () => {
+  const res = await fetch('/api/v1/config/app', { credentials: 'include' })
+  return res.json()
+}
+
+export const postAppConfig = async (accentColor) => {
+  const res = await fetch('/api/v1/config/app', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accentColor })
+  })
+  return res.json()
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat: add getAppConfig and postAppConfig API helpers"
+```
+
+---
+
+## Task 3: App.vue — Cinematic Navbar + Scanlines + Accent
+
+**Files:**
+- Modify: `BES-frontend/src/App.vue`
+
+- [ ] **Step 1: Update script — add accent color logic**
+
+At the top of `<script setup>`, add to imports:
+```js
+import { createClient, deactivateClient, subscribeToChannel } from './utils/websocket'
+import { getAppConfig } from './utils/api'
+```
+
+Add new refs after existing refs:
+```js
+const accentServer = ref('#ffffff')
+const wsAccentClient = ref(null)
+```
+
+Add the `applyAccent` function after `applyTheme`:
+```js
+function applyAccent(color) {
+  accentServer.value = color
+  document.documentElement.style.setProperty('--accent-server', color)
+}
+```
+
+Update `applyTheme` to handle accent properly:
+```js
+function applyTheme(t) {
+  document.documentElement.setAttribute('data-theme', t)
+  localStorage.setItem('bes-theme', t)
+}
+```
+(The accent CSS custom property cascade handles light mode automatically once `--accent-server` is set and `[data-theme="light"]` overrides `--accent-color`.)
+
+Update `onMounted` to fetch accent config and subscribe:
+```js
+onMounted(async () => {
+  applyTheme(theme.value)
+  try {
+    const res = await whoami()
+    authStore.login(res)
+  } catch {
+    // not authenticated — ok
+  }
+  try {
+    const cfg = await getAppConfig()
+    if (cfg?.accentColor) applyAccent(cfg.accentColor)
+  } catch {
+    // server not ready — keep default
+  }
+  const c = createClient()
+  wsAccentClient.value = c
+  subscribeToChannel(c, '/topic/app-config', (msg) => {
+    if (msg?.accentColor) applyAccent(msg.accentColor)
+  })
+})
+```
+
+Add `onUnmounted` cleanup — first update the `vue` import at line 1 of the script to add `onUnmounted`:
+```js
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+```
+
+Then add the cleanup:
+```js
+onUnmounted(() => {
+  deactivateClient(wsAccentClient.value)
+})
+```
+
+- [ ] **Step 2: Add scanlines overlay div** — Add as the very first child inside `<template>`, before `<nav>`:
+
+```html
+<!-- Global scanlines overlay -->
+<div
+  class="scanlines fixed inset-0 z-[9999] pointer-events-none"
+  style="background: repeating-linear-gradient(to bottom, transparent 0px, transparent 3px, rgba(0,0,0,0.045) 3px, rgba(0,0,0,0.045) 4px);"
+  aria-hidden="true"
+></div>
+```
+
+- [ ] **Step 3: Rewrite the `<nav>` template** — Replace the entire `<nav>` element with the cinematic version. Keep all computed props (role, isAuthenticated, activeEvent, etc.) — only the template changes.
+
+```html
+<nav
+  v-if="!hideNav"
+  class="fixed top-0 left-0 w-full z-40 bg-surface-900/95 border-b border-[rgba(255,255,255,0.07)] transition-all duration-300"
+>
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="grid grid-cols-[auto_1fr_auto] items-center h-16 gap-4">
+
+      <!-- Left: BES wordmark + glowing dot -->
+      <router-link to="/" class="flex items-center gap-2.5 group flex-shrink-0">
+        <div class="glow-dot"></div>
+        <span class="type-body text-[18px] tracking-[0.12em] text-content-primary">BES</span>
+      </router-link>
+
+      <!-- Center: Primary nav as parallelogram chips -->
+      <div class="hidden md:flex items-center justify-center gap-2">
+        <router-link to="/" v-slot="{ isActive }">
+          <span
+            class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
+            :class="isActive
+              ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
+              : 'text-content-muted hover:text-content-primary'"
+          >Home</span>
+        </router-link>
+        <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
+          <span
+            class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
+            :class="isActive
+              ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
+              : 'text-content-muted hover:text-content-primary'"
+          >Events</span>
+        </router-link>
+        <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
+          <span
+            class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
+            :class="isActive
+              ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
+              : 'text-content-muted hover:text-content-primary'"
+          >Admin</span>
+        </router-link>
+      </div>
+
+      <!-- Right: event chip + role + theme + logout -->
+      <div class="hidden md:flex items-center gap-2">
+
+        <!-- Active event dropdown -->
+        <div v-if="isAuthenticated && activeEvent" class="relative">
+          <button
+            @click="eventMenuOpen = !eventMenuOpen"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[200px]"
+          >
+            <span class="truncate">{{ activeEvent.name }}</span>
+            <i class="pi pi-chevron-down text-[10px] flex-shrink-0 opacity-50 transition-transform duration-200"
+               :class="eventMenuOpen ? 'rotate-180' : ''"></i>
+          </button>
+
+          <Transition
+            enter-active-class="transition duration-150 ease-out"
+            enter-from-class="opacity-0 translate-y-1"
+            enter-to-class="opacity-100 translate-y-0"
+            leave-active-class="transition duration-100 ease-in"
+            leave-from-class="opacity-100 translate-y-0"
+            leave-to-class="opacity-0 translate-y-1"
+          >
+            <div v-if="eventMenuOpen"
+              class="absolute right-0 top-full mt-2 w-52 z-50 bg-surface-800 border border-[rgba(255,255,255,0.07)] shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden relative"
+              style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)">
+              <div class="corner-bar-tl"></div>
+              <div class="px-3 py-2.5 border-b border-[rgba(255,255,255,0.07)]">
+                <p class="type-label text-content-muted mb-0.5">Current Event</p>
+                <p class="type-body text-content-primary truncate">{{ activeEvent.name }}</p>
+              </div>
+              <div class="py-1">
+                <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+                  @click="goToEventDetails"
+                  class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                  Event Details
+                </button>
+                <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
+                  @click="goToSection('Audition List')"
+                  class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                  Audition
+                </button>
+                <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+                  @click="goToSection('Update Event Details')"
+                  class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                  Participants
+                </button>
+                <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'"
+                  @click="goToSection('Score')"
+                  class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                  Scoreboard
+                </button>
+                <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+                  @click="goToSection('Battle Control')"
+                  class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                  Battle
+                </button>
+              </div>
+              <div class="border-t border-[rgba(255,255,255,0.07)] py-1">
+                <button @click="changeEvent"
+                  class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
+                  Change Event
+                </button>
+              </div>
+            </div>
+          </Transition>
+          <div v-if="eventMenuOpen" class="fixed inset-0 z-40" @click="eventMenuOpen = false"></div>
+        </div>
+
+        <div v-if="isAuthenticated" class="h-4 w-px bg-[rgba(255,255,255,0.12)]"></div>
+
+        <!-- Role badge -->
+        <span v-if="isAuthenticated && roleDisplay"
+          class="badge-neutral type-label px-2 py-0.5">
+          {{ roleDisplay.label }}
+        </span>
+
+        <!-- Theme toggle -->
+        <button @click="toggleTheme"
+          class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
+          <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
+        </button>
+
+        <router-link v-if="!isAuthenticated" to="/login">
+          <span class="px-4 py-1.5 para-chip type-label text-surface-900 bg-accent cursor-pointer">Login</span>
+        </router-link>
+
+        <button v-if="isAuthenticated"
+          @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
+          class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200">
+          <i class="pi pi-sign-out text-sm"></i>
+        </button>
+      </div>
+
+      <!-- Mobile Hamburger -->
+      <button @click="isOpen = !isOpen"
+        class="md:hidden inline-flex items-center justify-center w-9 h-9 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-colors focus:outline-none">
+        <i class="pi text-lg" :class="isOpen ? 'pi-times' : 'pi-bars'"></i>
+      </button>
+
+    </div>
+  </div>
+
+  <!-- Mobile Dropdown -->
+  <Transition
+    enter-active-class="transition duration-200 ease-out"
+    enter-from-class="opacity-0 -translate-y-2"
+    enter-to-class="opacity-100 translate-y-0"
+    leave-active-class="transition duration-150 ease-in"
+    leave-from-class="opacity-100 translate-y-0"
+    leave-to-class="opacity-0 -translate-y-2"
+  >
+    <div v-show="isOpen" class="md:hidden border-t border-[rgba(255,255,255,0.07)] bg-surface-900/98">
+      <div class="px-3 py-3 space-y-0.5">
+        <router-link to="/" v-slot="{ isActive }">
+          <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
+            :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
+            Home
+          </span>
+        </router-link>
+        <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
+          <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
+            :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
+            Events
+          </span>
+        </router-link>
+        <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
+          <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
+            :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
+            Admin
+          </span>
+        </router-link>
+
+        <template v-if="isAuthenticated && activeEvent">
+          <div class="px-4 pt-3 pb-1 section-rule">
+            <span class="section-rule-label">Current Event — {{ activeEvent.name }}</span>
+            <div class="section-rule-line"></div>
+          </div>
+          <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToEventDetails"
+            class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+            Event Details
+          </button>
+          <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'" @click="goToSection('Audition List')"
+            class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+            Audition
+          </button>
+          <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToSection('Update Event Details')"
+            class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+            Participants
+          </button>
+          <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'" @click="goToSection('Score')"
+            class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+            Scoreboard
+          </button>
+          <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToSection('Battle Control')"
+            class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
+            Battle
+          </button>
+          <button @click="changeEvent"
+            class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-muted hover:text-content-primary transition-colors">
+            Change Event
+          </button>
+        </template>
+      </div>
+
+      <div class="px-3 py-3 border-t border-[rgba(255,255,255,0.07)]">
+        <div v-if="isAuthenticated" class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <span v-if="roleDisplay" class="badge-neutral type-label">{{ roleDisplay.label }}</span>
+            <button @click="toggleTheme"
+              class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
+              <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
+            </button>
+          </div>
+          <button @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
+            class="flex items-center gap-2 px-4 py-2 type-label text-red-400 bg-red-950 hover:bg-red-900 transition-colors cursor-pointer"
+            style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)">
+            Logout
+          </button>
+        </div>
+        <router-link v-else to="/login">
+          <span class="flex items-center justify-center px-4 py-2.5 type-label para-chip text-surface-900 bg-accent w-full cursor-pointer">Login</span>
+        </router-link>
+      </div>
+    </div>
+  </Transition>
+</nav>
+```
+
+- [ ] **Step 4: Verify in browser**
+
+```bash
+cd BES-frontend && npm run dev
+```
+Check: cinematic navbar, glowing dot next to BES, parallelogram event dropdown, scanlines visible.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/App.vue
+git commit -m "feat: cinematic navbar, global scanlines, accent color WS subscribe"
+```
+
+---
+
+## Task 4: Backend — AppConfig entity, migration, service, controller
+
+**Files:**
+- Create: `BES/src/main/resources/db/migration/V20__add_app_config.sql`
+- Create: `BES/src/main/java/com/example/BES/models/AppConfig.java`
+- Create: `BES/src/main/java/com/example/BES/respositories/AppConfigRepository.java`
+- Create: `BES/src/main/java/com/example/BES/services/AppConfigService.java`
+- Create: `BES/src/main/java/com/example/BES/controllers/AppConfigController.java`
+- Create: `BES/src/test/java/com/example/BES/controllers/AppConfigControllerIntegrationTest.java`
+- Modify: `BES/src/main/java/com/example/BES/config/SecurityConfig.java`
+
+- [ ] **Step 1: Write the integration test first (TDD)**
+
+Create `BES/src/test/java/com/example/BES/controllers/AppConfigControllerIntegrationTest.java`:
+```java
+package com.example.BES.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class AppConfigControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void getAppConfig_unauthenticated_returnsDefault() throws Exception {
+        mockMvc.perform(get("/api/v1/config/app"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accentColor").value("#ffffff"));
+    }
+
+    @Test
+    public void postAppConfig_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/config/app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accentColor\":\"#ff0000\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    public void postAppConfig_admin_savesColor() throws Exception {
+        mockMvc.perform(post("/api/v1/config/app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accentColor\":\"#06b6d4\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accentColor").value("#06b6d4"));
+
+        mockMvc.perform(get("/api/v1/config/app"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accentColor").value("#06b6d4"));
+    }
+
+    @Test
+    @WithMockUser(username = "organiser", roles = {"ORGANISER"})
+    public void postAppConfig_organiser_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/config/app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"accentColor\":\"#ff0000\"}"))
+                .andExpect(status().isForbidden());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails** (controller doesn't exist yet):
+
+```bash
+cd BES && mvn test -Dtest=AppConfigControllerIntegrationTest
+```
+Expected: 404 Not Found for all tests (endpoint doesn't exist).
+
+- [ ] **Step 3: Create the Flyway migration**
+
+Create `BES/src/main/resources/db/migration/V20__add_app_config.sql`:
+```sql
+CREATE TABLE app_config (
+    id      BIGSERIAL PRIMARY KEY,
+    key     VARCHAR(100) NOT NULL UNIQUE,
+    value   TEXT         NOT NULL
+);
+
+INSERT INTO app_config (key, value) VALUES ('accentColor', '#ffffff');
+```
+
+- [ ] **Step 4: Create the JPA entity**
+
+Create `BES/src/main/java/com/example/BES/models/AppConfig.java`:
+```java
+package com.example.BES.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "app_config")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String key;
+
+    @Column(nullable = false)
+    private String value;
+}
+```
+
+- [ ] **Step 5: Create the repository**
+
+Create `BES/src/main/java/com/example/BES/respositories/AppConfigRepository.java`:
+```java
+package com.example.BES.respositories;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.BES.models.AppConfig;
+
+public interface AppConfigRepository extends JpaRepository<AppConfig, Long> {
+    Optional<AppConfig> findByKey(String key);
+}
+```
+
+- [ ] **Step 6: Create the service**
+
+Create `BES/src/main/java/com/example/BES/services/AppConfigService.java`:
+```java
+package com.example.BES.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import com.example.BES.models.AppConfig;
+import com.example.BES.respositories.AppConfigRepository;
+
+@Service
+public class AppConfigService {
+
+    private static final String ACCENT_KEY = "accentColor";
+    private static final String ACCENT_DEFAULT = "#ffffff";
+
+    @Autowired
+    private AppConfigRepository repo;
+
+    public String getAccentColor() {
+        return repo.findByKey(ACCENT_KEY)
+                   .map(AppConfig::getValue)
+                   .orElse(ACCENT_DEFAULT);
+    }
+
+    public String saveAccentColor(String color) {
+        AppConfig cfg = repo.findByKey(ACCENT_KEY)
+                            .orElse(new AppConfig(null, ACCENT_KEY, ACCENT_DEFAULT));
+        cfg.setValue(color);
+        repo.save(cfg);
+        return color;
+    }
+}
+```
+
+- [ ] **Step 7: Create the controller**
+
+Create `BES/src/main/java/com/example/BES/controllers/AppConfigController.java`:
+```java
+package com.example.BES.controllers;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.example.BES.services.AppConfigService;
+
+@RestController
+@RequestMapping("/api/v1/config")
+public class AppConfigController {
+
+    @Autowired
+    private AppConfigService service;
+
+    @Autowired
+    private SimpMessagingTemplate messaging;
+
+    @GetMapping("/app")
+    public ResponseEntity<Map<String, String>> getAppConfig() {
+        String color = service.getAccentColor();
+        return ResponseEntity.ok(Map.of("accentColor", color));
+    }
+
+    @PostMapping("/app")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String, String>> postAppConfig(@RequestBody Map<String, String> body) {
+        String color = body.get("accentColor");
+        if (color == null || color.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "accentColor is required"));
+        }
+        String saved = service.saveAccentColor(color);
+        messaging.convertAndSend("/topic/app-config", Map.of("accentColor", saved));
+        return ResponseEntity.ok(Map.of("accentColor", saved));
+    }
+}
+```
+
+- [ ] **Step 8: Update SecurityConfig** — Permit `GET /api/v1/config/app` publicly; POST is protected by `@PreAuthorize` on the controller.
+
+In `SecurityConfig.java`, add a line before `.anyRequest().authenticated()`:
+```java
+.requestMatchers(HttpMethod.GET, "/api/v1/config/app").permitAll()
+```
+
+The full `authorizeHttpRequests` block after the change:
+```java
+.authorizeHttpRequests(auth -> auth
+    .requestMatchers("/api/v1/auth/**").permitAll()
+    .requestMatchers("/api/v1/battle/**").permitAll()
+    .requestMatchers("/ws/**").permitAll()
+    .requestMatchers(HttpMethod.GET, "/api/v1/results").permitAll()
+    .requestMatchers(HttpMethod.GET, "/api/v1/config/app").permitAll()
+    .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+    .anyRequest().authenticated())
+```
+
+Also add the `HttpMethod` import if not present:
+```java
+import org.springframework.http.HttpMethod;
+```
+
+- [ ] **Step 9: Run tests to confirm they pass**
+
+```bash
+cd BES && mvn test -Dtest=AppConfigControllerIntegrationTest
+```
+Expected: all 4 tests PASS.
+
+- [ ] **Step 10: Run full test suite**
+
+```bash
+cd BES && mvn test
+```
+Expected: all tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add BES/src/main/resources/db/migration/V20__add_app_config.sql \
+        BES/src/main/java/com/example/BES/models/AppConfig.java \
+        BES/src/main/java/com/example/BES/respositories/AppConfigRepository.java \
+        BES/src/main/java/com/example/BES/services/AppConfigService.java \
+        BES/src/main/java/com/example/BES/controllers/AppConfigController.java \
+        BES/src/main/java/com/example/BES/config/SecurityConfig.java \
+        BES/src/test/java/com/example/BES/controllers/AppConfigControllerIntegrationTest.java
+git commit -m "feat: AppConfig entity, V20 migration, GET/POST /api/v1/config/app with WS broadcast"
+```
+
+---
+
+## Task 5: Login.vue — Cinematic Login Screen
+
+**Files:**
+- Modify: `BES-frontend/src/views/Login.vue`
+
+Login is the first impression of the new design. The left panel gets a Display-tier "BES" hero; the right panel gets a parallelogram form with accent border-left.
+
+- [ ] **Step 1: Replace the template** — Keep `<script setup>` unchanged. Replace `<template>` entirely:
+
+```html
+<template>
+  <div class="min-h-screen flex overflow-hidden bg-surface-950 relative">
+
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
+
+    <!-- ── Left panel: BES hero ───────────────────────────────── -->
+    <div class="hidden lg:flex lg:w-[52%] relative flex-col justify-between p-14 overflow-hidden">
+      <div class="absolute inset-0 bg-surface-900"></div>
+      <div class="corner-bar-tl" style="height: 40%"></div>
+      <div class="corner-bar-bl" style="width: 40%"></div>
+
+      <!-- Wordmark -->
+      <div class="relative z-10 flex items-center gap-2.5">
+        <div class="glow-dot"></div>
+        <span class="type-body tracking-[0.12em]">BES</span>
+      </div>
+
+      <!-- Hero -->
+      <div class="relative z-10">
+        <div class="type-display mb-6">BES</div>
+        <div class="section-rule mb-6">
+          <div class="section-rule-line"></div>
+        </div>
+        <p class="type-body text-content-secondary leading-relaxed max-w-md">
+          The all-in-one platform for street dance battle events — registration, judging, real-time battles.
+        </p>
+        <div class="flex flex-wrap gap-2 mt-8">
+          <span class="badge-neutral px-3 py-1.5">Event Management</span>
+          <span class="badge-neutral px-3 py-1.5">Audition Control</span>
+          <span class="badge-neutral px-3 py-1.5">Battle System</span>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="relative z-10 type-label text-content-muted">
+        &copy; {{ new Date().getFullYear() }} BES Platform
+      </div>
+    </div>
+
+    <!-- ── Right panel: Login form ───────────────────────────── -->
+    <div class="flex-1 flex items-center justify-center p-8 relative z-10">
+      <div class="w-full max-w-sm relative">
+        <!-- Corner bars on form panel -->
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
+
+        <div class="p-8 bg-surface-900 border border-[rgba(255,255,255,0.07)]"
+          style="clip-path: polygon(8px 0%,100% 0%,calc(100% - 8px) 100%,0% 100%)">
+
+          <div class="mb-8">
+            <div class="type-page-title mb-1">Sign In</div>
+            <p class="type-label text-content-muted">Battle Event System</p>
+          </div>
+
+          <form @submit.prevent="submitLogin" class="space-y-4">
+            <div>
+              <label class="type-label text-content-muted block mb-2">Username</label>
+              <input
+                v-model="username"
+                type="text"
+                placeholder="Username"
+                class="input-base w-full"
+                autocomplete="username"
+              />
+            </div>
+            <div>
+              <label class="type-label text-content-muted block mb-2">Password</label>
+              <div class="relative">
+                <input
+                  v-model="password"
+                  :type="showPassword ? 'text' : 'password'"
+                  placeholder="Password"
+                  class="input-base w-full pr-10"
+                  autocomplete="current-password"
+                />
+                <button type="button" @click="showPassword = !showPassword"
+                  class="absolute right-3 top-1/2 -translate-y-1/2 type-label text-content-muted hover:text-content-primary transition-colors">
+                  <i class="pi" :class="showPassword ? 'pi-eye-slash' : 'pi-eye'"></i>
+                </button>
+              </div>
+            </div>
+
+            <button
+              type="submit"
+              :disabled="isLoading"
+              class="w-full py-3 type-body bg-accent text-surface-900 transition-all duration-200 disabled:opacity-50 mt-2"
+              style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)">
+              {{ isLoading ? 'Signing in...' : 'Sign In' }}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error modal -->
+    <ActionDoneModal
+      :show="showModal"
+      :title="modalTitle"
+      :variant="modalVariant"
+      @accept="handleAccept"
+      @close="showModal = false"
+    >
+      <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+    </ActionDoneModal>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Verify in browser** — Navigate to http://localhost:5173/login. Expect: dark left panel with large "BES" display text, parallelogram form on the right, cinematic layout.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/Login.vue
+git commit -m "style: cinematic login screen with display-tier hero and parallelogram form"
+```
+
+---
+
+## Task 6: MainMenu.vue — Cinematic Quick-Action Home
+
+**Files:**
+- Modify: `BES-frontend/src/views/MainMenu.vue`
+
+- [ ] **Step 1: Replace the template** — Keep `<script setup>` unchanged. Replace `<template>`:
+
+```html
+<template>
+  <div class="page-container relative">
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
+
+    <div class="relative z-10">
+      <!-- Page header -->
+      <div class="mb-8">
+        <div class="type-page-title mb-1">Home</div>
+        <p class="type-label text-content-muted">{{ roleDisplay?.label ?? 'Welcome' }}</p>
+      </div>
+
+      <!-- Quick actions section -->
+      <div class="section-rule mb-6">
+        <span class="section-rule-label">Quick Actions</span>
+        <div class="section-rule-line"></div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+        <!-- Events card (Admin / Organiser) -->
+        <router-link
+          v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
+          to="/events"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-calendar text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Events</div>
+          <p class="type-label text-content-muted">Manage and browse events</p>
+        </router-link>
+
+        <!-- Audition List -->
+        <router-link
+          v-if="activeEvent"
+          :to="{ name: 'Audition List' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-list text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Audition</div>
+          <p class="type-label text-content-muted">Score and timer controls</p>
+        </router-link>
+
+        <!-- Participants (Admin / Organiser) -->
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER')"
+          :to="{ name: 'Update Event Details' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-users text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Participants</div>
+          <p class="type-label text-content-muted">Manage registrations and judges</p>
+        </router-link>
+
+        <!-- Scoreboard (Admin / Organiser / Emcee) -->
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE')"
+          :to="{ name: 'Score' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-chart-bar text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Scoreboard</div>
+          <p class="type-label text-content-muted">Live leaderboard</p>
+        </router-link>
+
+        <!-- Battle Control (Admin / Organiser) -->
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER')"
+          :to="{ name: 'Battle Control' }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-bolt text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Battle</div>
+          <p class="type-label text-content-muted">Bracket and match control</p>
+        </router-link>
+
+        <!-- Admin (Admin only) -->
+        <router-link
+          v-if="role === 'ROLE_ADMIN'"
+          to="/admin"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-cog text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Admin</div>
+          <p class="type-label text-content-muted">Genres, judges, theme config</p>
+        </router-link>
+
+      </div>
+
+      <!-- No event selected hint -->
+      <div v-if="!activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE')"
+        class="mt-8 p-4 semantic-chip-warning flex items-start gap-3">
+        <div class="w-2 h-2 rounded-full bg-amber-400 box-shadow-[0_0_6px_rgba(245,158,11,0.8)] mt-0.5 flex-shrink-0"></div>
+        <div>
+          <div class="type-body text-amber-400 mb-1">No Active Event</div>
+          <p class="type-label text-content-muted">
+            Select an event to access audition, scoring, and battle features.
+          </p>
+          <router-link :to="{ name: 'EventSelector' }" class="type-label text-accent underline mt-2 inline-block">
+            Select Event →
+          </router-link>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+```
+
+At the top of `<script setup>`, add if not present:
+```js
+import { computed } from 'vue'
+import { useAuthStore } from '@/utils/auth'
+
+const authStore = useAuthStore()
+const role = computed(() => authStore.user?.role?.[0]?.authority ?? '')
+const activeEvent = computed(() => authStore.activeEvent)
+const roleDisplay = computed(() => {
+  const labels = { ROLE_ADMIN: 'Admin', ROLE_ORGANISER: 'Organiser', ROLE_JUDGE: 'Judge', ROLE_EMCEE: 'Emcee' }
+  const label = labels[role.value]
+  return label ? { label } : null
+})
+```
+
+- [ ] **Step 2: Verify** — Navigate to `/`. Expect: parallelogram quick-action cards with corner bars, section rule, color bleed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/MainMenu.vue
+git commit -m "style: cinematic MainMenu with parallelogram quick-action cards"
+```
+
+---
+
+## Task 7: EventSelector.vue + Events.vue + EventCard.vue
+
+**Files:**
+- Modify: `BES-frontend/src/views/EventSelector.vue`
+- Modify: `BES-frontend/src/views/Events.vue`
+- Modify: `BES-frontend/src/components/EventCard.vue`
+
+- [ ] **Step 1: Update EventSelector.vue** — Read the current template. Apply these targeted changes:
+
+a) Wrap the page root `<div>` with `relative` and add `<div class="color-bleed"></div>` as first child.
+
+b) Replace the page title element with:
+```html
+<div class="type-page-title mb-1">Select Event</div>
+<p class="type-label text-content-muted">{{ events.length }} available</p>
+```
+
+c) Replace the event card grid items. Each event card chip should be:
+```html
+<button
+  v-for="event in events"
+  :key="event.id"
+  @click="selectEvent(event)"
+  class="card-hover p-5 text-left relative group w-full"
+>
+  <div class="corner-bar-tl"></div>
+  <div class="type-body mb-1">{{ event.name }}</div>
+  <div class="type-label text-content-muted">{{ event.date ?? 'No date set' }}</div>
+</button>
+```
+
+d) Replace section-divider `border-b` elements with `.section-rule`:
+```html
+<div class="section-rule mb-4">
+  <span class="section-rule-label">Available Events</span>
+  <div class="section-rule-line"></div>
+</div>
+```
+
+- [ ] **Step 2: Update Events.vue** — Read the current template. Apply these targeted changes:
+
+a) Add `color-bleed` div to page root.
+
+b) Replace page title with `type-page-title` class.
+
+c) Replace each event list row with a parallelogram chip:
+```html
+<div class="para-chip px-4 py-3 flex items-center gap-4 mb-2">
+  <span class="type-body">{{ event.name }}</span>
+  <span class="badge-neutral ml-auto">{{ event.status }}</span>
+</div>
+```
+
+d) Add section rules before grouped sections.
+
+- [ ] **Step 3: Update EventCard.vue** — Read the current component. Apply:
+
+a) Replace card container `class` — remove `rounded-2xl`, apply parallelogram:
+```html
+<div class="card-hover p-5 relative group w-full" style="...">
+```
+Note: EventCard has an absolute-positioned action panel. Since `clip-path` clips all children, keep the card's outer div WITHOUT `clip-path` but WITH a `::before` pseudo-element for the visual parallelogram background. OR: Verify that the action panel is positioned outside the card in the parent — in that case, `card-hover` with clip-path is safe.
+
+Check in `Events.vue` how EventCard is used. If the action panel overlays from outside the card boundary, use `card-hover` with clip-path. If the panel overflows the card, use this instead for EventCard's container:
+```html
+<div class="relative bg-[rgba(255,255,255,0.04)] border border-[rgba(255,255,255,0.07)] p-5 transition-all duration-200 hover:border-[color:var(--accent-muted)] hover:bg-[rgba(255,255,255,0.06)] group">
+  <div class="corner-bar-tl"></div>
+```
+
+b) Replace event name heading with `type-body` class.
+
+c) Replace any `font-heading`, `font-semibold`, `rounded-full` badge classes with cinematic equivalents.
+
+- [ ] **Step 4: Verify** — Navigate to `/events` and `/event/select`. Check parallelogram cards, section rules.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/EventSelector.vue \
+        BES-frontend/src/views/Events.vue \
+        BES-frontend/src/components/EventCard.vue
+git commit -m "style: cinematic EventSelector, Events, EventCard"
+```
+
+---
+
+## Task 8: EventDetails.vue — Section Rules and Stat Boxes
+
+**Files:**
+- Modify: `BES-frontend/src/views/EventDetails.vue` (1546 lines — targeted changes only)
+
+This is a large file. Make targeted search-and-replace changes:
+
+- [ ] **Step 1: Add color-bleed to page root** — Find the outermost `<div class="page-container ...">` and add as the very first child inside it:
+```html
+<div class="color-bleed"></div>
+```
+
+- [ ] **Step 2: Replace `border-b border-surface-700` section dividers** — Find all occurrences (likely 5-8) of:
+```html
+<h2 class="... font-heading ...">Section Title</h2>
+```
+And the adjacent `border-b` divider. Replace with section-rule pattern:
+```html
+<div class="section-rule mb-4">
+  <span class="section-rule-label">Section Title</span>
+  <div class="section-rule-line"></div>
+</div>
+```
+
+- [ ] **Step 3: Replace stat boxes** — Find all `stat-card` elements and ensure they use `type-stat` for the value and `type-label` for the label:
+```html
+<div class="stat-card">
+  <div class="type-stat">{{ value }}</div>
+  <div class="type-label text-content-muted mt-1">Label</div>
+</div>
+```
+
+- [ ] **Step 4: Replace page title** — Find the main `h1` or page title element:
+```html
+<div class="type-page-title mb-1">{{ eventName }}</div>
+```
+
+- [ ] **Step 5: Replace `rounded-2xl` card containers for genre accordion items** — Find genre cards and apply:
+```html
+<div class="para-chip p-4 mb-3 relative">
+```
+
+- [ ] **Step 6: Replace `rounded-full` badges** — Find all `badge-*` class elements that use `rounded-full` and remove `rounded-full` (the updated `.badge-*` in base.css already applies parallelogram clip-path).
+
+- [ ] **Step 7: Run dev and verify** — Open an event's details page. Check section rules, stat boxes, no rounded corners.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "style: cinematic EventDetails — section rules, parallelogram stat boxes"
+```
+
+---
+
+## Task 9: UpdateEventDetails.vue — Parallelogram Rows + Semantic Chips
+
+**Files:**
+- Modify: `BES-frontend/src/views/UpdateEventDetails.vue`
+
+- [ ] **Step 1: Read the file** — Run:
+```bash
+cat BES-frontend/src/views/UpdateEventDetails.vue
+```
+
+- [ ] **Step 2: Apply changes** — This is 215 lines. Make targeted changes:
+
+a) Add `color-bleed` to page root.
+
+b) Add page title with `type-page-title`.
+
+c) Replace table rows with parallelogram chips. Each participant row should be:
+```html
+<div class="para-chip px-4 py-3 flex items-center gap-3 mb-2">
+  <span class="type-body">{{ participant.stageName || participant.name }}</span>
+  <!-- status chips use semantic-chip-* classes -->
+  <span v-if="participant.verified" class="badge-success ml-auto">Verified</span>
+  <span v-else class="badge-warning">Pending</span>
+</div>
+```
+
+d) Replace section dividers with `.section-rule`.
+
+e) Error/warning banners: replace with `.semantic-chip-error` or `.semantic-chip-warning`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/UpdateEventDetails.vue
+git commit -m "style: cinematic UpdateEventDetails — parallelogram rows, semantic chips"
+```
+
+---
+
+## Task 10: AuditionList.vue — Context Bar + Filter Chips
+
+**Files:**
+- Modify: `BES-frontend/src/views/AuditionList.vue`
+
+- [ ] **Step 1: Apply changes** — Key targeted changes:
+
+a) Context bar (top): Convert to parallelogram chip with `type-label` text:
+```html
+<div class="para-chip px-4 py-2 flex items-center gap-4 mb-4">
+  <div class="glow-dot"></div>
+  <span class="type-label text-content-muted">{{ activeEvent?.name }}</span>
+  <span class="badge-neutral ml-auto">{{ participants.length }} registered</span>
+</div>
+```
+
+b) Filter chips: Replace `rounded-full` filter buttons with parallelogram:
+```html
+<button
+  v-for="genre in genres"
+  :key="genre.id"
+  @click="selectGenre(genre)"
+  class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
+  :class="selectedGenre?.id === genre.id
+    ? 'text-accent border-[color:var(--accent-muted)]'
+    : 'text-content-muted hover:text-content-primary'"
+>{{ genre.name }}</button>
+```
+
+c) Section rules before "Scored" / "Unscored" groups.
+
+d) Participant rows → `para-chip` with `type-body` name.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/views/AuditionList.vue
+git commit -m "style: cinematic AuditionList — parallelogram context bar, filter chips"
+```
+
+---
+
+## Task 11: Score.vue — Number/Stat Tier for Scores
+
+**Files:**
+- Modify: `BES-frontend/src/views/Score.vue` (1029 lines — targeted changes)
+
+- [ ] **Step 1: Apply targeted changes:**
+
+a) Add `color-bleed` to page root.
+
+b) Podium / top-3 score values → `type-stat` class:
+```html
+<div class="type-stat">{{ score.totalScore }}</div>
+<div class="type-label text-content-muted mt-1">{{ score.participantName }}</div>
+```
+
+c) Leaderboard rows → `para-chip`:
+```html
+<div class="para-chip px-4 py-3 flex items-center gap-4 mb-2">
+  <span class="type-stat text-[24px]">{{ rank }}</span>
+  <span class="type-body">{{ entry.name }}</span>
+  <span class="type-stat text-[20px] ml-auto">{{ entry.score }}</span>
+</div>
+```
+
+d) Section rules before "Top 3", "All Scores", "By Judge" sections.
+
+e) Stat boxes (total registered, genres) → `stat-card` with `type-stat` value.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/views/Score.vue
+git commit -m "style: cinematic Score — number/stat tier, parallelogram leaderboard rows"
+```
+
+---
+
+## Task 12: BattleControl.vue — Section Rules + Bracket Slots
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue` (1736 lines — targeted changes)
+
+- [ ] **Step 1: Apply targeted changes:**
+
+a) Add `color-bleed` to page root.
+
+b) All `border-b border-surface-700` section dividers → `.section-rule`.
+
+c) Bracket seed slot elements → `para-chip`:
+```html
+<div class="para-chip px-3 py-2 flex items-center gap-2">
+  <span class="type-label text-content-muted">{{ slotIndex + 1 }}</span>
+  <span class="type-body">{{ slot.name ?? 'Empty' }}</span>
+</div>
+```
+
+d) Phase indicator chips (IDLE / LOCKED / VOTING / REVEALED) → `.semantic-chip-*`:
+- IDLE → `badge-neutral`
+- LOCKED → `badge-warning`
+- VOTING → `badge-primary` (accent)
+- REVEALED → `badge-success`
+
+e) Page title → `type-page-title`.
+
+f) Section labels → `type-section` with section-rule.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "style: cinematic BattleControl — section rules, parallelogram bracket slots"
+```
+
+---
+
+## Task 13: AdminPage.vue — Theme Config Color Picker
+
+**Files:**
+- Modify: `BES-frontend/src/views/AdminPage.vue`
+
+- [ ] **Step 1: Add imports to `<script setup>`**
+
+Add to existing imports:
+```js
+import { getAppConfig, postAppConfig } from '@/utils/api'
+```
+
+Add new refs after existing refs:
+```js
+const accentColor = ref('#ffffff')
+const accentApplying = ref(false)
+
+const presetColors = [
+  { label: 'White / Silver', value: '#ffffff' },
+  { label: 'Gold', value: '#f59e0b' },
+  { label: 'Cyan', value: '#06b6d4' },
+  { label: 'Purple', value: '#8b5cf6' },
+  { label: 'Orange', value: '#f97316' },
+  { label: 'Emerald', value: '#10b981' },
+]
+```
+
+Add `onMounted` fetch (extend existing `onMounted` or create one):
+```js
+// inside onMounted:
+try {
+  const cfg = await getAppConfig()
+  if (cfg?.accentColor) accentColor.value = cfg.accentColor
+} catch { /* keep default */ }
+```
+
+Add apply function:
+```js
+const applyAccentToAll = async () => {
+  accentApplying.value = true
+  try {
+    await postAppConfig(accentColor.value)
+    // parent App.vue will pick up the WS broadcast
+  } catch {
+    openModal('Error', 'Failed to apply accent color. Please try again.', 'error')
+  } finally {
+    accentApplying.value = false
+  }
+}
+```
+
+- [ ] **Step 2: Add Theme Config section to the template** — Find the end of the last section in the template and add a new section before the closing `</div>`:
+
+```html
+<!-- ── Theme Config ────────────────────────────────────────────────── -->
+<div class="section-rule mb-6 mt-10">
+  <span class="section-rule-label">Theme Config</span>
+  <div class="section-rule-line"></div>
+</div>
+
+<div class="card p-6 relative max-w-lg">
+  <div class="corner-bar-tl"></div>
+  <div class="corner-bar-bl"></div>
+
+  <div class="mb-4">
+    <div class="type-label text-content-muted mb-2">Current Accent</div>
+    <div
+      class="w-full h-12 para-chip flex items-center justify-center type-label"
+      :style="{ background: accentColor, color: '#111' }"
+    >{{ accentColor }}</div>
+  </div>
+
+  <div class="mb-4">
+    <div class="type-label text-content-muted mb-2">Presets</div>
+    <div class="flex flex-wrap gap-2">
+      <button
+        v-for="preset in presetColors"
+        :key="preset.value"
+        @click="accentColor = preset.value"
+        class="w-8 h-8 transition-transform hover:scale-110"
+        style="clip-path: polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
+        :style="{ background: preset.value, outline: accentColor === preset.value ? '2px solid rgba(255,255,255,0.6)' : 'none', outlineOffset: '2px' }"
+        :title="preset.label"
+      ></button>
+    </div>
+  </div>
+
+  <div class="mb-4 flex items-center gap-3">
+    <div class="type-label text-content-muted flex-shrink-0">Custom</div>
+    <input
+      type="color"
+      v-model="accentColor"
+      class="w-10 h-8 cursor-pointer border-0 bg-transparent"
+    />
+    <span class="type-label text-content-muted font-source">{{ accentColor }}</span>
+  </div>
+
+  <button
+    @click="applyAccentToAll"
+    :disabled="accentApplying"
+    class="w-full py-2 type-body bg-accent text-surface-900 disabled:opacity-50 transition-all"
+    style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)">
+    {{ accentApplying ? 'Applying...' : 'Apply to All Clients' }}
+  </button>
+</div>
+```
+
+- [ ] **Step 3: Apply cinematic styling to existing sections** — AdminPage has genre, judge, image, and feedback sections. For each:
+
+a) Replace section headers `<h2 class="font-heading ...">` with:
+```html
+<div class="section-rule mb-4">
+  <span class="section-rule-label">Genres</span>
+  <div class="section-rule-line"></div>
+</div>
+```
+
+b) Replace list row cards with `para-chip` containers.
+
+c) Replace `rounded-full` badges with `badge-*` (parallelogram already applied by updated base.css).
+
+- [ ] **Step 4: Verify** — Navigate to `/admin`. Check Theme Config section with color picker. Select a preset — it should update the swatch. Click "Apply to All Clients" — accent should update across the app live.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/AdminPage.vue
+git commit -m "feat: AdminPage Theme Config section with accent color picker and WS broadcast"
+```
+
+---
+
+## Task 14: Results.vue + ResultsQR.vue
+
+**Files:**
+- Modify: `BES-frontend/src/views/Results.vue`
+- Modify: `BES-frontend/src/views/ResultsQR.vue`
+
+- [ ] **Step 1: Apply to Results.vue** — Targeted changes:
+
+a) Add `color-bleed` to page root.
+
+b) Page title → `type-page-title`.
+
+c) Reference code input → `input-base` (already styled; verify no regressions).
+
+d) Result rows → `para-chip` with score in `type-stat`:
+```html
+<div class="para-chip px-4 py-3 flex items-center gap-4 mb-2">
+  <span class="type-stat text-[22px]">{{ result.rank }}</span>
+  <div class="flex-1">
+    <div class="type-body">{{ result.name }}</div>
+    <div class="type-label text-content-muted">{{ result.genre }}</div>
+  </div>
+  <span class="type-stat text-[22px]">{{ result.score }}</span>
+</div>
+```
+
+e) Section rules between sections.
+
+- [ ] **Step 2: Apply to ResultsQR.vue** — Same parallelogram result rows + color bleed + page title pattern.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/Results.vue BES-frontend/src/views/ResultsQR.vue
+git commit -m "style: cinematic Results and ResultsQR — parallelogram rows, number/stat tier"
+```
+
+---
+
+## Task 15: Shared Components
+
+**Files:**
+- Modify: `BES-frontend/src/components/EmceeRoundView.vue`
+- Modify: `BES-frontend/src/components/FeedbackPopout.vue`
+- Modify: `BES-frontend/src/components/Timer.vue`
+- Modify: `BES-frontend/src/components/MiniScoreMenu.vue`
+- Modify: `BES-frontend/src/components/ReusableDropdown.vue`
+- Modify: `BES-frontend/src/components/SwipeableCardsV2.vue`
+- Modify: `BES-frontend/src/components/PairScoreCards.vue`
+
+Read each file before editing. Apply these universal patterns:
+
+- [ ] **Step 1: EmceeRoundView.vue** — Section rules for round separators. Participant status badges → `badge-success` / `badge-warning` (parallelogram from base.css). Participant name → `type-body`. Count label → `type-stat`.
+
+- [ ] **Step 2: FeedbackPopout.vue** — Tag chips → `para-chip-sm type-label`. Section headers → `section-rule`. Submit button → `bg-accent` parallelogram.
+
+- [ ] **Step 3: Timer.vue** — Time display → `type-stat` (42px Anton SC). Label → `type-label`. Start/stop buttons → `para-chip bg-accent type-body` for primary, `para-chip type-label` for secondary.
+
+- [ ] **Step 4: MiniScoreMenu.vue** — Each score option → `para-chip-sm type-label` hover state with `text-accent`.
+
+- [ ] **Step 5: ReusableDropdown.vue** — Dropdown trigger → `para-chip type-label`. Options list → `bg-surface-800 border border-[rgba(255,255,255,0.07)]`. Each option → `type-body hover:bg-[rgba(255,255,255,0.04)]`.
+
+- [ ] **Step 6: SwipeableCardsV2.vue** — Card outer container: keep existing width constraints (`w-[97%] p-2` per CLAUDE.md — do NOT increase padding). Replace `rounded-2xl` with parallelogram but keep the card compact for mobile judge UX. Score number → `type-stat`. Participant name → `type-body`.
+
+**IMPORTANT for SwipeableCardsV2:** Per CLAUDE.md, the judge scoring card has strict size constraints: `py-4` keypad buttons, `w-[97%]` card width, `p-2` card padding. Do not increase these regardless of the design language change. The parallelogram clip-path can be applied but sizing must remain untouched.
+
+- [ ] **Step 7: PairScoreCards.vue** — Score values → `type-stat`. Participant name → `type-body`. VS divider → `section-rule`. Card containers → `para-chip`.
+
+- [ ] **Step 8: ActionDoneModal.vue** — This modal is used across every view for confirmations and logout. Read the file then apply:
+
+a) Add `relative` to the modal container and add corner bars:
+```html
+<div class="relative bg-surface-800 border border-[rgba(255,255,255,0.07)] p-6"
+     style="clip-path: polygon(8px 0%,100% 0%,calc(100% - 8px) 100%,0% 100%)">
+  <div class="corner-bar-tl"></div>
+  <div class="corner-bar-bl"></div>
+```
+
+b) Modal title → `type-page-title`.
+
+c) For warning/error variants, wrap with the corresponding semantic chip class:
+```html
+<!-- Variant warning -->
+<div class="semantic-chip-warning p-4 mb-4 flex items-start gap-3">
+  <div class="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0 mt-1" style="box-shadow: 0 0 6px rgba(245,158,11,0.8)"></div>
+  <slot></slot>
+</div>
+<!-- Variant error -->
+<div class="semantic-chip-error p-4 mb-4 flex items-start gap-3">
+  <div class="w-2 h-2 rounded-full bg-red-400 flex-shrink-0 mt-1" style="box-shadow: 0 0 6px rgba(239,68,68,0.8)"></div>
+  <slot></slot>
+</div>
+```
+
+d) Action buttons → parallelogram shape. Confirm/accept → `bg-accent para-chip type-label`. Cancel/close → `para-chip type-label text-content-muted`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add BES-frontend/src/components/EmceeRoundView.vue \
+        BES-frontend/src/components/FeedbackPopout.vue \
+        BES-frontend/src/components/Timer.vue \
+        BES-frontend/src/components/MiniScoreMenu.vue \
+        BES-frontend/src/components/ReusableDropdown.vue \
+        BES-frontend/src/components/SwipeableCardsV2.vue \
+        BES-frontend/src/components/PairScoreCards.vue
+git commit -m "style: cinematic shared components — Anton SC, parallelogram chips, section rules"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Run full frontend test suite**
+```bash
+cd BES-frontend && npm test
+```
+Expected: all tests pass.
+
+- [ ] **Step 2: Run full backend test suite**
+```bash
+cd BES && mvn test
+```
+Expected: all tests pass.
+
+- [ ] **Step 3: Docker smoke test**
+```bash
+docker-compose up --build --no-cache
+```
+Open https://localhost. Verify: Anton SC everywhere, parallelogram shapes, cinematic navbar, scanlines, color bleed on page roots. Log in as admin and test accent color picker — all tabs should update live via WebSocket.
+
+- [ ] **Step 4: Light mode check** — Toggle light mode. Verify: scanlines at half opacity, color bleed hidden, accent inverts to dark automatically.
+
+- [ ] **Step 5: Do NOT change** — Confirm `BattleOverlay.vue`, `BracketVisualization.vue`, `Chart.vue` are unchanged: `git diff HEAD -- BES-frontend/src/views/BattleOverlay.vue BES-frontend/src/views/BracketVisualization.vue BES-frontend/src/views/Chart.vue` should show no diff.

--- a/docs/superpowers/specs/2026-05-30-ui-overhaul-design.md
+++ b/docs/superpowers/specs/2026-05-30-ui-overhaul-design.md
@@ -1,0 +1,280 @@
+# BES UI Overhaul — Design Spec
+**Date:** 2026-05-30  
+**Status:** Approved  
+
+---
+
+## Goal
+
+Unify the entire BES webapp under a single cinematic design language inspired by the existing `BattleOverlay.vue` and `BracketVisualization.vue` views. Every screen — from Login to AdminPage — should feel like it belongs to the same broadcast production system. The three already-redesigned views (`BattleOverlay`, `BracketVisualization`, `AuditionList`) serve as the reference point; all other views are brought into alignment with them.
+
+---
+
+## Design Decisions Summary
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Design direction | Cinematic Battle | Extend battle views' aesthetic across all screens |
+| Font strategy | Full Anton SC everywhere | All text tiers use Anton SC; letter-spacing + opacity replace font-weight |
+| Background base | Neutral black `#111111` | Easier to read on long admin sessions vs navy `#060818` |
+| Chrome intensity | Full broadcast | Scanlines, parallelogram chips, corner bars, color bleeds, section rules |
+| Semantic contrast | Left border + glowing dot | Strong enough to command attention without overpowering |
+| Primary accent | White/silver default, admin-configurable | Red conflicts with error states; accent is a shared runtime config |
+| Light mode | Kept | Accent auto-inverts to `rgba(0,0,0,0.78)` in light mode |
+
+---
+
+## 1. Color & Token System
+
+### Accent token (new)
+- **CSS custom property:** `--accent-color` — set at `<html>` level at runtime
+- **Dark mode default:** `rgba(255, 255, 255, 0.88)` (white/silver)
+- **Light mode override:** `rgba(0, 0, 0, 0.78)` (set via `[data-theme="light"]` CSS, ignores server config)
+- **Accent is stored as an opaque hex value** (e.g. `#ffffff`). Alpha variants are computed in CSS via `color-mix`, not JS. The default white/silver is `#ffffff`.
+- **Derived tokens** (CSS custom properties, computed from `--accent-color`):
+  - `--accent-muted: color-mix(in srgb, var(--accent-color) 25%, transparent)`
+  - `--accent-subtle: color-mix(in srgb, var(--accent-color) 7%, transparent)`
+  - Both are set once in `base.css` as default values; they update automatically when `--accent-color` changes at the `<html>` level.
+- **New utility classes** added to `base.css`:
+  - `.text-accent` → `color: var(--accent-color)`
+  - `.bg-accent` → `background: var(--accent-color)`
+  - `.border-accent` → `border-color: var(--accent-color)`
+  - `.glow-accent` → `box-shadow: 0 0 14px var(--accent-muted)`
+
+### Red (`primary-*`) — role change
+- **Was:** Brand/interactive color (buttons, links, active states, focus rings)
+- **Now:** Reserved exclusively for error, danger, and destructive action states
+- All `bg-primary-500`, `text-primary-400`, `border-primary-500` usage on interactive/brand elements is replaced with `var(--accent-color)` equivalents
+- Semantic error/danger usage of red is unchanged and intentional
+
+### Semantic state styling (left border + glowing dot)
+Applied to all alert banners, warning chips, status callouts:
+
+```css
+/* Error */
+border-left: 3px solid #ef4444;
+border: 1px solid rgba(239,68,68,0.2); /* top/right/bottom */
+background: rgba(239,68,68,0.10);
+/* dot: background #ef4444; box-shadow: 0 0 6px rgba(239,68,68,0.8) */
+
+/* Warning */
+border-left: 3px solid #f59e0b;
+border: 1px solid rgba(245,158,11,0.2);
+background: rgba(245,158,11,0.08);
+/* dot: background #f59e0b; box-shadow: 0 0 6px rgba(245,158,11,0.8) */
+
+/* Success */
+border-left: 3px solid #34d399;
+border: 1px solid rgba(52,211,153,0.2);
+background: rgba(52,211,153,0.08);
+/* dot: background #34d399; box-shadow: 0 0 6px rgba(52,211,153,0.8) */
+```
+
+### Surface scale (unchanged values)
+| Token | Value | Use |
+|---|---|---|
+| `surface-950` | `#080808` | Body background |
+| `surface-900` | `#111111` | Page base |
+| `surface-800` | `#1a1a1a` | Cards, panels |
+| `surface-700` | `#222222` | Elevated surfaces |
+| `surface-600` | `#2c2c2c` | Borders, dividers |
+| Parallelogram fill | `rgba(255,255,255,0.04)` | Chip background |
+| Parallelogram border | `rgba(255,255,255,0.07)` | Chip border |
+
+---
+
+## 2. Typography System
+
+All text uses **Anton SC**. Letter-spacing and opacity provide hierarchy — font-weight is not available (Anton SC is single-weight only). All text is `text-transform: uppercase`.
+
+`--font-sans` in `base.css` is changed from `'Inter'` to `'Anton SC'`. Inter is retained as `--font-body` for any future contexts requiring it but is no longer the default.
+
+**Important:** The `body` rule in `base.css` currently applies `leading-relaxed` (line-height 1.625). Anton SC is a display font with tightly packed glyphs — `leading-relaxed` creates excessive gaps. Change `body` line-height to `leading-tight` (1.25) and let individual tiers set their own `line-height: 1` or `line-height: 1.1` where needed.
+
+### Type scale (6 tiers)
+
+| Tier | Size | Letter-spacing | Opacity | Use |
+|---|---|---|---|---|
+| Display | `clamp(36px, 5vw, 56px)` | `0.06em` | 100% | Page heroes, login screen |
+| Page title | `28px` | `0.06em` | 94% (`#f0f0f0`) | View `h1` headings |
+| Section header | `13px` | `0.18em` | 55% | Group labels with rule line |
+| Body / row | `13px` | `0.05em` | 75% | Table rows, cards, form values |
+| Label | `10px` | `0.22em` | 35% | Field labels, badges, breadcrumbs |
+| Number / stat | `42px` | `0.02em` | 100% | Scores, counts, audition numbers |
+
+**Rule:** Wider letter-spacing = lower hierarchy. Size amplifies at Display and Page title only.
+
+**Text shadows:**
+- Display: `text-shadow: 2px 2px 0 var(--accent-muted)` (subtle lift)
+- Page title: `text-shadow: 1px 1px 0 var(--accent-muted)`
+- All others: none
+
+**Light mode:** Same scale, text colors flip to dark (`#0d0d0d` / `#404040` / `#757575`).
+
+---
+
+## 3. Cinematic Chrome System
+
+Six decorative elements with defined placement rules. Battle views (`BattleOverlay`, `BracketVisualization`, `Chart`) are **excluded** — they already have their own fully bespoke chrome and must not be touched.
+
+### 1 — Scanlines
+- **Where:** Global overlay on `App.vue` root layout div
+- **CSS:** `repeating-linear-gradient(to bottom, transparent 0px, transparent 3px, rgba(0,0,0,0.045) 3px, rgba(0,0,0,0.045) 4px)`
+- **Position:** `fixed; inset: 0; pointer-events: none; z-index: 9999`
+- **Light mode:** Opacity reduced to `0.5×` (use `opacity: 0.5` on the element)
+
+### 2 — Parallelogram chips
+- **Where:** All cards, list rows, stat boxes, inline badges
+- **CSS:** `clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%)`
+- **Background:** `rgba(255,255,255,0.04)` | **Border:** `1px solid rgba(255,255,255,0.07)`
+- **Replaces:** `.card` (rounded-2xl) and `.badge-*` (rounded-full) in **all modes** (dark and light) — the parallelogram shape is the universal card language of this design system, not a dark-mode-only feature
+- **Light mode:** Background `rgba(0,0,0,0.03)` | Border `rgba(0,0,0,0.08)`
+
+### 3 — Corner accent bars
+- **Where:** Panels, modals, large section cards (not individual row chips)
+- **CSS:**
+  ```css
+  /* top-left vertical */   position:absolute; top:0; left:0; width:2px; height:28%; background: linear-gradient(to bottom, var(--accent-color), transparent);
+  /* bottom-left horizontal */ position:absolute; bottom:0; left:0; height:2px; width:30%; background: linear-gradient(to right, var(--accent-color), transparent);
+  ```
+- Use only top-left + bottom-left bars (not all four corners — too busy)
+
+### 4 — Section rules
+- **Where:** Every section header throughout all views
+- **Pattern:** `[label text] ────────────────`
+- **CSS:** Label at `10px / 0.22em / opacity 28%` + `flex:1; height:1px; background: rgba(255,255,255,0.07)`
+- **Replaces:** `border-b border-surface-700` section dividers
+
+### 5 — Color bleed
+- **Where:** Page root background only (not individual cards)
+- **CSS:**
+  ```css
+  /* bottom-left */ radial-gradient(ellipse 50% 45% at 0% 100%, color-mix(in srgb, var(--accent-color) 7%, transparent), transparent 70%)
+  /* bottom-right */ radial-gradient(ellipse 40% 40% at 100% 100%, color-mix(in srgb, var(--accent-color) 4%, transparent), transparent 70%)
+  ```
+- **Light mode:** Hidden (`display: none` or `opacity: 0`)
+
+### 6 — Navbar / Topbar
+- **Where:** `App.vue` navbar
+- **Layout:** BES wordmark + glowing dot (left) · Nav links as parallelogram chips (center) · Active event + role (right)
+- **Active nav link:** bottom `2px` border using `var(--accent-color)` + subtle glow
+- **Font:** Full Anton SC (Label tier for nav items, Body tier for wordmark)
+- **Glowing dot:** `width:6px; height:6px; border-radius:50%; background: var(--accent-color); box-shadow: 0 0 8px var(--accent-muted)`
+
+---
+
+## 4. Accent Color Config System
+
+### Backend (new)
+
+**Entity:** `AppConfig`
+- Table: `app_config`
+- Fields: `id` (PK), `key` (varchar, unique), `value` (text)
+- Seed row: `('accentColor', 'rgba(255,255,255,0.88)')`
+
+**Migration:** `V19__add_app_config.sql`
+
+**Controller:** `AppConfigController` at `/api/v1/config/app`
+- `GET /api/v1/config/app` — public (no auth), returns `{ accentColor: String }`
+- `POST /api/v1/config/app` — admin only, body `{ accentColor: String }`, saves to DB then broadcasts via WebSocket
+
+**WebSocket:** broadcasts to `/topic/app-config` with payload `{ accentColor: String }` on every POST
+
+### Frontend
+
+**`App.vue` on mount:**
+```js
+const cfg = await getAppConfig()               // GET /api/v1/config/app
+applyAccent(cfg.accentColor)
+subscribeToChannel(client, '/topic/app-config', (msg) => applyAccent(msg.accentColor))
+
+function applyAccent(color) {
+  // color is always a hex string (e.g. '#ffffff') — alpha variants are computed by CSS color-mix
+  document.documentElement.style.setProperty('--accent-color', color)
+  // --accent-muted and --accent-subtle are defined in base.css using color-mix(in srgb, var(--accent-color) ...)
+  // so they update automatically — no JS derivation needed
+}
+```
+Light mode CSS overrides `--accent-color` via `[data-theme="light"]` rule — no JS needed.
+
+**`AdminPage.vue` — color picker section:**
+- Section header: "Theme Config"
+- Current color swatch (large parallelogram chip)
+- 6 preset swatches: white/silver, gold, cyan, purple, orange, emerald
+- Native `<input type="color">` for custom hex
+- "Apply to All Clients" button → `POST /api/v1/config/app`
+- Live preview panel showing the accent applied to a sample view
+
+---
+
+## 5. Light Mode Adaptations
+
+Light mode is toggled via `[data-theme="light"]` on `<html>` (existing behavior).
+
+| Element | Dark | Light |
+|---|---|---|
+| `--accent-color` | `rgba(255,255,255,0.88)` | `rgba(0,0,0,0.78)` — CSS override |
+| `--accent-muted` | `rgba(255,255,255,0.25)` | `rgba(0,0,0,0.22)` |
+| `--accent-subtle` | `rgba(255,255,255,0.07)` | `rgba(0,0,0,0.06)` |
+| Scanlines | `opacity: 1` | `opacity: 0.5` |
+| Color bleed | Visible | `opacity: 0` |
+| Parallelogram fill | `rgba(255,255,255,0.04)` | `rgba(0,0,0,0.03)` |
+| Anton SC text | `#f0f0f0` / opacity-based | `#0d0d0d` / opacity-based |
+| Corner bars | White gradients | Dark gradients |
+
+---
+
+## 6. Scope — Files to Update
+
+### `base.css` (design token layer — do first)
+- Change `--font-sans` to `'Anton SC'`
+- Add `--accent-color`, `--accent-muted`, `--accent-subtle` defaults
+- Add `.text-accent`, `.bg-accent`, `.border-accent`, `.glow-accent` utilities
+- Update `.card`, `.card-hover` to use parallelogram clip-path
+- Update `.badge-*` to parallelogram + new accent/semantic styles
+- Update `.input-base` to Anton SC
+- Add `.section-rule`, `.para-chip`, `.corner-bar`, `.semantic-chip` utilities
+- Update `[data-theme="light"]` block for new accent overrides + scanline/bleed adjustments
+
+### `App.vue`
+- New cinematic navbar (Anton SC, parallelogram nav chips, glowing dot)
+- Global scanlines overlay div
+- Fetch + subscribe to `/topic/app-config` on mount, apply `--accent-color`
+
+### Views to update (all follow token system once `base.css` is done)
+| View | Key changes |
+|---|---|
+| `Login.vue` | Display-tier "BES" hero, parallelogram form fields, accent border-left on form panel |
+| `MainMenu.vue` | Quick-action cards → parallelogram chips, section rules, color bleed on page |
+| `Events.vue` | Event list rows → parallelogram chips, section rules |
+| `EventCard.vue` | Card shape → parallelogram, corner bars, accent glow on hover |
+| `EventDetails.vue` | Section headers → section rules, stat boxes → parallelogram |
+| `UpdateEventDetails.vue` | Table rows → parallelogram chips, semantic state badges → left-border style |
+| `Score.vue` | Podium numbers → Number/stat tier, leaderboard rows → parallelogram |
+| `BattleControl.vue` | Section rules, bracket seed slots → parallelogram |
+| `AdminPage.vue` | Add Theme Config section with color picker |
+| `EventSelector.vue` | Event grid cards → parallelogram with corner bars |
+| `Results.vue` / `ResultsQR.vue` | Parallelogram result rows, Display-tier for scores |
+| `AuditionList.vue` | Context bar → parallelogram, filter chips → parallelogram |
+| `ActionDoneModal.vue` | Modal → corner bars, semantic chip styling |
+| Components: `ReusableDropdown`, `SwipeableCardsV2`, `PairScoreCards`, `EmceeRoundView`, `FeedbackPopout`, `Timer`, `MiniScoreMenu` | Parallelogram shapes, Anton SC labels, section rules |
+
+### Do NOT change
+- `BattleOverlay.vue` — already correct, has its own bespoke CSS system
+- `BracketVisualization.vue` — already correct, has its own bespoke CSS system
+- `Chart.vue` — already correct
+- `BattleJudge.vue` — battle screen, review separately
+- All WebSocket / API / backend logic files (this is purely a UI overhaul)
+
+---
+
+## 7. Migration Order
+
+1. **`base.css`** — tokens, utilities, light-mode overrides (everything inherits from here)
+2. **`App.vue`** — navbar + scanlines + accent config fetch/subscribe
+3. **Backend** — `AppConfig` entity, migration, controller, WebSocket broadcast
+4. **High-visibility views** — `Login`, `MainMenu`, `EventSelector`, `Events`
+5. **Event management views** — `EventDetails`, `UpdateEventDetails`, `AuditionList`, `Score`
+6. **Battle management** — `BattleControl`
+7. **Admin + results** — `AdminPage` (with color picker), `Results`, `ResultsQR`
+8. **Components** — shared components updated last (they inherit most styles from tokens)


### PR DESCRIPTION
## Summary
- Global type size increase (label/body/stat tiers) for better readability on phone
- Button interaction feedback (hover/active states) on all para-chip elements
- Judge scoring cards (solo + pair): cinematic design system, score centered H+V in landscape info column, feedback below score
- Pair selector tabs: participant name 22px, score 18px
- FeedbackPopout: fix tag size-jump on select, accent-muted selected state
- Timer (emcee): larger tap targets for phone use
- AuditionList filter bar: escape clip-path clipping, visible background
- Score.vue: remove all red primary-* classes, replace with accent

## Test plan
- [ ] Judge view (solo mode, landscape phone): score centered in left column, feedback button below
- [ ] Judge view (pair mode, landscape phone): same layout, participant tabs readable
- [ ] Feedback popout: tags don't resize on select, selected state clearly visible
- [ ] Emcee timer: 30s/45s/60s/90s buttons easy to tap on phone
- [ ] AuditionList: filter bar visible and not clipped
- [ ] Score.vue: no red elements remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)