### PR TITLE
feat: cinematic UI overhaul, genre/division redesign, registration rules, and repo housekeeping

### DIFF
--- a/.claude/commands/docker.md
+++ b/.claude/commands/docker.md
@@ -1,0 +1,2 @@
+docker compose down && docker compose up -d --build --no-cache
+please verify that the apps are running

--- a/.claude/commands/git_branch.md
+++ b/.claude/commands/git_branch.md
@@ -1,0 +1,4 @@
+create a new branch call $ARGUMENTS
+do a git fetch
+do a git rebase origin/main
+do a git push -u origin $ARGUMENTS

--- a/.claude/commands/git_commit.md
+++ b/.claude/commands/git_commit.md
@@ -1,0 +1,2 @@
+git add relevant changes and commit with a short message
+git push

--- a/.claude/commands/git_pull_request.md
+++ b/.claude/commands/git_pull_request.md
@@ -1,0 +1,1 @@
+make a pull request

--- a/.claude/skills/local-docker-verify/SKILL.md
+++ b/.claude/skills/local-docker-verify/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: local-docker-verify
+description: >
+  Use this skill whenever code changes have been made to the codebase —
+  including feature additions, bug fixes, refactors, config changes, dependency
+  updates, or any edit to source files — to verify the changes locally first,
+  then rebuild and verify the affected Docker containers.
+
+  ALWAYS trigger this skill automatically (without waiting for the user to ask)
+  when you detect any of these signals:
+    - You just wrote, edited, or scaffolded code files
+    - The user says "done", "try it", "test this", "does it work", "deploy",
+      "rebuild", or similar after a code change
+    - A compile/lint/type error was just fixed
+    - A dependency or config file (package.json, requirements.txt, Dockerfile,
+      docker-compose.yml, .env, etc.) was modified
+
+  This skill: (1) runs a local build/compile check, (2) identifies which of
+  the three containers (frontend, backend, database) are affected, (3) rebuilds
+  only those containers with --no-cache, (4) verifies all containers are healthy,
+  and (5) reports a clear status summary.
+---
+
+# Local → Docker Verify Skill
+
+Verify code changes locally first, then rebuild only affected Docker containers
+and confirm everything is running.
+
+---
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Frontend | Vue.js (Vite) |
+| Backend | Java Spring Boot (Maven) |
+| Database | PostgreSQL |
+
+---
+
+## Container Map
+
+| Container | Affected by changes to |
+|---|---|
+| `frontend` | `frontend/src/`, `.vue` files, `vite.config.*`, `package.json`, `package-lock.json`, frontend `.env` |
+| `backend` | `backend/src/`, `*.java`, `pom.xml`, `application.properties` / `application.yml`, backend `.env` |
+| `database` | `db/`, Flyway/Liquibase migration files (`V*.sql`), `docker-compose.yml` DB service definition, DB init scripts |
+
+> If unsure which containers are affected, rebuild all three. When in doubt,
+> over-rebuild rather than miss an affected service.
+
+---
+
+## Step 1 — Identify Affected Containers
+
+Based on the files changed in this session, determine which containers need
+to be rebuilt. State your reasoning explicitly, e.g.:
+
+> "Changes were made to `backend/routes/auth.js` and `package.json` →
+> rebuilding **backend** only."
+
+If the change touches a shared layer (e.g. environment variables, shared types,
+`docker-compose.yml` itself) → rebuild **all three**.
+
+---
+
+## Step 2 — Local Build / Compile Check
+
+Before touching Docker, verify the code compiles locally. Run only the checks
+for affected layers.
+
+**Frontend — Vue.js / Vite**
+```bash
+cd frontend
+npm install          # re-sync deps if package.json changed
+npm run build        # Vite production build — catches template/import/TS errors
+npm run lint         # optional but recommended
+```
+Success: Vite outputs `dist/` with no errors. Any Vue template compile error,
+missing import, or type error surfaces here before Docker.
+
+**Backend — Java Spring Boot / Maven**
+```bash
+cd backend
+./mvnw clean compile           # fast compile — no tests, no fat jar
+# OR run tests too:
+./mvnw clean test
+# OR full package without tests (for speed):
+./mvnw clean package -DskipTests
+```
+Watch for: Java compilation errors, missing Spring beans, bad `@Value`
+property bindings, and Flyway migration conflicts Spring reports at startup.
+
+**Database — PostgreSQL migrations**
+```bash
+# If Flyway is configured, validate without running:
+./mvnw flyway:validate \
+  -Dflyway.url=jdbc:postgresql://localhost:5432/<db> \
+  -Dflyway.user=<user> -Dflyway.password=<pass>
+# If no local PostgreSQL available, skip here — Spring Boot will
+# validate Flyway migrations on startup and errors appear in Step 4 logs.
+```
+
+If the local build **fails**: stop here, report the compiler output, fix it,
+and restart from Step 1. Do not proceed to Docker with broken code.
+
+If the local build **passes**: proceed to Step 3.
+
+---
+
+## Step 3 — Rebuild Affected Docker Containers
+
+**Targeted rebuild (preferred — faster)**
+```bash
+# frontend and/or backend: always --no-cache (code changes must not be stale)
+docker compose stop <service>
+docker compose rm -f <service>
+docker compose build --no-cache <service>
+docker compose up -d <service>
+```
+
+**Database container — use cache unless DB files changed**
+```bash
+# DB image rarely changes; only use --no-cache if migration files,
+# docker-compose.yml DB section, or init scripts were modified.
+docker compose stop db
+docker compose rm -f db
+docker compose build db          # no --no-cache (PostgreSQL image is large)
+docker compose up -d db
+```
+
+**Full rebuild (shared layer changed — e.g. docker-compose.yml, root .env)**
+```bash
+docker compose down
+docker compose build --no-cache frontend backend   # skip --no-cache for db
+docker compose build db
+docker compose up -d
+```
+
+Wait for all commands to complete before Step 4.
+
+---
+
+## Step 4 — Verify All Containers Are Running
+
+```bash
+docker compose ps
+```
+
+Check every container shows `running` / `Up`. Then health-check each:
+
+**Frontend (Vue.js served by Nginx or Vite preview)**
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<FRONTEND_PORT>
+# Expect: 200
+```
+
+**Backend (Spring Boot — use Actuator health endpoint)**
+```bash
+curl -s http://localhost:<BACKEND_PORT>/actuator/health
+# Expect: {"status":"UP"}
+# If Actuator not enabled, try the root or any known endpoint:
+curl -s -o /dev/null -w "%{http_code}" http://localhost:<BACKEND_PORT>/
+```
+
+**Database (PostgreSQL)**
+```bash
+docker compose exec db pg_isready -U <db_user>
+# Expect: /var/run/postgresql:5432 - accepting connections
+```
+
+If any container is unhealthy, pull its logs immediately:
+```bash
+docker compose logs --tail=80 <service>
+```
+
+For Spring Boot startup failures, look for:
+- `APPLICATION FAILED TO START` — bean/config error
+- `FlywayException` — migration conflict
+- `Connection refused` to DB — DB container not ready yet (add `depends_on` healthcheck or retry)
+
+
+---
+
+## Step 5 — Report Status
+
+Always output a status block in this format:
+
+```
+## Build & Verification Report
+
+**Trigger:** <what changed>
+**Affected containers rebuilt:** frontend | backend | db | all
+
+### Local Build
+- [ ] Frontend build: ✅ passed / ❌ failed — <error summary if failed>
+- [ ] Backend build:  ✅ passed / ❌ failed
+- [ ] DB migrations:  ✅ N/A / ✅ valid / ❌ failed
+
+### Docker Status
+| Container  | Status     | Health Check       |
+|------------|------------|--------------------|
+| frontend   | ✅ running  | HTTP 200            |
+| backend    | ✅ running  | HTTP 200 /health    |
+| db         | ✅ running  | pg_isready: OK      |
+
+### Result
+✅ All good — changes verified locally and in Docker.
+— OR —
+❌ Issue detected: <summary and next step>
+```
+
+---
+
+## Auto-Trigger Checklist (for the agent)
+
+Before responding after any code change, silently run through this:
+
+- [ ] Did I write, edit, or delete any source file this turn?
+- [ ] Did I modify a config or dependency file?
+- [ ] Did the user just approve or accept a code change?
+
+If **any** box is checked → run this skill without being asked. Do not skip it
+to save time; a broken Docker build is worse than a slower response.
+
+---
+
+## Edge Cases
+
+| Situation | Action |
+|---|---|
+| Port numbers unknown | Check `docker-compose.yml` for port mappings before running curl |
+| No `docker compose` (v2) | Fall back to `docker-compose` (hyphen, v1) |
+| Spring Boot fails in Docker but passed locally | Check: missing `COPY target/*.jar` in Dockerfile, wrong `SPRING_PROFILES_ACTIVE`, DB URL env var not set |
+| Vue build passes locally but blank page in Docker | Check: Nginx config missing `try_files` for Vue Router history mode; `VITE_*` env vars not passed at build time |
+| Spring Boot can't reach DB on startup | DB container may still be initialising. Check `depends_on` with healthcheck in `docker-compose.yml`, or wait and `docker compose restart backend` |
+| `pom.xml` changed | Always rebuild backend — dependency tree may have changed |
+| Flyway migration version conflict | Spring Boot will log `FlywayException`. Fix migration filename versioning, then rebuild backend only |
+| User says "skip docker, just check local" | Run Steps 1–2 only, report local build status |
+| `mvnw` not executable | Run `chmod +x ./mvnw` first |

--- a/.claude/skills/mrl-skill-dispatcher/SKILL.md
+++ b/.claude/skills/mrl-skill-dispatcher/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: mrl-skill-dispatcher
+description: >
+  Use this skill whenever the user wants to perform a task that may involve
+  multiple sub-skills discovered at runtime. This skill searches a local MRL
+  skill index using a Python script, fans out background tasks — one per
+  returned skill — waits for all of them to complete, then consolidates the
+  results into a single unified plan and task list for the user to review.
+  Trigger this skill when the user says things like "run my skills pipeline",
+  "dispatch skills for this task", "look up relevant skills and plan", or any
+  time a task should be decomposed via the MRL skill index at
+  /Users/bennylim/Documents/k3-agentic-skills.
+---
+
+# MRL Skill Dispatcher
+
+A skill that discovers relevant sub-skills for a given task via a local Python
+search index, runs each skill as a parallel background process, then
+consolidates all outputs into one unified plan for human review.
+
+---
+
+## Overview
+
+```
+User task (argument)
+       │
+       ▼
+mrl_search.py  ──►  list of relevant skill paths
+       │
+       ▼
+For each skill ──► background task (reads skill, executes it against the task)
+       │
+       ▼
+Wait for ALL background tasks to complete
+       │
+       ▼
+Consolidate outputs ──► unified plan + task list
+       │
+       ▼
+Present to user for review
+```
+
+---
+
+## Step 1 — Clarify the Argument
+
+Before running anything, confirm the **task argument** you will pass to
+`mrl_search.py`. This is a short natural-language description of what the user
+wants to accomplish, e.g.:
+
+> "set up a CI/CD pipeline for a Node.js project"
+
+If it is ambiguous, ask the user one clarifying question. Do not proceed until
+the argument is clear.
+
+---
+
+## Step 2 — Run the MRL Index Search
+
+```bash
+cd /Users/bennylim/Documents/k3-agentic-skills
+source venv/bin/activate
+python mrl-indexer/mrl_search.py "<ARGUMENT>"
+```
+
+Parse the output — it is a list of skill paths (or skill names/descriptions).
+Store the full list. If the list is empty, tell the user no relevant skills
+were found and stop.
+
+---
+
+## Step 3 — Fan Out: One Background Task Per Skill
+
+For each skill returned:
+
+1. Read the skill's `SKILL.md` (or equivalent entry point).
+2. Launch a **background task** that applies that skill to the user's original
+   task argument. Each background task should:
+   - Follow the skill's own instructions
+   - Produce a structured output: a list of concrete steps or actions relevant
+     to the user's task
+   - Record which skill it came from
+
+Run all background tasks **in parallel**. Do not wait for one to finish before
+starting the next.
+
+> **Note for Claude.ai / non-subagent environments:** True parallelism is not
+> available. Run each skill sequentially, but treat each as an isolated
+> execution — do not carry context from one skill run into the next. Complete
+> all skill runs before moving to Step 4.
+
+---
+
+## Step 4 — Wait for Completion
+
+Block until **all** background tasks have finished. Do not proceed to
+consolidation until every skill task has produced output (or reported a
+failure).
+
+If a skill task fails or produces no output, log it as `SKIPPED: <skill name>
+— reason` and continue with the rest.
+
+---
+
+## Step 5 — Consolidate into a Unified Plan
+
+Merge all skill outputs into a single coherent plan:
+
+1. **Deduplicate** — remove identical or near-identical steps that appear
+   across multiple skills.
+2. **Order** — sequence steps logically (setup before execution, dependencies
+   before dependents).
+3. **Attribute** — note which skill each step or section came from (a short
+   label is enough, e.g. `[ci-skill]`).
+4. **Flag conflicts** — if two skills recommend contradictory approaches,
+   surface the conflict clearly rather than silently picking one.
+
+Output format:
+
+```
+## Unified Plan: <task argument>
+
+### Summary
+<2–3 sentence overview of what will be done>
+
+### Task List
+- [ ] Step 1 — <description> [source: skill-name]
+- [ ] Step 2 — <description> [source: skill-name]
+...
+
+### Conflicts / Decisions Needed
+- <conflict or open question, if any>
+
+### Skipped Skills
+- <skill-name> — <reason> (if any)
+```
+
+---
+
+## Step 6 — Present to User for Review
+
+Show the unified plan and explicitly ask the user to review it before any
+execution begins:
+
+> "Here's the consolidated plan from all relevant skills. Please review — let
+> me know if you'd like to adjust, remove, or reorder any steps before we
+> proceed."
+
+**Do not begin executing the plan until the user approves.**
+
+---
+
+## Edge Cases
+
+| Situation | Behaviour |
+|---|---|
+| `mrl_search.py` returns 0 skills | Inform user, stop. |
+| Only 1 skill returned | Skip "consolidate" step, present that skill's output directly. |
+| Skill has no `SKILL.md` | Log as skipped, note missing entry point. |
+| Argument is vague | Ask one clarifying question before running Step 2. |
+| Background task times out | Mark as `SKIPPED: timeout`, continue. |
+
+---
+
+## Notes for Skill Authors
+
+When this dispatcher reads your skill, it will look for:
+- A clear list of **steps or actions** it should produce given a task argument
+- An **output section** or structured conclusion it can extract
+
+Design your skills to produce concrete, extractable step lists so the
+consolidation in Step 5 works cleanly.

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: session-start
+description: >
+  Run at the start of every session to verify git state, branch, stash, and
+  uncommitted migration files before doing any work. Invoke when user says
+  "start session", "check state", or when opening a new conversation.
+---
+
+# Session Start Checklist
+
+Run all checks silently and report any issues before proceeding.
+
+## Step 1 — Confirm active branch
+
+```bash
+git branch --show-current
+git log --oneline -3
+```
+
+**Stop and report** if the branch is not what the user expects. Do not edit any file until branch is confirmed correct.
+
+## Step 2 — Check for stashed WIP
+
+```bash
+git stash list
+```
+
+If stashes exist, report them. They may represent in-progress work that should be restored before starting new work.
+
+## Step 3 — Check for uncommitted migration files
+
+```bash
+git status --short | grep migration
+ls BES/src/main/resources/db/migration/ | tail -5
+```
+
+If any migration `.sql` file is **untracked (`??`)**, flag it immediately:
+> "⚠️ Untracked migration file found: [filename]. This must be committed before any Docker rebuild or it will be lost."
+
+## Step 4 — Check working tree
+
+```bash
+git status --short | grep -v "^??" | head -20
+```
+
+Report any uncommitted changes. Ask the user whether to continue with them or stash first.
+
+## Step 5 — Report
+
+Output a one-line status:
+```
+✅ Branch: <name> | No stash | Migrations committed | Working tree clean
+```
+or flag any issues found.
+
+---
+
+## Why this exists
+
+A branch switch mid-session (while the container agent was building) caused the wrong branch to be active. The DB had migrations V21–V26 applied but the SQL files were never committed. This caused hours of Flyway/Hibernate errors and entity patching before the root cause was found. Running this checklist at session start catches all of those conditions in under 10 seconds.

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,23 @@ BES-frontend/nginx/certs/*.key
 .agent-dispatch/shared/
 .agent-dispatch/.env
 .agent-docker/
+
+# Claude Code — local state (never commit)
+.claude.json
+.claude.json.backup
+.claude/.last-cleanup
+.claude/statsig/
+.claude/todos/
+.claude/projects/
+.claude/backups/
+
+# Build tool caches (Maven wrapper, npm)
+.m2/
+.npm/
+
+# Superpowers runtime
+.superpowers/
+
+# Temp / scratch files
+*_body.txt
+test_output.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,25 @@ Vue 3 frontend  →  Nginx (reverse proxy)  →  Spring Boot backend (port 5050)
 
 ## Key Conventions
 
+### Branch Discipline (enforced via `git-scope-guard` skill)
+
+**Before touching any code, invoke the `git-scope-guard` skill.** It checks whether the task fits the current branch's declared purpose.
+
+| Branch prefix | Allowed work |
+|---------------|-------------|
+| `feat/X` | Feature X + UI/bugs introduced by this feature |
+| `fix/X` | Fix bug X only |
+| `ui/X` | Visual changes to component X only |
+| `refactor/X` | Restructure X, no behavior changes |
+| `chore/X` | Maintenance (deps, config, tooling) |
+| `docs/X` | Documentation only |
+
+**If a task is out of scope:** do not execute. Check branch state first:
+- **Branch has uncommitted WIP** → create a GitHub issue only, then stop
+- **Branch is clean** → offer the user a choice: (A) create issue for later, or (B) switch to a new branch now and implement immediately
+
+When switching to a new branch (option B): check for open PRs on the current branch, pull latest main, rebase the new branch onto it, search for related open issues to bundle, then implement. "It's just a small fix" is not an exception to the flow.
+
 ### API (see `docs/API_CONVENTIONS.md` for full details)
 
 - URLs: `/api/v1/{resource}` (collection), `/api/v1/{resource}/{id}` (single)


### PR DESCRIPTION
## Summary

- **Cinematic design system** — full UI overhaul across all views (Login, MainMenu, Events, EventDetails, UpdateEventDetails, AuditionList, Score, BattleControl, AdminPage, Results) using Anton SC typography, parallelogram shapes, scanlines, and runtime accent colour via WebSocket
- **Genre/division UX redesign** — decoupled EventGenre from global Genre table; division management UI with inline editing, group-by-genre layout, and sheet import categories
- **Registration rules hardening** — entry-type validation at walk-in and sheet import level; team data moved to EventGenreParticipant level; unit tests added
- **Scoring & battle UX** — score inline with participant header, PairScoreCards redesign, MiniScoreMenu member names, battle control smoke format, guest management, audition card UX
- **AppConfig** — V20 migration, GET/POST `/api/v1/config/app`, WebSocket broadcast for live accent colour updates
- **Repo housekeeping** — commit `.claude/commands/` and `.claude/skills/` so they travel with the repo; expand `.gitignore` to cover Claude runtime artifacts, Maven/npm caches; add branch discipline docs to CLAUDE.md; bump `.agent-dispatch` submodule with DB migration safety rule

## Test plan

- [ ] Login → cinematic design renders, accent colour applies
- [ ] Events list → EventCard hover/tap action panel works
- [ ] EventDetails → genre accordion, division management (add/edit/delete), Google Sheets import with categories
- [ ] Walk-in registration → entry-type validation rejects mismatched team/solo entries
- [ ] Sheet import → deduplication, member display, entry-type validation
- [ ] AuditionList (Judge view) → swipeable score cards, feedback popout
- [ ] AuditionList (Emcee view) → timer, participant status
- [ ] Score → scoreboard with podium, inline score display
- [ ] BattleControl → smoke format, guest management, bracket seeding
- [ ] AdminPage → theme colour picker updates accent live across all clients
- [ ] Results portal → reference code lookup, QR scan
- [ ] Run `mvn test` — all backend integration tests pass
- [ ] Run `npm test` — all frontend unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)