### PR TITLE
fix: check-in concurrency — parallel display, duplicate guard, real-time operator sync

### DIFF
--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1145,6 +1145,14 @@ export const sendCheckinPreview = async (eventName, previewData) => {
   }
 }
 
+export const getCheckinPreviews = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${eventName}/checkin-preview`, { credentials: 'include' })
+    if (res.ok) return await res.json()
+    return []
+  } catch { return [] }
+}
+
 export const getBattleGuests = async (eventName) => {
   try {
     return await fetch(`${domain}/api/v1/event/battle-guests/${encodeURIComponent(eventName)}`, {

--- a/BES-frontend/src/utils/websocket.js
+++ b/BES-frontend/src/utils/websocket.js
@@ -10,18 +10,21 @@ export const createClient = () =>{
     })
 }
 export const subscribeToChannel = (client, topic, callback) =>{
-    if(!client.connected){
-        client.onConnect = ()=>{
-            client.subscribe(topic, (msg) =>{
-                callback(JSON.parse(msg.body))
-            })
-        }
-    }else{
-        client.subscribe(topic, (msg)=>{
+    const doSubscribe = () => {
+        client.subscribe(topic, (msg) => {
             callback(JSON.parse(msg.body))
         })
     }
-    client.activate()
+    if(!client.connected){
+        const prev = client.onConnect
+        client.onConnect = () => {
+            if (prev) prev()
+            doSubscribe()
+        }
+    }else{
+        doSubscribe()
+    }
+    if (!client.active) client.activate()
 }
 
 export const deactivateClient = (client) =>{

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback } from '@/utils/api';
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, verifyEventAccessCode } from '@/utils/api';
 import { getFeedbackGroups } from '@/utils/adminApi';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
@@ -33,6 +33,10 @@ const modalVariant = ref("info")
 const showModal = ref(false)
 const showMiniMenu = ref(false)
 const dynamicCallBack = ref(() => {})
+
+const resetConfirmCode = ref("")
+const resetCodeError = ref("")
+const resetCodeChecking = ref(false)
 
 const dynamicRole = async () => {
   const res = await whoami()
@@ -85,11 +89,35 @@ const openModal = (title, message, variant = 'info') => {
 }
 
 const confirmReset = (title, message) => {
+  resetConfirmCode.value = ""
+  resetCodeError.value = ""
+  resetCodeChecking.value = false
   modalTitle.value = title
   modalMessage.value = message
   modalVariant.value = 'warning'
   showModal.value = true
-  dynamicCallBack.value = async () => { showModal.value = false; await resetScore(); }
+  dynamicCallBack.value = async () => {
+    if (!resetConfirmCode.value.trim()) {
+      resetCodeError.value = "Enter the event access code to confirm."
+      return
+    }
+    resetCodeChecking.value = true
+    resetCodeError.value = ""
+    const activeEvent = getActiveEvent()
+    if (!activeEvent) {
+      resetCodeError.value = "No active event found."
+      resetCodeChecking.value = false
+      return
+    }
+    const result = await verifyEventAccessCode(activeEvent.id, resetConfirmCode.value.trim())
+    resetCodeChecking.value = false
+    if (result?.valid) {
+      showModal.value = false
+      await resetScore()
+    } else {
+      resetCodeError.value = "Incorrect access code."
+    }
+  }
 }
 
 const switchGenre = (g) => {
@@ -867,6 +895,21 @@ onMounted(async () => {
     @close="() => { showModal = false }"
   >
     <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+    <template v-if="modalVariant === 'warning'">
+      <div class="mt-4">
+        <input
+          v-model="resetConfirmCode"
+          type="text"
+          placeholder="Enter access code"
+          class="w-full px-3 py-2 type-body bg-surface-800 border border-surface-600 text-content-primary outline-none transition-colors"
+          style="clip-path:polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
+          :disabled="resetCodeChecking"
+          @keyup.enter="dynamicCallBack()"
+        />
+        <p v-if="resetCodeChecking" class="type-label text-accent mt-2">Verifying…</p>
+        <p v-if="resetCodeError" class="type-label text-red-400 mt-2">{{ resetCodeError }}</p>
+      </div>
+    </template>
   </ActionDoneModal>
 
   <FeedbackPopout

--- a/BES-frontend/src/views/AuditionNumber.vue
+++ b/BES-frontend/src/views/AuditionNumber.vue
@@ -4,19 +4,17 @@ import ActionDoneModal from './ActionDoneModal.vue'
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket'
 
 // ── State ──────────────────────────────────────────────────────────────────
-const currentPerson = ref(null)
-// { name, refCode, memberNames: [], genres: [{ genreName, auditionNumber, rolling }] }
+const slotKey = (participantId, name) => String(participantId ?? name)
+
+const activeSlots = ref([])
+// { slotId: string, person: { participantId, name, refCode, memberNames, genres[] }, queue: [], running: false }
 
 const history = ref([])
-const revealingRef = ref(null)
+const revealingRef = ref({})        // { [slotId | historyKey]: boolean }
 
-// Per-division slot animation
-const fakeNums = ref({})        // { [genreName]: number }
-const rollingIntervals = {}     // { [genreName]: intervalId }
-
-// Sequential animation queue — processes one division at a time
-const auditionQueue = []
-let queueRunning = false
+// Per-slot rolling animation state — keyed by "${slotId}-${genreName}"
+const fakeNums = ref({})
+const rollingIntervals = {}         // { "${slotId}-${genreName}": intervalId }
 
 const modalTitle = ref('')
 const modalMessage = ref('')
@@ -25,132 +23,143 @@ const showModal = ref(false)
 const wsClients = []
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
-const flushCurrentToHistory = () => {
-  if (currentPerson.value) {
-    // Capture any numbers still pending in the queue so history is accurate
-    const pendingNums = {}
-    auditionQueue.forEach(m => { if (isSamePerson(currentPerson.value, m)) pendingNums[m.genre] = m.auditionNumber })
-    const genres = currentPerson.value.genres.map(g => ({
-      ...g,
-      auditionNumber: g.auditionNumber ?? pendingNums[g.genreName] ?? null
-    }))
-    history.value.unshift({ ...currentPerson.value, genres })
-  }
-}
+const setReveal = (key, val) => { revealingRef.value = { ...revealingRef.value, [key]: val } }
+const toggleReveal = (key) => { revealingRef.value = { ...revealingRef.value, [key]: !revealingRef.value[key] } }
 
-function startRolling(genreName) {
-  clearInterval(rollingIntervals[genreName])
-  rollingIntervals[genreName] = setInterval(() => {
-    fakeNums.value = { ...fakeNums.value, [genreName]: Math.floor(Math.random() * 99) + 1 }
-  }, 80)
-}
-
-function stopRolling(genreName) {
-  clearInterval(rollingIntervals[genreName])
-  delete rollingIntervals[genreName]
+function stopRolling(slotId, genreName) {
+  const key = `${slotId}-${genreName}`
+  clearInterval(rollingIntervals[key])
+  delete rollingIntervals[key]
   const next = { ...fakeNums.value }
-  delete next[genreName]
+  delete next[key]
   fakeNums.value = next
 }
 
-function processNextInQueue() {
-  if (auditionQueue.length === 0) {
-    queueRunning = false
-    return
-  }
-  queueRunning = true
-  const msg = auditionQueue.shift()
-  animateAuditionNumber(msg)
+function stopAllSlotRolling(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
+  const allGenreKeys = new Set()
+  slot.person.genres.forEach(g => allGenreKeys.add(`${slotId}-${g.genreName}`))
+  allGenreKeys.forEach(k => {
+    clearInterval(rollingIntervals[k])
+    delete rollingIntervals[k]
+  })
+  const next = { ...fakeNums.value }
+  allGenreKeys.forEach(k => delete next[k])
+  fakeNums.value = next
 }
 
-function animateAuditionNumber(msg) {
-  // If person moved to history before animation ran, update history and skip animation
-  if (!isSamePerson(currentPerson.value, msg)) {
-    const historyEntry = history.value.find(h => h.name === msg.name)
-    if (historyEntry) {
-      const hGenre = historyEntry.genres.find(g => g.genreName === msg.genre)
-      if (hGenre) hGenre.auditionNumber = msg.auditionNumber
-    }
-    processNextInQueue()
-    return
+const flushSlotToHistory = (slotId) => {
+  const idx = activeSlots.value.findIndex(s => s.slotId === slotId)
+  if (idx !== -1) {
+    history.value.unshift({ ...activeSlots.value[idx].person })
+    activeSlots.value.splice(idx, 1)
   }
+}
 
-  // Update refCode once we have it
-  if (msg.refCode && !currentPerson.value.refCode) {
-    currentPerson.value.refCode = msg.refCode
-  }
+function animateSlot(slotId, msg) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
 
-  // Find or create the genre entry (auditionNumber stays null until animation reveals it)
-  let genre = currentPerson.value.genres.find(g => g.genreName === msg.genre)
+  if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+
+  let genre = slot.person.genres.find(g => g.genreName === msg.genre)
   if (!genre) {
     genre = { genreName: msg.genre, auditionNumber: null, rolling: false }
-    currentPerson.value.genres.push(genre)
+    slot.person.genres.push(genre)
   }
 
-  // Slot animation — reveal the number only when animation finishes (no spoiler)
   genre.rolling = true
-  startRolling(msg.genre)
+  const intervalKey = `${slotId}-${msg.genre}`
+  clearInterval(rollingIntervals[intervalKey])
+  rollingIntervals[intervalKey] = setInterval(() => {
+    fakeNums.value = { ...fakeNums.value, [intervalKey]: Math.floor(Math.random() * 99) + 1 }
+  }, 80)
+
   setTimeout(() => {
-    stopRolling(msg.genre)
-    const g = currentPerson.value?.genres.find(g => g.genreName === msg.genre)
-    if (g) {
-      g.rolling = false
-      g.auditionNumber = msg.auditionNumber
+    stopRolling(slotId, msg.genre)
+    const currentSlot = activeSlots.value.find(s => s.slotId === slotId)
+    if (currentSlot) {
+      const g = currentSlot.person.genres.find(g => g.genreName === msg.genre)
+      if (g) {
+        g.rolling = false
+        g.auditionNumber = msg.auditionNumber
+      }
     }
-    processNextInQueue()
+    processSlotQueue(slotId)
   }, 2000)
 }
 
-// ── WS Handlers ─────────────────────────────────────────────────────────────
-const isSamePerson = (a, b) =>
-  a && b && (a.participantId != null && b.participantId != null
-    ? a.participantId === b.participantId
-    : a.name === b.name)
+function processSlotQueue(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
 
+  if (slot.queue.length === 0) {
+    slot.running = false
+    if (slot.person.genres.every(g => g.auditionNumber !== null)) {
+      setTimeout(() => flushSlotToHistory(slotId), 1500)
+    }
+    return
+  }
+
+  slot.running = true
+  const msg = slot.queue.shift()
+  animateSlot(slotId, msg)
+}
+
+// ── WS Handlers ─────────────────────────────────────────────────────────────
 const onPreview = (msg) => {
-  if (isSamePerson(currentPerson.value, msg)) {
-    // Same person — merge any new genres without overwriting existing
-    if (msg.refCode && !currentPerson.value.refCode) currentPerson.value.refCode = msg.refCode
-    const existing = new Set(currentPerson.value.genres.map(g => g.genreName))
+  if (msg.cancelled) {
+    const id = slotKey(msg.participantId, msg.name)
+    const idx = activeSlots.value.findIndex(s => s.slotId === id)
+    if (idx !== -1) {
+      stopAllSlotRolling(id)
+      activeSlots.value.splice(idx, 1)
+    }
+    return
+  }
+
+  const id = slotKey(msg.participantId, msg.name)
+  const existing = activeSlots.value.find(s => s.slotId === id)
+  if (existing) {
+    if (msg.refCode && !existing.person.refCode) existing.person.refCode = msg.refCode
+    const existingGenres = new Set(existing.person.genres.map(g => g.genreName))
     for (const g of (msg.genres ?? [])) {
-      if (!existing.has(g.genreName)) {
-        currentPerson.value.genres.push({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false })
+      if (!existingGenres.has(g.genreName)) {
+        existing.person.genres.push({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false })
       }
     }
   } else {
-    // Different person — discard pending animations and flush current to history
-    if (currentPerson.value) {
-      auditionQueue.length = 0
-      flushCurrentToHistory()
-    }
-    currentPerson.value = {
-      participantId: msg.participantId ?? null,
-      name: msg.name,
-      refCode: msg.refCode ?? null,
-      memberNames: msg.memberNames ?? [],
-      genres: (msg.genres ?? []).map(g => ({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false }))
-    }
+    activeSlots.value.push({
+      slotId: id,
+      person: {
+        participantId: msg.participantId ?? null,
+        name: msg.name,
+        refCode: msg.refCode ?? null,
+        memberNames: msg.memberNames ?? [],
+        genres: (msg.genres ?? []).map(g => ({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false }))
+      },
+      queue: [],
+      running: false
+    })
   }
 }
 
 const onReceiveAuditionNumber = (msg) => {
-  if (isSamePerson(currentPerson.value, msg)) {
-    // Ensure genre row exists (pending state) — number revealed only after animation
-    if (!currentPerson.value.genres.find(g => g.genreName === msg.genre)) {
-      currentPerson.value.genres.push({ genreName: msg.genre, auditionNumber: null, rolling: false })
+  const id = slotKey(msg.participantId, msg.name)
+  const slot = activeSlots.value.find(s => s.slotId === id)
+  if (slot) {
+    if (!slot.person.genres.find(g => g.genreName === msg.genre)) {
+      slot.person.genres.push({ genreName: msg.genre, auditionNumber: null, rolling: false })
     }
-    if (msg.refCode && !currentPerson.value.refCode) currentPerson.value.refCode = msg.refCode
-    auditionQueue.push(msg)
-    if (!queueRunning) processNextInQueue()
+    if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+    slot.queue.push(msg)
+    if (!slot.running) processSlotQueue(id)
   } else {
-    // Late message — update history directly, no animation
-    const historyEntry = history.value.find(h => h.name === msg.name)
+    const historyEntry = history.value.find(h => slotKey(h.participantId, h.name) === id)
     if (historyEntry) {
       const hGenre = historyEntry.genres.find(g => g.genreName === msg.genre)
       if (hGenre) hGenre.auditionNumber = msg.auditionNumber
-    } else {
-      auditionQueue.push(msg)
-      if (!queueRunning) processNextInQueue()
     }
   }
 }
@@ -183,14 +192,14 @@ onBeforeUnmount(() => {
   <div class="page-container">
     <div class="color-bleed"></div>
 
-    <!-- ── Current Participant ─────────────────────────────────────────── -->
+    <!-- ── Current Participants ────────────────────────────────────────── -->
     <div class="section-rule mb-4">
       <span class="section-rule-label">Current Participant</span>
       <div class="section-rule-line"></div>
     </div>
 
     <!-- Idle state -->
-    <div v-if="!currentPerson" class="flex flex-col items-center justify-center py-16 text-center">
+    <div v-if="activeSlots.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
       <div class="para-chip-sm w-16 h-16 flex items-center justify-center mb-4">
         <i class="pi pi-qrcode text-content-muted text-2xl"></i>
       </div>
@@ -198,88 +207,98 @@ onBeforeUnmount(() => {
       <p class="type-label text-content-muted mt-1">Check in a participant on the Event Details page</p>
     </div>
 
-    <!-- Active participant card -->
-    <div v-else class="card-hover p-5 relative mb-6">
-      <div class="corner-bar-tl"></div>
-      <div class="corner-bar-bl"></div>
+    <!-- Active slots grid -->
+    <div
+      v-else
+      class="grid gap-4 mb-6"
+      :style="{ gridTemplateColumns: `repeat(${Math.min(activeSlots.length, 3)}, 1fr)` }"
+    >
+      <div
+        v-for="slot in activeSlots"
+        :key="slot.slotId"
+        class="card-hover p-5 relative"
+      >
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
 
-      <!-- Name row -->
-      <div class="flex items-start justify-between gap-4 mb-1">
-        <div class="flex-1 min-w-0">
-          <p class="type-label text-content-muted mb-1">Good Luck</p>
-          <p class="type-page-title text-content-primary leading-tight" style="font-size:clamp(1.4rem,4vw,2.2rem)">
-            {{ currentPerson.name }}
-          </p>
+        <!-- Name row -->
+        <div class="flex items-start justify-between gap-4 mb-1">
+          <div class="flex-1 min-w-0">
+            <p class="type-label text-content-muted mb-1">Good Luck</p>
+            <p class="type-page-title text-content-primary leading-tight" style="font-size:clamp(1.4rem,4vw,2.2rem)">
+              {{ slot.person.name }}
+            </p>
+          </div>
+          <!-- Ref code chip (hold to reveal) -->
+          <div
+            v-if="slot.person.refCode"
+            class="flex-shrink-0 para-chip-sm px-3 py-2 cursor-pointer select-none flex flex-col items-end gap-0.5"
+            @mousedown="setReveal(slot.slotId, true)" @mouseup="setReveal(slot.slotId, false)" @mouseleave="setReveal(slot.slotId, false)"
+            @touchstart="setReveal(slot.slotId, true)" @touchend="setReveal(slot.slotId, false)" @touchcancel="setReveal(slot.slotId, false)"
+          >
+            <span class="type-label text-content-muted">Ref Code</span>
+            <span v-if="revealingRef[slot.slotId]" class="font-source tracking-widest text-accent" style="font-size:1rem;letter-spacing:0.2em">
+              {{ slot.person.refCode }}
+            </span>
+            <span v-else class="type-label text-content-muted/40">Hold to reveal</span>
+          </div>
+          <div v-else-if="slot.person.genres.some(g => g.auditionNumber === null)" class="flex-shrink-0 para-chip-sm px-3 py-2 flex items-center gap-1.5">
+            <i class="pi pi-spin pi-spinner text-content-muted text-xs"></i>
+            <span class="type-label text-content-muted">Assigning…</span>
+          </div>
         </div>
-        <!-- Ref code chip (hold to reveal) -->
-        <div
-          v-if="currentPerson.refCode"
-          class="flex-shrink-0 para-chip-sm px-3 py-2 cursor-pointer select-none flex flex-col items-end gap-0.5"
-          @mousedown="revealingRef = 'current'" @mouseup="revealingRef = null" @mouseleave="revealingRef = null"
-          @touchstart="revealingRef = 'current'" @touchend="revealingRef = null" @touchcancel="revealingRef = null"
-        >
-          <span class="type-label text-content-muted">Ref Code</span>
-          <span v-if="revealingRef === 'current'" class="font-source tracking-widest text-accent" style="font-size:1rem;letter-spacing:0.2em">
-            {{ currentPerson.refCode }}
-          </span>
-          <span v-else class="type-label text-content-muted/40">Hold to reveal</span>
+
+        <!-- Team members -->
+        <div v-if="slot.person.memberNames?.length" class="flex items-center gap-1.5 type-label text-content-muted mb-3">
+          <i class="pi pi-users" style="font-size:0.65rem"></i>
+          <span>{{ slot.person.memberNames.join(' · ') }}</span>
         </div>
-        <div v-else-if="currentPerson.genres.some(g => g.auditionNumber === null)" class="flex-shrink-0 para-chip-sm px-3 py-2 flex items-center gap-1.5">
-          <i class="pi pi-spin pi-spinner text-content-muted text-xs"></i>
-          <span class="type-label text-content-muted">Assigning…</span>
+
+        <!-- Divisions -->
+        <div class="section-rule my-3">
+          <span class="section-rule-label">Divisions</span>
+          <div class="section-rule-line"></div>
         </div>
-      </div>
 
-      <!-- Team members -->
-      <div v-if="currentPerson.memberNames?.length" class="flex items-center gap-1.5 type-label text-content-muted mb-3">
-        <i class="pi pi-users" style="font-size:0.65rem"></i>
-        <span>{{ currentPerson.memberNames.join(' · ') }}</span>
-      </div>
+        <div class="space-y-2">
+          <div
+            v-for="g in slot.person.genres"
+            :key="g.genreName"
+            class="flex items-center gap-3 para-chip-sm px-3 py-2.5"
+            :style="g.auditionNumber !== null ? { borderColor: 'var(--accent-muted)', background: 'var(--accent-subtle)' } : {}"
+          >
+            <!-- Status dot -->
+            <span
+              class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+              :style="g.auditionNumber !== null
+                ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
+                : g.rolling
+                  ? 'background:rgba(245,158,11,0.7);box-shadow:0 0 6px rgba(245,158,11,0.5)'
+                  : 'background:rgba(255,255,255,0.15)'"
+            ></span>
 
-      <!-- Divisions -->
-      <div class="section-rule my-3">
-        <span class="section-rule-label">Divisions</span>
-        <div class="section-rule-line"></div>
-      </div>
+            <!-- Division name -->
+            <span class="type-body text-content-primary flex-1">{{ g.genreName }}</span>
 
-      <div class="space-y-2">
-        <div
-          v-for="g in currentPerson.genres"
-          :key="g.genreName"
-          class="flex items-center gap-3 para-chip-sm px-3 py-2.5"
-          :style="g.auditionNumber !== null ? { borderColor: 'var(--accent-muted)', background: 'var(--accent-subtle)' } : {}"
-        >
-          <!-- Status dot -->
-          <span
-            class="inline-block w-2 h-2 rounded-full flex-shrink-0"
-            :style="g.auditionNumber !== null
-              ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
-              : g.rolling
-                ? 'background:rgba(245,158,11,0.7);box-shadow:0 0 6px rgba(245,158,11,0.5)'
-                : 'background:rgba(255,255,255,0.15)'"
-          ></span>
-
-          <!-- Division name -->
-          <span class="type-body text-content-primary flex-1">{{ g.genreName }}</span>
-
-          <!-- Number area -->
-          <div class="flex items-baseline gap-1 tabular-nums min-w-[5rem] justify-end">
-            <!-- Rolling -->
-            <template v-if="g.rolling">
-              <span class="type-label text-amber-400/60 text-xs">Drawing</span>
-              <span class="type-stat text-amber-400" style="font-size:1.6rem">
-                {{ fakeNums[g.genreName] ?? '—' }}
-              </span>
-            </template>
-            <!-- Revealed -->
-            <template v-else-if="g.auditionNumber !== null">
-              <span class="type-label text-accent/60 text-xs">#</span>
-              <span class="type-stat text-accent" style="font-size:1.6rem">{{ g.auditionNumber }}</span>
-            </template>
-            <!-- Pending -->
-            <template v-else>
-              <span class="type-stat text-content-muted/20" style="font-size:1.6rem">—</span>
-            </template>
+            <!-- Number area -->
+            <div class="flex items-baseline gap-1 tabular-nums min-w-[5rem] justify-end">
+              <!-- Rolling -->
+              <template v-if="g.rolling">
+                <span class="type-label text-amber-400/60 text-xs">Drawing</span>
+                <span class="type-stat text-amber-400" style="font-size:1.6rem">
+                  {{ fakeNums[`${slot.slotId}-${g.genreName}`] ?? '—' }}
+                </span>
+              </template>
+              <!-- Revealed -->
+              <template v-else-if="g.auditionNumber !== null">
+                <span class="type-label text-accent/60 text-xs">#</span>
+                <span class="type-stat text-accent" style="font-size:1.6rem">{{ g.auditionNumber }}</span>
+              </template>
+              <!-- Pending -->
+              <template v-else>
+                <span class="type-stat text-content-muted/20" style="font-size:1.6rem">—</span>
+              </template>
+            </div>
           </div>
         </div>
       </div>
@@ -317,15 +336,15 @@ onBeforeUnmount(() => {
             </span>
           </div>
 
-          <!-- Ref code (press and hold to reveal) -->
+          <!-- Ref code (click to reveal) -->
           <span
             v-if="person.refCode"
             class="relative ml-auto shrink-0 inline-flex items-center gap-1.5 para-chip-sm px-2.5 py-1 type-label cursor-pointer select-none transition-colors"
-            :class="revealingRef === person.name + i ? 'text-accent' : 'text-content-muted hover:text-accent'"
-            @click="revealingRef = revealingRef === person.name + i ? null : person.name + i"
+            :class="revealingRef['h-' + person.name + '-' + i] ? 'text-accent' : 'text-content-muted hover:text-accent'"
+            @click="toggleReveal('h-' + person.name + '-' + i)"
           >
             <i class="pi pi-eye" style="font-size:0.6rem"></i>
-            <template v-if="revealingRef === person.name + i">
+            <template v-if="revealingRef['h-' + person.name + '-' + i]">
               <span class="font-source tracking-widest" style="font-size:0.75rem;letter-spacing:0.2em">{{ person.refCode }}</span>
             </template>
             <template v-else>Ref</template>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, onMounted, onUnmounted, watch, computed } from 'vue';
 import { RouterLink } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories } from '@/utils/api';
 import { setActiveEvent } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
@@ -937,6 +937,11 @@ onMounted(async () => {
       if (msg.eventName !== props.eventName) return
       fetchCheckinList()
     })
+    // Hydrate previewingIds from server state so late-joining/refreshed clients see current previews
+    const existingPreviews = await getCheckinPreviews(props.eventName)
+    for (const id of existingPreviews) {
+      previewingIds[id] = true
+    }
   }
 })
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -33,6 +33,7 @@ const batchVerifying = ref(false)
 const checkinList = ref([])
 const loadingCheckinList = ref(false)
 const checkingInId = ref(null)
+const confirming = ref(false)
 const checkinSearch = ref('')
 const participantsNumBreakdown = ref([])
 const totalParticipants = ref(0)
@@ -739,7 +740,13 @@ const fetchCheckinList = async () => {
 const checkIn = async (p) => {
   checkingInId.value = p.participantId
   try {
-    await checkInParticipant(p.participantId, p.eventId)
+    const res = await checkInParticipant(p.participantId, p.eventId)
+    if (res?.status === 409) {
+      checkinConfirm.value.phase = 'error'
+      checkinConfirm.value.errorMessage = 'Already checked in at another desk.'
+      checkingInId.value = null
+      return
+    }
     await Promise.all([fetchCheckinList(), refreshFromDb()])
   } catch (e) {
     console.error(e)
@@ -747,7 +754,7 @@ const checkIn = async (p) => {
   checkingInId.value = null
 }
 
-const checkinConfirm = ref({ show: false, participant: null, phase: 'confirm', refCode: null })
+const checkinConfirm = ref({ show: false, participant: null, phase: 'confirm', refCode: null, errorMessage: '' })
 // phase: 'confirm' → 'generating' → 'done'
 
 // Dialog slot machine animation state
@@ -797,9 +804,20 @@ const askCheckIn = (p) => {
   })
 }
 
+const closeCheckinDialog = () => {
+  if (checkinConfirm.value.phase === 'confirm' && checkinConfirm.value.participant) {
+    sendCheckinPreview(eventName.value, {
+      participantId: checkinConfirm.value.participant.participantId,
+      cancelled: true
+    })
+  }
+  checkinConfirm.value.show = false
+}
+
 const confirmCheckIn = async () => {
   const p = checkinConfirm.value.participant
-  if (!p) return
+  if (!p || confirming.value) return
+  confirming.value = true
 
   // Reset genre display state
   p.genres.forEach(g => { g.auditionNumber = null; g.rolling = false })
@@ -816,6 +834,10 @@ const confirmCheckIn = async () => {
   // checkIn awaits both the HTTP assignment AND fetchCheckinList + refreshFromDb,
   // so when it resolves we have fresh numbers in checkinList.value and verifiedDbParticipants.value
   await checkIn(p)
+  confirming.value = false
+
+  // Early exit if checkIn set an error phase (e.g. 409)
+  if (checkinConfirm.value.phase === 'error') return
 
   // Get ref code from fresh verifiedDbParticipants data
   const refEntry = verifiedDbParticipants.value.find(ep => ep.participantId === p.participantId)
@@ -2025,7 +2047,7 @@ onUnmounted(() => {
     >
       <div v-if="checkinConfirm.show" class="fixed inset-0 z-50 flex items-center justify-center p-4">
         <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
-          @click="checkinConfirm.phase !== 'generating' && (checkinConfirm.show = false)" />
+          @click="checkinConfirm.phase !== 'generating' && closeCheckinDialog()" />
         <div class="card-hover p-5 relative w-full max-w-md" style="clip-path:none">
           <div class="corner-bar-tl"></div>
           <div class="corner-bar-bl"></div>
@@ -2033,9 +2055,9 @@ onUnmounted(() => {
           <!-- Header -->
           <div class="flex items-center justify-between mb-4">
             <p class="type-body text-content-secondary">
-              {{ checkinConfirm.phase === 'confirm' ? 'Confirm Check-In' : checkinConfirm.phase === 'generating' ? 'Generating…' : 'Check-In Complete' }}
+              {{ checkinConfirm.phase === 'confirm' ? 'Confirm Check-In' : checkinConfirm.phase === 'generating' ? 'Generating…' : checkinConfirm.phase === 'error' ? 'Check-In Failed' : 'Check-In Complete' }}
             </p>
-            <button v-if="checkinConfirm.phase !== 'generating'" @click="checkinConfirm.show = false"
+            <button v-if="checkinConfirm.phase !== 'generating'" @click="closeCheckinDialog"
               class="p-1 text-content-muted hover:text-content-primary transition-colors">
               <i class="pi pi-times text-sm" />
             </button>
@@ -2113,12 +2135,13 @@ onUnmounted(() => {
           <div class="flex gap-3">
             <!-- Confirm phase -->
             <template v-if="checkinConfirm.phase === 'confirm'">
-              <button @click="checkinConfirm.show = false"
+              <button @click="closeCheckinDialog"
                 class="flex-1 py-2 para-chip-sm type-label text-content-muted hover:text-content-primary transition-all">
                 Cancel
               </button>
               <button @click="confirmCheckIn"
-                class="flex-1 py-2 para-chip type-label text-white transition-all"
+                :disabled="confirming"
+                class="flex-1 py-2 para-chip type-label text-white transition-all disabled:opacity-50"
                 style="background:rgba(255,255,255,0.12);box-shadow:0 0 12px var(--accent-subtle)"
               >
                 <i class="pi pi-check mr-1.5 text-xs"></i> Confirm
@@ -2128,6 +2151,18 @@ onUnmounted(() => {
             <div v-else-if="checkinConfirm.phase === 'generating'"
               class="flex-1 py-2 flex items-center justify-center gap-2 type-label text-content-muted">
               <i class="pi pi-spin pi-spinner text-xs"></i> Generating…
+            </div>
+            <!-- Error phase (e.g. 409 already checked in) -->
+            <div v-else-if="checkinConfirm.phase === 'error'"
+              class="flex-1 flex flex-col items-center gap-3">
+              <div class="flex items-center gap-2 type-label text-red-400">
+                <i class="pi pi-exclamation-circle text-sm"></i>
+                {{ checkinConfirm.errorMessage }}
+              </div>
+              <button @click="checkinConfirm.show = false"
+                class="px-4 py-2 para-chip-sm type-label text-content-muted hover:text-content-primary transition-colors">
+                Close
+              </button>
             </div>
             <!-- Done phase -->
             <button v-else @click="checkinConfirm.show = false"

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -34,6 +34,8 @@ const checkinList = ref([])
 const loadingCheckinList = ref(false)
 const checkingInId = ref(null)
 const confirming = ref(false)
+// participantId → true when any operator has that participant's dialog open
+const previewingIds = reactive({})
 const checkinSearch = ref('')
 const participantsNumBreakdown = ref([])
 const totalParticipants = ref(0)
@@ -916,9 +918,19 @@ onMounted(async () => {
         const genre = participant.genres.find(g => g.genreName === msg.genre)
         if (genre) genre.auditionNumber = msg.auditionNumber
       }
+      // Participant is now checked in — no longer in preview
+      if (msg.participantId) delete previewingIds[msg.participantId]
       if (!refreshPending) {
         refreshPending = true
         refreshFromDb().finally(() => { refreshPending = false })
+      }
+    })
+    subscribeToChannel(wsClient, '/topic/checkin-preview/', (msg) => {
+      if (!msg.participantId) return
+      if (msg.cancelled) {
+        delete previewingIds[msg.participantId]
+      } else {
+        previewingIds[msg.participantId] = true
       }
     })
     subscribeToChannel(wsClient, '/topic/walkin/', (msg) => {
@@ -1641,11 +1653,12 @@ onUnmounted(() => {
                 </div>
               </div>
               <div class="flex items-center gap-2 mt-2 justify-end">
-                <button v-if="!isCheckedIn(p)" @click="askCheckIn(p)" :disabled="checkingInId === p.participantId"
+                <button v-if="!isCheckedIn(p)" @click="askCheckIn(p)"
+                  :disabled="checkingInId === p.participantId || !!previewingIds[p.participantId]"
                   class="bg-accent para-chip-sm px-3 py-1.5 type-label disabled:opacity-50"
                 >
-                  <i class="pi text-xs" :class="checkingInId === p.participantId ? 'pi-spinner pi-spin' : 'pi-check'"></i>
-                  {{ checkingInId === p.participantId ? '…' : 'Check In' }}
+                  <i class="pi text-xs" :class="checkingInId === p.participantId ? 'pi-spinner pi-spin' : previewingIds[p.participantId] ? 'pi-clock' : 'pi-check'"></i>
+                  {{ checkingInId === p.participantId ? '…' : previewingIds[p.participantId] ? 'In Preview' : 'Check In' }}
                 </button>
                 <i v-else class="pi pi-check-circle text-emerald-400 text-sm"></i>
               </div>

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +64,7 @@ import com.example.BES.dtos.CreatePickupCrewDto;
 import com.example.BES.dtos.GetPickupCrewDto;
 import com.example.BES.services.AuditionFeedbackService;
 import com.example.BES.services.BattleGuestService;
+import com.example.BES.services.CheckinPreviewService;
 import com.example.BES.services.EventGenreParticpantService;
 import com.example.BES.services.PickupCrewService;
 import com.example.BES.services.ScoringCriteriaService;
@@ -138,6 +140,9 @@ public class EventController {
 
     @Autowired
     BattleGuestService battleGuestService;
+
+    @Autowired
+    CheckinPreviewService checkinPreviewService;
 
     @Autowired
     SimpMessagingTemplate messagingTemplate;
@@ -426,6 +431,13 @@ public class EventController {
         return new ResponseEntity<>(res, HttpStatus.OK);
     }
 
+    @Operation(summary = "Get Active Check-In Previews", description = "Returns the set of participant IDs currently being previewed (check-in dialog open) for an event")
+    @GetMapping("/{eventName}/checkin-preview")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<Set<Long>> getCheckinPreviews(@PathVariable String eventName) {
+        return ResponseEntity.ok(checkinPreviewService.getActivePreviews(eventName));
+    }
+
     @Operation(summary = "Send Check-In Preview", description = "Broadcasts participant details to AuditionNumber display before generating numbers")
     @PostMapping("/{eventName}/checkin-preview")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
@@ -433,6 +445,11 @@ public class EventController {
             @PathVariable String eventName,
             @RequestBody CheckinPreviewDto dto) {
         try {
+            if (Boolean.TRUE.equals(dto.cancelled)) {
+                checkinPreviewService.clearPreview(eventName, dto.participantId);
+            } else {
+                checkinPreviewService.setPreview(eventName, dto.participantId);
+            }
             messagingTemplate.convertAndSend("/topic/checkin-preview/", dto);
             return new ResponseEntity<>("ok", HttpStatus.OK);
         } catch (Exception e) {
@@ -448,6 +465,8 @@ public class EventController {
             @PathVariable Long eventId) {
         try {
             eventGenreParticipantService.getAllAuditionNumsViaQR(participantId, eventId);
+            String eventName = eventService.getEventNameById(eventId);
+            checkinPreviewService.clearPreview(eventName, participantId);
             return new ResponseEntity<>("registered", HttpStatus.CREATED);
         } catch (IllegalStateException e) {
             if ("already_checked_in".equals(e.getMessage())) {

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -449,6 +449,11 @@ public class EventController {
         try {
             eventGenreParticipantService.getAllAuditionNumsViaQR(participantId, eventId);
             return new ResponseEntity<>("registered", HttpStatus.CREATED);
+        } catch (IllegalStateException e) {
+            if ("already_checked_in".equals(e.getMessage())) {
+                return new ResponseEntity<>("already_checked_in", HttpStatus.CONFLICT);
+            }
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (Exception e) {
             return new ResponseEntity<>("Something is null", HttpStatus.BAD_REQUEST);
         }

--- a/BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
@@ -8,6 +8,7 @@ public class CheckinPreviewDto {
     public String refCode;
     public List<String> memberNames;
     public List<GenreEntry> genres;
+    public Boolean cancelled;
 
     public static class GenreEntry {
         public String genreName;

--- a/BES/src/main/java/com/example/BES/services/CheckinPreviewService.java
+++ b/BES/src/main/java/com/example/BES/services/CheckinPreviewService.java
@@ -1,0 +1,34 @@
+package com.example.BES.services;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CheckinPreviewService {
+
+    private final Map<String, Set<Long>> activePreviews = new ConcurrentHashMap<>();
+
+    public void setPreview(String eventName, Long participantId) {
+        activePreviews
+            .computeIfAbsent(eventName, k -> ConcurrentHashMap.newKeySet())
+            .add(participantId);
+    }
+
+    public void clearPreview(String eventName, Long participantId) {
+        Set<Long> previews = activePreviews.get(eventName);
+        if (previews != null) {
+            previews.remove(participantId);
+            if (previews.isEmpty()) {
+                activePreviews.remove(eventName);
+            }
+        }
+    }
+
+    public Set<Long> getActivePreviews(String eventName) {
+        return activePreviews.getOrDefault(eventName, Collections.emptySet());
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -118,6 +118,9 @@ public class EventGenreParticpantService {
     public void getAllAuditionNumsViaQR(Long participantId, Long eventId) {
         List<EventGenreParticipant> entries =
             repo.findByEventIdAndParticipantId(eventId, participantId);
+        if (entries.stream().allMatch(e -> e.getAuditionNumber() != null)) {
+            throw new IllegalStateException("already_checked_in");
+        }
         for (EventGenreParticipant entry : entries) {
             AddParticipantToEventGenreDto dto = new AddParticipantToEventGenreDto();
             dto.participantId = participantId;

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -118,7 +118,7 @@ public class EventGenreParticpantService {
     public void getAllAuditionNumsViaQR(Long participantId, Long eventId) {
         List<EventGenreParticipant> entries =
             repo.findByEventIdAndParticipantId(eventId, participantId);
-        if (entries.stream().allMatch(e -> e.getAuditionNumber() != null)) {
+        if (!entries.isEmpty() && entries.stream().allMatch(e -> e.getAuditionNumber() != null)) {
             throw new IllegalStateException("already_checked_in");
         }
         for (EventGenreParticipant entry : entries) {

--- a/BES/src/main/java/com/example/BES/services/EventService.java
+++ b/BES/src/main/java/com/example/BES/services/EventService.java
@@ -41,6 +41,12 @@ public class EventService {
         emailTemplateService.createDefaultTemplate(saved);
     }
 
+    public String getEventNameById(Long eventId) {
+        return repo.findById(eventId)
+            .map(Event::getEventName)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+    }
+
     public AddEventDto findEventbyNameSerivce(String eventName){
         Event event = repo.findByEventName(eventName).orElse(null);
         if(event != null){

--- a/BES/src/test/java/com/example/BES/controllers/EventControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/EventControllerIntegrationTest.java
@@ -41,6 +41,7 @@ import com.example.BES.models.EventGenreParticipant;
 import com.example.BES.models.EventParticipant;
 import com.example.BES.models.Genre;
 import com.example.BES.models.Participant;
+import com.example.BES.services.CheckinPreviewService;
 import com.example.BES.services.EventGenreParticpantService;
 import com.example.BES.services.EventGenreService;
 import com.example.BES.services.EventParticpantService;
@@ -81,6 +82,8 @@ public class EventControllerIntegrationTest {
     private JudgeService judgeService;
     @MockBean
     private ScoreService scoreService;
+    @MockBean
+    private CheckinPreviewService checkinPreviewService;
 
     @Test
     @WithMockUser

--- a/docs/superpowers/plans/2026-06-02-checkin-concurrency.md
+++ b/docs/superpowers/plans/2026-06-02-checkin-concurrency.md
@@ -1,0 +1,883 @@
+# Check-in Concurrency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix concurrent check-in race conditions: duplicate guard (409), per-slot independent animations on AuditionNumber display, cancel signal for ghost previews, double-confirm guard, and Reset Scores access code gate.
+
+**Architecture:** Backend adds a 409 guard in `EventGenreParticpantService` and a `cancelled` field on `CheckinPreviewDto`. Frontend replaces AuditionNumber's single `currentPerson` model with an `activeSlots` array where each slot owns its animation queue, keyed by `slotId-genreName` to allow parallel animations.
+
+**Tech Stack:** Spring Boot (Java), Vue 3 (Composition API), STOMP WebSocket
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java` | Add `cancelled` boolean field |
+| `BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java` | Throw `IllegalStateException("already_checked_in")` if all genres already have numbers |
+| `BES/src/main/java/com/example/BES/controllers/EventController.java` | Catch `IllegalStateException` → 409 on `registerParticipantAllGenres` |
+| `BES-frontend/src/views/AuditionNumber.vue` | Full refactor: `activeSlots` array, per-slot queues, parallel animation |
+| `BES-frontend/src/views/EventDetails.vue` | Double-confirm guard, 409 error state, cancel preview on dialog close |
+| `BES-frontend/src/views/AuditionList.vue` | Access code gate before Reset Scores executes |
+
+---
+
+## Task 1: Add `cancelled` field to `CheckinPreviewDto`
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java`
+
+- [ ] **Open the file and add the field**
+
+Replace the entire file with:
+
+```java
+package com.example.BES.dtos;
+
+import java.util.List;
+
+public class CheckinPreviewDto {
+    public Long participantId;
+    public String name;
+    public String refCode;
+    public Boolean cancelled;
+    public List<String> memberNames;
+    public List<GenreEntry> genres;
+
+    public static class GenreEntry {
+        public String genreName;
+        public Integer auditionNumber;
+    }
+}
+```
+
+- [ ] **Build to confirm no compile errors**
+
+```bash
+cd BES && mvn compile -q
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
+git commit -m "feat: add cancelled field to CheckinPreviewDto"
+```
+
+---
+
+## Task 2: Backend — 409 duplicate check-in guard
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java`
+- Modify: `BES/src/main/java/com/example/BES/controllers/EventController.java`
+
+- [ ] **Add duplicate check at the top of `getAllAuditionNumsViaQR` in the service**
+
+In `EventGenreParticpantService.java`, find the `getAllAuditionNumsViaQR` method (currently at line ~118) and add the already-assigned check as the first thing it does:
+
+```java
+public void getAllAuditionNumsViaQR(Long participantId, Long eventId) {
+    List<EventGenreParticipant> entries =
+        repo.findByEventIdAndParticipantId(eventId, participantId);
+    // Guard: if every entry already has a number, this is a duplicate check-in
+    boolean allAssigned = !entries.isEmpty() &&
+        entries.stream().allMatch(e -> e.getAuditionNumber() != null);
+    if (allAssigned) {
+        throw new IllegalStateException("already_checked_in");
+    }
+    for (EventGenreParticipant entry : entries) {
+        AddParticipantToEventGenreDto dto = new AddParticipantToEventGenreDto();
+        dto.participantId = participantId;
+        dto.eventId = eventId;
+        dto.eventGenreId = entry.getEventGenre().getId();
+        int attempts = 0;
+        while (true) {
+            try {
+                getAuditionNumViaQR(dto);
+                break;
+            } catch (Exception e) {
+                if (++attempts >= 3) throw e;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Update the controller to return 409 for `IllegalStateException`**
+
+In `EventController.java`, find `registerParticipantAllGenres` (currently at line ~445) and split the catch:
+
+```java
+@GetMapping("/register-participant/{participantId}/{eventId}")
+public ResponseEntity<String> registerParticipantAllGenres(
+        @PathVariable Long participantId,
+        @PathVariable Long eventId) {
+    try {
+        eventGenreParticipantService.getAllAuditionNumsViaQR(participantId, eventId);
+        return new ResponseEntity<>("registered", HttpStatus.CREATED);
+    } catch (IllegalStateException e) {
+        if ("already_checked_in".equals(e.getMessage())) {
+            return new ResponseEntity<>("already_checked_in", HttpStatus.CONFLICT);
+        }
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    } catch (Exception e) {
+        return new ResponseEntity<>("Something is null", HttpStatus.BAD_REQUEST);
+    }
+}
+```
+
+- [ ] **Build to confirm no compile errors**
+
+```bash
+cd BES && mvn compile -q
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java \
+        BES/src/main/java/com/example/BES/controllers/EventController.java
+git commit -m "feat: return 409 when participant already has all audition numbers"
+```
+
+---
+
+## Task 3: EventDetails.vue — double-confirm guard + cancel preview + 409 handling
+
+**Files:**
+- Modify: `BES-frontend/src/views/EventDetails.vue`
+
+- [ ] **Add `confirming` ref near the other checkin refs (around line 750)**
+
+```js
+const checkingInId = ref(null)
+const confirming = ref(false)   // ← add this line
+```
+
+- [ ] **Update `confirmCheckIn` to guard against double-submit and handle 409**
+
+Find `confirmCheckIn` (around line 800) and replace it entirely:
+
+```js
+const confirmCheckIn = async () => {
+  const p = checkinConfirm.value.participant
+  if (!p || confirming.value) return
+
+  confirming.value = true
+  p.genres.forEach(g => { g.auditionNumber = null; g.rolling = false })
+  dialogNumberQueue.length = 0
+  Object.values(dialogRollingIntervals).forEach(clearInterval)
+  for (const k in dialogRollingIntervals) delete dialogRollingIntervals[k]
+  dialogFakeNums.value = {}
+
+  checkinConfirm.value.phase = 'generating'
+  checkinConfirm.value.refCode = null
+
+  try {
+    await checkIn(p)
+
+    // 409 — already checked in by another desk
+    if (checkingInId.value === null && checkinConfirm.value.phase === 'generating') {
+      // checkIn sets checkingInId back to null; inspect participants for the result
+    }
+
+    const refEntry = verifiedDbParticipants.value.find(ep => ep.participantId === p.participantId)
+    checkinConfirm.value.refCode = refEntry?.referenceCode || null
+
+    const freshParticipant = checkinList.value.find(ep => ep.participantId === p.participantId)
+    if (freshParticipant) {
+      for (const ug of freshParticipant.genres) {
+        if (ug.auditionNumber != null) {
+          dialogNumberQueue.push({ genre: ug.genreName, auditionNumber: ug.auditionNumber })
+        }
+      }
+    }
+
+    if (dialogNumberQueue.length === 0) {
+      checkinConfirm.value.phase = 'done'
+    } else {
+      processNextDialogNumber()
+    }
+  } finally {
+    confirming.value = false
+  }
+}
+```
+
+- [ ] **Update `checkIn` to surface 409 as a distinct error state**
+
+Find `checkIn` (around line 739) and replace it:
+
+```js
+const checkIn = async (p) => {
+  checkingInId.value = p.participantId
+  try {
+    const res = await checkInParticipant(p.participantId, p.eventId)
+    if (res?.status === 409) {
+      checkinConfirm.value.phase = 'error'
+      checkinConfirm.value.errorMessage = 'Already checked in at another desk.'
+      return
+    }
+    await Promise.all([fetchCheckinList(), refreshFromDb()])
+  } catch (e) {
+    console.error(e)
+  }
+  checkingInId.value = null
+}
+```
+
+- [ ] **Add `errorMessage` to `checkinConfirm` initial shape and the error phase to the template**
+
+Find the `checkinConfirm` ref (around line 750):
+
+```js
+const checkinConfirm = ref({ show: false, participant: null, phase: 'confirm', refCode: null, errorMessage: '' })
+```
+
+In the template, find the `<!-- Actions -->` section of the check-in dialog and add an error phase between generating and done:
+
+```html
+<!-- Error phase -->
+<div v-else-if="checkinConfirm.phase === 'error'"
+  class="flex-1 py-2 flex flex-col items-center gap-3">
+  <div class="flex items-center gap-2 type-label text-red-400">
+    <i class="pi pi-exclamation-circle text-sm"></i>
+    {{ checkinConfirm.errorMessage }}
+  </div>
+  <button @click="checkinConfirm.show = false"
+    class="para-chip-sm px-4 py-2 type-label text-content-muted hover:text-content-primary transition-colors">
+    Close
+  </button>
+</div>
+```
+
+Also update the dialog header to cover the error phase:
+
+```html
+{{ checkinConfirm.phase === 'confirm' ? 'Confirm Check-In'
+   : checkinConfirm.phase === 'generating' ? 'Generating…'
+   : checkinConfirm.phase === 'error' ? 'Check-In Failed'
+   : 'Check-In Complete' }}
+```
+
+- [ ] **Disable confirm button while confirming**
+
+Find the confirm button in the template and update:
+
+```html
+<button @click="confirmCheckIn"
+  :disabled="confirming"
+  class="flex-1 py-2 para-chip type-label text-white transition-all disabled:opacity-50"
+  style="background:rgba(255,255,255,0.12);box-shadow:0 0 12px var(--accent-subtle)"
+>
+  <i class="pi pi-check mr-1.5 text-xs"></i> Confirm
+</button>
+```
+
+- [ ] **Send cancel preview when dialog closes in `confirm` phase**
+
+Find the close button in the check-in dialog header (the `×` button) and update its handler:
+
+```html
+<button v-if="checkinConfirm.phase !== 'generating'" @click="closeCheckinDialog"
+  class="p-1 text-content-muted hover:text-content-primary transition-colors">
+  <i class="pi pi-times text-sm" />
+</button>
+```
+
+Add `closeCheckinDialog` near the other checkin functions:
+
+```js
+const closeCheckinDialog = () => {
+  if (checkinConfirm.value.phase === 'confirm' && checkinConfirm.value.participant) {
+    sendCheckinPreview(eventName.value, {
+      participantId: checkinConfirm.value.participant.participantId,
+      cancelled: true
+    })
+  }
+  checkinConfirm.value.show = false
+}
+```
+
+Also update the backdrop click handler to use `closeCheckinDialog`:
+
+```html
+@click="checkinConfirm.phase !== 'generating' && closeCheckinDialog()"
+```
+
+- [ ] **Commit**
+
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "feat: double-confirm guard, 409 error state, cancel preview on dialog close"
+```
+
+---
+
+## Task 4: AuditionNumber.vue — multi-slot refactor
+
+**Files:**
+- Modify: `BES-frontend/src/views/AuditionNumber.vue`
+
+This is a full rewrite of the `<script setup>` logic and template. Work through it section by section.
+
+- [ ] **Replace all state declarations**
+
+Remove the old `currentPerson`, `auditionQueue`, `queueRunning`, `fakeNums`, `rollingIntervals` declarations and replace with:
+
+```js
+// Each slot: { slotId, person, queue, running }
+// slotId = String(participantId ?? name)
+const activeSlots = ref([])
+const history = ref([])
+const revealingRef = ref(null)
+
+// Keyed by `${slotId}-${genreName}` to allow parallel animations across slots
+const fakeNums = ref({})
+const rollingIntervals = {}
+
+const modalTitle = ref('')
+const modalMessage = ref('')
+const showModal = ref(false)
+
+const wsClients = []
+```
+
+- [ ] **Replace all helper functions**
+
+Remove `flushCurrentToHistory`, `startRolling`, `stopRolling`, `processNextInQueue`, `animateAuditionNumber` and add:
+
+```js
+const slotKey = (participantId, name) => String(participantId ?? name)
+
+const flushSlotToHistory = (slotId) => {
+  const idx = activeSlots.value.findIndex(s => s.slotId === slotId)
+  if (idx === -1) return
+  const slot = activeSlots.value[idx]
+  history.value.unshift({ ...slot.person })
+  activeSlots.value.splice(idx, 1)
+}
+
+function startRolling(slotId, genreName) {
+  const key = `${slotId}-${genreName}`
+  clearInterval(rollingIntervals[key])
+  rollingIntervals[key] = setInterval(() => {
+    fakeNums.value = { ...fakeNums.value, [key]: Math.floor(Math.random() * 99) + 1 }
+  }, 80)
+}
+
+function stopRolling(slotId, genreName) {
+  const key = `${slotId}-${genreName}`
+  clearInterval(rollingIntervals[key])
+  delete rollingIntervals[key]
+  const next = { ...fakeNums.value }
+  delete next[key]
+  fakeNums.value = next
+}
+
+function checkSlotComplete(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
+  const allDone = slot.person.genres.every(g => g.auditionNumber !== null)
+  if (allDone && slot.queue.length === 0) {
+    setTimeout(() => flushSlotToHistory(slotId), 1500)
+  }
+}
+
+function processSlotQueue(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot || slot.queue.length === 0) {
+    if (slot) slot.running = false
+    checkSlotComplete(slotId)
+    return
+  }
+  slot.running = true
+  const msg = slot.queue.shift()
+  animateSlot(slotId, msg)
+}
+
+function animateSlot(slotId, msg) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
+
+  if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+
+  let genre = slot.person.genres.find(g => g.genreName === msg.genre)
+  if (!genre) {
+    genre = { genreName: msg.genre, auditionNumber: null, rolling: false }
+    slot.person.genres.push(genre)
+  }
+
+  genre.rolling = true
+  startRolling(slotId, msg.genre)
+  setTimeout(() => {
+    stopRolling(slotId, msg.genre)
+    const s = activeSlots.value.find(s => s.slotId === slotId)
+    const g = s?.person.genres.find(g => g.genreName === msg.genre)
+    if (g) { g.rolling = false; g.auditionNumber = msg.auditionNumber }
+    processSlotQueue(slotId)
+  }, 2000)
+}
+```
+
+- [ ] **Replace WS handlers**
+
+Remove `isSamePerson`, `onPreview`, `onReceiveAuditionNumber` and replace with:
+
+```js
+const isSamePerson = (slot, msg) => {
+  if (!slot || !msg) return false
+  const sid = slot.person.participantId
+  const mid = msg.participantId
+  return (sid != null && mid != null) ? sid === mid : slot.person.name === msg.name
+}
+
+const findSlot = (msg) =>
+  activeSlots.value.find(s => isSamePerson(s, msg))
+
+const onPreview = (msg) => {
+  // Cancel signal — remove the matching slot
+  if (msg.cancelled) {
+    const idx = activeSlots.value.findIndex(s => isSamePerson(s, msg))
+    if (idx !== -1) {
+      const slot = activeSlots.value[idx]
+      // Stop any running animations for this slot
+      slot.person.genres.forEach(g => stopRolling(slot.slotId, g.genreName))
+      activeSlots.value.splice(idx, 1)
+    }
+    return
+  }
+
+  const existing = findSlot(msg)
+  if (existing) {
+    // Merge new genres into existing slot without overwriting
+    if (msg.refCode && !existing.person.refCode) existing.person.refCode = msg.refCode
+    const existingNames = new Set(existing.person.genres.map(g => g.genreName))
+    for (const g of (msg.genres ?? [])) {
+      if (!existingNames.has(g.genreName)) {
+        existing.person.genres.push({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false })
+      }
+    }
+  } else {
+    // New slot
+    const slotId = slotKey(msg.participantId, msg.name)
+    activeSlots.value.push({
+      slotId,
+      person: {
+        participantId: msg.participantId ?? null,
+        name: msg.name,
+        refCode: msg.refCode ?? null,
+        memberNames: msg.memberNames ?? [],
+        genres: (msg.genres ?? []).map(g => ({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false }))
+      },
+      queue: [],
+      running: false
+    })
+  }
+}
+
+const onReceiveAuditionNumber = (msg) => {
+  const slot = findSlot(msg)
+  if (slot) {
+    // Ensure genre row exists in pending state
+    if (!slot.person.genres.find(g => g.genreName === msg.genre)) {
+      slot.person.genres.push({ genreName: msg.genre, auditionNumber: null, rolling: false })
+    }
+    if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+    slot.queue.push(msg)
+    if (!slot.running) processSlotQueue(slot.slotId)
+  } else {
+    // Late message — update history directly
+    const historyEntry = history.value.find(h =>
+      msg.participantId != null ? h.participantId === msg.participantId : h.name === msg.name
+    )
+    if (historyEntry) {
+      const hGenre = historyEntry.genres.find(g => g.genreName === msg.genre)
+      if (hGenre) hGenre.auditionNumber = msg.auditionNumber
+    }
+  }
+}
+
+const onRepeatAudition = (msg) => {
+  const judgeLabel = msg.judge ? ` · Judge: ${msg.judge}` : ''
+  modalTitle.value = `Hey ${msg.name}!`
+  modalMessage.value = `Your audition number is ${msg.genre} #${msg.audition}${judgeLabel}`
+  showModal.value = true
+}
+
+const clearHistory = () => { history.value = [] }
+```
+
+- [ ] **Update `onBeforeUnmount` to clear all slot intervals**
+
+```js
+onBeforeUnmount(() => {
+  Object.values(rollingIntervals).forEach(clearInterval)
+  wsClients.forEach(c => deactivateClient(c))
+})
+```
+
+(The keys changed but `Object.values(rollingIntervals)` still works — no change needed here.)
+
+- [ ] **Replace the entire `<template>`**
+
+```html
+<template>
+  <div class="page-container">
+    <div class="color-bleed"></div>
+
+    <!-- ── Live Previews ──────────────────────────────────────────────────── -->
+    <div class="section-rule mb-4">
+      <span class="section-rule-label">Live Previews</span>
+      <div class="section-rule-line"></div>
+    </div>
+
+    <!-- Idle state -->
+    <div v-if="activeSlots.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
+      <div class="para-chip-sm w-16 h-16 flex items-center justify-center mb-4">
+        <i class="pi pi-qrcode text-content-muted text-2xl"></i>
+      </div>
+      <p class="type-body text-content-secondary">Waiting for check-in…</p>
+      <p class="type-label text-content-muted mt-1">Check in a participant on the Event Details page</p>
+    </div>
+
+    <!-- Slot grid: up to 3 per row -->
+    <div
+      v-else
+      class="grid gap-4 mb-6"
+      :style="{ gridTemplateColumns: `repeat(${Math.min(activeSlots.length, 3)}, 1fr)` }"
+    >
+      <div
+        v-for="slot in activeSlots"
+        :key="slot.slotId"
+        class="card-hover p-4 relative"
+      >
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
+
+        <!-- Name row -->
+        <div class="flex items-start justify-between gap-3 mb-1">
+          <div class="flex-1 min-w-0">
+            <p class="type-label text-content-muted mb-1">Good Luck</p>
+            <p class="type-page-title text-content-primary leading-tight truncate" style="font-size:clamp(1.1rem,3vw,1.8rem)">
+              {{ slot.person.name }}
+            </p>
+          </div>
+          <!-- Ref code chip -->
+          <div
+            v-if="slot.person.refCode"
+            class="flex-shrink-0 para-chip-sm px-3 py-2 cursor-pointer select-none flex flex-col items-end gap-0.5"
+            @mousedown="revealingRef = slot.slotId" @mouseup="revealingRef = null" @mouseleave="revealingRef = null"
+            @touchstart="revealingRef = slot.slotId" @touchend="revealingRef = null" @touchcancel="revealingRef = null"
+          >
+            <span class="type-label text-content-muted">Ref Code</span>
+            <span v-if="revealingRef === slot.slotId" class="font-source tracking-widest text-accent" style="font-size:0.9rem;letter-spacing:0.2em">
+              {{ slot.person.refCode }}
+            </span>
+            <span v-else class="type-label text-content-muted/40">Hold to reveal</span>
+          </div>
+          <div v-else-if="slot.person.genres.some(g => g.auditionNumber === null)" class="flex-shrink-0 para-chip-sm px-2 py-1.5 flex items-center gap-1">
+            <i class="pi pi-spin pi-spinner text-content-muted text-xs"></i>
+            <span class="type-label text-content-muted">Assigning…</span>
+          </div>
+        </div>
+
+        <!-- Team members -->
+        <div v-if="slot.person.memberNames?.length" class="flex items-center gap-1.5 type-label text-content-muted mb-2">
+          <i class="pi pi-users" style="font-size:0.65rem"></i>
+          <span class="truncate">{{ slot.person.memberNames.join(' · ') }}</span>
+        </div>
+
+        <!-- Divisions -->
+        <div class="section-rule my-2">
+          <span class="section-rule-label">Divisions</span>
+          <div class="section-rule-line"></div>
+        </div>
+
+        <div class="space-y-1.5">
+          <div
+            v-for="g in slot.person.genres"
+            :key="g.genreName"
+            class="flex items-center gap-2 para-chip-sm px-2.5 py-2"
+            :style="g.auditionNumber !== null ? { borderColor: 'var(--accent-muted)', background: 'var(--accent-subtle)' } : {}"
+          >
+            <span
+              class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+              :style="g.auditionNumber !== null
+                ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
+                : g.rolling
+                  ? 'background:rgba(245,158,11,0.7);box-shadow:0 0 6px rgba(245,158,11,0.5)'
+                  : 'background:rgba(255,255,255,0.15)'"
+            ></span>
+            <span class="type-body text-content-primary flex-1 truncate">{{ g.genreName }}</span>
+            <div class="flex items-baseline gap-0.5 tabular-nums min-w-[4rem] justify-end">
+              <template v-if="g.rolling">
+                <span class="type-label text-amber-400/60 text-xs">Drawing</span>
+                <span class="type-stat text-amber-400" style="font-size:1.4rem">
+                  {{ fakeNums[`${slot.slotId}-${g.genreName}`] ?? '—' }}
+                </span>
+              </template>
+              <template v-else-if="g.auditionNumber !== null">
+                <span class="type-label text-accent/60 text-xs">#</span>
+                <span class="type-stat text-accent" style="font-size:1.4rem">{{ g.auditionNumber }}</span>
+              </template>
+              <template v-else>
+                <span class="type-stat text-content-muted/20" style="font-size:1.4rem">—</span>
+              </template>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── History ──────────────────────────────────────────────────────── -->
+    <template v-if="history.length > 0">
+      <div class="section-rule mb-3">
+        <span class="section-rule-label">History</span>
+        <div class="section-rule-line"></div>
+        <button @click="clearHistory" class="para-chip-sm px-2 py-0.5 type-label text-content-muted hover:text-content-primary transition-colors ml-3 flex-shrink-0">
+          Clear
+        </button>
+      </div>
+
+      <div class="space-y-2">
+        <div
+          v-for="(person, i) in history"
+          :key="(person.participantId ?? person.name) + i"
+          class="para-chip-sm px-3 py-2.5 flex items-center gap-3 flex-wrap"
+          :class="i === 0 ? 'border-white/15' : 'opacity-50'"
+        >
+          <span class="type-body text-content-primary shrink-0 min-w-[6rem]">{{ person.name }}</span>
+          <div class="flex flex-wrap gap-1.5 flex-1 min-w-0">
+            <span
+              v-for="g in person.genres"
+              :key="g.genreName"
+              class="inline-flex items-center gap-1 badge-neutral capitalize"
+            >
+              <span class="text-content-muted">{{ g.genreName }}</span>
+              <span class="text-accent">#{{ g.auditionNumber }}</span>
+            </span>
+          </div>
+          <span
+            v-if="person.refCode"
+            class="relative ml-auto shrink-0 inline-flex items-center gap-1.5 para-chip-sm px-2.5 py-1 type-label cursor-pointer select-none transition-colors"
+            :class="revealingRef === (person.participantId ?? person.name) + i ? 'text-accent' : 'text-content-muted hover:text-accent'"
+            @click="revealingRef = revealingRef === (person.participantId ?? person.name) + i ? null : (person.participantId ?? person.name) + i"
+          >
+            <i class="pi pi-eye" style="font-size:0.6rem"></i>
+            <template v-if="revealingRef === (person.participantId ?? person.name) + i">
+              <span class="font-source tracking-widest" style="font-size:0.75rem;letter-spacing:0.2em">{{ person.refCode }}</span>
+            </template>
+            <template v-else>Ref</template>
+          </span>
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <ActionDoneModal
+    :show="showModal"
+    :title="modalTitle"
+    variant="info"
+    @accept="() => { showModal = false }"
+    @close="() => { showModal = false }"
+  >
+    <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+  </ActionDoneModal>
+</template>
+```
+
+- [ ] **Verify the dev server starts with no errors**
+
+```bash
+cd BES-frontend && npm run dev
+```
+
+Open `http://localhost:5173/event/audition-number` — should show "Waiting for check-in…" idle state.
+
+- [ ] **Commit**
+
+```bash
+git add BES-frontend/src/views/AuditionNumber.vue
+git commit -m "feat: multi-slot parallel animation in AuditionNumber display"
+```
+
+---
+
+## Task 5: AuditionList.vue — Reset Scores access code gate
+
+**Files:**
+- Modify: `BES-frontend/src/views/AuditionList.vue`
+
+- [ ] **Add access code gate state near the other modal refs (around line 30)**
+
+```js
+const resetConfirmCode = ref('')
+const resetCodeError = ref('')
+const resetCodeChecking = ref(false)
+```
+
+- [ ] **Replace `confirmReset` to use the two-step gate**
+
+Find `confirmReset` (around line 87) and replace:
+
+```js
+const confirmReset = (title, message) => {
+  resetConfirmCode.value = ''
+  resetCodeError.value = ''
+  modalTitle.value = title
+  modalMessage.value = message
+  modalVariant.value = 'warning'
+  showModal.value = true
+  // dynamicCallBack now handles code validation before reset
+  dynamicCallBack.value = async () => {
+    if (!resetConfirmCode.value.trim()) {
+      resetCodeError.value = 'Enter the event access code to confirm.'
+      return
+    }
+    const activeEvent = getActiveEvent()
+    if (!activeEvent?.id) {
+      resetCodeError.value = 'Could not resolve event ID.'
+      return
+    }
+    resetCodeChecking.value = true
+    try {
+      const res = await verifyEventAccessCode(activeEvent.id, resetConfirmCode.value.trim())
+      if (!res?.valid) {
+        resetCodeError.value = 'Incorrect access code.'
+        resetCodeChecking.value = false
+        return
+      }
+    } catch {
+      resetCodeError.value = 'Could not verify access code.'
+      resetCodeChecking.value = false
+      return
+    }
+    resetCodeChecking.value = false
+    showModal.value = false
+    await resetScore()
+  }
+}
+```
+
+- [ ] **Add `verifyEventAccessCode` and `getActiveEvent` to the imports at the top of the file**
+
+Find the existing import line and add `verifyEventAccessCode`:
+
+```js
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, verifyEventAccessCode } from '@/utils/api';
+```
+
+And add `getActiveEvent` to the auth import:
+
+```js
+import { getActiveEvent } from '@/utils/auth';
+```
+
+- [ ] **Add the access code input to `ActionDoneModal` in the template**
+
+Find the `ActionDoneModal` at the bottom of the template (around line 862) and replace it:
+
+```html
+<ActionDoneModal
+  :show="showModal"
+  :title="modalTitle"
+  :variant="modalVariant"
+  @accept="() => { dynamicCallBack() }"
+  @close="() => { showModal = false; resetCodeError = '' }"
+>
+  <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+  <!-- Access code gate — only shown for reset (warning variant) -->
+  <template v-if="modalVariant === 'warning'">
+    <div class="mt-4 space-y-2">
+      <label class="type-label text-content-muted">Event Access Code</label>
+      <input
+        v-model="resetConfirmCode"
+        type="text"
+        placeholder="Enter access code…"
+        class="input-base w-full"
+        @keyup.enter="dynamicCallBack()"
+      />
+      <p v-if="resetCodeError" class="type-label text-red-400">{{ resetCodeError }}</p>
+      <p v-if="resetCodeChecking" class="type-label text-content-muted">Verifying…</p>
+    </div>
+  </template>
+</ActionDoneModal>
+```
+
+- [ ] **Verify the reset flow in the browser**
+
+Start the dev server, navigate to `/event/audition-list`, select Judge role and a genre. Click Reset — the modal should now show the access code input. Entering the wrong code should show an error. Entering the correct code should execute the reset.
+
+- [ ] **Commit**
+
+```bash
+git add BES-frontend/src/views/AuditionList.vue
+git commit -m "feat: require access code before Reset Scores executes"
+```
+
+---
+
+## Task 6: Full build verification
+
+- [ ] **Build the backend**
+
+```bash
+cd BES && mvn clean package -DskipTests
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Build the frontend**
+
+```bash
+cd BES-frontend && npm run build
+```
+
+Expected: no errors, `dist/` generated
+
+- [ ] **Run frontend linter**
+
+```bash
+cd BES-frontend && npm run lint 2>/dev/null || npx eslint src/views/AuditionNumber.vue src/views/EventDetails.vue src/views/AuditionList.vue
+```
+
+Expected: no errors
+
+- [ ] **Final commit if any lint fixes were made, then push**
+
+```bash
+git add -A
+git status  # confirm only expected files
+git commit -m "chore: lint fixes for checkin-concurrency changes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|-----------------|------|
+| 409 duplicate check-in guard | Task 2 |
+| Cancel signal via `cancelled: true` on existing topic | Tasks 1, 3 |
+| Multi-slot grid (3-per-row) | Task 4 |
+| Per-slot independent animation queue | Task 4 |
+| `fakeNums`/`rollingIntervals` keyed by `slotId-genreName` | Task 4 |
+| Preview fires on dialog open (unchanged) | Task 3 (no change to `askCheckIn`) |
+| Cancel on dialog close (confirm phase only) | Task 3 |
+| Double-confirm guard | Task 3 |
+| Reset Scores access code gate | Task 5 |
+| `/topic/audition/` message format unchanged | Task 4 (only internal processing changed) |
+| `EventDetails`, `AuditionList`, `AuditionAdjust` unaffected | Tasks 1–3 only touch their own files |
+
+**No placeholders:** All code blocks are complete and runnable.
+
+**Type consistency:** `slotId` is always `String(participantId ?? name)` via `slotKey()`. `fakeNums` and `rollingIntervals` keys are always `${slotId}-${genreName}`. `flushSlotToHistory` takes `slotId` string throughout.

--- a/docs/superpowers/specs/2026-06-02-checkin-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-02-checkin-concurrency-design.md
@@ -1,0 +1,180 @@
+# Check-in Concurrency & Display Design
+
+**Date:** 2026-06-02
+**Branch:** `fix/checkin-concurrency`
+**Scope:** EventDetails.vue check-in flow · AuditionNumber.vue display · AuditionList.vue reset gate
+
+---
+
+## Problem
+
+3–4 operators run the check-in desk simultaneously. Several race conditions exist:
+
+1. **Double check-in** — stale list (30s poll) lets two operators check in the same person. Backend has no duplicate guard.
+2. **Preview-then-cancel stuck** — `sendCheckinPreview` fires on dialog open (not confirm). Cancelling leaves AuditionNumber permanently showing a ghost preview with no numbers.
+3. **Serial animation blocks concurrent check-ins** — the global `auditionQueue` processes one genre animation at a time across all participants. Two simultaneous confirmations queue serially instead of animating in parallel.
+4. **AuditionNumber single-slot design** — new person's preview immediately flushes current person to history, losing their animation if their numbers haven't arrived yet.
+5. **Reset Scores too easy to trigger accidentally** — no friction before wiping all judge scores for a genre.
+6. **Double-confirm** — confirm button has no debounce; rapid double-tap fires two check-in requests.
+
+---
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| 1 | Backend returns **409** if participant already has all audition numbers assigned. Frontend shows "Already checked in at another desk." |
+| 2 | Preview fires **on dialog open** (existing behaviour kept) — important for the display screen to show the person before the number is generated. Cancel sends an explicit cancel signal. |
+| 3 | AuditionNumber moves to a **multi-slot grid** — up to 3 slots per row, wrapping to a second row. Each slot is independent. |
+| 4 | Each slot has its **own animation queue** — parallel animations across slots. `fakeNums` and `rollingIntervals` keyed by `slotId-genreName` to avoid collision when two slots share the same genre name. |
+| 5 | Cancel sends a WS cancel signal on the **existing `/topic/checkin-preview/`** channel with `cancelled: true`. Only `AuditionNumber.vue` subscribes to this channel — no other consumers affected. |
+| 6 | Reset Scores requires **re-entering the event access code** before executing. |
+| 7 | Confirm button **disabled after first click**, re-enabled only on error response. |
+
+---
+
+## Architecture
+
+### AuditionNumber.vue — multi-slot state model
+
+Replace `currentPerson` (single ref) with `activeSlots` (array):
+
+```js
+// Before
+const currentPerson = ref(null)
+const auditionQueue = []       // global, serial
+let queueRunning = false
+const fakeNums = ref({})       // keyed by genreName
+const rollingIntervals = {}    // keyed by genreName
+
+// After
+const activeSlots = ref([])
+// Each slot: {
+//   slotId,          // participantId (or name fallback)
+//   person,          // { participantId, name, refCode, memberNames, genres[] }
+//   queue: [],       // per-slot pending number messages
+//   running: false,  // per-slot animation flag
+// }
+const fakeNums = ref({})       // keyed by `${slotId}-${genreName}`
+const rollingIntervals = {}    // keyed by `${slotId}-${genreName}`
+```
+
+`history` stays unchanged — completed slots move to history exactly as before.
+
+### WS message handling (AuditionNumber.vue only)
+
+**`/topic/checkin-preview/` → `onPreview(msg)`**
+
+```
+if msg.cancelled:
+  remove slot matching msg.participantId → done
+
+if slot exists for msg.participantId:
+  merge new genres into existing slot (same-person duplicate preview)
+else:
+  add new slot to activeSlots
+```
+
+No flushing, no queue clearing. Each slot is created/removed independently.
+
+**`/topic/audition/` → `onReceiveAuditionNumber(msg)`**
+
+```
+find slot matching msg.participantId:
+  if found:
+    push msg to slot.queue
+    if !slot.running: processSlotQueue(slotId)
+  else:
+    check history → patch directly (late message, no animation)
+```
+
+`processSlotQueue(slotId)` runs the 2-second slot-machine animation using `fakeNums[slotId-genre]` and `rollingIntervals[slotId-genre]`. When slot's queue empties and all genres have numbers, move slot to history after a short pause (1.5s so the audience sees the final numbers).
+
+### Channel safety — `/topic/audition/` subscribers
+
+The message format broadcast on `/topic/audition/` does **not change**. Only `AuditionNumber.vue`'s internal processing logic changes. The other three subscribers are unaffected:
+
+| File | What it does with `/topic/audition/` | Impact |
+|------|--------------------------------------|--------|
+| `EventDetails.vue` | Patches `checkinList[participant].genre.auditionNumber` | None |
+| `AuditionList.vue` | Adds/updates participant rows | None |
+| `AuditionAdjust.vue` | Patches `checkinList` via `applyAuditionMsg` | None |
+
+### Cancel signal — backend
+
+Extend the existing `POST /api/v1/event/{eventName}/checkin-preview` endpoint — add an optional `cancelled` boolean to the request body:
+
+```json
+{ "participantId": 123, "cancelled": true }
+```
+
+Backend checks `cancelled` and broadcasts the same payload on `/topic/checkin-preview/`. No new route needed.
+
+`AuditionNumber.vue` checks `msg.cancelled` first in `onPreview` before any other logic — if true, remove the matching slot and return.
+
+**EventDetails.vue:** call `sendCheckinPreview(eventName, { participantId, cancelled: true })` when the confirm dialog closes while still in `confirm` phase (not `generating`, not `done`). No call needed if the dialog closes after confirming — the slot moves to history naturally once numbers arrive.
+
+### Backend — duplicate check-in guard
+
+In the service method called by `GET /api/v1/event/register-participant/{participantId}/{eventId}`:
+
+- Before assigning numbers, check if all `EventGenreParticipant` rows for this participant+event already have `auditionNumber != null`.
+- If yes → return `409 Conflict` with body `"already_checked_in"`.
+- Frontend `checkIn()` catches 409 → sets `checkinConfirm.phase = 'error'` → shows "Already checked in at another desk." with a close button.
+
+### EventDetails.vue — double-confirm guard
+
+```js
+// confirmCheckIn()
+const confirmCheckIn = async () => {
+  if (confirming.value) return   // guard
+  confirming.value = true
+  try {
+    // ... existing logic
+  } finally {
+    confirming.value = false
+  }
+}
+```
+
+Confirm button: `:disabled="checkinConfirm.phase !== 'confirm' || confirming"`.
+
+### AuditionList.vue — Reset Scores gate
+
+Replace the current single-confirm modal with a two-step flow:
+
+1. Operator clicks Reset → warning modal appears explaining consequences.
+2. Modal shows an input: "Enter event access code to confirm".
+3. Frontend calls existing `GET /api/v1/event/{eventName}` (or a dedicated endpoint) to validate the access code.
+4. Only on match → execute `resetJudgeScores` + `resetJudgeFeedback`.
+
+The access code is already stored on the `Event` entity and visible to organisers on EventDetails. No new data model needed.
+
+---
+
+## Grid layout (AuditionNumber.vue template)
+
+```
+1 slot  → single full-width card
+2 slots → 2-column grid
+3 slots → 3-column grid
+4 slots → 3-column grid (row 1: 3, row 2: 1)
+5 slots → 3-column grid (row 1: 3, row 2: 2)
+```
+
+CSS: `grid-template-columns: repeat(min(activeSlots.length, 3), 1fr)` — Vue computed from slot count.
+
+Each slot card shows: operator tag · status dot (pending amber / rolling amber-pulse / done white) · participant name · member names · per-genre rows with number area.
+
+Slot auto-moves to history after animation completes + 1.5s display pause.
+
+---
+
+## What does NOT change
+
+- `/topic/audition/` message format — untouched
+- `/topic/checkin-preview/` message format for normal previews — untouched (cancel adds a new optional field)
+- `history` display in AuditionNumber — untouched
+- `onRepeatAudition` (`/topic/error/`) — untouched
+- All other EventDetails functionality (walk-in, genre adjust, payment verify, etc.)
+- AuditionList scoring, feedback, and emcee view


### PR DESCRIPTION
## Summary

- **409 duplicate guard** — backend returns 409 if participant already has all audition numbers assigned; frontend shows "Already checked in at another desk" instead of silently re-assigning
- **AuditionNumber multi-slot refactor** — replaces single `currentPerson` + global serial queue with `activeSlots` array; each slot owns its own queue and animation state, keyed by `slotId-genreName` to prevent interval collision; up to 3 slots animate in parallel in a CSS grid
- **Cancel preview signal** — closing the check-in dialog in confirm phase broadcasts `{ cancelled: true }` on `/topic/checkin-preview/`; AuditionNumber removes only the matching slot; other slots unaffected
- **Double-confirm guard** — confirm button disabled after first click, re-enabled only on error response
- **Real-time operator button lock** — EventDetails subscribes to `/topic/checkin-preview/`; button shows "In Preview" + disabled while any operator has that participant's dialog open; clears on cancel or when audition numbers arrive
- **Preview persistence on refresh** — `CheckinPreviewService` (in-memory ConcurrentHashMap) tracks active previews per event; new `GET /{eventName}/checkin-preview` endpoint hydrates `previewingIds` on mount so late-joining/refreshed clients see current state
- **Reset Scores access code gate** — AuditionList requires event access code re-entry before `resetJudgeScores` + `resetJudgeFeedback` execute
- **WebSocket subscription bug fix** — `subscribeToChannel` was overwriting `onConnect` on each call; only the last-registered subscription actually fired. Fixed by chaining handlers, so all subscriptions on a shared client now work

## Files changed
- `BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java` — add `cancelled` field
- `BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java` — 409 duplicate guard
- `BES/src/main/java/com/example/BES/services/CheckinPreviewService.java` — new in-memory preview tracker
- `BES/src/main/java/com/example/BES/services/EventService.java` — `getEventNameById` helper
- `BES/src/main/java/com/example/BES/controllers/EventController.java` — 409 handler, preview state management, GET endpoint
- `BES-frontend/src/utils/websocket.js` — fix `onConnect` chain bug
- `BES-frontend/src/utils/api.js` — add `getCheckinPreviews`
- `BES-frontend/src/views/AuditionNumber.vue` — full multi-slot refactor
- `BES-frontend/src/views/EventDetails.vue` — double-confirm, cancel preview, 409 error state, real-time lock, preview hydration
- `BES-frontend/src/views/AuditionList.vue` — Reset Scores access code gate

## Test plan
- [ ] Two operators open check-in dialog for same participant simultaneously → second gets 409 error
- [ ] Operator opens dialog → other operator's button shows "In Preview" immediately (no refresh)
- [ ] Operator cancels → other operator's button re-enables immediately
- [ ] Operator refreshes while another has dialog open → button still shows "In Preview"
- [ ] Two operators check in different participants → AuditionNumber shows 2 side-by-side cards animating in parallel
- [ ] Rapid double-tap confirm → only one check-in request fires
- [ ] Reset Scores with wrong code → blocked with error message; correct code → executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)