### PR TITLE
feat: battle division state persistence (issue #42)

### DIFF
--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1145,6 +1145,14 @@ export const sendCheckinPreview = async (eventName, previewData) => {
   }
 }
 
+export const getCheckinPreviews = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${eventName}/checkin-preview`, { credentials: 'include' })
+    if (res.ok) return await res.json()
+    return []
+  } catch { return [] }
+}
+
 export const getBattleGuests = async (eventName) => {
   try {
     return await fetch(`${domain}/api/v1/event/battle-guests/${encodeURIComponent(eventName)}`, {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -497,6 +497,19 @@ export const setBattlePair = async(leftBattler, rightBattler, isFinal = false, l
   }
 }
 
+export const clearBattlePair = async () => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/battle-pair`, {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json' }
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
 export const setBattleScore = async (isFinal = false) => {
   try {
     return await fetch(`${domain}/api/v1/battle/score`, {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -538,6 +538,19 @@ export const revealChampion = async (genreName, championName) => {
   }
 }
 
+export const getBattleChampions = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/champions?event=${encodeURIComponent(eventName)}`, {
+      credentials: 'include',
+      headers: { 'Accept': 'application/json' }
+    })
+    return res.ok ? res.json() : {}
+  } catch (e) {
+    console.log(e)
+    return {}
+  }
+}
+
 export const dismissChampionReveal = async () => {
   try {
     return await fetch(`${domain}/api/v1/battle/champion-reveal`, {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -552,13 +552,13 @@ export const dismissChampionReveal = async () => {
   }
 }
 
-export const setBracketState = async (rounds, topSize) => {
+export const setBracketState = async (rounds, topSize, currentRoundIndex = 0) => {
   try {
     return await fetch(`${domain}/api/v1/battle/bracket`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rounds, topSize: String(topSize) })
+      body: JSON.stringify({ rounds, topSize: String(topSize), currentRoundIndex })
     })
   } catch (e) { console.error(e) }
 }
@@ -566,6 +566,31 @@ export const setBracketState = async (rounds, topSize) => {
 export const getBracketState = async () => {
   try {
     const res = await fetch(`${domain}/api/v1/battle/bracket`, { credentials: 'include' })
+    return res.ok ? await res.json() : null
+  } catch (_e) { return null }
+}
+
+export const setActiveGenre = async (eventName, genreName) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/active-genre`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventName, genreName })
+    })
+  } catch (e) { console.error(e) }
+}
+
+export const getActiveGenre = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/active-genre`, { credentials: 'include' })
+    return res.ok ? await res.json() : null
+  } catch (_e) { return null }
+}
+
+export const getBattleState = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/state`, { credentials: 'include' })
     return res.ok ? await res.json() : null
   } catch (_e) { return null }
 }

--- a/BES-frontend/src/utils/battleLogic.js
+++ b/BES-frontend/src/utils/battleLogic.js
@@ -2,7 +2,7 @@ import { ref, computed } from "vue"
 
 export function useBattleLogic(){
     const rounds = ref({})
-    const topSize = ref(localStorage.getItem("topSize") || "16")
+    const topSize = ref(Number(localStorage.getItem("topSize")) || 16)
 
     const roundSizes = computed(()=>{
         const arr = []

--- a/BES-frontend/src/utils/websocket.js
+++ b/BES-frontend/src/utils/websocket.js
@@ -10,18 +10,21 @@ export const createClient = () =>{
     })
 }
 export const subscribeToChannel = (client, topic, callback) =>{
-    if(!client.connected){
-        client.onConnect = ()=>{
-            client.subscribe(topic, (msg) =>{
-                callback(JSON.parse(msg.body))
-            })
-        }
-    }else{
-        client.subscribe(topic, (msg)=>{
+    const doSubscribe = () => {
+        client.subscribe(topic, (msg) => {
             callback(JSON.parse(msg.body))
         })
     }
-    client.activate()
+    if(!client.connected){
+        const prev = client.onConnect
+        client.onConnect = () => {
+            if (prev) prev()
+            doSubscribe()
+        }
+    }else{
+        doSubscribe()
+    }
+    if (!client.active) client.activate()
 }
 
 export const deactivateClient = (client) =>{

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback } from '@/utils/api';
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, verifyEventAccessCode } from '@/utils/api';
 import { getFeedbackGroups } from '@/utils/adminApi';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
@@ -33,6 +33,10 @@ const modalVariant = ref("info")
 const showModal = ref(false)
 const showMiniMenu = ref(false)
 const dynamicCallBack = ref(() => {})
+
+const resetConfirmCode = ref("")
+const resetCodeError = ref("")
+const resetCodeChecking = ref(false)
 
 const dynamicRole = async () => {
   const res = await whoami()
@@ -85,11 +89,35 @@ const openModal = (title, message, variant = 'info') => {
 }
 
 const confirmReset = (title, message) => {
+  resetConfirmCode.value = ""
+  resetCodeError.value = ""
+  resetCodeChecking.value = false
   modalTitle.value = title
   modalMessage.value = message
   modalVariant.value = 'warning'
   showModal.value = true
-  dynamicCallBack.value = async () => { showModal.value = false; await resetScore(); }
+  dynamicCallBack.value = async () => {
+    if (!resetConfirmCode.value.trim()) {
+      resetCodeError.value = "Enter the event access code to confirm."
+      return
+    }
+    resetCodeChecking.value = true
+    resetCodeError.value = ""
+    const activeEvent = getActiveEvent()
+    if (!activeEvent) {
+      resetCodeError.value = "No active event found."
+      resetCodeChecking.value = false
+      return
+    }
+    const result = await verifyEventAccessCode(activeEvent.id, resetConfirmCode.value.trim())
+    resetCodeChecking.value = false
+    if (result?.valid) {
+      showModal.value = false
+      await resetScore()
+    } else {
+      resetCodeError.value = "Incorrect access code."
+    }
+  }
 }
 
 const switchGenre = (g) => {
@@ -867,6 +895,21 @@ onMounted(async () => {
     @close="() => { showModal = false }"
   >
     <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+    <template v-if="modalVariant === 'warning'">
+      <div class="mt-4">
+        <input
+          v-model="resetConfirmCode"
+          type="text"
+          placeholder="Enter access code"
+          class="w-full px-3 py-2 type-body bg-surface-800 border border-surface-600 text-content-primary outline-none transition-colors"
+          style="clip-path:polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
+          :disabled="resetCodeChecking"
+          @keyup.enter="dynamicCallBack()"
+        />
+        <p v-if="resetCodeChecking" class="type-label text-accent mt-2">Verifying…</p>
+        <p v-if="resetCodeError" class="type-label text-red-400 mt-2">{{ resetCodeError }}</p>
+      </div>
+    </template>
   </ActionDoneModal>
 
   <FeedbackPopout

--- a/BES-frontend/src/views/AuditionNumber.vue
+++ b/BES-frontend/src/views/AuditionNumber.vue
@@ -4,19 +4,17 @@ import ActionDoneModal from './ActionDoneModal.vue'
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket'
 
 // ── State ──────────────────────────────────────────────────────────────────
-const currentPerson = ref(null)
-// { name, refCode, memberNames: [], genres: [{ genreName, auditionNumber, rolling }] }
+const slotKey = (participantId, name) => String(participantId ?? name)
+
+const activeSlots = ref([])
+// { slotId: string, person: { participantId, name, refCode, memberNames, genres[] }, queue: [], running: false }
 
 const history = ref([])
-const revealingRef = ref(null)
+const revealingRef = ref({})        // { [slotId | historyKey]: boolean }
 
-// Per-division slot animation
-const fakeNums = ref({})        // { [genreName]: number }
-const rollingIntervals = {}     // { [genreName]: intervalId }
-
-// Sequential animation queue — processes one division at a time
-const auditionQueue = []
-let queueRunning = false
+// Per-slot rolling animation state — keyed by "${slotId}-${genreName}"
+const fakeNums = ref({})
+const rollingIntervals = {}         // { "${slotId}-${genreName}": intervalId }
 
 const modalTitle = ref('')
 const modalMessage = ref('')
@@ -25,132 +23,143 @@ const showModal = ref(false)
 const wsClients = []
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
-const flushCurrentToHistory = () => {
-  if (currentPerson.value) {
-    // Capture any numbers still pending in the queue so history is accurate
-    const pendingNums = {}
-    auditionQueue.forEach(m => { if (isSamePerson(currentPerson.value, m)) pendingNums[m.genre] = m.auditionNumber })
-    const genres = currentPerson.value.genres.map(g => ({
-      ...g,
-      auditionNumber: g.auditionNumber ?? pendingNums[g.genreName] ?? null
-    }))
-    history.value.unshift({ ...currentPerson.value, genres })
-  }
-}
+const setReveal = (key, val) => { revealingRef.value = { ...revealingRef.value, [key]: val } }
+const toggleReveal = (key) => { revealingRef.value = { ...revealingRef.value, [key]: !revealingRef.value[key] } }
 
-function startRolling(genreName) {
-  clearInterval(rollingIntervals[genreName])
-  rollingIntervals[genreName] = setInterval(() => {
-    fakeNums.value = { ...fakeNums.value, [genreName]: Math.floor(Math.random() * 99) + 1 }
-  }, 80)
-}
-
-function stopRolling(genreName) {
-  clearInterval(rollingIntervals[genreName])
-  delete rollingIntervals[genreName]
+function stopRolling(slotId, genreName) {
+  const key = `${slotId}-${genreName}`
+  clearInterval(rollingIntervals[key])
+  delete rollingIntervals[key]
   const next = { ...fakeNums.value }
-  delete next[genreName]
+  delete next[key]
   fakeNums.value = next
 }
 
-function processNextInQueue() {
-  if (auditionQueue.length === 0) {
-    queueRunning = false
-    return
-  }
-  queueRunning = true
-  const msg = auditionQueue.shift()
-  animateAuditionNumber(msg)
+function stopAllSlotRolling(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
+  const allGenreKeys = new Set()
+  slot.person.genres.forEach(g => allGenreKeys.add(`${slotId}-${g.genreName}`))
+  allGenreKeys.forEach(k => {
+    clearInterval(rollingIntervals[k])
+    delete rollingIntervals[k]
+  })
+  const next = { ...fakeNums.value }
+  allGenreKeys.forEach(k => delete next[k])
+  fakeNums.value = next
 }
 
-function animateAuditionNumber(msg) {
-  // If person moved to history before animation ran, update history and skip animation
-  if (!isSamePerson(currentPerson.value, msg)) {
-    const historyEntry = history.value.find(h => h.name === msg.name)
-    if (historyEntry) {
-      const hGenre = historyEntry.genres.find(g => g.genreName === msg.genre)
-      if (hGenre) hGenre.auditionNumber = msg.auditionNumber
-    }
-    processNextInQueue()
-    return
+const flushSlotToHistory = (slotId) => {
+  const idx = activeSlots.value.findIndex(s => s.slotId === slotId)
+  if (idx !== -1) {
+    history.value.unshift({ ...activeSlots.value[idx].person })
+    activeSlots.value.splice(idx, 1)
   }
+}
 
-  // Update refCode once we have it
-  if (msg.refCode && !currentPerson.value.refCode) {
-    currentPerson.value.refCode = msg.refCode
-  }
+function animateSlot(slotId, msg) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
 
-  // Find or create the genre entry (auditionNumber stays null until animation reveals it)
-  let genre = currentPerson.value.genres.find(g => g.genreName === msg.genre)
+  if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+
+  let genre = slot.person.genres.find(g => g.genreName === msg.genre)
   if (!genre) {
     genre = { genreName: msg.genre, auditionNumber: null, rolling: false }
-    currentPerson.value.genres.push(genre)
+    slot.person.genres.push(genre)
   }
 
-  // Slot animation — reveal the number only when animation finishes (no spoiler)
   genre.rolling = true
-  startRolling(msg.genre)
+  const intervalKey = `${slotId}-${msg.genre}`
+  clearInterval(rollingIntervals[intervalKey])
+  rollingIntervals[intervalKey] = setInterval(() => {
+    fakeNums.value = { ...fakeNums.value, [intervalKey]: Math.floor(Math.random() * 99) + 1 }
+  }, 80)
+
   setTimeout(() => {
-    stopRolling(msg.genre)
-    const g = currentPerson.value?.genres.find(g => g.genreName === msg.genre)
-    if (g) {
-      g.rolling = false
-      g.auditionNumber = msg.auditionNumber
+    stopRolling(slotId, msg.genre)
+    const currentSlot = activeSlots.value.find(s => s.slotId === slotId)
+    if (currentSlot) {
+      const g = currentSlot.person.genres.find(g => g.genreName === msg.genre)
+      if (g) {
+        g.rolling = false
+        g.auditionNumber = msg.auditionNumber
+      }
     }
-    processNextInQueue()
+    processSlotQueue(slotId)
   }, 2000)
 }
 
-// ── WS Handlers ─────────────────────────────────────────────────────────────
-const isSamePerson = (a, b) =>
-  a && b && (a.participantId != null && b.participantId != null
-    ? a.participantId === b.participantId
-    : a.name === b.name)
+function processSlotQueue(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
 
+  if (slot.queue.length === 0) {
+    slot.running = false
+    if (slot.person.genres.every(g => g.auditionNumber !== null)) {
+      setTimeout(() => flushSlotToHistory(slotId), 1500)
+    }
+    return
+  }
+
+  slot.running = true
+  const msg = slot.queue.shift()
+  animateSlot(slotId, msg)
+}
+
+// ── WS Handlers ─────────────────────────────────────────────────────────────
 const onPreview = (msg) => {
-  if (isSamePerson(currentPerson.value, msg)) {
-    // Same person — merge any new genres without overwriting existing
-    if (msg.refCode && !currentPerson.value.refCode) currentPerson.value.refCode = msg.refCode
-    const existing = new Set(currentPerson.value.genres.map(g => g.genreName))
+  if (msg.cancelled) {
+    const id = slotKey(msg.participantId, msg.name)
+    const idx = activeSlots.value.findIndex(s => s.slotId === id)
+    if (idx !== -1) {
+      stopAllSlotRolling(id)
+      activeSlots.value.splice(idx, 1)
+    }
+    return
+  }
+
+  const id = slotKey(msg.participantId, msg.name)
+  const existing = activeSlots.value.find(s => s.slotId === id)
+  if (existing) {
+    if (msg.refCode && !existing.person.refCode) existing.person.refCode = msg.refCode
+    const existingGenres = new Set(existing.person.genres.map(g => g.genreName))
     for (const g of (msg.genres ?? [])) {
-      if (!existing.has(g.genreName)) {
-        currentPerson.value.genres.push({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false })
+      if (!existingGenres.has(g.genreName)) {
+        existing.person.genres.push({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false })
       }
     }
   } else {
-    // Different person — discard pending animations and flush current to history
-    if (currentPerson.value) {
-      auditionQueue.length = 0
-      flushCurrentToHistory()
-    }
-    currentPerson.value = {
-      participantId: msg.participantId ?? null,
-      name: msg.name,
-      refCode: msg.refCode ?? null,
-      memberNames: msg.memberNames ?? [],
-      genres: (msg.genres ?? []).map(g => ({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false }))
-    }
+    activeSlots.value.push({
+      slotId: id,
+      person: {
+        participantId: msg.participantId ?? null,
+        name: msg.name,
+        refCode: msg.refCode ?? null,
+        memberNames: msg.memberNames ?? [],
+        genres: (msg.genres ?? []).map(g => ({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false }))
+      },
+      queue: [],
+      running: false
+    })
   }
 }
 
 const onReceiveAuditionNumber = (msg) => {
-  if (isSamePerson(currentPerson.value, msg)) {
-    // Ensure genre row exists (pending state) — number revealed only after animation
-    if (!currentPerson.value.genres.find(g => g.genreName === msg.genre)) {
-      currentPerson.value.genres.push({ genreName: msg.genre, auditionNumber: null, rolling: false })
+  const id = slotKey(msg.participantId, msg.name)
+  const slot = activeSlots.value.find(s => s.slotId === id)
+  if (slot) {
+    if (!slot.person.genres.find(g => g.genreName === msg.genre)) {
+      slot.person.genres.push({ genreName: msg.genre, auditionNumber: null, rolling: false })
     }
-    if (msg.refCode && !currentPerson.value.refCode) currentPerson.value.refCode = msg.refCode
-    auditionQueue.push(msg)
-    if (!queueRunning) processNextInQueue()
+    if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+    slot.queue.push(msg)
+    if (!slot.running) processSlotQueue(id)
   } else {
-    // Late message — update history directly, no animation
-    const historyEntry = history.value.find(h => h.name === msg.name)
+    const historyEntry = history.value.find(h => slotKey(h.participantId, h.name) === id)
     if (historyEntry) {
       const hGenre = historyEntry.genres.find(g => g.genreName === msg.genre)
       if (hGenre) hGenre.auditionNumber = msg.auditionNumber
-    } else {
-      auditionQueue.push(msg)
-      if (!queueRunning) processNextInQueue()
     }
   }
 }
@@ -183,14 +192,14 @@ onBeforeUnmount(() => {
   <div class="page-container">
     <div class="color-bleed"></div>
 
-    <!-- ── Current Participant ─────────────────────────────────────────── -->
+    <!-- ── Current Participants ────────────────────────────────────────── -->
     <div class="section-rule mb-4">
       <span class="section-rule-label">Current Participant</span>
       <div class="section-rule-line"></div>
     </div>
 
     <!-- Idle state -->
-    <div v-if="!currentPerson" class="flex flex-col items-center justify-center py-16 text-center">
+    <div v-if="activeSlots.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
       <div class="para-chip-sm w-16 h-16 flex items-center justify-center mb-4">
         <i class="pi pi-qrcode text-content-muted text-2xl"></i>
       </div>
@@ -198,88 +207,98 @@ onBeforeUnmount(() => {
       <p class="type-label text-content-muted mt-1">Check in a participant on the Event Details page</p>
     </div>
 
-    <!-- Active participant card -->
-    <div v-else class="card-hover p-5 relative mb-6">
-      <div class="corner-bar-tl"></div>
-      <div class="corner-bar-bl"></div>
+    <!-- Active slots grid -->
+    <div
+      v-else
+      class="grid gap-4 mb-6"
+      :style="{ gridTemplateColumns: `repeat(${Math.min(activeSlots.length, 3)}, 1fr)` }"
+    >
+      <div
+        v-for="slot in activeSlots"
+        :key="slot.slotId"
+        class="card-hover p-5 relative"
+      >
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
 
-      <!-- Name row -->
-      <div class="flex items-start justify-between gap-4 mb-1">
-        <div class="flex-1 min-w-0">
-          <p class="type-label text-content-muted mb-1">Good Luck</p>
-          <p class="type-page-title text-content-primary leading-tight" style="font-size:clamp(1.4rem,4vw,2.2rem)">
-            {{ currentPerson.name }}
-          </p>
+        <!-- Name row -->
+        <div class="flex items-start justify-between gap-4 mb-1">
+          <div class="flex-1 min-w-0">
+            <p class="type-label text-content-muted mb-1">Good Luck</p>
+            <p class="type-page-title text-content-primary leading-tight" style="font-size:clamp(1.4rem,4vw,2.2rem)">
+              {{ slot.person.name }}
+            </p>
+          </div>
+          <!-- Ref code chip (hold to reveal) -->
+          <div
+            v-if="slot.person.refCode"
+            class="flex-shrink-0 para-chip-sm px-3 py-2 cursor-pointer select-none flex flex-col items-end gap-0.5"
+            @mousedown="setReveal(slot.slotId, true)" @mouseup="setReveal(slot.slotId, false)" @mouseleave="setReveal(slot.slotId, false)"
+            @touchstart="setReveal(slot.slotId, true)" @touchend="setReveal(slot.slotId, false)" @touchcancel="setReveal(slot.slotId, false)"
+          >
+            <span class="type-label text-content-muted">Ref Code</span>
+            <span v-if="revealingRef[slot.slotId]" class="font-source tracking-widest text-accent" style="font-size:1rem;letter-spacing:0.2em">
+              {{ slot.person.refCode }}
+            </span>
+            <span v-else class="type-label text-content-muted/40">Hold to reveal</span>
+          </div>
+          <div v-else-if="slot.person.genres.some(g => g.auditionNumber === null)" class="flex-shrink-0 para-chip-sm px-3 py-2 flex items-center gap-1.5">
+            <i class="pi pi-spin pi-spinner text-content-muted text-xs"></i>
+            <span class="type-label text-content-muted">Assigning…</span>
+          </div>
         </div>
-        <!-- Ref code chip (hold to reveal) -->
-        <div
-          v-if="currentPerson.refCode"
-          class="flex-shrink-0 para-chip-sm px-3 py-2 cursor-pointer select-none flex flex-col items-end gap-0.5"
-          @mousedown="revealingRef = 'current'" @mouseup="revealingRef = null" @mouseleave="revealingRef = null"
-          @touchstart="revealingRef = 'current'" @touchend="revealingRef = null" @touchcancel="revealingRef = null"
-        >
-          <span class="type-label text-content-muted">Ref Code</span>
-          <span v-if="revealingRef === 'current'" class="font-source tracking-widest text-accent" style="font-size:1rem;letter-spacing:0.2em">
-            {{ currentPerson.refCode }}
-          </span>
-          <span v-else class="type-label text-content-muted/40">Hold to reveal</span>
+
+        <!-- Team members -->
+        <div v-if="slot.person.memberNames?.length" class="flex items-center gap-1.5 type-label text-content-muted mb-3">
+          <i class="pi pi-users" style="font-size:0.65rem"></i>
+          <span>{{ slot.person.memberNames.join(' · ') }}</span>
         </div>
-        <div v-else-if="currentPerson.genres.some(g => g.auditionNumber === null)" class="flex-shrink-0 para-chip-sm px-3 py-2 flex items-center gap-1.5">
-          <i class="pi pi-spin pi-spinner text-content-muted text-xs"></i>
-          <span class="type-label text-content-muted">Assigning…</span>
+
+        <!-- Divisions -->
+        <div class="section-rule my-3">
+          <span class="section-rule-label">Divisions</span>
+          <div class="section-rule-line"></div>
         </div>
-      </div>
 
-      <!-- Team members -->
-      <div v-if="currentPerson.memberNames?.length" class="flex items-center gap-1.5 type-label text-content-muted mb-3">
-        <i class="pi pi-users" style="font-size:0.65rem"></i>
-        <span>{{ currentPerson.memberNames.join(' · ') }}</span>
-      </div>
+        <div class="space-y-2">
+          <div
+            v-for="g in slot.person.genres"
+            :key="g.genreName"
+            class="flex items-center gap-3 para-chip-sm px-3 py-2.5"
+            :style="g.auditionNumber !== null ? { borderColor: 'var(--accent-muted)', background: 'var(--accent-subtle)' } : {}"
+          >
+            <!-- Status dot -->
+            <span
+              class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+              :style="g.auditionNumber !== null
+                ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
+                : g.rolling
+                  ? 'background:rgba(245,158,11,0.7);box-shadow:0 0 6px rgba(245,158,11,0.5)'
+                  : 'background:rgba(255,255,255,0.15)'"
+            ></span>
 
-      <!-- Divisions -->
-      <div class="section-rule my-3">
-        <span class="section-rule-label">Divisions</span>
-        <div class="section-rule-line"></div>
-      </div>
+            <!-- Division name -->
+            <span class="type-body text-content-primary flex-1">{{ g.genreName }}</span>
 
-      <div class="space-y-2">
-        <div
-          v-for="g in currentPerson.genres"
-          :key="g.genreName"
-          class="flex items-center gap-3 para-chip-sm px-3 py-2.5"
-          :style="g.auditionNumber !== null ? { borderColor: 'var(--accent-muted)', background: 'var(--accent-subtle)' } : {}"
-        >
-          <!-- Status dot -->
-          <span
-            class="inline-block w-2 h-2 rounded-full flex-shrink-0"
-            :style="g.auditionNumber !== null
-              ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
-              : g.rolling
-                ? 'background:rgba(245,158,11,0.7);box-shadow:0 0 6px rgba(245,158,11,0.5)'
-                : 'background:rgba(255,255,255,0.15)'"
-          ></span>
-
-          <!-- Division name -->
-          <span class="type-body text-content-primary flex-1">{{ g.genreName }}</span>
-
-          <!-- Number area -->
-          <div class="flex items-baseline gap-1 tabular-nums min-w-[5rem] justify-end">
-            <!-- Rolling -->
-            <template v-if="g.rolling">
-              <span class="type-label text-amber-400/60 text-xs">Drawing</span>
-              <span class="type-stat text-amber-400" style="font-size:1.6rem">
-                {{ fakeNums[g.genreName] ?? '—' }}
-              </span>
-            </template>
-            <!-- Revealed -->
-            <template v-else-if="g.auditionNumber !== null">
-              <span class="type-label text-accent/60 text-xs">#</span>
-              <span class="type-stat text-accent" style="font-size:1.6rem">{{ g.auditionNumber }}</span>
-            </template>
-            <!-- Pending -->
-            <template v-else>
-              <span class="type-stat text-content-muted/20" style="font-size:1.6rem">—</span>
-            </template>
+            <!-- Number area -->
+            <div class="flex items-baseline gap-1 tabular-nums min-w-[5rem] justify-end">
+              <!-- Rolling -->
+              <template v-if="g.rolling">
+                <span class="type-label text-amber-400/60 text-xs">Drawing</span>
+                <span class="type-stat text-amber-400" style="font-size:1.6rem">
+                  {{ fakeNums[`${slot.slotId}-${g.genreName}`] ?? '—' }}
+                </span>
+              </template>
+              <!-- Revealed -->
+              <template v-else-if="g.auditionNumber !== null">
+                <span class="type-label text-accent/60 text-xs">#</span>
+                <span class="type-stat text-accent" style="font-size:1.6rem">{{ g.auditionNumber }}</span>
+              </template>
+              <!-- Pending -->
+              <template v-else>
+                <span class="type-stat text-content-muted/20" style="font-size:1.6rem">—</span>
+              </template>
+            </div>
           </div>
         </div>
       </div>
@@ -317,15 +336,15 @@ onBeforeUnmount(() => {
             </span>
           </div>
 
-          <!-- Ref code (press and hold to reveal) -->
+          <!-- Ref code (click to reveal) -->
           <span
             v-if="person.refCode"
             class="relative ml-auto shrink-0 inline-flex items-center gap-1.5 para-chip-sm px-2.5 py-1 type-label cursor-pointer select-none transition-colors"
-            :class="revealingRef === person.name + i ? 'text-accent' : 'text-content-muted hover:text-accent'"
-            @click="revealingRef = revealingRef === person.name + i ? null : person.name + i"
+            :class="revealingRef['h-' + person.name + '-' + i] ? 'text-accent' : 'text-content-muted hover:text-accent'"
+            @click="toggleReveal('h-' + person.name + '-' + i)"
           >
             <i class="pi pi-eye" style="font-size:0.6rem"></i>
-            <template v-if="revealingRef === person.name + i">
+            <template v-if="revealingRef['h-' + person.name + '-' + i]">
               <span class="font-source tracking-widest" style="font-size:0.75rem;letter-spacing:0.2em">{{ person.refCode }}</span>
             </template>
             <template v-else>Ref</template>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, addBattleGuest, battleJudgeVote, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, addBattleGuest, battleJudgeVote, clearBattlePair, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -22,8 +22,13 @@ const currentRound = ref(0)
 const currentTop = ref('')
 const battlePhase = ref('IDLE')
 const showResetConfirm = ref(false)
+const showSizeChangeConfirm = ref(false)  // prompt before switching bracket size
+const showRoundChangeConfirm = ref(false) // prompt before switching round during battle
+const pendingSize = ref(null)            // the size user wants to switch to
+const pendingRoundIdx = ref(null)        // the round index user wants to switch to
 const finalTieBlocked = ref(false)
 const revealActive = ref(false)
+let skipSizeChangeClear = false          // guard: suppress clear when topSize changes programmatically
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
 const showRecoveryBanner = ref(false)
 const recoveryState      = ref(null)
@@ -233,6 +238,7 @@ const nextPair = async () => {
       currentRound.value += 1
       saveGenreBattleState(selectedGenre.value)
     } else {
+      await clearBattlePair()
       await setBattlePhase('IDLE')
       battlePhase.value = 'IDLE'
       currentWinner.value = -2
@@ -601,7 +607,27 @@ const onDragEnd = () => {
   dragOverKey.value = null
 }
 
+// Re-broadcast the current battle pair to the overlay if a bracket drag/drop changed
+// its slots. Called after onDrop / onSmokeDrop so currentBattlePair already reflects
+// the updated rounds.
+const reBroadcastCurrentPairIfActive = () => {
+  if (isSmoke.value || currentBattle.value.length === 0) return
+  const pair = currentBattlePair.value
+  if (pair?.[0] && pair?.[1]) {
+    setBattlePair(pair[0], pair[1], currentTop.value === 'Top2',
+      getMembersFor(pair[0]), getMembersFor(pair[1]))
+  }
+}
+
 const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
+  // Capture whether the current pair is affected BEFORE clearing drag state
+  const curRound = currentTop.value
+  const curMatch = currentRound.value
+  const tgtIsCurrent = tgtRound === curRound && tgtMatch === curMatch
+  const srcIsCurrent = dragSource.value
+    ? dragSource.value.roundKey === curRound && dragSource.value.matchIdx === curMatch
+    : false
+
   // Pool → bracket drop
   if (poolDragName.value) {
     const name = poolDragName.value
@@ -613,6 +639,7 @@ const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
     rounds.value[tgtRound][tgtMatch][2] = null
     localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
+    if (tgtIsCurrent) reBroadcastCurrentPairIfActive()
     return
   }
   if (!dragSource.value) return
@@ -631,6 +658,7 @@ const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
 
   localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
+  if (tgtIsCurrent || srcIsCurrent) reBroadcastCurrentPairIfActive()
 }
 
 const onPoolDragStart = (name, event) => {
@@ -791,6 +819,63 @@ const currentGenreChampion = computed(() => {
 
 const isFinalInProgress = computed(() => !isSmoke.value && currentTop.value === 'Top2')
 
+// True when the current bracket has any placed participants (used for size-change guard)
+const bracketHasData = computed(() => {
+  if (isSmoke.value) return Array.isArray(rounds.value) && rounds.value.some(r => r?.name)
+  return Object.values(rounds.value).some(pairList =>
+    Array.isArray(pairList) && pairList.some(m => Array.isArray(m) && (m[0] || m[1]))
+  )
+})
+
+// Round tab status: 'active' (has current battle), 'done' (all winners set),
+// 'filled' (all slots filled + previous round complete), 'locked' (waiting for
+// previous round to finish), 'empty' (slots not yet filled)
+const roundTabStatus = (idx) => {
+  if (isSmoke.value) return 'empty'
+  const size = roundSizes.value[idx]
+  if (!size) return 'empty'
+  const pairList = rounds.value[`Top${size}`]
+  if (!Array.isArray(pairList)) return 'empty'
+  // Active battle in this round?
+  const hasActive = currentBattle.value.length > 0 && currentTop.value === `Top${size}`
+  if (hasActive) return 'active'
+  // All winners set? (round completed)
+  const allHaveWinners = pairList.every(m => Array.isArray(m) && m[2])
+  if (allHaveWinners && pairList.length > 0 && pairList.some(m => m[0] || m[1])) return 'done'
+  // Previous round incomplete? This round is locked
+  if (idx > 0) {
+    const prevSize = roundSizes.value[idx - 1]
+    const prevList = rounds.value[`Top${prevSize}`]
+    if (Array.isArray(prevList) && prevList.length > 0 && !prevList.every(m => Array.isArray(m) && m[2])) {
+      return 'locked'
+    }
+  }
+  // All slots filled? Ready to start
+  const allFilled = pairList.every(m => Array.isArray(m) && m[0] && m[1])
+  if (allFilled) return 'filled'
+  return 'empty'
+}
+
+// True when every match in the active round tab has both slots filled
+// AND the previous round (if any) is fully complete (all winners set).
+const isActiveRoundFilled = computed(() => {
+  if (isSmoke.value) return true
+  const idx = activeRoundIdx.value
+  const size = roundSizes.value[idx]
+  if (!size) return false
+  // Current round: all slots filled
+  const pairList = rounds.value[`Top${size}`]
+  if (!Array.isArray(pairList)) return false
+  if (!pairList.every(m => Array.isArray(m) && m[0] && m[1])) return false
+  // Previous round (if any): all winners set
+  if (idx > 0) {
+    const prevSize = roundSizes.value[idx - 1]
+    const prevList = rounds.value[`Top${prevSize}`]
+    if (Array.isArray(prevList) && !prevList.every(m => Array.isArray(m) && m[2])) return false
+  }
+  return true
+})
+
 // All judges have cast a vote (none still at -3 = "hasn't voted this round")
 const allJudgesVoted = computed(() => {
   const judges = battleJudges.value?.judges ?? []
@@ -842,6 +927,11 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
     currentTop.value = ''
     currentRound.value = 0
     currentWinner.value = -2
+    // Ensure the backend is also clean — clearBattlePair doesn't persist, so
+    // explicitly set IDLE on the backend in case a stale pair was left behind.
+    await clearBattlePair()
+    await setBattlePhase('IDLE')
+    battlePhase.value = 'IDLE'
     return
   }
   const { battle, top, round, phase } = JSON.parse(saved)
@@ -853,12 +943,14 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
   const pair = currentBattlePair.value
   if (pair?.[0] && pair?.[1]) {
     await setBattlePair(pair[0], pair[1], top === 'Top2', getMembersFor(pair[0]), getMembersFor(pair[1]))
-    battlePhase.value = 'LOCKED'
-    // Restore VOTING phase so "Reveal Champion" is available immediately if judges already voted
-    if (phase === 'VOTING') {
-      await setBattlePhase('VOTING')
-      battlePhase.value = 'VOTING'
+    // setBattlePair always forces backend phase to LOCKED. If the saved state was
+    // VOTING or DECIDED, restore it. Set local phase once at the end to avoid a WS
+    // race where the async LOCKED message overwrites a prior local assignment.
+    const targetPhase = (phase === 'VOTING' || phase === 'DECIDED') ? phase : 'LOCKED'
+    if (targetPhase !== 'LOCKED') {
+      await setBattlePhase(targetPhase)
     }
+    battlePhase.value = targetPhase
   }
 }
 
@@ -1079,26 +1171,49 @@ const startRevote = async () => {
   currentWinner.value = -2
 }
 
+const lockChampion = async () => {
+  const winner = tentativeWinner.value === 0
+    ? currentBattlePair.value?.[0]
+    : currentBattlePair.value?.[1]
+  if (!winner) return
+  genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
+  localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winner)
+  await setBattlePhase('DECIDED')
+  battlePhase.value = 'DECIDED'
+  saveGenreBattleState(selectedGenre.value)
+}
+
+const unlockChampion = async () => {
+  const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
+  genreChampions.value = rest
+  localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
+  await setBattlePhase('VOTING')
+  battlePhase.value = 'VOTING'
+  saveGenreBattleState(selectedGenre.value)
+}
+
 const revealChampionForGenre = async () => {
-  // Case 1: live voting round — score not yet submitted, use tentative winner from votes
-  if (showFinalReveal.value && !currentGenreChampion.value) {
-    const winnerName = tentativeWinner.value === 0
-      ? currentBattlePair.value?.[0]
-      : currentBattlePair.value?.[1]
+  // Case 1: DECIDED phase — champion locked, score not yet submitted
+  if (battlePhase.value === 'DECIDED' && !currentGenreChampion.value) {
+    const championName = genreChampions.value[selectedGenre.value]
+    if (!championName) return
     const res = await setBattleScore(true)
     if (res?.status === 409) { finalTieBlocked.value = true; return }
     const data = await res.json()
     currentWinner.value = Number(data.winner)
     if (data.winner === 0 || data.winner === 1) {
       setWinner(currentTop.value, currentRound.value, data.winner)
-      genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winnerName }
-      localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winnerName)
-      await revealChampion(selectedGenre.value, winnerName)
+      await revealChampion(selectedGenre.value, championName)
+      // Stay in DECIDED so the genre remains re-revealable forever
+      await setBattlePhase('DECIDED')
+      battlePhase.value = 'DECIDED'
+      saveGenreBattleState(selectedGenre.value)
       revealActive.value = true
     }
     return
   }
   // Case 2: score already in bracket (winner in rounds data) OR tracked in genreChampions
+  // (re-reveal). Also stays DECIDED.
   const champion = currentGenreChampion.value ?? genreChampions.value[selectedGenre.value]
   if (!champion) return
   // Update live match winner display so the WIN button reflects the correct side
@@ -1129,17 +1244,94 @@ const confirmResetBracket = async () => {
   rounds.value = initRounds()
   placeGuestsInBracket()
   broadcastBracket()
+  await clearBattlePair()
   await setBattlePhase('IDLE')
   battlePhase.value = 'IDLE'
   currentWinner.value = -2
   currentBattle.value = []
   currentTop.value = ''
+  currentRound.value = 0
+  activeRoundIdx.value = 0
+  finalTieBlocked.value = false
   localStorage.removeItem('currentTop')
+  localStorage.removeItem(sizeStateKey(topSize.value))
   saveGenreBattleState(selectedGenre.value)
-  // Clear champion tracking for this genre
+  // Clear champion tracking — both backend (DB) and local (ref + localStorage)
+  await dismissChampionReveal()
+  revealActive.value = false
   const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
   genreChampions.value = rest
   localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
+}
+
+const requestSizeChange = (newSize) => {
+  if (bracketHasData.value && Number(topSize.value) !== newSize) {
+    pendingSize.value = newSize
+    showSizeChangeConfirm.value = true
+  } else {
+    topSize.value = newSize
+  }
+}
+
+const confirmSizeChange = async () => {
+  showSizeChangeConfirm.value = false
+  // Reset bracket data for the current genre before switching size
+  localStorage.removeItem(`Top${topSize.value}${selectedGenre.value}Rounds`)
+  localStorage.removeItem(sizeStateKey(topSize.value))
+  topSize.value = pendingSize.value
+  pendingSize.value = null
+}
+
+const cancelSizeChange = () => {
+  showSizeChangeConfirm.value = false
+  pendingSize.value = null
+}
+
+// True when the active battle is happening in the currently-viewed round tab.
+// Smoke mode has only one "round" (the queue) — always true when battle is active.
+const isActiveBattleInThisRound = computed(() => {
+  if (currentBattle.value.length === 0) return false
+  if (isSmoke.value) return true
+  const size = roundSizes.value[activeRoundIdx.value]
+  return size != null && currentTop.value === `Top${size}`
+})
+
+// Effective phase for the currently-viewed round: IDLE if the active battle
+// is in a different round, otherwise the global phase.
+const effectivePhase = computed(() =>
+  isActiveBattleInThisRound.value ? battlePhase.value : 'IDLE'
+)
+
+// Guard: prompt before switching round tab when battle is in progress
+const requestRoundChange = (idx) => {
+  if (battlePhase.value !== 'IDLE' && idx !== activeRoundIdx.value) {
+    pendingRoundIdx.value = idx
+    showRoundChangeConfirm.value = true
+  } else {
+    activeRoundIdx.value = idx
+  }
+}
+
+const confirmRoundChange = () => {
+  showRoundChangeConfirm.value = false
+  activeRoundIdx.value = pendingRoundIdx.value
+  pendingRoundIdx.value = null
+}
+
+const cancelRoundChange = () => {
+  showRoundChangeConfirm.value = false
+  pendingRoundIdx.value = null
+}
+
+// Guard: prompt before switching genre when battle is in progress
+const requestGenreChange = (genre) => {
+  if (battlePhase.value !== 'IDLE' && genre !== selectedGenre.value) {
+    if (confirm(`A battle is in progress for "${selectedGenre.value}". Switching to "${genre}" will save the current state. Continue?`)) {
+      selectedGenre.value = genre
+    }
+  } else {
+    selectedGenre.value = genre
+  }
 }
 
 watch(selectedEvent, async (newVal) => {
@@ -1184,21 +1376,23 @@ watch(uniqueGenres, (genres) => {
   genreChampions.value = { ...locals, ...genreChampions.value }
 }, { immediate: true })
 
-// When all judges vote in the final, capture the winner immediately — before the
-// organiser clicks Reveal. This persists the state across genre switches and refreshes.
-// When showFinalReveal goes false due to a revote that results in a tie, clear any
-// previously saved champion so stale data doesn't linger.
+// When all judges revote to a tie in the final, clear any previously locked
+// champion so stale data doesn't linger. (Champion is only saved via Lock button.)
 watch(showFinalReveal, (newVal) => {
   if (!selectedGenre.value) return
-  if (newVal) {
-    const winner = tentativeWinner.value === 0
-      ? currentBattlePair.value?.[0]
-      : currentBattlePair.value?.[1]
-    if (!winner) return
-    genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
-    localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winner)
-  } else if (isFinalInProgress.value && allJudgesVoted.value && tentativeWinner.value === -1) {
-    // All judges voted but it's a tie — remove any pending champion
+  if (!newVal && isFinalInProgress.value && allJudgesVoted.value && tentativeWinner.value === -1) {
+    const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
+    genreChampions.value = rest
+    localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
+  }
+})
+
+// When showFinalReveal is already false (e.g. after a Start Round reset) and judges
+// subsequently vote to a tie in the final, the watch above won't fire (no transition).
+// This watcher catches the steady-state tie condition and clears the champion.
+watch([allJudgesVoted, tentativeWinner], ([voted, winner]) => {
+  if (!selectedGenre.value) return
+  if (voted && winner === -1 && isFinalInProgress.value && genreChampions.value[selectedGenre.value]) {
     const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
     genreChampions.value = rest
     localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
@@ -1210,18 +1404,6 @@ watch(selectedGenre, async (newVal, oldVal) => {
   if (oldVal && revealActive.value) await dismissChampionReveal()
   revealActive.value = false
   if (newVal) {
-    // If all judges voted in the final but organiser hasn't clicked Reveal yet,
-    // save the winner before switching away so the button reappears on return.
-    if (oldVal && showFinalReveal.value) {
-      const winner = tentativeWinner.value === 0
-        ? currentBattlePair.value?.[0]
-        : currentBattlePair.value?.[1]
-      if (winner) {
-        genreChampions.value = { ...genreChampions.value, [oldVal]: winner }
-        localStorage.setItem(genreChampionLocalKey(oldVal), winner)
-      }
-    }
-
     // Persist outgoing genre's topSize before switching
     if (oldVal) localStorage.setItem(genreTopSizeKey(oldVal), String(topSize.value))
 
@@ -1239,6 +1421,7 @@ watch(selectedGenre, async (newVal, oldVal) => {
       const savedSize = localStorage.getItem(genreTopSizeKey(newVal))
       const restoredSize = savedSize ? Number(savedSize) : (oldVal ? 16 : Number(topSize.value))
       if (restoredSize !== Number(topSize.value)) {
+        skipSizeChangeClear = true
         topSize.value = restoredSize
         localStorage.setItem('topSize', String(restoredSize))
       }
@@ -1266,60 +1449,92 @@ watch(selectedGenre, async (newVal, oldVal) => {
     // mountJudgeSyncDone guards against firing before onMounted loads battleJudges from API.
     // oldVal check (truthy) skips the immediate fire and empty-string initialization cases.
     if (mountJudgeSyncDone && oldVal) await syncJudgesForGenre(newVal, oldVal)
+    // Re-read authoritative phase from backend after restoration. The WS LOCKED
+    // message from setBattlePair can race past the local phase assignment inside
+    // restoreAndBroadcastGenreBattle. Brief delay lets WS messages flush first.
+    if (oldVal) {
+      await new Promise(r => setTimeout(r, 150))
+      const confirmed = await getBattlePhase()
+      if (confirmed?.phase) battlePhase.value = confirmed.phase
+      // Defensive: if this genre has a champion locked, force DECIDED regardless
+      // of what the backend returned (WS messages can corrupt the phase mid-switch).
+      if (genreChampions.value[newVal] && battlePhase.value !== 'DECIDED') {
+        await setBattlePhase('DECIDED')
+        battlePhase.value = 'DECIDED'
+        saveGenreBattleState(newVal)
+      }
+    }
   } else {
     pickupCrews.value = []
   }
 }, { immediate: true })
 
 const sizeStateKey = (size) => `battleSizeState_${selectedEvent.value}_${selectedGenre.value}_${size}`
+const roundIdxKey = () => `battleRoundIdx_${selectedEvent.value}_${selectedGenre.value}_${topSize.value}`
+
+// Persist the active round tab selection so it survives refresh and genre switch.
+// Does NOT auto-broadcast to overlay — the overlay stays on the IDLE announcement
+// until the operator explicitly clicks "Start Round".
+watch(activeRoundIdx, (idx) => {
+  if (selectedEvent.value && selectedGenre.value) {
+    localStorage.setItem(roundIdxKey(), String(idx))
+  }
+})
 
 watch(topSize, async (newVal, oldVal) => {
   if (!newVal) return
-  // Reset to first round tab so the bracket is always visible after a size change
-  activeRoundIdx.value = 0
-  // Save last-selected pair for outgoing size so we can restore it on return
+  // Restore previously-selected round tab for this size; default to 0 (first round).
+  // Only when event+genre are known — during setup they're still null, defer to onMounted.
+  if (selectedEvent.value && selectedGenre.value) {
+    const savedIdx = localStorage.getItem(roundIdxKey())
+    activeRoundIdx.value = savedIdx !== null ? Math.min(Number(savedIdx), roundSizes.value.length - 1) : 0
+  }
+  // Save outgoing size's battle state so it can be restored on return (no overlay broadcast)
   if (oldVal && currentBattle.value.length > 0) {
     localStorage.setItem(sizeStateKey(oldVal), JSON.stringify({
       battle: toRaw(currentBattle.value),
       top: currentTop.value,
       round: currentRound.value,
+      phase: battlePhase.value,
     }))
   }
   localStorage.setItem("topSize", newVal)
+  // Also save per-genre so it survives refresh (not just genre switch)
+  if (selectedEvent.value && selectedGenre.value) {
+    localStorage.setItem(genreTopSizeKey(selectedGenre.value), String(newVal))
+  }
   const storedRounds = localStorage.getItem(`Top${newVal}${selectedGenre.value}Rounds`)
   rounds.value = JSON.parse(storedRounds) || initRounds()
   currentWinner.value = -2
+  // Only clear battle on user-initiated size change (not programmatic from
+  // genre switch or initial load). The onMounted recovery handles init.
+  if (oldVal && !skipSizeChangeClear) {
+    await clearBattlePair()
+    await setBattlePhase('IDLE')
+    battlePhase.value = 'IDLE'
+    currentBattle.value = []
+    currentTop.value = ''
+  }
+  skipSizeChangeClear = false
   broadcastBracket()
 
-  // Restore last pair for this size; if none, show the first filled pair in the bracket
+  // Restore the incoming size's battle state (pair + phase). Do NOT push to overlay —
+  // the overlay updates only when the operator clicks a round tab or "Start Round".
   const savedSizeState = localStorage.getItem(sizeStateKey(newVal))
   if (savedSizeState) {
-    const { battle, top, round } = JSON.parse(savedSizeState)
+    const { battle, top, round, phase: savedPhase } = JSON.parse(savedSizeState)
     currentBattle.value = battle ?? []
     currentTop.value = top ?? ''
     currentRound.value = round ?? 0
-    // Broadcast the restored pair so the overlay reflects this size immediately
-    const pair = currentBattlePair.value
-    if (!isSmoke.value && pair?.[0] && pair?.[1]) {
-      await setBattlePair(pair[0], pair[1], top === 'Top2', getMembersFor(pair[0]), getMembersFor(pair[1]))
-    }
+    // Restore phase locally — but don't broadcast. The overlay stays on whatever
+    // it was last showing. When the operator clicks a round tab, the activeRoundIdx
+    // watcher will find and broadcast the correct pair from the bracket data.
+    battlePhase.value = savedPhase && savedPhase !== 'IDLE' ? savedPhase : 'IDLE'
+    saveGenreBattleState(selectedGenre.value)
   } else {
     currentBattle.value = []
     currentTop.value = ''
     currentRound.value = 0
-    // Broadcast first filled pair so the overlay immediately reflects the new format
-    if (!isSmoke.value) {
-      const topKey = `Top${newVal}`
-      const pairList = rounds.value[topKey] ?? []
-      const firstFilledIdx = pairList.findIndex(m => Array.isArray(m) && m[0] && m[1])
-      if (firstFilledIdx >= 0) {
-        const [left, right] = pairList[firstFilledIdx]
-        currentBattle.value = [firstFilledIdx, pairList]
-        currentTop.value = topKey
-        currentRound.value = firstFilledIdx
-        await setBattlePair(left, right, false, getMembersFor(left), getMembersFor(right))
-      }
-    }
   }
 }, { immediate: true })
 
@@ -1373,6 +1588,19 @@ watch(rounds, () => {
 
 onMounted(async () => {
   initialiseDropdown()
+  // Restore per-genre bracket size (survives refresh)
+  if (selectedEvent.value && selectedGenre.value) {
+    const savedSize = localStorage.getItem(genreTopSizeKey(selectedGenre.value))
+    if (savedSize) {
+      topSize.value = Number(savedSize)
+      localStorage.setItem('topSize', savedSize)
+    }
+  }
+  // Now that event+genre are set, restore the saved round tab with correct keys
+  const savedRoundIdx = localStorage.getItem(roundIdxKey())
+  if (savedRoundIdx !== null) {
+    activeRoundIdx.value = Math.min(Number(savedRoundIdx), roundSizes.value.length - 1)
+  }
   await fetchAllJudges(selectedEvent.value)
   await fetchBattleGuests()
   battleJudges.value = await getBattleJudges()
@@ -1526,14 +1754,14 @@ onUnmounted(() => {
           <button
             v-for="g in uniqueGenres"
             :key="g"
-            @click="selectedGenre = g"
+            @click="requestGenreChange(g)"
             class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150 inline-flex items-center gap-1.5"
             :class="selectedGenre === g
               ? 'text-accent border-[color:var(--accent-muted)]'
               : 'text-content-muted hover:text-content-primary'"
           >
             {{ g }}
-            <i v-if="g === selectedGenre && (showFinalReveal || (genreChampions[g] && !currentGenreChampion))" class="pi pi-star-fill text-[9px] text-amber-400" title="Judges voted — ready to reveal champion"></i>
+            <i v-if="(g === selectedGenre && battlePhase === 'DECIDED') || genreChampions[g]" class="pi pi-star-fill text-[9px] text-amber-400" title="Champion locked — ready to reveal"></i>
           </button>
         </div>
         <!-- Format toggle — hidden for smoke genres (format auto-detected from genre name) -->
@@ -1543,7 +1771,7 @@ onUnmounted(() => {
             <button
               v-for="s in sizes.filter(s => s !== 7)"
               :key="s"
-              @click="topSize = s"
+              @click="requestSizeChange(s)"
               class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150"
               :class="topSize === s
                 ? 'text-accent border-[color:var(--accent-muted)]'
@@ -1844,12 +2072,22 @@ onUnmounted(() => {
           <button
             v-for="(size, idx) in roundSizes"
             :key="idx"
-            @click="activeRoundIdx = idx"
-            class="para-chip-sm px-4 py-1.5 type-label transition-all duration-150"
-            :class="activeRoundIdx === idx
-              ? 'text-accent border-[color:var(--accent-muted)]'
-              : 'text-content-muted hover:text-content-primary'"
-          >Top {{ size }}</button>
+            @click="requestRoundChange(idx)"
+            class="para-chip-sm px-4 py-1.5 type-label transition-all duration-150 inline-flex items-center gap-1.5"
+            :class="{
+              'text-accent border-[color:var(--accent-muted)]': activeRoundIdx === idx,
+              'text-emerald-400/70 border-emerald-500/30': activeRoundIdx !== idx && roundTabStatus(idx) === 'done',
+              'text-content-muted/40 cursor-not-allowed': roundTabStatus(idx) === 'locked',
+              'text-content-muted hover:text-content-primary': activeRoundIdx !== idx && roundTabStatus(idx) !== 'done' && roundTabStatus(idx) !== 'locked',
+              'border-amber-400/40 text-amber-400': roundTabStatus(idx) === 'active',
+            }"
+            :title="roundTabStatus(idx) === 'locked' ? 'Waiting for previous round to complete' : ''"
+          >
+            <i v-if="roundTabStatus(idx) === 'active'" class="pi pi-circle-fill text-[6px] text-amber-400" title="Active battle"></i>
+            <i v-else-if="roundTabStatus(idx) === 'done'" class="pi pi-check text-[9px] text-emerald-400/70" title="Round complete"></i>
+            <i v-else-if="roundTabStatus(idx) === 'locked'" class="pi pi-lock text-[8px] text-content-muted/40" title="Waiting for previous round"></i>
+            Top {{ size }}
+          </button>
         </div>
 
         <!-- Active round matches -->
@@ -1955,9 +2193,9 @@ onUnmounted(() => {
                     :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
                   >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
                 </div>
-                <!-- Start from this match -->
+                <!-- Start from this match — only when round is idle and all slots filled -->
                 <button
-                  v-if="match[0] && match[1]"
+                  v-if="match[0] && match[1] && isActiveRoundFilled && effectivePhase === 'IDLE'"
                   @click="initiateBattlePairAt(`Top${size}`, rounds[`Top${size}`], mIdx)"
                   class="flex-shrink-0 flex items-center justify-center w-8 ml-1.5 self-stretch rounded text-accent border border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)] hover:bg-[color:var(--accent-muted)] transition-colors"
                   title="Start round from this match"
@@ -1966,12 +2204,19 @@ onUnmounted(() => {
             </div>
 
             <button
+              v-if="effectivePhase === 'IDLE'"
+              :disabled="!isActiveRoundFilled"
               @click="initiateBattlePair(`Top${size}`, rounds[`Top${size}`])"
-              class="w-full py-2 bg-accent para-chip type-label transition-all duration-200"
+              class="w-full py-2 para-chip type-label transition-all duration-200"
+              :class="isActiveRoundFilled ? 'bg-accent' : 'bg-surface-700 text-content-muted cursor-not-allowed'"
+              :title="isActiveRoundFilled ? '' : 'All slots must be filled and the previous round must be completed'"
             >
               <i class="pi pi-play text-xs mr-1.5"></i>
               Start Round
             </button>
+            <div v-else class="w-full py-2 text-center type-label text-content-muted">
+              Active battle in {{ currentTop }}
+            </div>
           </div>
         </template>
       </div>
@@ -2057,6 +2302,48 @@ onUnmounted(() => {
       </div>
     </Transition>
 
+    <!-- Bracket size change confirmation modal -->
+    <Transition name="fade">
+      <div v-if="showSizeChangeConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+        <div class="card-hover p-6 max-w-sm w-full mx-4 relative">
+          <div class="corner-bar-tl"></div>
+          <div class="type-page-title text-lg mb-2">Change Bracket Size?</div>
+          <p class="type-body text-content-muted mb-6">The current bracket has participants placed. Changing the size will reset all bracket data for this genre. Continue?</p>
+          <div class="flex gap-3 justify-end">
+            <button
+              @click="cancelSizeChange"
+              class="para-chip-sm px-4 py-2 type-label transition-all"
+            >Cancel</button>
+            <button
+              @click="confirmSizeChange"
+              class="para-chip-sm px-4 py-2 type-label bg-amber-600/20 text-amber-400 border-amber-500/40 hover:bg-amber-600/30 transition-all"
+            >Change Size</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
+    <!-- Round change confirmation modal -->
+    <Transition name="fade">
+      <div v-if="showRoundChangeConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+        <div class="card-hover p-6 max-w-sm w-full mx-4 relative">
+          <div class="corner-bar-tl"></div>
+          <div class="type-page-title text-lg mb-2">Switch Round?</div>
+          <p class="type-body text-content-muted mb-6">A battle is in progress. Switching rounds will not affect the active battle — you can continue viewing other rounds safely.</p>
+          <div class="flex gap-3 justify-end">
+            <button
+              @click="cancelRoundChange"
+              class="para-chip-sm px-4 py-2 type-label transition-all"
+            >Cancel</button>
+            <button
+              @click="confirmRoundChange"
+              class="para-chip-sm px-4 py-2 type-label text-accent border-[color:var(--accent-muted)] transition-all"
+            >Switch Round</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
     <!-- Live match tracker -->
     <div class="card p-5">
       <div class="section-rule mb-4">
@@ -2068,18 +2355,21 @@ onUnmounted(() => {
         <div
           class="inline-flex items-center gap-2 px-3 py-1.5"
           :class="{
-            'semantic-chip-success': battlePhase === 'REVEALED',
-            'semantic-chip-warning': battlePhase === 'LOCKED',
-            'semantic-chip-warning animate-pulse': battlePhase === 'VOTING',
-            'semantic-chip-warning opacity-50': battlePhase === 'IDLE',
+            'semantic-chip-success': effectivePhase === 'REVEALED',
+            'semantic-chip-warning': effectivePhase === 'LOCKED',
+            'semantic-chip-warning animate-pulse': effectivePhase === 'VOTING',
+            'semantic-chip-warning opacity-50': effectivePhase === 'IDLE',
           }"
         >
           <div
             class="w-2 h-2 rounded-full"
-            :style="battlePhase === 'REVEALED' ? 'background:#34d399;box-shadow:0 0 8px rgba(52,211,153,0.8)' : battlePhase === 'LOCKED' ? 'background:#f59e0b;box-shadow:0 0 8px rgba(245,158,11,0.8)' : battlePhase === 'VOTING' ? 'background:#f59e0b;box-shadow:0 0 8px rgba(245,158,11,0.8)' : 'background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,0.5)'"
+            :style="effectivePhase === 'REVEALED' ? 'background:#34d399;box-shadow:0 0 8px rgba(52,211,153,0.8)' : effectivePhase === 'LOCKED' ? 'background:#f59e0b;box-shadow:0 0 8px rgba(245,158,11,0.8)' : effectivePhase === 'VOTING' ? 'background:#f59e0b;box-shadow:0 0 8px rgba(245,158,11,0.8)' : 'background:#6b7280;box-shadow:0 0 8px rgba(107,114,128,0.5)'"
           ></div>
-          <span class="type-body" :class="battlePhase === 'REVEALED' ? 'text-emerald-400' : battlePhase === 'LOCKED' ? 'text-amber-400' : battlePhase === 'VOTING' ? 'text-amber-400' : 'text-gray-400'">{{ battlePhase }}</span>
+          <span class="type-body" :class="effectivePhase === 'REVEALED' ? 'text-emerald-400' : effectivePhase === 'LOCKED' ? 'text-amber-400' : effectivePhase === 'VOTING' ? 'text-amber-400' : 'text-gray-400'">{{ effectivePhase }}</span>
         </div>
+        <span v-if="!isActiveBattleInThisRound && battlePhase !== 'IDLE'" class="type-label text-content-muted">
+          (active battle in {{ currentTop }})
+        </span>
         <!-- Save state indicator — next to phase badge so operator sees it -->
         <Transition name="recovery-fade" mode="out-in">
           <span v-if="saveStatus === 'saving'" key="saving" class="inline-flex items-center gap-1.5 px-2.5 py-1 type-label text-content-muted" style="font-size:10px;letter-spacing:0.16em;background:rgba(255,255,255,0.04);clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)">
@@ -2125,8 +2415,8 @@ onUnmounted(() => {
         <span class="type-body text-content-primary">{{ winnerAnnouncement }}</span>
       </div>
 
-      <!-- Match pairs (standard) -->
-      <div v-if="!isSmoke" class="grid grid-cols-3 gap-3 mb-4">
+      <!-- Match pairs (standard) — only shown when viewing the active round -->
+      <div v-if="!isSmoke && isActiveBattleInThisRound" class="grid grid-cols-3 gap-3 mb-4">
         <div class="stat-card relative">
           <div class="corner-bar-tl"></div>
           <span class="type-label text-content-muted mb-1">Previous</span>
@@ -2162,7 +2452,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Match pairs (smoke) -->
-      <div v-else class="grid grid-cols-2 gap-3 mb-4">
+      <div v-if="isSmoke" class="grid grid-cols-2 gap-3 mb-4">
         <div class="stat-card relative" style="box-shadow: 0 0 0 1px var(--accent-muted), 0 8px 40px var(--accent-subtle);">
           <div class="corner-bar-tl"></div>
           <span class="type-label text-accent mb-1">Current Match</span>
@@ -2180,8 +2470,8 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- Action buttons -->
-      <div class="flex flex-wrap gap-2">
+      <!-- Action buttons — only for the active round -->
+      <div v-if="isActiveBattleInThisRound" class="flex flex-wrap gap-2">
         <!-- LOCKED: open voting -->
         <button
           v-if="battlePhase === 'LOCKED'"
@@ -2202,6 +2492,49 @@ onUnmounted(() => {
           {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}
         </button>
 
+        <!-- VOTING + final + all judges voted → Lock Champion.
+             Enabled when clear winner, disabled on tie (listens in real-time). -->
+        <button
+          v-if="battlePhase === 'VOTING' && isFinalInProgress && allJudgesVoted"
+          :disabled="!showFinalReveal"
+          @click="lockChampion"
+          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+          :class="showFinalReveal
+            ? 'border-amber-400/50 text-amber-400 bg-amber-400/10 hover:bg-amber-400/20'
+            : 'border-gray-500/30 text-content-muted bg-surface-700/30 cursor-not-allowed'"
+          :title="showFinalReveal ? 'Lock the champion' : 'Cannot lock — result is a tie'"
+        >
+          <i class="pi pi-lock text-xs"></i>
+          Lock Champion
+        </button>
+
+        <!-- DECIDED: champion locked, ready to reveal or unlock for revote -->
+        <template v-if="battlePhase === 'DECIDED'">
+          <button
+            v-if="!revealActive"
+            @click="revealChampionForGenre"
+            class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
+          >
+            <i class="pi pi-star text-xs"></i>
+            Reveal Champion
+          </button>
+          <button
+            v-if="revealActive"
+            @click="dismissReveal"
+            class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+          >
+            <i class="pi pi-times text-xs"></i>
+            Dismiss Reveal
+          </button>
+          <button
+            @click="unlockChampion"
+            class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 text-content-muted hover:text-content-primary transition-all"
+          >
+            <i class="pi pi-unlock text-xs"></i>
+            Unlock
+          </button>
+        </template>
+
         <!-- REVEALED: previous + next -->
         <template v-if="battlePhase === 'REVEALED'">
           <button
@@ -2220,14 +2553,11 @@ onUnmounted(() => {
           </button>
         </template>
 
-        <!-- Champion Reveal — only for the final (Top2).
-             showFinalReveal: judges voted live in the final.
-             currentGenreChampion: winner slot in rounds['Top2'][0][2] is set — only
-             possible after the actual final match is scored, not from Top4/etc propagation.
-             genreChampions[selectedGenre]: pending champion saved when organiser switched
-             genres before clicking Reveal — persists across genre switches. -->
+        <!-- Champion Reveal (re-reveal) — winner already scored or tracked.
+             Only shown when a champion was previously locked/revealed for this genre.
+             Not shown during DECIDED (has its own button above). -->
         <button
-          v-if="(showFinalReveal || currentGenreChampion || genreChampions[selectedGenre]) && !revealActive"
+          v-if="battlePhase !== 'DECIDED' && (currentGenreChampion || genreChampions[selectedGenre]) && !revealActive"
           @click="revealChampionForGenre"
           class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
         >
@@ -2242,7 +2572,10 @@ onUnmounted(() => {
           <i class="pi pi-times text-xs"></i>
           Dismiss Reveal
         </button>
+      </div>
 
+      <!-- Always-visible actions -->
+      <div class="flex flex-wrap gap-2 mt-2">
         <button
           @click="showResetConfirm = true"
           class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 text-red-400 border-red-500/30 transition-all"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, addBattleGuest, battleJudgeVote, getBattleGuests, getBattleJudges, getBattlePhase, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, addBattleGuest, battleJudgeVote, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -25,6 +25,8 @@ const showResetConfirm = ref(false)
 const finalTieBlocked = ref(false)
 const revealActive = ref(false)
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+const showRecoveryBanner = ref(false)
+const recoveryState      = ref(null)
 
 const HEX_RE = /^#[0-9A-Fa-f]{6}$/
 const overlayConfigError = ref('')
@@ -523,7 +525,7 @@ function initRounds() {
   return standardBattleRound()
 }
 
-const broadcastBracket = () => setBracketState(toRaw(rounds.value), topSize.value)
+const broadcastBracket = () => setBracketState(toRaw(rounds.value), topSize.value, currentRound.value)
 
 const onDragStart = (roundKey, matchIdx, slotIdx, event) => {
   dragSource.value = { roundKey, matchIdx, slotIdx }
@@ -822,6 +824,13 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
   }
 }
 
+const jumpToRecoveredPair = async () => {
+  if (!recoveryState.value) return
+  showRecoveryBanner.value = false
+  currentRound.value = recoveryState.value.currentRoundIndex ?? 0
+  await restoreAndBroadcastGenreBattle(selectedGenre.value)
+}
+
 // Per-genre judge persistence helpers — stores { id, vote } so votes survive genre switches
 const genreJudgeKey = (genre) => `battleJudges_${selectedEvent.value}_${genre}`
 let judgeSyncing = false  // prevents concurrent syncJudgesForGenre calls
@@ -1078,9 +1087,12 @@ watch(selectedGenre, async (newVal, oldVal) => {
     rounds.value = JSON.parse(storedRounds) || initRounds()
     pickupCrews.value = await getPickupCrews(selectedEvent.value, newVal)
     placeGuestsInBracket()
-    broadcastBracket()
     if (oldVal) {
       saveGenreBattleState(oldVal)
+      await setActiveGenre(selectedEvent.value, newVal)
+    }
+    broadcastBracket()
+    if (oldVal) {
       await restoreAndBroadcastGenreBattle(newVal)
     }
     // Sync per-genre judges on genre switch.
@@ -1170,6 +1182,14 @@ onMounted(async () => {
     const storedTop = localStorage.getItem('currentTop')
     if (storedTop) currentTop.value = storedTop
   }
+  // Recovery banner: if a battle was in progress, offer to jump back to the active pair
+  if (battlePhase.value !== 'IDLE' && currentBattlePair.value?.[0]) {
+    const raw = await getBattleState()
+    if (raw && raw.currentRoundIndex !== undefined) {
+      recoveryState.value = raw
+      showRecoveryBanner.value = true
+    }
+  }
   wsClient.value = createClient()
   // Single onConnect handler — multiple subscribeToChannel calls before connection
   // overwrite each other's onConnect, so we wire everything here directly.
@@ -1248,6 +1268,32 @@ onUnmounted(() => {
         <i class="pi pi-external-link text-xs text-content-muted"></i>
       </a>
     </div>
+
+    <!-- Recovery banner -->
+    <Transition name="recovery-fade">
+      <div
+        v-if="showRecoveryBanner && recoveryState"
+        class="recovery-banner"
+        role="alert"
+        aria-live="polite"
+      >
+        <div class="recovery-body">
+          <span class="recovery-dot"></span>
+          <div class="recovery-text">
+            <span class="recovery-title">IN PROGRESS</span>
+            <span class="recovery-detail">ROUND {{ recoveryState.currentRoundIndex + 1 }} — {{ recoveryState.currentPair?.left ?? '???' }} VS {{ recoveryState.currentPair?.right ?? '???' }}</span>
+          </div>
+        </div>
+        <div class="recovery-actions">
+          <button class="recovery-btn recovery-btn-jump" @click="jumpToRecoveredPair">
+            JUMP TO PAIR
+          </button>
+          <button class="recovery-btn recovery-btn-dismiss" @click="showRecoveryBanner = false">
+            DISMISS
+          </button>
+        </div>
+      </div>
+    </Transition>
 
     <!-- Config bar + Bracket (merged) -->
     <div class="card p-5">
@@ -2095,4 +2141,92 @@ onUnmounted(() => {
   margin: 4px 0 0;
   padding: 0 2px;
 }
+
+/* ── Recovery banner ────────────────────────────────── */
+.recovery-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 18px;
+  border-left: 3px solid rgba(245,158,11,0.85);
+  background: rgba(245,158,11,0.08);
+  font-family: 'Anton SC', sans-serif;
+}
+.recovery-body {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.recovery-dot {
+  flex-shrink: 0;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: rgba(245,158,11,0.85);
+  box-shadow: 0 0 8px rgba(245,158,11,0.6), 0 0 16px rgba(245,158,11,0.3);
+  animation: recoveryPulse 1.8s ease-in-out infinite;
+}
+.recovery-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.recovery-title {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: rgba(245,158,11,0.85);
+  text-transform: uppercase;
+}
+.recovery-detail {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.75);
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.recovery-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.recovery-btn {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border: none;
+  cursor: pointer;
+  clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%);
+  transition: background 0.2s, color 0.2s;
+}
+.recovery-btn-jump {
+  background: rgba(245,158,11,0.85);
+  color: #060a14;
+}
+.recovery-btn-jump:hover {
+  background: rgba(245,158,11,1);
+}
+.recovery-btn-dismiss {
+  background: rgba(255,255,255,0.08);
+  color: rgba(255,255,255,0.55);
+}
+.recovery-btn-dismiss:hover {
+  background: rgba(255,255,255,0.14);
+  color: rgba(255,255,255,0.75);
+}
+
+@keyframes recoveryPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.4; transform: scale(0.7); }
+}
+
+.recovery-fade-enter-active,
+.recovery-fade-leave-active { transition: opacity 0.3s ease; }
+.recovery-fade-enter-from,
+.recovery-fade-leave-to { opacity: 0; }
 </style>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -28,6 +28,16 @@ const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: 
 const showRecoveryBanner = ref(false)
 const recoveryState      = ref(null)
 
+const saveStatus = ref('idle') // 'idle' | 'saving' | 'saved' | 'error'
+let saveTimer = null
+const markSaving = () => { saveStatus.value = 'saving'; clearTimeout(saveTimer) }
+const markSaved  = () => {
+  saveStatus.value = 'saved'
+  clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => { saveStatus.value = 'idle' }, 2200)
+}
+const markSaveError = () => { saveStatus.value = 'error' }
+
 const HEX_RE = /^#[0-9A-Fa-f]{6}$/
 const overlayConfigError = ref('')
 const pushOverlayConfig = async () => {
@@ -129,6 +139,7 @@ const updateSmokePair = async () => {
 }
 
 const initiateBattlePairAt = async (top, pairList, startIdx) => {
+  markSaving()
   currentWinner.value = -2
   revealActive.value = false
   await resetJudgeVote()
@@ -147,11 +158,11 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
   currentTop.value = top
   localStorage.setItem('currentTop', top)
   saveGenreBattleState(selectedGenre.value)
+  markSaved()
 }
 
 const initiateBattlePair = async (top, pairList) => {
-  // Reset winner FIRST so the winnerAnnouncement computed doesn't fire setWinner
-  // with stale winner + new round/top values when reactive state updates below.
+  markSaving()
   currentWinner.value = -2
   revealActive.value = false
   await resetJudgeVote()
@@ -179,10 +190,12 @@ const initiateBattlePair = async (top, pairList) => {
   currentTop.value = top
   localStorage.setItem('currentTop', top)
   saveGenreBattleState(selectedGenre.value)
+  markSaved()
 }
 
 const prevPair = async () => {
   if (currentBattle.value.length !== 0 && currentBattle.value[0] > 0) {
+    markSaving()
     currentBattle.value = [currentBattle.value[0] - 1, currentBattle.value[1]]
     const left = currentBattle?.value[1][currentBattle?.value[0]][0]
     const right = currentBattle?.value[1][currentBattle?.value[0]][1]
@@ -192,14 +205,16 @@ const prevPair = async () => {
     currentWinner.value = -2
     currentRound.value -= 1
     saveGenreBattleState(selectedGenre.value)
+    markSaved()
   }
 }
 
 const nextPair = async () => {
   if (currentBattle.value.length === 0) return
+  markSaving()
   await resetJudgeVote()
   if (isSmoke.value) {
-    await update7toSmokeMatch(currentWinner.value)  // handles queue reorder + updateSmokePair + currentWinner reset
+    await update7toSmokeMatch(currentWinner.value)
     await setBattlePair(rounds.value[0].name, rounds.value[1].name, false, getMembersFor(rounds.value[0].name), getMembersFor(rounds.value[1].name))
     await setBattlePhase('LOCKED')
     battlePhase.value = 'LOCKED'
@@ -216,7 +231,6 @@ const nextPair = async () => {
       currentRound.value += 1
       saveGenreBattleState(selectedGenre.value)
     } else {
-      // Last battle of this round — end match and return to IDLE
       await setBattlePhase('IDLE')
       battlePhase.value = 'IDLE'
       currentWinner.value = -2
@@ -226,6 +240,7 @@ const nextPair = async () => {
       saveGenreBattleState(selectedGenre.value)
     }
   }
+  markSaved()
 }
 
 const topParticipants = computed(() => {
@@ -847,7 +862,7 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
 
 const jumpToRecoveredPair = async () => {
   if (!recoveryState.value) return
-  showRecoveryBanner.value = false
+  markSaving()
   const { currentPair, currentRoundIndex, battlePhase: restoredPhase, bracket } = recoveryState.value
 
   if (!isSmoke.value && bracket?.rounds) {
@@ -884,6 +899,7 @@ const jumpToRecoveredPair = async () => {
   await setBattlePhase(phase)
   battlePhase.value = phase
   saveGenreBattleState(selectedGenre.value)
+  markSaved()
 }
 
 // Per-genre judge persistence helpers — stores { id, vote } so votes survive genre switches
@@ -1076,9 +1092,11 @@ const dismissReveal = async () => {
 }
 
 const openVoting = async () => {
+  markSaving()
   await setBattlePhase('VOTING')
   battlePhase.value = 'VOTING'
   saveGenreBattleState(selectedGenre.value)
+  markSaved()
 }
 
 const confirmResetBracket = async () => {
@@ -1235,12 +1253,12 @@ onMounted(async () => {
     const storedTop = localStorage.getItem('currentTop')
     if (storedTop) currentTop.value = storedTop
   }
-  // Recovery banner — always check backend state (local refs are empty on fresh load)
+  // Auto-restore from backend state on refresh — always check regardless of local state
   const battleState = await getBattleState()
   if (battleState?.battlePhase && battleState.battlePhase !== 'IDLE' && battleState.currentPair?.left) {
-    currentRound.value = battleState.currentRoundIndex ?? 0
     recoveryState.value = battleState
-    showRecoveryBanner.value = true
+    await jumpToRecoveredPair()   // restore silently
+    showRecoveryBanner.value = true  // then notify the operator
   }
   wsClient.value = createClient()
   // Single onConnect handler — multiple subscribeToChannel calls before connection
@@ -1274,7 +1292,20 @@ onUnmounted(() => {
     <!-- Page header -->
     <div>
       <div class="type-page-title">Battle Control</div>
-      <p class="type-label text-content-muted mt-1">Manage brackets, rounds, and live voting</p>
+      <div class="flex items-center gap-3 mt-1">
+        <p class="type-label text-content-muted">Manage brackets, rounds, and live voting</p>
+        <Transition name="recovery-fade" mode="out-in">
+          <span v-if="saveStatus === 'saving'" key="saving" class="inline-flex items-center gap-1 type-label text-content-muted" style="font-size:10px;letter-spacing:0.18em">
+            <i class="pi pi-spin pi-spinner" style="font-size:9px"></i> SAVING
+          </span>
+          <span v-else-if="saveStatus === 'saved'" key="saved" class="inline-flex items-center gap-1 type-label text-emerald-400" style="font-size:10px;letter-spacing:0.18em">
+            <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span> SAVED
+          </span>
+          <span v-else-if="saveStatus === 'error'" key="error" class="inline-flex items-center gap-1 type-label text-amber-400" style="font-size:10px;letter-spacing:0.18em">
+            <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span> SAVE FAILED
+          </span>
+        </Transition>
+      </div>
     </div>
 
     <!-- Quick access links -->
@@ -1332,14 +1363,11 @@ onUnmounted(() => {
         <div class="recovery-body">
           <span class="recovery-dot"></span>
           <div class="recovery-text">
-            <span class="recovery-title">IN PROGRESS</span>
+            <span class="recovery-title">RESTORED</span>
             <span class="recovery-detail">ROUND {{ recoveryState.currentRoundIndex + 1 }} — {{ recoveryState.currentPair?.left ?? '???' }} VS {{ recoveryState.currentPair?.right ?? '???' }}</span>
           </div>
         </div>
         <div class="recovery-actions">
-          <button class="recovery-btn recovery-btn-jump" @click="jumpToRecoveredPair">
-            JUMP TO PAIR
-          </button>
           <button class="recovery-btn recovery-btn-dismiss" @click="showRecoveryBanner = false">
             DISMISS
           </button>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1519,7 +1519,7 @@ onUnmounted(() => {
               : 'text-content-muted hover:text-content-primary'"
           >
             {{ g }}
-            <i v-if="genreChampions[g] || (g === selectedGenre && showFinalReveal)" class="pi pi-star-fill text-[9px] text-amber-400" :title="genreChampions[g] ? `Champion: ${genreChampions[g]}` : 'Judges voted — ready to reveal'"></i>
+            <i v-if="g === selectedGenre && showFinalReveal" class="pi pi-star-fill text-[9px] text-amber-400" title="Judges voted — ready to reveal champion"></i>
           </button>
         </div>
         <!-- Format toggle — hidden for smoke genres (format auto-detected from genre name) -->

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -157,6 +157,7 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
   currentRound.value = startIdx
   currentTop.value = top
   localStorage.setItem('currentTop', top)
+  broadcastBracket()  // syncs currentRoundIndex to backend so recovery finds the right pair
   saveGenreBattleState(selectedGenre.value)
   markSaved()
 }
@@ -881,9 +882,12 @@ const jumpToRecoveredPair = async () => {
     }
     currentTop.value = topKey
     localStorage.setItem('currentTop', topKey)
-    currentRound.value = currentRoundIndex ?? 0
     const pairList = bracket.rounds[topKey] ?? []
-    currentBattle.value = [currentRoundIndex ?? 0, pairList]
+    // Find pair by name — currentRoundIndex can be stale if broadcastBracket wasn't called
+    const nameIdx = pairList.findIndex(m => m[0] === currentPair.left && m[1] === currentPair.right)
+    const resolvedIdx = nameIdx >= 0 ? nameIdx : (currentRoundIndex ?? 0)
+    currentRound.value = resolvedIdx
+    currentBattle.value = [resolvedIdx, pairList]
     await setBattlePair(
       currentPair.left, currentPair.right, currentPair.isFinal,
       currentPair.leftMembers?.length ? currentPair.leftMembers : getMembersFor(currentPair.left),
@@ -1292,20 +1296,7 @@ onUnmounted(() => {
     <!-- Page header -->
     <div>
       <div class="type-page-title">Battle Control</div>
-      <div class="flex items-center gap-3 mt-1">
-        <p class="type-label text-content-muted">Manage brackets, rounds, and live voting</p>
-        <Transition name="recovery-fade" mode="out-in">
-          <span v-if="saveStatus === 'saving'" key="saving" class="inline-flex items-center gap-1 type-label text-content-muted" style="font-size:10px;letter-spacing:0.18em">
-            <i class="pi pi-spin pi-spinner" style="font-size:9px"></i> SAVING
-          </span>
-          <span v-else-if="saveStatus === 'saved'" key="saved" class="inline-flex items-center gap-1 type-label text-emerald-400" style="font-size:10px;letter-spacing:0.18em">
-            <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span> SAVED
-          </span>
-          <span v-else-if="saveStatus === 'error'" key="error" class="inline-flex items-center gap-1 type-label text-amber-400" style="font-size:10px;letter-spacing:0.18em">
-            <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span> SAVE FAILED
-          </span>
-        </Transition>
-      </div>
+      <p class="type-label text-content-muted mt-1">Manage brackets, rounds, and live voting</p>
     </div>
 
     <!-- Quick access links -->
@@ -1938,6 +1929,18 @@ onUnmounted(() => {
           ></div>
           <span class="type-body" :class="battlePhase === 'REVEALED' ? 'text-emerald-400' : battlePhase === 'LOCKED' ? 'text-amber-400' : battlePhase === 'VOTING' ? 'text-amber-400' : 'text-gray-400'">{{ battlePhase }}</span>
         </div>
+        <!-- Save state indicator — next to phase badge so operator sees it -->
+        <Transition name="recovery-fade" mode="out-in">
+          <span v-if="saveStatus === 'saving'" key="saving" class="inline-flex items-center gap-1.5 px-2.5 py-1 type-label text-content-muted" style="font-size:10px;letter-spacing:0.16em;background:rgba(255,255,255,0.04);clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)">
+            <i class="pi pi-spin pi-spinner" style="font-size:9px"></i> SAVING
+          </span>
+          <span v-else-if="saveStatus === 'saved'" key="saved" class="inline-flex items-center gap-1.5 px-2.5 py-1 type-label text-emerald-400" style="font-size:10px;letter-spacing:0.16em;background:rgba(52,211,153,0.08);clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)">
+            <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400" style="box-shadow:0 0 6px rgba(52,211,153,0.7)"></span> SAVED
+          </span>
+          <span v-else-if="saveStatus === 'error'" key="error" class="inline-flex items-center gap-1.5 px-2.5 py-1 type-label text-amber-400" style="font-size:10px;letter-spacing:0.16em;background:rgba(245,158,11,0.08);clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)">
+            <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400" style="box-shadow:0 0 6px rgba(245,158,11,0.7)"></span> SAVE FAILED
+          </span>
+        </Transition>
       </div>
 
       <!-- Final tie warning -->

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1289,6 +1289,11 @@ watch(topSize, async (newVal, oldVal) => {
     currentBattle.value = battle ?? []
     currentTop.value = top ?? ''
     currentRound.value = round ?? 0
+    // Broadcast the restored pair so the overlay reflects this size immediately
+    const pair = currentBattlePair.value
+    if (!isSmoke.value && pair?.[0] && pair?.[1]) {
+      await setBattlePair(pair[0], pair[1], top === 'Top2', getMembersFor(pair[0]), getMembersFor(pair[1]))
+    }
   } else {
     currentBattle.value = []
     currentTop.value = ''

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2211,11 +2211,12 @@ onUnmounted(() => {
           </button>
         </template>
 
-        <!-- Champion Reveal — only for the final (Top2). Shows immediately when judges
-             vote (showFinalReveal), and persists when returning to the genre after the
-             final is done (genreChampions set + no non-final round active). -->
+        <!-- Champion Reveal — only for the final (Top2).
+             showFinalReveal: judges voted live in the final.
+             currentGenreChampion: winner slot in rounds['Top2'][0][2] is set — only
+             possible after the actual final match is scored, not from Top4/etc propagation. -->
         <button
-          v-if="(showFinalReveal || (genreChampions[selectedGenre] && (isFinalInProgress || currentBattle.length === 0))) && !revealActive"
+          v-if="(showFinalReveal || currentGenreChampion) && !revealActive"
           @click="revealChampionForGenre"
           class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
         >

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2206,10 +2206,11 @@ onUnmounted(() => {
           </button>
         </template>
 
-        <!-- Champion Reveal — shows as soon as judges vote (genreChampions tracks this),
-             persists across genre switches and refreshes regardless of live phase state -->
+        <!-- Champion Reveal — only for the final (Top2). Shows immediately when judges
+             vote (showFinalReveal), and persists when returning to the genre after the
+             final is done (genreChampions set + no non-final round active). -->
         <button
-          v-if="(genreChampions[selectedGenre] || showFinalReveal) && !revealActive"
+          v-if="(showFinalReveal || (genreChampions[selectedGenre] && (isFinalInProgress || currentBattle.length === 0))) && !revealActive"
           @click="revealChampionForGenre"
           class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
         >

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -537,6 +537,7 @@ const applyToFirstRound = () => {
       if (r?.name && guestNames.has(r.name)) return r // pinned guest
       return { name: filteredSeeds[si++] ?? null, score: r?.score ?? 0 }
     })
+    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     return
   }
@@ -1560,7 +1561,7 @@ watch(topSize, async (newVal, oldVal) => {
   if (selectedEvent.value && selectedGenre.value) {
     localStorage.setItem(genreTopSizeKey(selectedGenre.value), String(newVal))
   }
-  const storedRounds = localStorage.getItem(`Top${newVal}${selectedGenre.value}Rounds`)
+  const storedRounds = localStorage.getItem(`Top${newVal}${selectedEvent.value}${selectedGenre.value}Rounds`)
   rounds.value = JSON.parse(storedRounds) || initRounds()
   currentWinner.value = -2
   // Only clear battle on user-initiated size change (not programmatic from
@@ -1573,7 +1574,9 @@ watch(topSize, async (newVal, oldVal) => {
     currentTop.value = ''
   }
   skipSizeChangeClear = false
-  broadcastBracket()
+  // Guard against broadcasting before event/genre are known (initial load with null values
+  // would send empty initRounds() to DB, corrupting the stored bracket).
+  if (selectedEvent.value && selectedGenre.value) broadcastBracket()
 
   // Restore the incoming size's battle state (pair + phase). Do NOT push to overlay —
   // the overlay updates only when the operator clicks a round tab or "Start Round".

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -921,36 +921,52 @@ const saveGenreBattleState = (genre) => {
 }
 
 const restoreAndBroadcastGenreBattle = async (genre) => {
+  // At this point, switchActiveGenreService has already loaded this genre's state from DB
+  // and broadcast it to all connected clients (overlay, bracket, judge). We only need
+  // to restore local BattleControl UI state — no backend calls needed here.
   const saved = localStorage.getItem(genreBattleStateKey(genre))
-  if (!saved) {
+  if (saved) {
+    const { battle, top, round, phase } = JSON.parse(saved)
+    currentBattle.value = battle ?? []
+    currentTop.value = top ?? ''
+    currentRound.value = round ?? 0
+    currentWinner.value = -2
+    battlePhase.value = phase ?? 'IDLE'
+    return
+  }
+  // No localStorage: reconstruct local state from backend (already loaded by switchActiveGenreService).
+  // Do NOT clear or re-push to backend — it already has the correct state.
+  const state = await getBattleState()
+  if (!state?.currentPair?.left || state.battlePhase === 'IDLE') {
     currentBattle.value = []
     currentTop.value = ''
     currentRound.value = 0
     currentWinner.value = -2
-    // Ensure the backend is also clean — clearBattlePair doesn't persist, so
-    // explicitly set IDLE on the backend in case a stale pair was left behind.
-    await clearBattlePair()
-    await setBattlePhase('IDLE')
-    battlePhase.value = 'IDLE'
     return
   }
-  const { battle, top, round, phase } = JSON.parse(saved)
-  currentBattle.value = battle ?? []
-  currentTop.value = top ?? ''
-  currentRound.value = round ?? 0
+  battlePhase.value = state.battlePhase ?? 'IDLE'
   currentWinner.value = -2
-  // Re-broadcast so the overlay updates to this genre's current pair without needing "Start Round"
-  const pair = currentBattlePair.value
-  if (pair?.[0] && pair?.[1]) {
-    await setBattlePair(pair[0], pair[1], top === 'Top2', getMembersFor(pair[0]), getMembersFor(pair[1]))
-    // setBattlePair always forces backend phase to LOCKED. If the saved state was
-    // VOTING or DECIDED, restore it. Set local phase once at the end to avoid a WS
-    // race where the async LOCKED message overwrites a prior local assignment.
-    const targetPhase = (phase === 'VOTING' || phase === 'DECIDED') ? phase : 'LOCKED'
-    if (targetPhase !== 'LOCKED') {
-      await setBattlePhase(targetPhase)
+  if (!isSmoke.value && state.bracket?.rounds) {
+    const bRounds = state.bracket.rounds
+    let topKey = state.currentPair.isFinal ? 'Top2' : null
+    if (!topKey) {
+      for (const key of Object.keys(bRounds)) {
+        const matchList = bRounds[key]
+        if (!Array.isArray(matchList)) continue
+        if (matchList.some(m => m[0] === state.currentPair.left && m[1] === state.currentPair.right)) {
+          topKey = key; break
+        }
+      }
     }
-    battlePhase.value = targetPhase
+    if (topKey) {
+      currentTop.value = topKey
+      const pairList = bRounds[topKey] ?? []
+      const nameIdx = pairList.findIndex(m => m[0] === state.currentPair.left && m[1] === state.currentPair.right)
+      const resolvedIdx = nameIdx >= 0 ? nameIdx : (state.currentRoundIndex ?? 0)
+      currentRound.value = resolvedIdx
+      currentBattle.value = [resolvedIdx, pairList]
+      saveGenreBattleState(genre)
+    }
   }
 }
 
@@ -974,6 +990,7 @@ const jumpToRecoveredPair = async () => {
     genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: restoredChampion }
   }
 
+  // Restore local bracket and pair position first (no backend calls yet)
   if (!isSmoke.value && bracket?.rounds) {
     rounds.value = bracket.rounds
     // Find which round key contains this match
@@ -996,6 +1013,23 @@ const jumpToRecoveredPair = async () => {
     const resolvedIdx = nameIdx >= 0 ? nameIdx : (currentRoundIndex ?? 0)
     currentRound.value = resolvedIdx
     currentBattle.value = [resolvedIdx, pairList]
+  }
+
+  // REVEALED: backend already has the correct state loaded from DB on startup.
+  // Calling setBattlePair would force LOCKED and broadcast it to all connected devices.
+  if (restoredPhase === 'REVEALED') {
+    battlePhase.value = 'REVEALED'
+    const match = rounds.value[currentTop.value]?.[currentRound.value]
+    if (match?.[2]) {
+      currentWinner.value = match[2] === currentBattlePair.value?.[0] ? 0 : 1
+    }
+    saveGenreBattleState(selectedGenre.value)
+    markSaved()
+    return
+  }
+
+  // Non-REVEALED: re-broadcast pair and phase to overlay and judges
+  if (!isSmoke.value && bracket?.rounds) {
     await setBattlePair(
       currentPair.left, currentPair.right, currentPair.isFinal,
       currentPair.leftMembers?.length ? currentPair.leftMembers : getMembersFor(currentPair.left),
@@ -1731,7 +1765,7 @@ onUnmounted(() => {
           <span class="recovery-dot"></span>
           <div class="recovery-text">
             <span class="recovery-title">RESTORED</span>
-            <span class="recovery-detail">ROUND {{ recoveryState.currentRoundIndex + 1 }} — {{ recoveryState.currentPair?.left ?? '???' }} VS {{ recoveryState.currentPair?.right ?? '???' }}</span>
+            <span class="recovery-detail">{{ recoveryState.currentPair?.left ?? '???' }} VS {{ recoveryState.currentPair?.right ?? '???' }}</span>
           </div>
         </div>
         <div class="recovery-actions">

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -151,7 +151,7 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
   await resetJudgeVote()
   if (top === 'Top2' && Array.isArray(rounds.value['Top2']?.[0])) {
     rounds.value['Top2'][0][2] = null
-    localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
   }
   currentBattle.value = [startIdx, pairList]
@@ -184,7 +184,7 @@ const initiateBattlePair = async (top, pairList) => {
   // preventing a stale "Reveal Champion" button from appearing alongside showFinalReveal.
   if (top === 'Top2' && Array.isArray(rounds.value['Top2']?.[0])) {
     rounds.value['Top2'][0][2] = null
-    localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
   }
   currentBattle.value = [0, pairList]
@@ -488,7 +488,7 @@ const placeGuestsInBracket = () => {
       }
       if (lowestSlot) lowestSlot.name = guest.guestName
     }
-    localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     return
   }
@@ -524,7 +524,7 @@ const placeGuestsInBracket = () => {
     }
     if (lowestMatch !== null) lowestMatch[lowestSlot] = guest.guestName
   }
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -553,7 +553,7 @@ const applyToFirstRound = () => {
   freeSlots.forEach(([mi, si], idx) => {
     rounds.value[key][mi][si] = filteredSeeds[idx] ?? null
   })
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -637,7 +637,7 @@ const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
     if (guestNames.has(rounds.value[tgtRound][tgtMatch][tgtSlot])) return // never overwrite a pinned guest
     rounds.value[tgtRound][tgtMatch][tgtSlot] = name
     rounds.value[tgtRound][tgtMatch][2] = null
-    localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     if (tgtIsCurrent) reBroadcastCurrentPairIfActive()
     return
@@ -656,7 +656,7 @@ const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
   rounds.value[srcRound][srcMatch][2] = null
   if (srcRound !== tgtRound || srcMatch !== tgtMatch) rounds.value[tgtRound][tgtMatch][2] = null
 
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
   if (tgtIsCurrent || srcIsCurrent) reBroadcastCurrentPairIfActive()
 }
@@ -723,7 +723,7 @@ const onSmokeDrop = (tgtIdx) => {
     dragOverKey.value = null
     if (guestNames.has(tgtName)) return // never overwrite a pinned guest
     if (rounds.value[tgtIdx]) rounds.value[tgtIdx] = { ...rounds.value[tgtIdx], name }
-    localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     return
   }
@@ -737,14 +737,14 @@ const onSmokeDrop = (tgtIdx) => {
   const srcName = rounds.value[srcIdx]?.name
   if (rounds.value[srcIdx]) rounds.value[srcIdx] = { ...rounds.value[srcIdx], name: tgtName ?? null }
   if (rounds.value[tgtIdx]) rounds.value[tgtIdx] = { ...rounds.value[tgtIdx], name: srcName ?? null }
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
 const clearSmokeSlot = (idx) => {
   if (!rounds.value[idx]) return
   rounds.value[idx] = { ...rounds.value[idx], name: null }
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -752,7 +752,7 @@ const clearSlot = (roundKey, matchIdx, slotIdx) => {
   const match = rounds.value[roundKey][matchIdx]
   match[slotIdx] = null
   match[2] = null
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -783,12 +783,12 @@ function setWinner(roundKey, matchIdx, slotIdx) {
   match[2] = winner
   const roundIndex = roundSizes.value.indexOf(parseInt(roundKey.replace("Top", "")))
   const nextRoundSize = roundSizes.value[roundIndex + 1]
-  if (!nextRoundSize) { localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value))); broadcastBracket(); return }
+  if (!nextRoundSize) { localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value))); broadcastBracket(); return }
   const nextRoundKey = `Top${nextRoundSize}`
   const nextMatchIdx = Math.floor(matchIdx / 2)
   const nextSlotIdx = matchIdx % 2
   rounds.value[nextRoundKey][nextMatchIdx][nextSlotIdx] = winner
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -802,7 +802,7 @@ function clearWinner(roundKey, matchIdx) {
     rounds.value[`Top${nextRoundSize}`][nextMatchIdx][nextSlotIdx] = null
   }
   match[2] = null
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -947,6 +947,10 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
   battlePhase.value = state.battlePhase ?? 'IDLE'
   currentWinner.value = -2
   if (!isSmoke.value && state.bracket?.rounds) {
+    // Populate rounds.value from DB so the bracket UI is visible, then cache to localStorage
+    // so future genre switches don't need to fall back to DB again.
+    rounds.value = state.bracket.rounds
+    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${genre}Rounds`, JSON.stringify(state.bracket.rounds))
     const bRounds = state.bracket.rounds
     let topKey = state.currentPair.isFinal ? 'Top2' : null
     if (!topKey) {
@@ -1062,9 +1066,14 @@ const syncJudgesForGenre = async (newGenre, prevGenre) => {
   if (judgeSyncing) return
   judgeSyncing = true
   try {
-    // Refresh from backend first so we save the true current state (not stale cache)
-    battleJudges.value = await getBattleJudges()
+    // Save outgoing genre's judges from UI cache BEFORE fetching from backend.
+    // setActiveGenre already switched the backend to newGenre, so getBattleJudges()
+    // would return newGenre's judges — overwriting prevGenre's localStorage with the
+    // wrong list and permanently losing the outgoing genre's judge assignment.
     if (prevGenre) saveGenreJudges(prevGenre)
+    // Now fetch backend to find out which judges are currently loaded (newGenre's) so
+    // we can remove them before installing prevGenre→newGenre's saved set.
+    battleJudges.value = await getBattleJudges()
     const toRemove = battleJudges.value?.judges ?? []
     // Remove sequentially — parallel DELETEs cause ConcurrentModificationException on the
     // backend's ArrayList, silently leaving judges behind and contaminating the next genre.
@@ -1074,15 +1083,16 @@ const syncJudgesForGenre = async (newGenre, prevGenre) => {
     const raw = JSON.parse(localStorage.getItem(genreJudgeKey(newGenre)) ?? '[]')
     if (raw.length > 0) {
       // Support both old format (array of ids) and new format (array of { id, vote })
-      const entries = raw.map(s => (typeof s === 'object' ? s : { id: s, vote: -1 }))
+      const entries = raw.map(s => (typeof s === 'object' ? s : { id: s, vote: -3 }))
       // Add sequentially for the same reason as removes above
       for (const { id } of entries) {
         await addBattleJudge(id)
       }
-      // Restore non-default votes — addBattleJudge sets vote=-1, so only restore others
+      // Restore non-default votes — addBattleJudge sets vote=-3 ("not voted"), so skip those.
+      // -1 is a real tie vote and must be restored; only -3 means "hasn't voted this round".
       await Promise.all(
         entries
-          .filter(({ vote }) => vote !== undefined && vote !== -1)
+          .filter(({ vote }) => vote !== undefined && vote !== -3)
           .map(({ id, vote }) => battleJudgeVote(id, vote))
       )
     }
@@ -1152,7 +1162,7 @@ const submitRemoveBattleGuest = async (guest) => {
       }
     }
   }
-  localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -1227,23 +1237,24 @@ const unlockChampion = async () => {
 }
 
 const revealChampionForGenre = async () => {
-  // Case 1: DECIDED phase — champion locked, score not yet submitted
+  // Case 1: DECIDED phase — champion locked, score not yet submitted to bracket.
+  // Do NOT call setBattleScore here — judge votes may be stale after a page refresh.
+  // We already know who won (genreChampions), so determine the side directly from the pair.
   if (battlePhase.value === 'DECIDED' && !currentGenreChampion.value) {
     const championName = genreChampions.value[selectedGenre.value]
     if (!championName) return
-    const res = await setBattleScore(true)
-    if (res?.status === 409) { finalTieBlocked.value = true; return }
-    const data = await res.json()
-    currentWinner.value = Number(data.winner)
-    if (data.winner === 0 || data.winner === 1) {
-      setWinner(currentTop.value, currentRound.value, data.winner)
-      await revealChampion(selectedGenre.value, championName)
-      // Stay in DECIDED so the genre remains re-revealable forever
-      await setBattlePhase('DECIDED')
-      battlePhase.value = 'DECIDED'
-      saveGenreBattleState(selectedGenre.value)
-      revealActive.value = true
-    }
+    const pair = currentBattlePair.value
+    if (!pair) return
+    const side = championName === pair[0] ? 0 : (championName === pair[1] ? 1 : -1)
+    if (side === -1) return
+    setWinner(currentTop.value, currentRound.value, side)
+    currentWinner.value = side
+    await revealChampion(selectedGenre.value, championName)
+    // Stay in DECIDED so the genre remains re-revealable forever
+    await setBattlePhase('DECIDED')
+    battlePhase.value = 'DECIDED'
+    saveGenreBattleState(selectedGenre.value)
+    revealActive.value = true
     return
   }
   // Case 2: score already in bracket (winner in rounds data) OR tracked in genreChampions
@@ -1274,7 +1285,7 @@ const openVoting = async () => {
 
 const confirmResetBracket = async () => {
   showResetConfirm.value = false
-  localStorage.removeItem(`Top${topSize.value}${selectedGenre.value}Rounds`)
+  localStorage.removeItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`)
   rounds.value = initRounds()
   placeGuestsInBracket()
   broadcastBracket()
@@ -1310,7 +1321,7 @@ const requestSizeChange = (newSize) => {
 const confirmSizeChange = async () => {
   showSizeChangeConfirm.value = false
   // Reset bracket data for the current genre before switching size
-  localStorage.removeItem(`Top${topSize.value}${selectedGenre.value}Rounds`)
+  localStorage.removeItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`)
   localStorage.removeItem(sizeStateKey(topSize.value))
   topSize.value = pendingSize.value
   pendingSize.value = null
@@ -1359,7 +1370,7 @@ const cancelRoundChange = () => {
 
 // Guard: prompt before switching genre when battle is in progress
 const requestGenreChange = (genre) => {
-  if (battlePhase.value !== 'IDLE' && genre !== selectedGenre.value) {
+  if (battlePhase.value !== 'IDLE' && battlePhase.value !== 'DECIDED' && genre !== selectedGenre.value) {
     if (confirm(`A battle is in progress for "${selectedGenre.value}". Switching to "${genre}" will save the current state. Continue?`)) {
       selectedGenre.value = genre
     }
@@ -1368,7 +1379,7 @@ const requestGenreChange = (genre) => {
   }
 }
 
-watch(selectedEvent, async (newVal) => {
+watch(selectedEvent, async (newVal, oldVal) => {
   if (newVal) {
     localStorage.setItem("selectedEvent", newVal)
     const [scoreRes, participantRes] = await Promise.all([
@@ -1392,6 +1403,14 @@ watch(selectedEvent, async (newVal) => {
     memberLookup.value = lookup
     pickupCrews.value = []
     await fetchAllJudges(newVal)
+    // When the event changes but the selected genre name stays the same (shared genre name
+    // across events), watch(selectedGenre) never fires so setActiveGenre is never called.
+    // Re-register with the backend here so state is loaded from the correct event's row.
+    if (oldVal && selectedGenre.value) {
+      saveGenreBattleState(selectedGenre.value)
+      await setActiveGenre(newVal, selectedGenre.value)
+      await restoreAndBroadcastGenreBattle(selectedGenre.value)
+    }
   }
 }, { immediate: true })
 
@@ -1467,7 +1486,7 @@ watch(selectedGenre, async (newVal, oldVal) => {
       if (pending) genreChampions.value = { ...genreChampions.value, [newVal]: pending }
     }
     localStorage.setItem("selectedGenre", newVal)
-    const storedRounds = localStorage.getItem(`Top${topSize.value}${newVal}Rounds`)
+    const storedRounds = localStorage.getItem(`Top${topSize.value}${selectedEvent.value}${newVal}Rounds`)
     rounds.value = JSON.parse(storedRounds) || initRounds()
     pickupCrews.value = await getPickupCrews(selectedEvent.value, newVal)
     placeGuestsInBracket()
@@ -1475,7 +1494,11 @@ watch(selectedGenre, async (newVal, oldVal) => {
       saveGenreBattleState(oldVal)
       await setActiveGenre(selectedEvent.value, newVal)
     }
-    broadcastBracket()
+    // Only broadcast local rounds on a genre SWITCH (oldVal truthy) when localStorage has data.
+    // On initial load (oldVal falsy), setActiveGenre in onMounted hasn't completed yet so the
+    // backend still points at the previous event — broadcasting here would corrupt that event's
+    // DB row. onMounted handles state restoration after setActiveGenre confirms the correct event.
+    if (storedRounds && oldVal) broadcastBracket()
     if (oldVal) {
       await restoreAndBroadcastGenreBattle(newVal)
     }
@@ -1622,6 +1645,14 @@ watch(rounds, () => {
 
 onMounted(async () => {
   initialiseDropdown()
+  // Tell the backend which event+genre is active on every load.
+  // watch(selectedGenre) only calls setActiveGenre when the genre CHANGES (oldVal truthy),
+  // so on initial load or after an event switch via EventSelector (which remounts this page),
+  // the backend still points at the previous event. Calling it here ensures the correct
+  // (eventName, genreName) DB row is loaded before any getBattleState/getBattlePhase reads.
+  if (selectedEvent.value && selectedGenre.value) {
+    await setActiveGenre(selectedEvent.value, selectedGenre.value)
+  }
   // Restore per-genre bracket size (survives refresh)
   if (selectedEvent.value && selectedGenre.value) {
     const savedSize = localStorage.getItem(genreTopSizeKey(selectedGenre.value))
@@ -1679,7 +1710,11 @@ onMounted(async () => {
   // overwrite each other's onConnect, so we wire everything here directly.
   wsClient.value.onConnect = () => {
     wsClient.value.subscribe('/topic/battle/phase', (raw) => {
-      battlePhase.value = JSON.parse(raw.body).phase
+      const msg = JSON.parse(raw.body)
+      // Ignore phase messages intended for a different genre — stale WS from a genre
+      // switch can arrive after we've already switched back and set the correct phase.
+      if (msg.genre && msg.genre !== selectedGenre.value) return
+      battlePhase.value = msg.phase
     })
     // NOTE: /topic/battle/judges is intentionally NOT subscribed here.
     // syncJudgesForGenre does multiple remove+add operations in sequence; each

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1533,7 +1533,7 @@ onUnmounted(() => {
               : 'text-content-muted hover:text-content-primary'"
           >
             {{ g }}
-            <i v-if="g === selectedGenre && showFinalReveal" class="pi pi-star-fill text-[9px] text-amber-400" title="Judges voted — ready to reveal champion"></i>
+            <i v-if="g === selectedGenre && (showFinalReveal || (genreChampions[g] && !currentGenreChampion))" class="pi pi-star-fill text-[9px] text-amber-400" title="Judges voted — ready to reveal champion"></i>
           </button>
         </div>
         <!-- Format toggle — hidden for smoke genres (format auto-detected from genre name) -->
@@ -2223,9 +2223,11 @@ onUnmounted(() => {
         <!-- Champion Reveal — only for the final (Top2).
              showFinalReveal: judges voted live in the final.
              currentGenreChampion: winner slot in rounds['Top2'][0][2] is set — only
-             possible after the actual final match is scored, not from Top4/etc propagation. -->
+             possible after the actual final match is scored, not from Top4/etc propagation.
+             genreChampions[selectedGenre]: pending champion saved when organiser switched
+             genres before clicking Reveal — persists across genre switches. -->
         <button
-          v-if="(showFinalReveal || currentGenreChampion) && !revealActive"
+          v-if="(showFinalReveal || currentGenreChampion || genreChampions[selectedGenre]) && !revealActive"
           @click="revealChampionForGenre"
           class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
         >

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1709,7 +1709,10 @@ onUnmounted(() => {
               <div
                 v-for="(match, mIdx) in rounds[`Top${size}`]"
                 :key="mIdx"
-                class="card-hover p-3 relative flex items-stretch min-h-[44px]"
+                class="card-hover p-3 relative flex items-stretch min-h-[44px] transition-all duration-200"
+                :style="currentTop === `Top${size}` && mIdx === currentRound && battlePhase !== 'IDLE'
+                  ? 'border-color:var(--accent-color);box-shadow:0 0 0 1px var(--accent-color),0 0 16px var(--accent-muted);'
+                  : ''"
               >
                 <div class="corner-bar-tl"></div>
                 <!-- Slot 0 — left -->

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1709,10 +1709,7 @@ onUnmounted(() => {
               <div
                 v-for="(match, mIdx) in rounds[`Top${size}`]"
                 :key="mIdx"
-                class="card-hover p-3 relative flex items-stretch min-h-[44px] transition-all duration-200"
-                :style="currentTop === `Top${size}` && mIdx === currentRound && battlePhase !== 'IDLE'
-                  ? 'border-color:var(--accent-color);box-shadow:0 0 0 1px var(--accent-color),0 0 16px var(--accent-muted);'
-                  : ''"
+                class="card-hover p-3 relative flex items-stretch min-h-[44px]"
               >
                 <div class="corner-bar-tl"></div>
                 <!-- Slot 0 — left -->

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, addBattleGuest, battleJudgeVote, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, addBattleGuest, battleJudgeVote, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -27,6 +27,7 @@ const revealActive = ref(false)
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
 const showRecoveryBanner = ref(false)
 const recoveryState      = ref(null)
+const genreChampions     = ref({})
 
 const saveStatus = ref('idle') // 'idle' | 'saving' | 'saved' | 'error'
 let saveTimer = null
@@ -864,7 +865,22 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
 const jumpToRecoveredPair = async () => {
   if (!recoveryState.value) return
   markSaving()
-  const { currentPair, currentRoundIndex, battlePhase: restoredPhase, bracket } = recoveryState.value
+  const { currentPair, currentRoundIndex, battlePhase: restoredPhase, bracket, champion: restoredChampion } = recoveryState.value
+
+  // Restore topSize from DB bracket state — browser localStorage may be stale if
+  // the operator switched sizes on another session or after clearing storage.
+  if (bracket?.topSize !== undefined) {
+    const restored = Number(bracket.topSize)
+    if (!isNaN(restored) && restored !== Number(topSize.value)) {
+      topSize.value = restored
+      localStorage.setItem('topSize', String(restored))
+    }
+  }
+
+  // Restore champion if the DB recorded one for this genre
+  if (restoredChampion && selectedGenre.value) {
+    genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: restoredChampion }
+  }
 
   if (!isSmoke.value && bracket?.rounds) {
     rounds.value = bracket.rounds
@@ -1081,12 +1097,14 @@ const revealChampionForGenre = async () => {
     if (data.winner === 0 || data.winner === 1) {
       setWinner(currentTop.value, currentRound.value, data.winner)
       await revealChampion(selectedGenre.value, winnerName)
+      genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winnerName }
       revealActive.value = true
     }
     return
   }
-  if (!currentGenreChampion.value) return
-  await revealChampion(selectedGenre.value, currentGenreChampion.value)
+  if (!currentGenreChampion.value && !genreChampions.value[selectedGenre.value]) return
+  const champion = genreChampions.value[selectedGenre.value] ?? currentGenreChampion.value
+  await revealChampion(selectedGenre.value, champion)
   revealActive.value = true
 }
 
@@ -1145,19 +1163,31 @@ watch(selectedEvent, async (newVal) => {
   }
 }, { immediate: true })
 
+const genreTopSizeKey = (genre) => `battleTopSize_${selectedEvent.value}_${genre}`
+
 watch(selectedGenre, async (newVal, oldVal) => {
   // Dismiss before resetting revealActive — the check must happen while it's still true
   if (oldVal && revealActive.value) await dismissChampionReveal()
   revealActive.value = false
   if (newVal) {
-    // Auto-detect format from genre name — smoke genres always use topSize=7, others reset to 16
+    // Persist outgoing genre's topSize before switching
+    if (oldVal) localStorage.setItem(genreTopSizeKey(oldVal), String(topSize.value))
+
+    // Restore per-genre topSize — smoke auto-detection takes priority, otherwise
+    // use the saved size for this genre or fall back to 16.
     const genreNeedsSmoke = newVal.toLowerCase().includes('7 to smoke') || newVal.toLowerCase().includes('7tosmoke')
-    if (genreNeedsSmoke && Number(topSize.value) !== 7) {
-      topSize.value = 7
-      localStorage.setItem('topSize', '7')
-    } else if (!genreNeedsSmoke && Number(topSize.value) === 7) {
-      topSize.value = 16
-      localStorage.setItem('topSize', '16')
+    if (genreNeedsSmoke) {
+      if (Number(topSize.value) !== 7) {
+        topSize.value = 7
+        localStorage.setItem('topSize', '7')
+      }
+    } else {
+      const savedSize = localStorage.getItem(genreTopSizeKey(newVal))
+      const restoredSize = savedSize ? Number(savedSize) : (Number(topSize.value) === 7 ? 16 : Number(topSize.value))
+      if (restoredSize !== Number(topSize.value)) {
+        topSize.value = restoredSize
+        localStorage.setItem('topSize', String(restoredSize))
+      }
     }
     localStorage.setItem("selectedGenre", newVal)
     const storedRounds = localStorage.getItem(`Top${topSize.value}${newVal}Rounds`)
@@ -1258,6 +1288,10 @@ onMounted(async () => {
   mountJudgeSyncDone = true
   const savedConfig = await getOverlayConfig()
   if (savedConfig?.showImages !== undefined) overlayConfig.value = savedConfig
+  if (selectedEvent.value) {
+    const champions = await getBattleChampions(selectedEvent.value)
+    if (champions && typeof champions === 'object') genreChampions.value = champions
+  }
   const phaseData = await getBattlePhase()
   battlePhase.value = phaseData?.phase ?? 'IDLE'
   // Restore currentTop from localStorage only if a battle is genuinely in progress
@@ -1388,11 +1422,14 @@ onUnmounted(() => {
             v-for="g in uniqueGenres"
             :key="g"
             @click="selectedGenre = g"
-            class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150"
+            class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150 inline-flex items-center gap-1.5"
             :class="selectedGenre === g
               ? 'text-accent border-[color:var(--accent-muted)]'
               : 'text-content-muted hover:text-content-primary'"
-          >{{ g }}</button>
+          >
+            {{ g }}
+            <i v-if="genreChampions[g]" class="pi pi-star-fill text-[9px] text-amber-400" :title="`Champion: ${genreChampions[g]}`"></i>
+          </button>
         </div>
         <!-- Format toggle — hidden for smoke genres (format auto-detected from genre name) -->
         <template v-if="!isGenreSmoke">

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1186,14 +1186,23 @@ watch(uniqueGenres, (genres) => {
 
 // When all judges vote in the final, capture the winner immediately — before the
 // organiser clicks Reveal. This persists the state across genre switches and refreshes.
+// When showFinalReveal goes false due to a revote that results in a tie, clear any
+// previously saved champion so stale data doesn't linger.
 watch(showFinalReveal, (newVal) => {
-  if (!newVal || !selectedGenre.value) return
-  const winner = tentativeWinner.value === 0
-    ? currentBattlePair.value?.[0]
-    : currentBattlePair.value?.[1]
-  if (!winner) return
-  genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
-  localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winner)
+  if (!selectedGenre.value) return
+  if (newVal) {
+    const winner = tentativeWinner.value === 0
+      ? currentBattlePair.value?.[0]
+      : currentBattlePair.value?.[1]
+    if (!winner) return
+    genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
+    localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winner)
+  } else if (isFinalInProgress.value && allJudgesVoted.value && tentativeWinner.value === -1) {
+    // All judges voted but it's a tie — remove any pending champion
+    const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
+    genreChampions.value = rest
+    localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
+  }
 })
 
 watch(selectedGenre, async (newVal, oldVal) => {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -128,6 +128,27 @@ const updateSmokePair = async () => {
   await updateSmokeList(rounds.value)
 }
 
+const initiateBattlePairAt = async (top, pairList, startIdx) => {
+  currentWinner.value = -2
+  revealActive.value = false
+  await resetJudgeVote()
+  if (top === 'Top2' && Array.isArray(rounds.value['Top2']?.[0])) {
+    rounds.value['Top2'][0][2] = null
+    localStorage.setItem(`Top${topSize.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
+    broadcastBracket()
+  }
+  currentBattle.value = [startIdx, pairList]
+  const left = pairList[startIdx][0]
+  const right = pairList[startIdx][1]
+  await setBattlePair(left, right, top === 'Top2', getMembersFor(left), getMembersFor(right))
+  await setBattlePhase('LOCKED')
+  battlePhase.value = 'LOCKED'
+  currentRound.value = startIdx
+  currentTop.value = top
+  localStorage.setItem('currentTop', top)
+  saveGenreBattleState(selectedGenre.value)
+}
+
 const initiateBattlePair = async (top, pairList) => {
   // Reset winner FIRST so the winnerAnnouncement computed doesn't fire setWinner
   // with stale winner + new round/top values when reactive state updates below.
@@ -827,8 +848,42 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
 const jumpToRecoveredPair = async () => {
   if (!recoveryState.value) return
   showRecoveryBanner.value = false
-  currentRound.value = recoveryState.value.currentRoundIndex ?? 0
-  await restoreAndBroadcastGenreBattle(selectedGenre.value)
+  const { currentPair, currentRoundIndex, battlePhase: restoredPhase, bracket } = recoveryState.value
+
+  if (!isSmoke.value && bracket?.rounds) {
+    rounds.value = bracket.rounds
+    // Find which round key contains this match
+    let topKey = 'Top2'
+    if (!currentPair.isFinal) {
+      for (const key of Object.keys(bracket.rounds)) {
+        const matchList = bracket.rounds[key]
+        if (!Array.isArray(matchList)) continue
+        if (matchList.some(m => m[0] === currentPair.left && m[1] === currentPair.right)) {
+          topKey = key
+          break
+        }
+      }
+    }
+    currentTop.value = topKey
+    localStorage.setItem('currentTop', topKey)
+    currentRound.value = currentRoundIndex ?? 0
+    const pairList = bracket.rounds[topKey] ?? []
+    currentBattle.value = [currentRoundIndex ?? 0, pairList]
+    await setBattlePair(
+      currentPair.left, currentPair.right, currentPair.isFinal,
+      currentPair.leftMembers?.length ? currentPair.leftMembers : getMembersFor(currentPair.left),
+      currentPair.rightMembers?.length ? currentPair.rightMembers : getMembersFor(currentPair.right)
+    )
+  } else {
+    // Smoke or no bracket data — just re-broadcast the pair
+    await setBattlePair(currentPair.left, currentPair.right, false,
+      getMembersFor(currentPair.left), getMembersFor(currentPair.right))
+  }
+
+  const phase = restoredPhase && restoredPhase !== 'IDLE' ? restoredPhase : 'LOCKED'
+  await setBattlePhase(phase)
+  battlePhase.value = phase
+  saveGenreBattleState(selectedGenre.value)
 }
 
 // Per-genre judge persistence helpers — stores { id, vote } so votes survive genre switches
@@ -1159,15 +1214,13 @@ onMounted(async () => {
   await fetchAllJudges(selectedEvent.value)
   await fetchBattleGuests()
   battleJudges.value = await getBattleJudges()
-  // Sync backend to the current genre's saved judges.
-  // On reload, the backend may have stale judges from a previous genre.
-  // If localStorage has a saved state for this genre, use it as truth.
-  // If not, save what the backend has so future genre switches work correctly.
+  // Backend DB is now authoritative for judges (persisted on every change).
+  // On refresh, don't call syncJudgesForGenre — that removes all judges and re-adds
+  // from localStorage, which broadcasts an empty list and makes BattleJudge ask "who are you?".
+  // Just seed localStorage if it's empty so future genre switches have a value to restore.
   if (selectedGenre.value) {
     const savedRaw = localStorage.getItem(genreJudgeKey(selectedGenre.value))
-    if (savedRaw !== null) {
-      await syncJudgesForGenre(selectedGenre.value, null)
-    } else {
+    if (savedRaw === null) {
       saveGenreJudges(selectedGenre.value)
     }
   }
@@ -1182,13 +1235,12 @@ onMounted(async () => {
     const storedTop = localStorage.getItem('currentTop')
     if (storedTop) currentTop.value = storedTop
   }
-  // Recovery banner: if a battle was in progress, offer to jump back to the active pair
-  if (battlePhase.value !== 'IDLE' && currentBattlePair.value?.[0]) {
-    const raw = await getBattleState()
-    if (raw && raw.currentRoundIndex !== undefined) {
-      recoveryState.value = raw
-      showRecoveryBanner.value = true
-    }
+  // Recovery banner — always check backend state (local refs are empty on fresh load)
+  const battleState = await getBattleState()
+  if (battleState?.battlePhase && battleState.battlePhase !== 'IDLE' && battleState.currentPair?.left) {
+    currentRound.value = battleState.currentRoundIndex ?? 0
+    recoveryState.value = battleState
+    showRecoveryBanner.value = true
   }
   wsClient.value = createClient()
   // Single onConnect handler — multiple subscribeToChannel calls before connection
@@ -1733,6 +1785,13 @@ onUnmounted(() => {
                     :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
                   >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
                 </div>
+                <!-- Start from this match -->
+                <button
+                  v-if="match[0] && match[1]"
+                  @click="initiateBattlePairAt(`Top${size}`, rounds[`Top${size}`], mIdx)"
+                  class="flex-shrink-0 flex items-center justify-center w-8 ml-1.5 self-stretch rounded text-accent border border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)] hover:bg-[color:var(--accent-muted)] transition-colors"
+                  title="Start round from this match"
+                ><i class="pi pi-play text-[10px]"></i></button>
               </div>
             </div>
 

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -36,7 +36,7 @@ const markSaved  = () => {
   clearTimeout(saveTimer)
   saveTimer = setTimeout(() => { saveStatus.value = 'idle' }, 2200)
 }
-const markSaveError = () => { saveStatus.value = 'error' }
+const _markSaveError = () => { saveStatus.value = 'error' }
 
 const HEX_RE = /^#[0-9A-Fa-f]{6}$/
 const overlayConfigError = ref('')

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1101,6 +1101,11 @@ const revealChampionForGenre = async () => {
   // Case 2: score already in bracket (winner in rounds data) OR tracked in genreChampions
   const champion = currentGenreChampion.value ?? genreChampions.value[selectedGenre.value]
   if (!champion) return
+  // Update live match winner display so the WIN button reflects the correct side
+  if (currentBattlePair.value) {
+    const side = champion === currentBattlePair.value[0] ? 0 : (champion === currentBattlePair.value[1] ? 1 : -1)
+    if (side !== -1) currentWinner.value = side
+  }
   await revealChampion(selectedGenre.value, champion)
   revealActive.value = true
 }
@@ -1131,6 +1136,10 @@ const confirmResetBracket = async () => {
   currentTop.value = ''
   localStorage.removeItem('currentTop')
   saveGenreBattleState(selectedGenre.value)
+  // Clear champion tracking for this genre
+  const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
+  genreChampions.value = rest
+  localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
 }
 
 watch(selectedEvent, async (newVal) => {
@@ -1257,6 +1266,8 @@ const sizeStateKey = (size) => `battleSizeState_${selectedEvent.value}_${selecte
 
 watch(topSize, async (newVal, oldVal) => {
   if (!newVal) return
+  // Reset to first round tab so the bracket is always visible after a size change
+  activeRoundIdx.value = 0
   // Save last-selected pair for outgoing size so we can restore it on return
   if (oldVal && currentBattle.value.length > 0) {
     localStorage.setItem(sizeStateKey(oldVal), JSON.stringify({
@@ -1508,7 +1519,7 @@ onUnmounted(() => {
               : 'text-content-muted hover:text-content-primary'"
           >
             {{ g }}
-            <i v-if="genreChampions[g]" class="pi pi-star-fill text-[9px] text-amber-400" :title="`Champion: ${genreChampions[g]}`"></i>
+            <i v-if="genreChampions[g] || (g === selectedGenre && showFinalReveal)" class="pi pi-star-fill text-[9px] text-amber-400" :title="genreChampions[g] ? `Champion: ${genreChampions[g]}` : 'Judges voted — ready to reveal'"></i>
           </button>
         </div>
         <!-- Format toggle — hidden for smoke genres (format auto-detected from genre name) -->

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1080,30 +1080,27 @@ const startRevote = async () => {
 }
 
 const revealChampionForGenre = async () => {
-  if (showFinalReveal.value) {
-    // Capture winner name before broadcasting (tentativeWinner computed from live votes)
+  // Case 1: live voting round — score not yet submitted, use tentative winner from votes
+  if (showFinalReveal.value && !currentGenreChampion.value) {
     const winnerName = tentativeWinner.value === 0
       ? currentBattlePair.value?.[0]
       : currentBattlePair.value?.[1]
-    // Directly broadcast the score — bypasses submitGetScore's early-return guard
     const res = await setBattleScore(true)
-    if (res?.status === 409) {
-      // Defensive: shouldn't happen since tentativeWinner !== -1
-      finalTieBlocked.value = true
-      return
-    }
+    if (res?.status === 409) { finalTieBlocked.value = true; return }
     const data = await res.json()
     currentWinner.value = Number(data.winner)
     if (data.winner === 0 || data.winner === 1) {
       setWinner(currentTop.value, currentRound.value, data.winner)
-      await revealChampion(selectedGenre.value, winnerName)
       genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winnerName }
+      localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winnerName)
+      await revealChampion(selectedGenre.value, winnerName)
       revealActive.value = true
     }
     return
   }
-  if (!currentGenreChampion.value && !genreChampions.value[selectedGenre.value]) return
-  const champion = genreChampions.value[selectedGenre.value] ?? currentGenreChampion.value
+  // Case 2: score already in bracket (winner in rounds data) OR tracked in genreChampions
+  const champion = currentGenreChampion.value ?? genreChampions.value[selectedGenre.value]
+  if (!champion) return
   await revealChampion(selectedGenre.value, champion)
   revealActive.value = true
 }
@@ -1164,17 +1161,56 @@ watch(selectedEvent, async (newVal) => {
 }, { immediate: true })
 
 const genreTopSizeKey = (genre) => `battleTopSize_${selectedEvent.value}_${genre}`
+const genreChampionLocalKey = (genre) => `battleChampion_${selectedEvent.value}_${genre}`
+
+// Load pending champions from localStorage for all genres as they become known
+watch(uniqueGenres, (genres) => {
+  if (!selectedEvent.value || !genres?.length) return
+  const locals = {}
+  for (const g of genres) {
+    const p = localStorage.getItem(genreChampionLocalKey(g))
+    if (p) locals[g] = p
+  }
+  // Merge: backend confirmed data (already in genreChampions) takes precedence
+  genreChampions.value = { ...locals, ...genreChampions.value }
+}, { immediate: true })
+
+// When all judges vote in the final, capture the winner immediately — before the
+// organiser clicks Reveal. This persists the state across genre switches and refreshes.
+watch(showFinalReveal, (newVal) => {
+  if (!newVal || !selectedGenre.value) return
+  const winner = tentativeWinner.value === 0
+    ? currentBattlePair.value?.[0]
+    : currentBattlePair.value?.[1]
+  if (!winner) return
+  genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
+  localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winner)
+})
 
 watch(selectedGenre, async (newVal, oldVal) => {
   // Dismiss before resetting revealActive — the check must happen while it's still true
   if (oldVal && revealActive.value) await dismissChampionReveal()
   revealActive.value = false
   if (newVal) {
+    // If all judges voted in the final but organiser hasn't clicked Reveal yet,
+    // save the winner before switching away so the button reappears on return.
+    if (oldVal && showFinalReveal.value) {
+      const winner = tentativeWinner.value === 0
+        ? currentBattlePair.value?.[0]
+        : currentBattlePair.value?.[1]
+      if (winner) {
+        genreChampions.value = { ...genreChampions.value, [oldVal]: winner }
+        localStorage.setItem(genreChampionLocalKey(oldVal), winner)
+      }
+    }
+
     // Persist outgoing genre's topSize before switching
     if (oldVal) localStorage.setItem(genreTopSizeKey(oldVal), String(topSize.value))
 
     // Restore per-genre topSize — smoke auto-detection takes priority, otherwise
-    // use the saved size for this genre or fall back to 16.
+    // use the saved size for this genre.  When no saved size exists, default to 16
+    // for a genre switch (don't inherit the outgoing genre's size), but keep the
+    // global localStorage value on first/immediate load so a refresh is stable.
     const genreNeedsSmoke = newVal.toLowerCase().includes('7 to smoke') || newVal.toLowerCase().includes('7tosmoke')
     if (genreNeedsSmoke) {
       if (Number(topSize.value) !== 7) {
@@ -1183,11 +1219,17 @@ watch(selectedGenre, async (newVal, oldVal) => {
       }
     } else {
       const savedSize = localStorage.getItem(genreTopSizeKey(newVal))
-      const restoredSize = savedSize ? Number(savedSize) : (Number(topSize.value) === 7 ? 16 : Number(topSize.value))
+      const restoredSize = savedSize ? Number(savedSize) : (oldVal ? 16 : Number(topSize.value))
       if (restoredSize !== Number(topSize.value)) {
         topSize.value = restoredSize
         localStorage.setItem('topSize', String(restoredSize))
       }
+    }
+
+    // Restore pending champion for incoming genre from localStorage
+    if (newVal && !genreChampions.value[newVal]) {
+      const pending = localStorage.getItem(genreChampionLocalKey(newVal))
+      if (pending) genreChampions.value = { ...genreChampions.value, [newVal]: pending }
     }
     localStorage.setItem("selectedGenre", newVal)
     const storedRounds = localStorage.getItem(`Top${topSize.value}${newVal}Rounds`)
@@ -1211,14 +1253,48 @@ watch(selectedGenre, async (newVal, oldVal) => {
   }
 }, { immediate: true })
 
-watch(topSize, async (newVal) => {
-  if (newVal) {
-    localStorage.setItem("topSize", newVal)
-    const storedRounds = localStorage.getItem(`Top${newVal}${selectedGenre.value}Rounds`)
-    rounds.value = JSON.parse(storedRounds) || initRounds()
+const sizeStateKey = (size) => `battleSizeState_${selectedEvent.value}_${selectedGenre.value}_${size}`
+
+watch(topSize, async (newVal, oldVal) => {
+  if (!newVal) return
+  // Save last-selected pair for outgoing size so we can restore it on return
+  if (oldVal && currentBattle.value.length > 0) {
+    localStorage.setItem(sizeStateKey(oldVal), JSON.stringify({
+      battle: toRaw(currentBattle.value),
+      top: currentTop.value,
+      round: currentRound.value,
+    }))
+  }
+  localStorage.setItem("topSize", newVal)
+  const storedRounds = localStorage.getItem(`Top${newVal}${selectedGenre.value}Rounds`)
+  rounds.value = JSON.parse(storedRounds) || initRounds()
+  currentWinner.value = -2
+  broadcastBracket()
+
+  // Restore last pair for this size; if none, show the first filled pair in the bracket
+  const savedSizeState = localStorage.getItem(sizeStateKey(newVal))
+  if (savedSizeState) {
+    const { battle, top, round } = JSON.parse(savedSizeState)
+    currentBattle.value = battle ?? []
+    currentTop.value = top ?? ''
+    currentRound.value = round ?? 0
+  } else {
     currentBattle.value = []
-    currentWinner.value = -2
-    broadcastBracket()
+    currentTop.value = ''
+    currentRound.value = 0
+    // Broadcast first filled pair so the overlay immediately reflects the new format
+    if (!isSmoke.value) {
+      const topKey = `Top${newVal}`
+      const pairList = rounds.value[topKey] ?? []
+      const firstFilledIdx = pairList.findIndex(m => Array.isArray(m) && m[0] && m[1])
+      if (firstFilledIdx >= 0) {
+        const [left, right] = pairList[firstFilledIdx]
+        currentBattle.value = [firstFilledIdx, pairList]
+        currentTop.value = topKey
+        currentRound.value = firstFilledIdx
+        await setBattlePair(left, right, false, getMembersFor(left), getMembersFor(right))
+      }
+    }
   }
 }, { immediate: true })
 
@@ -1290,7 +1366,11 @@ onMounted(async () => {
   if (savedConfig?.showImages !== undefined) overlayConfig.value = savedConfig
   if (selectedEvent.value) {
     const champions = await getBattleChampions(selectedEvent.value)
-    if (champions && typeof champions === 'object') genreChampions.value = champions
+    // Merge: localStorage pending (already loaded by watch(uniqueGenres)) +
+    // backend confirmed. Backend wins on conflict (official record).
+    if (champions && typeof champions === 'object') {
+      genreChampions.value = { ...genreChampions.value, ...champions }
+    }
   }
   const phaseData = await getBattlePhase()
   battlePhase.value = phaseData?.phase ?? 'IDLE'
@@ -2087,19 +2167,9 @@ onUnmounted(() => {
           Open Voting
         </button>
 
-        <!-- VOTING: final + all judges voted + clear winner → one-click Reveal Champion -->
+        <!-- VOTING: non-final, not all voted, or tie → Get Score / Rematch -->
         <button
-          v-if="showFinalReveal"
-          @click="revealChampionForGenre"
-          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
-        >
-          <i class="pi pi-star text-xs"></i>
-          Reveal Champion
-        </button>
-
-        <!-- VOTING: all other cases (non-final, not all voted, or tie) -->
-        <button
-          v-else-if="battlePhase === 'VOTING'"
+          v-if="battlePhase === 'VOTING' && !showFinalReveal"
           @click="submitGetScore"
           class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
         >
@@ -2125,9 +2195,10 @@ onUnmounted(() => {
           </button>
         </template>
 
-        <!-- Champion Reveal -->
+        <!-- Champion Reveal — shows as soon as judges vote (genreChampions tracks this),
+             persists across genre switches and refreshes regardless of live phase state -->
         <button
-          v-if="currentGenreChampion && !revealActive"
+          v-if="(genreChampions[selectedGenre] || showFinalReveal) && !revealActive"
           @click="revealChampionForGenre"
           class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
         >

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1231,6 +1231,15 @@ const syncJudgeVoteSubscriptions = () => {
 // Re-sync vote subscriptions whenever judge list changes (add/remove)
 watch(() => battleJudges.value?.judges?.length, syncJudgeVoteSubscriptions)
 
+// Broadcast smoke list to overlay in real-time as operator assigns participants —
+// fires on any smoke rounds mutation (drag/drop, add, clear) without waiting for Start Round.
+let smokeListSyncTimer = null
+watch(rounds, () => {
+  if (!isSmoke.value || !Array.isArray(rounds.value) || rounds.value.length === 0) return
+  clearTimeout(smokeListSyncTimer)
+  smokeListSyncTimer = setTimeout(() => updateSmokeList(rounds.value), 250)
+}, { deep: true })
+
 onMounted(async () => {
   initialiseDropdown()
   await fetchAllJudges(selectedEvent.value)

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -150,10 +150,15 @@ onMounted(async () => {
   battleJudges.value = await getBattleJudges()
   resolveJudgeIdentity(battleJudges.value?.judges ?? [])
 
-  // 5. Restore vote from localStorage (backend WS overrides if different)
-  if (battlePhase.value === 'VOTING') {
-    const stored = restoreVoteFromStorage()
-    if (stored !== null) confirmedVote.value = stored
+  // 5. Restore vote from backend judges list if available, fall back to localStorage
+  if (battlePhase.value === 'VOTING' && judgeId.value != null) {
+    const myJudge = (battleJudges.value?.judges ?? []).find(j => j.id === judgeId.value)
+    if (myJudge && (myJudge.vote === 0 || myJudge.vote === 1 || myJudge.vote === -1)) {
+      confirmedVote.value = myJudge.vote
+    } else {
+      const stored = restoreVoteFromStorage()
+      if (stored !== null) confirmedVote.value = stored
+    }
   }
 
   // 6. WS subscriptions

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -251,12 +251,12 @@ onUnmounted(() => {
       <!-- Phase blocker (LOCKED / IDLE) -->
       <Transition name="phase-fade">
         <div
-          v-if="battlePhase === 'LOCKED' || battlePhase === 'IDLE'"
+          v-if="battlePhase === 'LOCKED' || battlePhase === 'IDLE' || battlePhase === 'DECIDED'"
           class="panels-blocker"
           aria-live="polite"
         >
-          <span class="blocker-icon">{{ battlePhase === 'LOCKED' ? '🔒' : '⏳' }}</span>
-          <span class="blocker-text">{{ battlePhase === 'LOCKED' ? 'VOTING NOT OPEN' : 'WAITING…' }}</span>
+          <span class="blocker-icon">{{ battlePhase === 'DECIDED' ? '⭐' : battlePhase === 'LOCKED' ? '🔒' : '⏳' }}</span>
+          <span class="blocker-text">{{ battlePhase === 'DECIDED' ? 'CHAMPION DECIDED' : battlePhase === 'LOCKED' ? 'VOTING NOT OPEN' : 'WAITING…' }}</span>
         </div>
       </Transition>
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -66,10 +66,6 @@ const glitching = ref(false)
 // stale leftWin/rightWin assignments from a previous pair's score animation.
 let animToken = 0
 
-// prevTopSize: tracks the topSize last seen from a bracket message so we can
-// detect format changes (smoke ↔ standard).
-let prevTopSize = null
-
 // pendingEntrance: set when pair WS arrives while phase is IDLE so the entrance
 // animation fires after LOCKED confirms and panels mount (isBlank flips false).
 let pendingEntrance = false
@@ -390,9 +386,6 @@ onMounted(async () => {
   // Restore state from backend on mount — handles OBS refresh and genre switches.
   // Runs for both standard and smoke mode so genre-switch detection always works.
   const state = await getBattleState()
-  if (state?.bracket?.topSize !== undefined) {
-    prevTopSize = Number(state.bracket.topSize)
-  }
   if (state?.genreName !== undefined) {
     isSmoke.value = genreNameIsSmoke(state.genreName)
     activeGenreName.value = state.genreName
@@ -432,7 +425,6 @@ onMounted(async () => {
     const newTopSize = msg.topSize !== undefined ? Number(msg.topSize) : null
     if (newTopSize !== null) {
       isSmoke.value = newTopSize === 7
-      prevTopSize = newTopSize
     }
 
     // On format switch standard → smoke: Chart handles its own subscriptions.

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { getBattleJudges, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
+import { getBattleJudges, getBattleState, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket';
 import { computed, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useDelay } from '@/utils/utils';
@@ -299,15 +299,30 @@ onMounted(async () => {
   })
 
   if (!isSmoke.value) {
-    battleJudges.value = await getBattleJudges()
-    const res = await getCurrentBattlePair()
-    if (res) await updateBattlePair(res)
+    // Restore state from backend on mount — handles OBS refresh and genre switches
+    const state = await getBattleState()
+    if (state?.battlePhase) battlePhase.value = state.battlePhase
+    if (state?.judges?.length) {
+      battleJudges.value = { judges: state.judges }
+    } else {
+      battleJudges.value = await getBattleJudges()
+    }
+    const pair = state?.currentPair?.left ? state.currentPair : await getCurrentBattlePair()
+    if (pair) await updateBattlePair(pair)
     const cPair2   = createClient(); clients.push(cPair2)
     const cScore2  = createClient(); clients.push(cScore2)
     const cJudges2 = createClient(); clients.push(cJudges2)
     subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
     subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => updateScore(msg))
     subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
+    // Subscribe to battle/state for genre switches
+    const cState = createClient(); clients.push(cState)
+    subscribeToChannel(cState, '/topic/battle/state', (msg) => {
+      if (!msg) return
+      if (msg.battlePhase !== undefined) battlePhase.value = msg.battlePhase
+      if (msg.judges?.length) updateBattleJudge({ judges: msg.judges })
+      if (msg.currentPair?.left) updateBattlePair(msg.currentPair)
+    })
   }
 })
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -62,7 +62,12 @@ const glitching = ref(false)
 // stale leftWin/rightWin assignments from a previous pair's score animation.
 let animToken = 0
 
-const isSmoke = computed(() => route.query.isSmoke === 'true')
+// Start from URL param; updated in real-time when backend state reports a different genre
+const isSmoke = ref(route.query.isSmoke === 'true')
+
+const genreNameIsSmoke = (name) =>
+  typeof name === 'string' &&
+  (name.toLowerCase().includes('7 to smoke') || name.toLowerCase().includes('7tosmoke'))
 
 const judgePanelClass = computed(() => {
   if (isSmoke.value) return 'smoke-judge-always-on'
@@ -298,9 +303,13 @@ onMounted(async () => {
     }
   })
 
+  // Restore state from backend on mount — handles OBS refresh and genre switches.
+  // Runs for both standard and smoke mode so genre-switch detection always works.
+  const state = await getBattleState()
+  if (state?.genreName !== undefined) {
+    isSmoke.value = genreNameIsSmoke(state.genreName)
+  }
   if (!isSmoke.value) {
-    // Restore state from backend on mount — handles OBS refresh and genre switches
-    const state = await getBattleState()
     if (state?.battlePhase) battlePhase.value = state.battlePhase
     if (state?.judges?.length) {
       battleJudges.value = { judges: state.judges }
@@ -309,21 +318,31 @@ onMounted(async () => {
     }
     const pair = state?.currentPair?.left ? state.currentPair : await getCurrentBattlePair()
     if (pair) await updateBattlePair(pair)
-    const cPair2   = createClient(); clients.push(cPair2)
-    const cScore2  = createClient(); clients.push(cScore2)
-    const cJudges2 = createClient(); clients.push(cJudges2)
-    subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => updateBattlePair(msg))
-    subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => updateScore(msg))
-    subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => updateBattleJudge(msg))
-    // Subscribe to battle/state for genre switches
-    const cState = createClient(); clients.push(cState)
-    subscribeToChannel(cState, '/topic/battle/state', (msg) => {
-      if (!msg) return
+  }
+
+  // Subscribe to pair, score, judges — for standard mode.
+  // Connections are kept alive even in smoke mode so a live format switch works immediately.
+  const cPair2   = createClient(); clients.push(cPair2)
+  const cScore2  = createClient(); clients.push(cScore2)
+  const cJudges2 = createClient(); clients.push(cJudges2)
+  subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => { if (!isSmoke.value) updateBattlePair(msg) })
+  subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => { if (!isSmoke.value) updateScore(msg) })
+  subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => { if (!isSmoke.value) updateBattleJudge(msg) })
+
+  // Always subscribe to /topic/battle/state — detects format/genre switches in real-time
+  const cState = createClient(); clients.push(cState)
+  subscribeToChannel(cState, '/topic/battle/state', async (msg) => {
+    if (!msg) return
+    const wasSmoke = isSmoke.value
+    if (msg.genreName !== undefined) isSmoke.value = genreNameIsSmoke(msg.genreName)
+    if (!isSmoke.value) {
       if (msg.battlePhase !== undefined) battlePhase.value = msg.battlePhase
       if (msg.judges?.length) updateBattleJudge({ judges: msg.judges })
-      if (msg.currentPair?.left) updateBattlePair(msg.currentPair)
-    })
-  }
+      // On format switch from smoke → standard, restore the pair from state
+      if (wasSmoke && !isSmoke.value && msg.currentPair?.left) await updateBattlePair(msg.currentPair)
+      else if (!wasSmoke && msg.currentPair?.left) updateBattlePair(msg.currentPair)
+    }
+  })
 })
 
 onBeforeUnmount(() => {

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { getBattleJudges, getBattleState, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket';
-import { computed, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useDelay } from '@/utils/utils';
 import { useRoute } from 'vue-router'
 import Chart from './Chart.vue';
@@ -28,6 +28,10 @@ const currentWinner = ref(-2)
 const battleJudges  = ref([])
 
 const isFinal = ref(false)
+
+// Tracks the currently active genre name so stale phase WS messages from a
+// recently-deactivated genre can be discarded (same filter applied in BattleControl).
+const activeGenreName = ref('')
 
 // Judge panel visibility: true = off-screen (idle/battle), false = visible (score revealed)
 const hideJudgeDecision = ref(true)
@@ -66,6 +70,10 @@ let animToken = 0
 // detect format changes (smoke ↔ standard).
 let prevTopSize = null
 
+// pendingEntrance: set when pair WS arrives while phase is IDLE so the entrance
+// animation fires after LOCKED confirms and panels mount (isBlank flips false).
+let pendingEntrance = false
+
 // Start from URL param; updated in real-time when backend state reports a different genre
 const isSmoke = ref(route.query.isSmoke === 'true')
 
@@ -93,8 +101,11 @@ const runEntrance = async () => {
 }
 
 // ── Empty-pair state ───────────────────────────────────────────────────────
-// True while no battle is in progress — overlay shows waiting announcement
-const isBlank = computed(() => !isSmoke.value && battlePhase.value === 'IDLE')
+// Show WAITING whenever phase is IDLE, OR whenever no pair names are set (any phase).
+// This prevents the truly-transparent no-content state — either WAITING or panels, always.
+const isBlank = computed(() =>
+  !isSmoke.value && (battlePhase.value === 'IDLE' || (!leftName.value && !rightName.value))
+)
 
 // ── Battle pair update ─────────────────────────────────────────────────────
 const updateBattlePair = async (msg) => {
@@ -175,6 +186,8 @@ const updateBattlePair = async (msg) => {
   // Reset all state before new pair
   leftWin.value          = false
   rightWin.value         = false
+  leftReset.value        = false
+  rightReset.value       = false
   currentWinner.value    = -2
   vsAnim.value           = ''
   showVotingIndicator.value = false
@@ -191,7 +204,13 @@ const updateBattlePair = async (msg) => {
   imageLeft.value  = msg.left  ? await getImage(`${msg.left}.png`)  : null
   imageRight.value = msg.right ? await getImage(`${msg.right}.png`) : null
 
-  await runEntrance()
+  // If phase is still IDLE, isBlank=true so panels aren't in DOM yet.
+  // Defer entrance to the LOCKED handler which fires after panels mount.
+  if (battlePhase.value === 'IDLE') {
+    pendingEntrance = true
+  } else {
+    await runEntrance()
+  }
 }
 
 // ── Judge list update ──────────────────────────────────────────────────────
@@ -345,6 +364,9 @@ onMounted(async () => {
   clients.push(cPhase)
   subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
     if (!msg?.phase) return
+    // Ignore phase messages from a different (inactive) genre — stale WS from a
+    // genre switch can arrive late and corrupt the current genre's phase display.
+    if (msg.genre && activeGenreName.value && msg.genre !== activeGenreName.value) return
     battlePhase.value = msg.phase
     showVotingIndicator.value = msg.phase === 'VOTING'
     if (msg.phase === 'LOCKED') {
@@ -358,6 +380,10 @@ onMounted(async () => {
       rightWin.value          = false
       leftReset.value         = false
       rightReset.value        = false
+      if (pendingEntrance) {
+        pendingEntrance = false
+        nextTick(() => runEntrance())
+      }
     }
   })
 
@@ -369,6 +395,7 @@ onMounted(async () => {
   }
   if (state?.genreName !== undefined) {
     isSmoke.value = genreNameIsSmoke(state.genreName)
+    activeGenreName.value = state.genreName
   }
   if (!isSmoke.value) {
     if (state?.battlePhase) battlePhase.value = state.battlePhase
@@ -379,8 +406,8 @@ onMounted(async () => {
     }
     const pair = state?.currentPair?.left ? state.currentPair : await getCurrentBattlePair()
     if (pair) await updateBattlePair(pair)
-    // If phase is REVEALED, restore winner visual state without replaying the score animation
-    if (state?.battlePhase === 'REVEALED' && state?.bracket?.rounds) {
+    // Restore winner visual state for REVEALED and DECIDED without replaying the score animation
+    if ((state?.battlePhase === 'REVEALED' || state?.battlePhase === 'DECIDED') && state?.bracket?.rounds) {
       restoreRevealedState(state.bracket.rounds)
     }
   }
@@ -465,7 +492,10 @@ onMounted(async () => {
   subscribeToChannel(cState, '/topic/battle/state', async (msg) => {
     if (!msg) return
     const wasSmoke = isSmoke.value
-    if (msg.genreName !== undefined) isSmoke.value = genreNameIsSmoke(msg.genreName)
+    if (msg.genreName !== undefined) {
+      isSmoke.value = genreNameIsSmoke(msg.genreName)
+      activeGenreName.value = msg.genreName
+    }
     if (!isSmoke.value) {
       if (msg.battlePhase !== undefined) battlePhase.value = msg.battlePhase
       if (msg.judges?.length) updateBattleJudge({ judges: msg.judges })
@@ -474,18 +504,22 @@ onMounted(async () => {
         await updateBattlePair(msg.currentPair)
       } else if (!wasSmoke && msg.currentPair?.left) {
         const pairChanged = msg.currentPair.left !== leftName.value || msg.currentPair.right !== rightName.value
+        const needsWinnerRestore = msg.battlePhase === 'REVEALED' || msg.battlePhase === 'DECIDED'
         if (pairChanged) {
-          if (msg.battlePhase === 'REVEALED' && msg.bracket?.rounds) {
-            // Await so winner state is applied after entrance animation completes
+          if (needsWinnerRestore && msg.bracket?.rounds) {
+            // Await so winner state is applied after entrance animation completes.
+            // Applies to both REVEALED and DECIDED (genre switch back to a completed genre).
             await updateBattlePair(msg.currentPair)
             restoreRevealedState(msg.bracket.rounds)
           } else {
             // Only animate if the pair actually changed; prevents re-animation on every bracket drag
             updateBattlePair(msg.currentPair)
           }
-        } else if (msg.battlePhase === 'REVEALED' && msg.bracket?.rounds && !leftWin.value && !rightWin.value) {
-          // Same pair, REVEALED phase — winner state not yet shown (e.g. after OBS reconnect)
-          restoreRevealedState(msg.bracket.rounds)
+        } else if (needsWinnerRestore && !leftWin.value && !rightWin.value) {
+          // Same pair but no winner shown — re-trigger entrance animation so panels reappear
+          // after a WAITING state caused by a genre switch through an IDLE genre.
+          await updateBattlePair(msg.currentPair)
+          if (msg.bracket?.rounds) restoreRevealedState(msg.bracket.rounds)
         }
       }
     }
@@ -598,14 +632,14 @@ onUnmounted(() => {
     ═══════════════════════════════════════════════════ -->
     <template v-if="!isSmoke">
 
-      <!-- Blank announcement — no active pair, waiting for next battle -->
+      <!-- Blank announcement — no active pair -->
       <div v-if="isBlank" class="blank-announce" role="status" aria-live="polite">
         <div class="blank-ring"></div>
         <div class="blank-label">WAITING</div>
         <div class="blank-sub">NEXT BATTLE COMING UP</div>
       </div>
 
-      <!-- Battler panels (only when a pair is present) -->
+      <!-- Battler panels -->
       <template v-else>
 
       <!-- Left battler panel -->
@@ -737,31 +771,35 @@ body.transparent-page #app {
 </style>
 
 <style scoped>
-/* ── Blank announcement (IDLE phase) ──────────────────────── */
+/* ── Blank announcement ─────────────────────────────────────── */
 .blank-announce {
   position: absolute; inset: 0;
   display: flex; flex-direction: column;
   align-items: center; justify-content: center; gap: 18px;
   z-index: 60;
+  /* No background — stays transparent like the pair panels so OBS sees through consistently.
+     Text is readable on any background via drop shadows. */
 }
 .blank-ring {
   width: 80px; height: 80px;
   border-radius: 50%;
-  border: 2px solid rgba(255,255,255,0.12);
+  border: 2px solid rgba(255,255,255,0.6);
+  filter: drop-shadow(0 0 6px rgba(0,0,0,0.8));
   animation: blankPulse 2.4s ease-in-out infinite;
 }
 .blank-label {
   font-family: 'Anton SC', sans-serif;
   font-size: clamp(22px, 3.5vw, 42px);
   letter-spacing: 0.28em; text-transform: uppercase;
-  color: rgba(255,255,255,0.55);
-  text-shadow: 0 0 40px rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.85);
+  text-shadow: 0 2px 8px rgba(0,0,0,0.9), 0 0 40px rgba(255,255,255,0.3);
 }
 .blank-sub {
   font-family: 'Inter', sans-serif;
   font-size: 12px; font-weight: 600;
   letter-spacing: 0.18em; text-transform: uppercase;
-  color: rgba(255,255,255,0.18);
+  color: rgba(255,255,255,0.6);
+  text-shadow: 0 1px 4px rgba(0,0,0,0.9);
 }
 @keyframes blankPulse {
   0%, 100% { transform: scale(1); opacity: 0.5; }

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -329,7 +329,22 @@ onMounted(async () => {
   subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => { if (!isSmoke.value) updateScore(msg) })
   subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => { if (!isSmoke.value) updateBattleJudge(msg) })
 
-  // Always subscribe to /topic/battle/state — detects format/genre switches in real-time
+  // /topic/battle/bracket — fires when operator changes bracket format or size in BattleControl.
+  // Use topSize to determine smoke mode (7 = smoke, anything else = standard).
+  const cBracket = createClient(); clients.push(cBracket)
+  subscribeToChannel(cBracket, '/topic/battle/bracket', async (msg) => {
+    if (!msg) return
+    const wasSmoke = isSmoke.value
+    if (msg.topSize !== undefined) isSmoke.value = String(msg.topSize) === '7'
+    // On format switch standard → smoke: Chart handles its own subscriptions.
+    // On format switch smoke → standard: fetch current pair from backend to show something.
+    if (wasSmoke && !isSmoke.value) {
+      const state = await getBattleState()
+      if (state?.currentPair?.left) await updateBattlePair(state.currentPair)
+    }
+  })
+
+  // Always subscribe to /topic/battle/state — detects genre switches in real-time
   const cState = createClient(); clients.push(cState)
   subscribeToChannel(cState, '/topic/battle/state', async (msg) => {
     if (!msg) return

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -300,6 +300,28 @@ const updateScore = async (msg) => {
   // msg.message === -1: tie — panels stay
 }
 
+// ── Revealed state restore ─────────────────────────────────────────────────
+// Sets winner visual state (leftWin/rightWin/winnerTagVisible) from bracket data
+// without replaying the score animation. Used when restoring a REVEALED phase.
+const restoreRevealedState = (rounds) => {
+  for (const matchList of Object.values(rounds)) {
+    if (!Array.isArray(matchList)) continue
+    const match = matchList.find(m => m[0] === leftName.value && m[1] === rightName.value && m[2])
+    if (match) {
+      currentWinner.value = match[2] === leftName.value ? 0 : 1
+      if (match[2] === leftName.value) {
+        leftWin.value = true
+        vsAnim.value  = 'knock-right'
+      } else {
+        rightWin.value = true
+        vsAnim.value   = 'knock-left'
+      }
+      winnerTagVisible.value = true
+      return
+    }
+  }
+}
+
 // ── Mount ──────────────────────────────────────────────────────────────────
 onMounted(async () => {
   document.documentElement.classList.add('transparent-page')
@@ -355,6 +377,10 @@ onMounted(async () => {
     }
     const pair = state?.currentPair?.left ? state.currentPair : await getCurrentBattlePair()
     if (pair) await updateBattlePair(pair)
+    // If phase is REVEALED, restore winner visual state without replaying the score animation
+    if (state?.battlePhase === 'REVEALED' && state?.bracket?.rounds) {
+      restoreRevealedState(state.bracket.rounds)
+    }
   }
 
   // Subscribe to pair, score, judges — for standard mode.
@@ -445,9 +471,19 @@ onMounted(async () => {
       if (wasSmoke && !isSmoke.value && msg.currentPair?.left) {
         await updateBattlePair(msg.currentPair)
       } else if (!wasSmoke && msg.currentPair?.left) {
-        if (msg.currentPair.left !== leftName.value || msg.currentPair.right !== rightName.value) {
-          // Only animate if the pair actually changed; prevents re-animation on every bracket drag
-          updateBattlePair(msg.currentPair)
+        const pairChanged = msg.currentPair.left !== leftName.value || msg.currentPair.right !== rightName.value
+        if (pairChanged) {
+          if (msg.battlePhase === 'REVEALED' && msg.bracket?.rounds) {
+            // Await so winner state is applied after entrance animation completes
+            await updateBattlePair(msg.currentPair)
+            restoreRevealedState(msg.bracket.rounds)
+          } else {
+            // Only animate if the pair actually changed; prevents re-animation on every bracket drag
+            updateBattlePair(msg.currentPair)
+          }
+        } else if (msg.battlePhase === 'REVEALED' && msg.bracket?.rounds && !leftWin.value && !rightWin.value) {
+          // Same pair, REVEALED phase — winner state not yet shown (e.g. after OBS reconnect)
+          restoreRevealedState(msg.bracket.rounds)
         }
       }
     }

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -310,11 +310,13 @@ const restoreRevealedState = (rounds) => {
     if (match) {
       currentWinner.value = match[2] === leftName.value ? 0 : 1
       if (match[2] === leftName.value) {
-        leftWin.value = true
-        vsAnim.value  = 'knock-right'
+        leftWin.value    = true
+        rightReset.value = true   // slide loser off screen
+        vsAnim.value     = 'knock-right'
       } else {
-        rightWin.value = true
-        vsAnim.value   = 'knock-left'
+        rightWin.value  = true
+        leftReset.value = true    // slide loser off screen
+        vsAnim.value    = 'knock-left'
       }
       winnerTagVisible.value = true
       return

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -344,6 +344,46 @@ onMounted(async () => {
     }
   })
 
+  // Champion reveal — re-plays the winner animation when organiser clicks Reveal Champion
+  // after a refresh or genre switch (score already submitted, but overlay needs to animate).
+  const cChampion = createClient(); clients.push(cChampion)
+  subscribeToChannel(cChampion, '/topic/battle/champion-reveal', async (msg) => {
+    if (!msg || msg.dismiss || isSmoke.value) return
+    const champion = msg.championName
+    if (!champion) return
+    // If we don't have a current pair loaded, fetch it first
+    if (!leftName.value) {
+      const freshState = await getBattleState()
+      if (freshState?.currentPair?.left) await updateBattlePair(freshState.currentPair)
+    }
+    const side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
+    if (side === -1) return
+    animToken++
+    const myToken = animToken
+    const ok = () => !unmounted && animToken === myToken
+    // Brief pause before reveal so entrance animation can complete if pair was just loaded
+    await useDelay().wait(350)
+    if (!ok()) return
+    hideJudgeDecision.value = true
+    judgeAnim.value = ''
+    if (side === 0) {
+      leftWin.value          = true
+      winnerTagVisible.value = true
+      vsAnim.value           = 'knock-right'
+      await useDelay().wait(100)
+      if (!ok()) return
+      rightReset.value = true
+    } else {
+      rightWin.value         = true
+      winnerTagVisible.value = true
+      vsAnim.value           = 'knock-left'
+      await useDelay().wait(100)
+      if (!ok()) return
+      leftReset.value = true
+    }
+    currentWinner.value = side
+  })
+
   // Always subscribe to /topic/battle/state — detects genre switches in real-time
   const cState = createClient(); clients.push(cState)
   subscribeToChannel(cState, '/topic/battle/state', async (msg) => {

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -62,6 +62,10 @@ const glitching = ref(false)
 // stale leftWin/rightWin assignments from a previous pair's score animation.
 let animToken = 0
 
+// prevTopSize: tracks the topSize last seen from a bracket message so we can
+// detect format changes (smoke ↔ standard).
+let prevTopSize = null
+
 // Start from URL param; updated in real-time when backend state reports a different genre
 const isSmoke = ref(route.query.isSmoke === 'true')
 
@@ -88,6 +92,10 @@ const runEntrance = async () => {
   stageShaking.value = false
 }
 
+// ── Empty-pair state ───────────────────────────────────────────────────────
+// True while no battle is in progress — overlay shows waiting announcement
+const isBlank = computed(() => !isSmoke.value && battlePhase.value === 'IDLE')
+
 // ── Battle pair update ─────────────────────────────────────────────────────
 const updateBattlePair = async (msg) => {
   if (!msg) return
@@ -107,6 +115,32 @@ const updateBattlePair = async (msg) => {
 
   // Increment token — aborts any in-progress updateScore for the previous pair
   animToken++
+
+  // EMPTY PAIR: organiser cleared the battle (end of round / reset). Skip
+  // entrance animation, just blank the overlay.
+  if (!msg.left && !msg.right) {
+    hideJudgeDecision.value  = true
+    judgeAnim.value          = ''
+    votesVisible.value       = false
+    winnerTagVisible.value   = false
+    leftWin.value            = false
+    rightWin.value           = false
+    leftReset.value          = false
+    rightReset.value         = false
+    vsAnim.value             = ''
+    currentWinner.value      = -2
+    showVotingIndicator.value = false
+    imageLeft.value  = null
+    imageRight.value = null
+    leftScore.value  = 0
+    rightScore.value = 0
+    leftMembers.value  = []
+    rightMembers.value = []
+    leftName.value  = ''
+    rightName.value = ''
+    isFinal.value   = false
+    return
+  }
 
   // STANDARD MODE: if the judge panel is visible, clean it up before the new pair
   if (!hideJudgeDecision.value) {
@@ -154,8 +188,8 @@ const updateBattlePair = async (msg) => {
   leftScore.value   = msg.leftScore  ?? 0
   rightScore.value  = msg.rightScore ?? 0
   isFinal.value     = !!msg.isFinal
-  imageLeft.value  = await getImage(`${msg.left}.png`)
-  imageRight.value = await getImage(`${msg.right}.png`)
+  imageLeft.value  = msg.left  ? await getImage(`${msg.left}.png`)  : null
+  imageRight.value = msg.right ? await getImage(`${msg.right}.png`) : null
 
   await runEntrance()
 }
@@ -306,6 +340,9 @@ onMounted(async () => {
   // Restore state from backend on mount — handles OBS refresh and genre switches.
   // Runs for both standard and smoke mode so genre-switch detection always works.
   const state = await getBattleState()
+  if (state?.bracket?.topSize !== undefined) {
+    prevTopSize = Number(state.bracket.topSize)
+  }
   if (state?.genreName !== undefined) {
     isSmoke.value = genreNameIsSmoke(state.genreName)
   }
@@ -331,11 +368,18 @@ onMounted(async () => {
 
   // /topic/battle/bracket — fires when operator changes bracket format or size in BattleControl.
   // Use topSize to determine smoke mode (7 = smoke, anything else = standard).
+  // Format change: overlay will receive phase → IDLE from BattleControl, triggering the
+  // blank announcement. No manual wipe needed here.
   const cBracket = createClient(); clients.push(cBracket)
   subscribeToChannel(cBracket, '/topic/battle/bracket', async (msg) => {
     if (!msg) return
     const wasSmoke = isSmoke.value
-    if (msg.topSize !== undefined) isSmoke.value = String(msg.topSize) === '7'
+    const newTopSize = msg.topSize !== undefined ? Number(msg.topSize) : null
+    if (newTopSize !== null) {
+      isSmoke.value = newTopSize === 7
+      prevTopSize = newTopSize
+    }
+
     // On format switch standard → smoke: Chart handles its own subscriptions.
     // On format switch smoke → standard: fetch current pair from backend to show something.
     if (wasSmoke && !isSmoke.value) {
@@ -351,12 +395,16 @@ onMounted(async () => {
     if (!msg || msg.dismiss || isSmoke.value) return
     const champion = msg.championName
     if (!champion) return
-    // If we don't have a current pair loaded, fetch it first
-    if (!leftName.value) {
+    // Check if the champion matches the current overlay pair. If not (e.g. stale pair
+    // from before a genre switch), fetch the authoritative pair from the backend.
+    let side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
+    if (side === -1) {
       const freshState = await getBattleState()
-      if (freshState?.currentPair?.left) await updateBattlePair(freshState.currentPair)
+      if (freshState?.currentPair?.left) {
+        await updateBattlePair(freshState.currentPair)
+        side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
+      }
     }
-    const side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
     if (side === -1) return
     animToken++
     const myToken = animToken
@@ -394,8 +442,14 @@ onMounted(async () => {
       if (msg.battlePhase !== undefined) battlePhase.value = msg.battlePhase
       if (msg.judges?.length) updateBattleJudge({ judges: msg.judges })
       // On format switch from smoke → standard, restore the pair from state
-      if (wasSmoke && !isSmoke.value && msg.currentPair?.left) await updateBattlePair(msg.currentPair)
-      else if (!wasSmoke && msg.currentPair?.left) updateBattlePair(msg.currentPair)
+      if (wasSmoke && !isSmoke.value && msg.currentPair?.left) {
+        await updateBattlePair(msg.currentPair)
+      } else if (!wasSmoke && msg.currentPair?.left) {
+        if (msg.currentPair.left !== leftName.value || msg.currentPair.right !== rightName.value) {
+          // Only animate if the pair actually changed; prevents re-animation on every bracket drag
+          updateBattlePair(msg.currentPair)
+        }
+      }
     }
   })
 })
@@ -506,6 +560,16 @@ onUnmounted(() => {
     ═══════════════════════════════════════════════════ -->
     <template v-if="!isSmoke">
 
+      <!-- Blank announcement — no active pair, waiting for next battle -->
+      <div v-if="isBlank" class="blank-announce" role="status" aria-live="polite">
+        <div class="blank-ring"></div>
+        <div class="blank-label">WAITING</div>
+        <div class="blank-sub">NEXT BATTLE COMING UP</div>
+      </div>
+
+      <!-- Battler panels (only when a pair is present) -->
+      <template v-else>
+
       <!-- Left battler panel -->
       <div
         class="battler-panel left-panel"
@@ -601,6 +665,16 @@ onUnmounted(() => {
         </div>
       </transition>
 
+      <!-- DECIDED indicator — champion locked, waiting for reveal -->
+      <transition name="fade-indicator">
+        <div v-if="battlePhase === 'DECIDED'" class="decided-indicator" aria-label="Champion decided">
+          <span class="decided-dot" aria-hidden="true"></span>
+          <span class="decided-label">JUDGES HAVE DECIDED</span>
+        </div>
+      </transition>
+
+      </template> <!-- end v-else (battler panels) -->
+
     </template>
 
     <!-- ══════════════════════════════════════════════════
@@ -625,6 +699,37 @@ body.transparent-page #app {
 </style>
 
 <style scoped>
+/* ── Blank announcement (IDLE phase) ──────────────────────── */
+.blank-announce {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 18px;
+  z-index: 60;
+}
+.blank-ring {
+  width: 80px; height: 80px;
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,0.12);
+  animation: blankPulse 2.4s ease-in-out infinite;
+}
+.blank-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(22px, 3.5vw, 42px);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(255,255,255,0.55);
+  text-shadow: 0 0 40px rgba(255,255,255,0.12);
+}
+.blank-sub {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: rgba(255,255,255,0.18);
+}
+@keyframes blankPulse {
+  0%, 100% { transform: scale(1); opacity: 0.5; }
+  50%       { transform: scale(1.12); opacity: 1; }
+}
+
 /* ── Screen-reader only ─────────────────────────────────────── */
 .sr-only {
   position: absolute; width: 1px; height: 1px; padding: 0;
@@ -1091,6 +1196,29 @@ body.transparent-page #app {
   color: rgba(255,255,255,0.45);
   text-transform: uppercase;
 }
+/* DECIDED indicator */
+.decided-indicator {
+  position: absolute;
+  bottom: 2vh; left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: flex; align-items: center; gap: 8px;
+}
+.decided-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: #f59e0b;
+  box-shadow: 0 0 10px rgba(245,158,11,0.7);
+  animation: votingPulse 1.2s ease-in-out infinite;
+}
+.decided-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.2em;
+  color: rgba(245,158,11,0.75);
+  text-transform: uppercase;
+}
+
 /* Fade transition for voting indicator */
 .fade-indicator-enter-active,
 .fade-indicator-leave-active { transition: opacity 0.3s ease; }

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -324,7 +324,10 @@ onMounted(async () => {
       if (data?.currentPair?.left) {
         activePair.value = { left: data.currentPair.left, right: data.currentPair.right }
       }
-      if (data?.genreName) currentGenre.value = data.genreName
+      if (data?.genreName) {
+        if (data.genreName !== currentGenre.value) championReveal.value = null
+        currentGenre.value = data.genreName
+      }
     })
 
     wsClient.subscribe('/topic/battle/bracket', (msg) => {

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
-import { getBracketState, getOverlayConfig } from '@/utils/api'
+import { getBattleState, getBracketState, getOverlayConfig } from '@/utils/api'
 import { createClient } from '@/utils/websocket'
 
 const bracketState   = ref(null)
@@ -287,14 +287,45 @@ function getActiveMatchInfo() {
 
 // ── lifecycle ─────────────────────────────────────────────
 onMounted(async () => {
-  const state = await getBracketState()
-  if (state && (state.topSize || state.rounds)) bracketState.value = state
+  // Restore state from backend — authoritative source for bracket/pair/genre
+  const battleState = await getBattleState()
+  if (battleState?.bracket && (battleState.bracket.topSize || battleState.bracket.rounds)) {
+    bracketState.value = battleState.bracket
+  }
+  if (battleState?.currentPair?.left) {
+    activePair.value = { left: battleState.currentPair.left, right: battleState.currentPair.right }
+  }
+  if (battleState?.genreName) {
+    currentGenre.value = battleState.genreName
+  }
+
+  if (!bracketState.value) {
+    const state = await getBracketState()
+    if (state && (state.topSize || state.rounds)) bracketState.value = state
+  }
 
   const cfg = await getOverlayConfig()
   if (cfg) overlayConfig.value = cfg
 
   wsClient = createClient()
   wsClient.onConnect = () => {
+
+    wsClient.subscribe('/topic/battle/state', (msg) => {
+      const data = JSON.parse(msg.body)
+      if (data?.bracket && (data.bracket.topSize || data.bracket.rounds)) {
+        if (animRunning) {
+          pendingBracket.value = data.bracket
+        } else {
+          pendingBracket.value = null
+          prevBracketUpdate = { state: bracketState.value, timestamp: Date.now() }
+          bracketState.value = data.bracket
+        }
+      }
+      if (data?.currentPair?.left) {
+        activePair.value = { left: data.currentPair.left, right: data.currentPair.right }
+      }
+      if (data?.genreName) currentGenre.value = data.genreName
+    })
 
     wsClient.subscribe('/topic/battle/bracket', (msg) => {
       const newState = JSON.parse(msg.body)

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -234,6 +234,7 @@ onBeforeUnmount(() => {
               ></div>
             </div>
             <div class="col-name">{{ item.name }}</div>
+            <div v-if="idx >= 2" class="queue-pos" aria-label="Queue position">#{{ idx - 1 }}</div>
           </div>
         </template>
       </TransitionGroup>
@@ -495,6 +496,15 @@ body.transparent-page #app {
 .col-active-right .col-name {
   color: color-mix(in srgb, var(--right-color) 50%, #fff);
   text-shadow: 0 0 12px color-mix(in srgb, var(--right-color) 80%, transparent);
+}
+
+/* ── Queue position label ─────────────────────────────── */
+.queue-pos {
+  font-size: clamp(8px, 0.9vw, 11px);
+  letter-spacing: 0.18em;
+  color: rgba(255,255,255,0.22);
+  text-align: center;
+  margin-top: 1px;
 }
 
 /* ── VS chip ──────────────────────────────────────────── */

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, onMounted, onUnmounted, watch, computed } from 'vue';
 import { RouterLink } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories } from '@/utils/api';
 import { setActiveEvent } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
@@ -937,6 +937,11 @@ onMounted(async () => {
       if (msg.eventName !== props.eventName) return
       fetchCheckinList()
     })
+    // Hydrate previewingIds from server state so late-joining/refreshed clients see current previews
+    const existingPreviews = await getCheckinPreviews(props.eventName)
+    for (const id of existingPreviews) {
+      previewingIds[id] = true
+    }
   }
 })
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -33,6 +33,7 @@ const batchVerifying = ref(false)
 const checkinList = ref([])
 const loadingCheckinList = ref(false)
 const checkingInId = ref(null)
+const confirming = ref(false)
 const checkinSearch = ref('')
 const participantsNumBreakdown = ref([])
 const totalParticipants = ref(0)
@@ -739,7 +740,13 @@ const fetchCheckinList = async () => {
 const checkIn = async (p) => {
   checkingInId.value = p.participantId
   try {
-    await checkInParticipant(p.participantId, p.eventId)
+    const res = await checkInParticipant(p.participantId, p.eventId)
+    if (res?.status === 409) {
+      checkinConfirm.value.phase = 'error'
+      checkinConfirm.value.errorMessage = 'Already checked in at another desk.'
+      checkingInId.value = null
+      return
+    }
     await Promise.all([fetchCheckinList(), refreshFromDb()])
   } catch (e) {
     console.error(e)
@@ -747,7 +754,7 @@ const checkIn = async (p) => {
   checkingInId.value = null
 }
 
-const checkinConfirm = ref({ show: false, participant: null, phase: 'confirm', refCode: null })
+const checkinConfirm = ref({ show: false, participant: null, phase: 'confirm', refCode: null, errorMessage: '' })
 // phase: 'confirm' → 'generating' → 'done'
 
 // Dialog slot machine animation state
@@ -797,9 +804,20 @@ const askCheckIn = (p) => {
   })
 }
 
+const closeCheckinDialog = () => {
+  if (checkinConfirm.value.phase === 'confirm' && checkinConfirm.value.participant) {
+    sendCheckinPreview(eventName.value, {
+      participantId: checkinConfirm.value.participant.participantId,
+      cancelled: true
+    })
+  }
+  checkinConfirm.value.show = false
+}
+
 const confirmCheckIn = async () => {
   const p = checkinConfirm.value.participant
-  if (!p) return
+  if (!p || confirming.value) return
+  confirming.value = true
 
   // Reset genre display state
   p.genres.forEach(g => { g.auditionNumber = null; g.rolling = false })
@@ -816,6 +834,10 @@ const confirmCheckIn = async () => {
   // checkIn awaits both the HTTP assignment AND fetchCheckinList + refreshFromDb,
   // so when it resolves we have fresh numbers in checkinList.value and verifiedDbParticipants.value
   await checkIn(p)
+  confirming.value = false
+
+  // Early exit if checkIn set an error phase (e.g. 409)
+  if (checkinConfirm.value.phase === 'error') return
 
   // Get ref code from fresh verifiedDbParticipants data
   const refEntry = verifiedDbParticipants.value.find(ep => ep.participantId === p.participantId)
@@ -2025,7 +2047,7 @@ onUnmounted(() => {
     >
       <div v-if="checkinConfirm.show" class="fixed inset-0 z-50 flex items-center justify-center p-4">
         <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
-          @click="checkinConfirm.phase !== 'generating' && (checkinConfirm.show = false)" />
+          @click="checkinConfirm.phase !== 'generating' && closeCheckinDialog()" />
         <div class="card-hover p-5 relative w-full max-w-md" style="clip-path:none">
           <div class="corner-bar-tl"></div>
           <div class="corner-bar-bl"></div>
@@ -2033,9 +2055,9 @@ onUnmounted(() => {
           <!-- Header -->
           <div class="flex items-center justify-between mb-4">
             <p class="type-body text-content-secondary">
-              {{ checkinConfirm.phase === 'confirm' ? 'Confirm Check-In' : checkinConfirm.phase === 'generating' ? 'Generating…' : 'Check-In Complete' }}
+              {{ checkinConfirm.phase === 'confirm' ? 'Confirm Check-In' : checkinConfirm.phase === 'generating' ? 'Generating…' : checkinConfirm.phase === 'error' ? 'Check-In Failed' : 'Check-In Complete' }}
             </p>
-            <button v-if="checkinConfirm.phase !== 'generating'" @click="checkinConfirm.show = false"
+            <button v-if="checkinConfirm.phase !== 'generating'" @click="closeCheckinDialog"
               class="p-1 text-content-muted hover:text-content-primary transition-colors">
               <i class="pi pi-times text-sm" />
             </button>
@@ -2113,12 +2135,13 @@ onUnmounted(() => {
           <div class="flex gap-3">
             <!-- Confirm phase -->
             <template v-if="checkinConfirm.phase === 'confirm'">
-              <button @click="checkinConfirm.show = false"
+              <button @click="closeCheckinDialog"
                 class="flex-1 py-2 para-chip-sm type-label text-content-muted hover:text-content-primary transition-all">
                 Cancel
               </button>
               <button @click="confirmCheckIn"
-                class="flex-1 py-2 para-chip type-label text-white transition-all"
+                :disabled="confirming"
+                class="flex-1 py-2 para-chip type-label text-white transition-all disabled:opacity-50"
                 style="background:rgba(255,255,255,0.12);box-shadow:0 0 12px var(--accent-subtle)"
               >
                 <i class="pi pi-check mr-1.5 text-xs"></i> Confirm
@@ -2128,6 +2151,18 @@ onUnmounted(() => {
             <div v-else-if="checkinConfirm.phase === 'generating'"
               class="flex-1 py-2 flex items-center justify-center gap-2 type-label text-content-muted">
               <i class="pi pi-spin pi-spinner text-xs"></i> Generating…
+            </div>
+            <!-- Error phase (e.g. 409 already checked in) -->
+            <div v-else-if="checkinConfirm.phase === 'error'"
+              class="flex-1 flex flex-col items-center gap-3">
+              <div class="flex items-center gap-2 type-label text-red-400">
+                <i class="pi pi-exclamation-circle text-sm"></i>
+                {{ checkinConfirm.errorMessage }}
+              </div>
+              <button @click="checkinConfirm.show = false"
+                class="px-4 py-2 para-chip-sm type-label text-content-muted hover:text-content-primary transition-colors">
+                Close
+              </button>
             </div>
             <!-- Done phase -->
             <button v-else @click="checkinConfirm.show = false"

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -34,6 +34,8 @@ const checkinList = ref([])
 const loadingCheckinList = ref(false)
 const checkingInId = ref(null)
 const confirming = ref(false)
+// participantId → true when any operator has that participant's dialog open
+const previewingIds = reactive({})
 const checkinSearch = ref('')
 const participantsNumBreakdown = ref([])
 const totalParticipants = ref(0)
@@ -916,9 +918,19 @@ onMounted(async () => {
         const genre = participant.genres.find(g => g.genreName === msg.genre)
         if (genre) genre.auditionNumber = msg.auditionNumber
       }
+      // Participant is now checked in — no longer in preview
+      if (msg.participantId) delete previewingIds[msg.participantId]
       if (!refreshPending) {
         refreshPending = true
         refreshFromDb().finally(() => { refreshPending = false })
+      }
+    })
+    subscribeToChannel(wsClient, '/topic/checkin-preview/', (msg) => {
+      if (!msg.participantId) return
+      if (msg.cancelled) {
+        delete previewingIds[msg.participantId]
+      } else {
+        previewingIds[msg.participantId] = true
       }
     })
     subscribeToChannel(wsClient, '/topic/walkin/', (msg) => {
@@ -1641,11 +1653,12 @@ onUnmounted(() => {
                 </div>
               </div>
               <div class="flex items-center gap-2 mt-2 justify-end">
-                <button v-if="!isCheckedIn(p)" @click="askCheckIn(p)" :disabled="checkingInId === p.participantId"
+                <button v-if="!isCheckedIn(p)" @click="askCheckIn(p)"
+                  :disabled="checkingInId === p.participantId || !!previewingIds[p.participantId]"
                   class="bg-accent para-chip-sm px-3 py-1.5 type-label disabled:opacity-50"
                 >
-                  <i class="pi text-xs" :class="checkingInId === p.participantId ? 'pi-spinner pi-spin' : 'pi-check'"></i>
-                  {{ checkingInId === p.participantId ? '…' : 'Check In' }}
+                  <i class="pi text-xs" :class="checkingInId === p.participantId ? 'pi-spinner pi-spin' : previewingIds[p.participantId] ? 'pi-clock' : 'pi-check'"></i>
+                  {{ checkingInId === p.participantId ? '…' : previewingIds[p.participantId] ? 'In Preview' : 'Check In' }}
                 </button>
                 <i v-else class="pi pi-check-circle text-emerald-400 text-sm"></i>
               </div>

--- a/BES-frontend/src/views/__tests__/BattleOverlay.test.js
+++ b/BES-frontend/src/views/__tests__/BattleOverlay.test.js
@@ -4,6 +4,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 vi.mock('@/utils/api', () => ({
   getBattleJudges: vi.fn().mockResolvedValue({ judges: [] }),
+  getBattleState: vi.fn().mockResolvedValue(null),
   getCurrentBattlePair: vi.fn().mockResolvedValue(null),
   getImage: vi.fn().mockResolvedValue(null),
   getOverlayConfig: vi.fn().mockResolvedValue({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }),

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -33,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.example.BES.dtos.battle.ChampionRevealDto;
 import com.example.BES.dtos.battle.DeleteImageDto;
+import com.example.BES.dtos.battle.SetActiveGenreDto;
 import com.example.BES.dtos.battle.SetBattleModeDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
 import com.example.BES.dtos.battle.SetBattlePhaseDto;
@@ -331,5 +332,25 @@ public class BattleController {
     public ResponseEntity<?> setOverlayConfig(@Valid @RequestBody SetOverlayConfigDto dto) {
         battleService.setOverlayConfigService(dto);
         return ResponseEntity.ok(battleService.getOverlayConfig());
+    }
+
+    @PostMapping("/active-genre")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> setActiveGenre(@Valid @RequestBody SetActiveGenreDto dto) {
+        battleService.switchActiveGenreService(dto);
+        return ResponseEntity.ok(Map.of("message", "Active genre set"));
+    }
+
+    @GetMapping("/active-genre")
+    public ResponseEntity<?> getActiveGenre() {
+        return ResponseEntity.ok(Map.of(
+            "eventName", battleService.getActiveEventName() != null ? battleService.getActiveEventName() : "",
+            "genreName", battleService.getActiveGenreName() != null ? battleService.getActiveGenreName() : ""
+        ));
+    }
+
+    @GetMapping("/state")
+    public ResponseEntity<?> getBattleState() {
+        return ResponseEntity.ok(battleService.getBattleStateService());
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -117,6 +117,15 @@ public class BattleController {
         ));
     }
 
+    @DeleteMapping("/battle-pair")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> clearBattlePair(){
+        battleService.clearBattlePairService();
+        return ResponseEntity.ok(Map.of(
+            "message", "battle pair cleared"
+        ));
+    }
+
     @PostMapping("/score")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
     public ResponseEntity<?> setBattleScore(@RequestBody(required = false) SetBattleScoreDto dto){

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -161,6 +161,11 @@ public class BattleController {
         return ResponseEntity.ok(Map.of("message", "Champion reveal broadcast"));
     }
 
+    @GetMapping("/champions")
+    public ResponseEntity<?> getChampionsForEvent(@RequestParam String event){
+        return ResponseEntity.ok(battleService.getChampionsForEvent(event));
+    }
+
     @GetMapping("/judges")
     public ResponseEntity<?> getAllBattleJudges(){
         return ResponseEntity.ok(Map.of(

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +64,7 @@ import com.example.BES.dtos.CreatePickupCrewDto;
 import com.example.BES.dtos.GetPickupCrewDto;
 import com.example.BES.services.AuditionFeedbackService;
 import com.example.BES.services.BattleGuestService;
+import com.example.BES.services.CheckinPreviewService;
 import com.example.BES.services.EventGenreParticpantService;
 import com.example.BES.services.PickupCrewService;
 import com.example.BES.services.ScoringCriteriaService;
@@ -138,6 +140,9 @@ public class EventController {
 
     @Autowired
     BattleGuestService battleGuestService;
+
+    @Autowired
+    CheckinPreviewService checkinPreviewService;
 
     @Autowired
     SimpMessagingTemplate messagingTemplate;
@@ -426,6 +431,13 @@ public class EventController {
         return new ResponseEntity<>(res, HttpStatus.OK);
     }
 
+    @Operation(summary = "Get Active Check-In Previews", description = "Returns the set of participant IDs currently being previewed (check-in dialog open) for an event")
+    @GetMapping("/{eventName}/checkin-preview")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<Set<Long>> getCheckinPreviews(@PathVariable String eventName) {
+        return ResponseEntity.ok(checkinPreviewService.getActivePreviews(eventName));
+    }
+
     @Operation(summary = "Send Check-In Preview", description = "Broadcasts participant details to AuditionNumber display before generating numbers")
     @PostMapping("/{eventName}/checkin-preview")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
@@ -433,6 +445,11 @@ public class EventController {
             @PathVariable String eventName,
             @RequestBody CheckinPreviewDto dto) {
         try {
+            if (Boolean.TRUE.equals(dto.cancelled)) {
+                checkinPreviewService.clearPreview(eventName, dto.participantId);
+            } else {
+                checkinPreviewService.setPreview(eventName, dto.participantId);
+            }
             messagingTemplate.convertAndSend("/topic/checkin-preview/", dto);
             return new ResponseEntity<>("ok", HttpStatus.OK);
         } catch (Exception e) {
@@ -448,6 +465,8 @@ public class EventController {
             @PathVariable Long eventId) {
         try {
             eventGenreParticipantService.getAllAuditionNumsViaQR(participantId, eventId);
+            String eventName = eventService.getEventNameById(eventId);
+            checkinPreviewService.clearPreview(eventName, participantId);
             return new ResponseEntity<>("registered", HttpStatus.CREATED);
         } catch (IllegalStateException e) {
             if ("already_checked_in".equals(e.getMessage())) {

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -449,6 +449,11 @@ public class EventController {
         try {
             eventGenreParticipantService.getAllAuditionNumsViaQR(participantId, eventId);
             return new ResponseEntity<>("registered", HttpStatus.CREATED);
+        } catch (IllegalStateException e) {
+            if ("already_checked_in".equals(e.getMessage())) {
+                return new ResponseEntity<>("already_checked_in", HttpStatus.CONFLICT);
+            }
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (Exception e) {
             return new ResponseEntity<>("Something is null", HttpStatus.BAD_REQUEST);
         }

--- a/BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
@@ -8,6 +8,7 @@ public class CheckinPreviewDto {
     public String refCode;
     public List<String> memberNames;
     public List<GenreEntry> genres;
+    public Boolean cancelled;
 
     public static class GenreEntry {
         public String genreName;

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetActiveGenreDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetActiveGenreDto.java
@@ -1,0 +1,17 @@
+package com.example.BES.dtos.battle;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class SetActiveGenreDto {
+
+    @NotBlank
+    private String eventName;
+
+    @NotBlank
+    private String genreName;
+
+    public String getEventName() { return eventName; }
+    public void setEventName(String eventName) { this.eventName = eventName; }
+    public String getGenreName() { return genreName; }
+    public void setGenreName(String genreName) { this.genreName = genreName; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java
@@ -3,6 +3,7 @@ package com.example.BES.dtos.battle;
 public class SetBracketStateDto {
     private String topSize;
     private Object rounds;
+    private Integer currentRoundIndex;
 
     public String getTopSize() {
         return topSize;
@@ -15,5 +16,11 @@ public class SetBracketStateDto {
     }
     public void setRounds(Object rounds) {
         this.rounds = rounds;
+    }
+    public Integer getCurrentRoundIndex() {
+        return currentRoundIndex;
+    }
+    public void setCurrentRoundIndex(Integer currentRoundIndex) {
+        this.currentRoundIndex = currentRoundIndex;
     }
 }

--- a/BES/src/main/java/com/example/BES/models/BattleActiveGenre.java
+++ b/BES/src/main/java/com/example/BES/models/BattleActiveGenre.java
@@ -1,0 +1,23 @@
+package com.example.BES.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "battle_active_genre")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BattleActiveGenre {
+
+    @Id
+    private Integer id;
+
+    @Column(name = "event_name")
+    private String eventName;
+
+    @Column(name = "genre_name")
+    private String genreName;
+}

--- a/BES/src/main/java/com/example/BES/models/BattleGenreState.java
+++ b/BES/src/main/java/com/example/BES/models/BattleGenreState.java
@@ -1,0 +1,60 @@
+package com.example.BES.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "battle_genre_state", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"event_name", "genre_name"})
+})
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BattleGenreState {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_name")
+    private String eventName;
+
+    @Column(name = "genre_name")
+    private String genreName;
+
+    @Column(name = "bracket_json", columnDefinition = "TEXT")
+    private String bracketJson;
+
+    @Column(name = "top_size")
+    private Integer topSize;
+
+    @Column(name = "current_round_index")
+    private Integer currentRoundIndex;
+
+    @Column(name = "current_pair_left")
+    private String currentPairLeft;
+
+    @Column(name = "current_pair_left_members", columnDefinition = "TEXT")
+    private String currentPairLeftMembers;
+
+    @Column(name = "current_pair_right")
+    private String currentPairRight;
+
+    @Column(name = "current_pair_right_members", columnDefinition = "TEXT")
+    private String currentPairRightMembers;
+
+    @Column(name = "is_final")
+    private Boolean isFinal;
+
+    @Column(name = "battle_phase")
+    private String battlePhase;
+
+    @Column(name = "judges_json", columnDefinition = "TEXT")
+    private String judgesJson;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/BES/src/main/java/com/example/BES/models/BattleGenreState.java
+++ b/BES/src/main/java/com/example/BES/models/BattleGenreState.java
@@ -55,6 +55,9 @@ public class BattleGenreState {
     @Column(name = "judges_json", columnDefinition = "TEXT")
     private String judgesJson;
 
+    @Column(name = "champion")
+    private String champion;
+
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/BES/src/main/java/com/example/BES/respositories/BattleActiveGenreRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/BattleActiveGenreRepository.java
@@ -1,0 +1,6 @@
+package com.example.BES.respositories;
+
+import com.example.BES.models.BattleActiveGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BattleActiveGenreRepository extends JpaRepository<BattleActiveGenre, Integer> {}

--- a/BES/src/main/java/com/example/BES/respositories/BattleGenreStateRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/BattleGenreStateRepository.java
@@ -2,8 +2,10 @@ package com.example.BES.respositories;
 
 import com.example.BES.models.BattleGenreState;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 import java.util.Optional;
 
 public interface BattleGenreStateRepository extends JpaRepository<BattleGenreState, Long> {
     Optional<BattleGenreState> findByEventNameAndGenreName(String eventName, String genreName);
+    List<BattleGenreState> findByEventName(String eventName);
 }

--- a/BES/src/main/java/com/example/BES/respositories/BattleGenreStateRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/BattleGenreStateRepository.java
@@ -1,0 +1,9 @@
+package com.example.BES.respositories;
+
+import com.example.BES.models.BattleGenreState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface BattleGenreStateRepository extends JpaRepository<BattleGenreState, Long> {
+    Optional<BattleGenreState> findByEventNameAndGenreName(String eventName, String genreName);
+}

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -194,7 +194,7 @@ public class BattleService {
             if (exists) return 0;
             BattleJudge battleJudge = new BattleJudge();
             battleJudge.setName(judge.getName());
-            battleJudge.setVote(-1);
+            battleJudge.setVote(-3);
             battleJudge.setId(dto.getId());
             judges.add(battleJudge);
             code = dto.getId().intValue();
@@ -226,7 +226,7 @@ public class BattleService {
 
     public void resetJudgeVotesService() {
         synchronized (judges) {
-            for (BattleJudge judge : judges) judge.setVote(-1);
+            for (BattleJudge judge : judges) judge.setVote(-3);
         }
         messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
         persistActiveState();

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -125,7 +125,10 @@ public class BattleService {
             "isFinal",      currentIsFinal
         ));
         battlePhase = "LOCKED";
-        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
+            "phase", battlePhase,
+            "genre", activeGenreName != null ? activeGenreName : ""
+        ));
         persistActiveState();
     }
 
@@ -173,7 +176,10 @@ public class BattleService {
         ));
         if (res == 0 || res == 1) {
             battlePhase = "REVEALED";
-            messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+            messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
+                "phase", battlePhase,
+                "genre", activeGenreName != null ? activeGenreName : ""
+            ));
             persistActiveState();
         }
         return res;
@@ -273,7 +279,10 @@ public class BattleService {
     public void setBattlePhaseService(String phase) {
         if ("REVEALED".equals(phase)) return;
         battlePhase = phase;
-        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
+            "phase", battlePhase,
+            "genre", activeGenreName != null ? activeGenreName : ""
+        ));
         persistActiveState();
     }
 
@@ -326,7 +335,10 @@ public class BattleService {
         activeGenreName = dto.getGenreName();
         loadGenreStateIntoMemory(activeEventName, activeGenreName);
         broadcastStateSnapshot();
-        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
+            "phase", battlePhase,
+            "genre", activeGenreName != null ? activeGenreName : ""
+        ));
     }
 
     public Map<String, Object> getBattleStateService() {

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -129,6 +129,26 @@ public class BattleService {
         persistActiveState();
     }
 
+    public void clearBattlePairService() {
+        getCurrentPair().leftBattler.setName("");
+        getCurrentPair().leftBattler.setScore(0);
+        getCurrentPair().leftBattler.setMembers(new ArrayList<>());
+        getCurrentPair().rightBattler.setName("");
+        getCurrentPair().rightBattler.setScore(0);
+        getCurrentPair().rightBattler.setMembers(new ArrayList<>());
+        currentIsFinal = false;
+        messagingTemplate.convertAndSend("/topic/battle/battle-pair", Map.of(
+            "left",         "",
+            "leftScore",    0,
+            "leftMembers",  new ArrayList<>(),
+            "right",        "",
+            "rightScore",   0,
+            "rightMembers", new ArrayList<>(),
+            "isFinal",      false
+        ));
+        // Does NOT change phase — caller sets phase afterward
+    }
+
     public Integer setScoreService(boolean isFinal) {
         List<Integer> score = new ArrayList<>();
         Integer res = -100;
@@ -270,6 +290,8 @@ public class BattleService {
 
     public void broadcastChampionReveal(ChampionRevealDto dto) {
         if (dto.isDismiss()) {
+            champion = null;
+            persistActiveState();
             messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of("dismiss", true));
         } else {
             champion = dto.getChampionName() != null ? dto.getChampionName() : "";
@@ -304,6 +326,7 @@ public class BattleService {
         activeGenreName = dto.getGenreName();
         loadGenreStateIntoMemory(activeEventName, activeGenreName);
         broadcastStateSnapshot();
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
     }
 
     public Map<String, Object> getBattleStateService() {

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -1,5 +1,6 @@
 package com.example.BES.services;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,30 +13,51 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.BES.dtos.battle.ChampionRevealDto;
+import com.example.BES.dtos.battle.SetActiveGenreDto;
 import com.example.BES.dtos.battle.SetBattleModeDto;
-import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetBattlerPairDto;
 import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
 import com.example.BES.dtos.battle.SetVoteDto;
+import com.example.BES.models.BattleActiveGenre;
+import com.example.BES.models.BattleGenreState;
 import com.example.BES.models.Judge;
+import com.example.BES.respositories.BattleActiveGenreRepository;
+import com.example.BES.respositories.BattleGenreStateRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
 
 @Service
 public class BattleService {
+
     @Autowired
     JudgeService judgeService;
 
     @Autowired
     SimpMessagingTemplate messagingTemplate;
 
-    // top 32, top 16 or 7ts
+    @Autowired
+    BattleGenreStateRepository battleGenreStateRepository;
+
+    @Autowired
+    BattleActiveGenreRepository battleActiveGenreRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
     private List<String> modes = Arrays.asList("Top32", "Top16", "7-to-Smoke");
+    private String selectedMode;
+
     private Object bracketState = null;
+    private Integer currentRoundIndex = 0;
     private List<Battler> battlers = new ArrayList<>();
-    // IDLE | LOCKED | VOTING | REVEALED
     private String battlePhase = "IDLE";
     private boolean currentIsFinal = false;
     private Map<String, Object> overlayConfig = new HashMap<>(Map.of(
@@ -43,16 +65,14 @@ public class BattleService {
         "leftColor",  "#dc2626",
         "rightColor", "#2563eb"
     ));
-    public List<String> getModes() {
-        return modes;
-    }
-    private String selectedMode;
     private BattlePair currentPair;
     private final List<BattleJudge> judges = Collections.synchronizedList(new ArrayList<>());
-    // standby or judge
     private String status;
 
-    BattleService(){
+    private String activeEventName;
+    private String activeGenreName;
+
+    BattleService() {
         selectedMode = "";
         currentPair = new BattlePair();
         Battler left = new Battler();
@@ -61,22 +81,32 @@ public class BattleService {
         currentPair.rightBattler = right;
     }
 
-    public List<Battler> getSmokeBattlersService(){
-        return battlers;
-    }
-
-    public void setSmokeBattlersService(SetSmokeBattlersDto dto){
-        battlers = new ArrayList<>();
-        for (Battler battler : dto.getBattlers()) {
-            battlers.add(battler);
+    @PostConstruct
+    public void loadStateFromDb() {
+        try {
+            battleActiveGenreRepository.findById(1).ifPresent(active -> {
+                if (active.getEventName() != null && active.getGenreName() != null) {
+                    activeEventName = active.getEventName();
+                    activeGenreName = active.getGenreName();
+                    loadGenreStateIntoMemory(activeEventName, activeGenreName);
+                }
+            });
+        } catch (Exception e) {
+            System.err.println("Failed to load battle state from DB on startup: " + e.getMessage());
         }
-        messagingTemplate.convertAndSend("/topic/battle/smoke",
-            Map.of(
-                "battlers", battlers
-            ));
     }
 
-    public void setBattlerPairService(SetBattlerPairDto dto){
+    public List<String> getModes() { return modes; }
+
+    public List<Battler> getSmokeBattlersService() { return battlers; }
+
+    public void setSmokeBattlersService(SetSmokeBattlersDto dto) {
+        battlers = new ArrayList<>();
+        for (Battler battler : dto.getBattlers()) battlers.add(battler);
+        messagingTemplate.convertAndSend("/topic/battle/smoke", Map.of("battlers", battlers));
+    }
+
+    public void setBattlerPairService(SetBattlerPairDto dto) {
         getCurrentPair().leftBattler.setName(dto.getLeftBattler());
         getCurrentPair().leftBattler.setScore(0);
         getCurrentPair().leftBattler.setMembers(dto.getLeftMembers());
@@ -84,173 +114,149 @@ public class BattleService {
         getCurrentPair().rightBattler.setScore(0);
         getCurrentPair().rightBattler.setMembers(dto.getRightMembers());
         currentIsFinal = dto.isFinal();
-        messagingTemplate.convertAndSend("/topic/battle/battle-pair",
-            Map.of(
-                "left", currentPair.getLeftBattler().getName(),
-                "leftScore", currentPair.getLeftBattler().getScore(),
-                "leftMembers", currentPair.getLeftBattler().getMembers(),
-                "right", currentPair.getRightBattler().getName(),
-                "rightScore", currentPair.getRightBattler().getScore(),
-                "rightMembers", currentPair.getRightBattler().getMembers(),
-                "isFinal", currentIsFinal
-            ));
-        // Auto-transition to LOCKED when a new pair is set
+        messagingTemplate.convertAndSend("/topic/battle/battle-pair", Map.of(
+            "left",         currentPair.getLeftBattler().getName(),
+            "leftScore",    currentPair.getLeftBattler().getScore(),
+            "leftMembers",  currentPair.getLeftBattler().getMembers(),
+            "right",        currentPair.getRightBattler().getName(),
+            "rightScore",   currentPair.getRightBattler().getScore(),
+            "rightMembers", currentPair.getRightBattler().getMembers(),
+            "isFinal",      currentIsFinal
+        ));
         battlePhase = "LOCKED";
         messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        persistActiveState();
     }
 
-    public Integer setScoreService(boolean isFinal){
-        // Broadcast the score here
-        // This is where we reveal the judge decision on the screen
-        // After that we add the point
+    public Integer setScoreService(boolean isFinal) {
         List<Integer> score = new ArrayList<>();
         Integer res = -100;
         synchronized (judges) {
-            if(judges.size() == 0){
-                res = -2;
-            }
-            for (BattleJudge judge : judges) {
-                score.add(judge.getVote());
-            }
+            if (judges.size() == 0) { res = -2; }
+            for (BattleJudge judge : judges) score.add(judge.getVote());
         }
-        if(Collections.frequency(score, 0) == Collections.frequency(score, 1)){
-            if (isFinal) return -3;   // final tie — blocked, do not broadcast
+        if (Collections.frequency(score, 0) == Collections.frequency(score, 1)) {
+            if (isFinal) return -3;
             res = -1;
-        }else if(Collections.frequency(score, 0) > Collections.frequency(score, 1)){
+        } else if (Collections.frequency(score, 0) > Collections.frequency(score, 1)) {
             currentPair.getLeftBattler().setScore(currentPair.leftBattler.getScore() + 1);
             res = 0;
-        }else{
+        } else {
             currentPair.getRightBattler().setScore(currentPair.rightBattler.getScore() + 1);
             res = 1;
         }
-        messagingTemplate.convertAndSend("/topic/battle/score",
-            Map.of(
-                "message", res,
-                "left", currentPair.getLeftBattler().getScore(),
-                "right", currentPair.getRightBattler().getScore()
-            ));
-        // Auto-transition: winner → REVEALED, tie → stay VOTING
+        messagingTemplate.convertAndSend("/topic/battle/score", Map.of(
+            "message", res,
+            "left",    currentPair.getLeftBattler().getScore(),
+            "right",   currentPair.getRightBattler().getScore()
+        ));
         if (res == 0 || res == 1) {
             battlePhase = "REVEALED";
             messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+            persistActiveState();
         }
         return res;
     }
 
-    public Integer removeBattleJudgeService(SetJudgeDto dto){
+    public Integer removeBattleJudgeService(SetJudgeDto dto) {
         judges.removeIf(judge -> Objects.equals(judge.getId(), dto.getId()));
-        messagingTemplate.convertAndSend("/topic/battle/judges",
-            Map.of(
-                "judges", judges
-            ));
+        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+        persistActiveState();
         return dto.getId().intValue();
     }
 
-    public Integer setBattleJudgeService(SetJudgeDto dto){
-        // Need to broadcast this as well, before the battle starts the judge decision overlay will be shown to verify the name
+    public Integer setBattleJudgeService(SetJudgeDto dto) {
         Judge judge = judgeService.getJudgeById(dto.getId());
         Integer code = -50;
-        if(judge != null){
+        if (judge != null) {
             Boolean exists = judges.stream().anyMatch(j -> j.getName().equals(judge.getName()));
-            if(exists) return 0;
+            if (exists) return 0;
             BattleJudge battleJudge = new BattleJudge();
             battleJudge.setName(judge.getName());
             battleJudge.setVote(-1);
             battleJudge.setId(dto.getId());
             judges.add(battleJudge);
             code = dto.getId().intValue();
-        }else{
+        } else {
             return -1;
         }
-        // send all three judges to update
-        messagingTemplate.convertAndSend("/topic/battle/judges",
-            Map.of(
-                "judges", judges
-            ));
+        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+        persistActiveState();
         return code;
     }
 
-    // Might need to have an option to remove judge
-    public Integer setVoteService(SetVoteDto dto){
-        // This need to broadcast as well
-        // To reflect on the overlay screen
+    public Integer setVoteService(SetVoteDto dto) {
         Integer code = -50;
         Optional<BattleJudge> battleJude = judges.stream()
             .filter(j -> j.getId().equals(dto.getId())).findFirst();
-        if(battleJude.isPresent()){
+        if (battleJude.isPresent()) {
             battleJude.get().setVote(dto.getVote());
-        }else{
+        } else {
             return -2;
         }
         code = dto.getVote();
-        // need to include the judge id
-        messagingTemplate.convertAndSend(String.format("/topic/battle/vote/%d", dto.getId()),
-            Map.of(
-                "vote", code,
-                "judge", dto.getId()
-            ));
+        messagingTemplate.convertAndSend(
+            String.format("/topic/battle/vote/%d", dto.getId()),
+            Map.of("vote", code, "judge", dto.getId())
+        );
+        persistActiveState();
         return code;
     }
 
-    public Object getBracketState() {
-        return bracketState;
+    public void resetJudgeVotesService() {
+        synchronized (judges) {
+            for (BattleJudge judge : judges) judge.setVote(-1);
+        }
+        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+        persistActiveState();
     }
 
+    public Object getBracketState() { return bracketState; }
+
     public void setBracketStateService(SetBracketStateDto dto) {
-        Map<String, Object> state = new java.util.HashMap<>();
+        Map<String, Object> state = new HashMap<>();
         state.put("topSize", dto.getTopSize());
         state.put("rounds", dto.getRounds());
         this.bracketState = state;
+        if (dto.getCurrentRoundIndex() != null) {
+            this.currentRoundIndex = dto.getCurrentRoundIndex();
+        }
         messagingTemplate.convertAndSend("/topic/battle/bracket", state);
+        persistActiveState();
     }
 
-    public String getSelectedMode() {
-        return selectedMode;
-    }
+    public String getSelectedMode() { return selectedMode; }
+
     public void setSelectedMode(SetBattleModeDto dto) {
-        // when the battle starts cannot change it
         this.selectedMode = dto.getMode();
     }
-    public BattlePair getCurrentPair() {
-        return currentPair;
-    }
-    public void setCurrentPair(BattlePair currentPair) {
-        this.currentPair = currentPair;
-    }
-    public List<BattleJudge> getJudges() {
-        return judges;
-    }
+
+    public BattlePair getCurrentPair() { return currentPair; }
+
+    public void setCurrentPair(BattlePair currentPair) { this.currentPair = currentPair; }
+
+    public List<BattleJudge> getJudges() { return judges; }
+
     public void setJudges(List<BattleJudge> judges) {
-        synchronized (this.judges) {
-            this.judges.clear();
-            this.judges.addAll(judges);
-        }
-    }
-    public String getStatus() {
-        return status;
-    }
-    public void setStatus(String status) {
-        this.status = status;
+        synchronized (this.judges) { this.judges.clear(); this.judges.addAll(judges); }
     }
 
-    public String getBattlePhase() {
-        return battlePhase;
-    }
+    public String getStatus() { return status; }
 
-    public boolean isCurrentFinal() {
-        return currentIsFinal;
-    }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getBattlePhase() { return battlePhase; }
+
+    public boolean isCurrentFinal() { return currentIsFinal; }
 
     public void setBattlePhaseService(String phase) {
-        // REVEALED is only set by the backend on score reveal, not manually
         if ("REVEALED".equals(phase)) return;
         battlePhase = phase;
         messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        persistActiveState();
     }
 
-    public Map<String, Object> getOverlayConfig() {
-        return overlayConfig;
-    }
+    public Map<String, Object> getOverlayConfig() { return overlayConfig; }
 
     public void setOverlayConfigService(SetOverlayConfigDto dto) {
         Map<String, Object> newConfig = new HashMap<>();
@@ -261,87 +267,177 @@ public class BattleService {
         messagingTemplate.convertAndSend("/topic/battle/overlay-config", newConfig);
     }
 
-    public void resetJudgeVotesService() {
-        synchronized (judges) {
-            for (BattleJudge judge : judges) {
-                judge.setVote(-1);
-            }
-        }
-        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
-    }
-
     public void broadcastChampionReveal(ChampionRevealDto dto) {
         if (dto.isDismiss()) {
-            messagingTemplate.convertAndSend("/topic/battle/champion-reveal",
-                Map.of("dismiss", true));
+            messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of("dismiss", true));
         } else {
-            messagingTemplate.convertAndSend("/topic/battle/champion-reveal",
-                Map.of("dismiss", false,
-                       "genreName",     dto.getGenreName()     != null ? dto.getGenreName()     : "",
-                       "championName",  dto.getChampionName()  != null ? dto.getChampionName()  : ""));
+            messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of(
+                "dismiss",       false,
+                "genreName",     dto.getGenreName()    != null ? dto.getGenreName()    : "",
+                "championName",  dto.getChampionName() != null ? dto.getChampionName() : ""
+            ));
         }
     }
 
-    public class BattleJudge {
+    @Transactional
+    public void switchActiveGenreService(SetActiveGenreDto dto) {
+        persistActiveState();
+        BattleActiveGenre active = battleActiveGenreRepository.findById(1)
+            .orElse(new BattleActiveGenre(1, null, null));
+        active.setEventName(dto.getEventName());
+        active.setGenreName(dto.getGenreName());
+        battleActiveGenreRepository.save(active);
+        activeEventName = dto.getEventName();
+        activeGenreName = dto.getGenreName();
+        loadGenreStateIntoMemory(activeEventName, activeGenreName);
+        broadcastStateSnapshot();
+    }
+
+    public Map<String, Object> getBattleStateService() {
+        if (activeEventName == null || activeGenreName == null) return new HashMap<>();
+        Map<String, Object> state = new HashMap<>();
+        state.put("eventName", activeEventName);
+        state.put("genreName", activeGenreName);
+        state.put("bracket", bracketState);
+        state.put("currentRoundIndex", currentRoundIndex);
+        Map<String, Object> pair = new HashMap<>();
+        pair.put("left",         currentPair.getLeftBattler().getName());
+        pair.put("leftMembers",  currentPair.getLeftBattler().getMembers());
+        pair.put("right",        currentPair.getRightBattler().getName());
+        pair.put("rightMembers", currentPair.getRightBattler().getMembers());
+        pair.put("isFinal",      currentIsFinal);
+        state.put("currentPair", pair);
+        state.put("battlePhase", battlePhase);
+        synchronized (judges) {
+            state.put("judges", new ArrayList<>(judges));
+        }
+        return state;
+    }
+
+    public String getActiveEventName() { return activeEventName; }
+    public String getActiveGenreName() { return activeGenreName; }
+
+    private void persistActiveState() {
+        if (activeEventName == null || activeGenreName == null) return;
+        try {
+            BattleGenreState s = battleGenreStateRepository
+                .findByEventNameAndGenreName(activeEventName, activeGenreName)
+                .orElse(new BattleGenreState());
+            s.setEventName(activeEventName);
+            s.setGenreName(activeGenreName);
+            s.setBracketJson(bracketState != null ? objectMapper.writeValueAsString(bracketState) : null);
+            if (bracketState instanceof Map) {
+                Object ts = ((Map<?, ?>) bracketState).get("topSize");
+                if (ts != null) {
+                    try { s.setTopSize(Integer.parseInt(ts.toString())); }
+                    catch (NumberFormatException ignored) {}
+                }
+            }
+            s.setCurrentRoundIndex(currentRoundIndex);
+            s.setCurrentPairLeft(currentPair.getLeftBattler().getName());
+            s.setCurrentPairLeftMembers(
+                objectMapper.writeValueAsString(currentPair.getLeftBattler().getMembers()));
+            s.setCurrentPairRight(currentPair.getRightBattler().getName());
+            s.setCurrentPairRightMembers(
+                objectMapper.writeValueAsString(currentPair.getRightBattler().getMembers()));
+            s.setIsFinal(currentIsFinal);
+            s.setBattlePhase(battlePhase);
+            synchronized (judges) {
+                s.setJudgesJson(objectMapper.writeValueAsString(new ArrayList<>(judges)));
+            }
+            s.setUpdatedAt(LocalDateTime.now());
+            battleGenreStateRepository.save(s);
+        } catch (Exception e) {
+            System.err.println("Failed to persist battle state: " + e.getMessage());
+        }
+    }
+
+    private void loadGenreStateIntoMemory(String eventName, String genreName) {
+        Optional<BattleGenreState> stateOpt =
+            battleGenreStateRepository.findByEventNameAndGenreName(eventName, genreName);
+        if (stateOpt.isEmpty()) { resetToDefaults(); return; }
+        BattleGenreState s = stateOpt.get();
+        try {
+            bracketState = s.getBracketJson() != null
+                ? objectMapper.readValue(s.getBracketJson(), Map.class) : null;
+            currentRoundIndex = s.getCurrentRoundIndex() != null ? s.getCurrentRoundIndex() : 0;
+            currentPair.getLeftBattler().setName(s.getCurrentPairLeft() != null ? s.getCurrentPairLeft() : "");
+            currentPair.getLeftBattler().setScore(0);
+            currentPair.getLeftBattler().setMembers(s.getCurrentPairLeftMembers() != null
+                ? objectMapper.readValue(s.getCurrentPairLeftMembers(), new TypeReference<List<String>>(){})
+                : new ArrayList<>());
+            currentPair.getRightBattler().setName(s.getCurrentPairRight() != null ? s.getCurrentPairRight() : "");
+            currentPair.getRightBattler().setScore(0);
+            currentPair.getRightBattler().setMembers(s.getCurrentPairRightMembers() != null
+                ? objectMapper.readValue(s.getCurrentPairRightMembers(), new TypeReference<List<String>>(){})
+                : new ArrayList<>());
+            currentIsFinal = Boolean.TRUE.equals(s.getIsFinal());
+            battlePhase = s.getBattlePhase() != null ? s.getBattlePhase() : "IDLE";
+            synchronized (judges) {
+                judges.clear();
+                if (s.getJudgesJson() != null) {
+                    List<BattleJudge> restored =
+                        objectMapper.readValue(s.getJudgesJson(), new TypeReference<List<BattleJudge>>(){});
+                    judges.addAll(restored);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load genre state from DB: " + e.getMessage());
+            resetToDefaults();
+        }
+    }
+
+    private void resetToDefaults() {
+        bracketState = null;
+        currentRoundIndex = 0;
+        currentPair.getLeftBattler().setName("");
+        currentPair.getLeftBattler().setScore(0);
+        currentPair.getLeftBattler().setMembers(new ArrayList<>());
+        currentPair.getRightBattler().setName("");
+        currentPair.getRightBattler().setScore(0);
+        currentPair.getRightBattler().setMembers(new ArrayList<>());
+        currentIsFinal = false;
+        battlePhase = "IDLE";
+        synchronized (judges) { judges.clear(); }
+    }
+
+    private void broadcastStateSnapshot() {
+        messagingTemplate.convertAndSend("/topic/battle/state", getBattleStateService());
+    }
+
+    public static class BattleJudge {
         private Long id;
         private String name;
-        /*
-         *  0 is for battler 1
-         *  1 is for battler 2 
-         *  -1 is tie
-         */
         private Integer vote;
-        public String getName() {
-            return name;
-        }
-        public void setName(String name) {
-            this.name = name;
-        }
-        public Integer getVote() {
-            return vote;
-        }
-        public void setVote(Integer vote) {
-            this.vote = vote;
-        }
-        public Long getId() {
-            return id;
-        }
-        public void setId(Long id) {
-            this.id = id;
-        }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public Integer getVote() { return vote; }
+        public void setVote(Integer vote) { this.vote = vote; }
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
     }
 
     public static class Battler {
         private String name;
         private Integer score;
         private List<String> members = new ArrayList<>();
-        Battler(){
-            name = "";
-            score = 0;
-        }
+        Battler() { name = ""; score = 0; }
         public String getName() { return name; }
         public void setName(String name) { this.name = name; }
         public Integer getScore() { return score; }
         public void setScore(Integer score) { this.score = score; }
         public List<String> getMembers() { return members; }
-        public void setMembers(List<String> members) { this.members = members != null ? members : new ArrayList<>(); }
+        public void setMembers(List<String> members) {
+            this.members = members != null ? members : new ArrayList<>();
+        }
     }
+
     public class BattlePair {
-        
         private Battler leftBattler;
         private Battler rightBattler;
-        
-        public Battler getLeftBattler() {
-            return leftBattler;
-        }
-        public Battler getRightBattler() {
-            return rightBattler;
-        }
-        public void setLeftBattler(Battler leftBattler) {
-            this.leftBattler = leftBattler;
-        }
-        public void setRightBattler(Battler rightBattler) {
-            this.rightBattler = rightBattler;
-        }
+        public Battler getLeftBattler() { return leftBattler; }
+        public Battler getRightBattler() { return rightBattler; }
+        public void setLeftBattler(Battler leftBattler) { this.leftBattler = leftBattler; }
+        public void setRightBattler(Battler rightBattler) { this.rightBattler = rightBattler; }
     }
 }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -71,6 +71,7 @@ public class BattleService {
 
     private String activeEventName;
     private String activeGenreName;
+    private String champion = null;
 
     BattleService() {
         selectedMode = "";
@@ -271,12 +272,24 @@ public class BattleService {
         if (dto.isDismiss()) {
             messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of("dismiss", true));
         } else {
+            champion = dto.getChampionName() != null ? dto.getChampionName() : "";
+            persistActiveState();
             messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of(
                 "dismiss",       false,
                 "genreName",     dto.getGenreName()    != null ? dto.getGenreName()    : "",
-                "championName",  dto.getChampionName() != null ? dto.getChampionName() : ""
+                "championName",  champion
             ));
         }
+    }
+
+    public Map<String, String> getChampionsForEvent(String eventName) {
+        Map<String, String> result = new HashMap<>();
+        battleGenreStateRepository.findByEventName(eventName).forEach(s -> {
+            if (s.getChampion() != null && !s.getChampion().isBlank()) {
+                result.put(s.getGenreName(), s.getChampion());
+            }
+        });
+        return result;
     }
 
     @Transactional
@@ -308,6 +321,7 @@ public class BattleService {
         pair.put("isFinal",      currentIsFinal);
         state.put("currentPair", pair);
         state.put("battlePhase", battlePhase);
+        state.put("champion", champion);
         synchronized (judges) {
             state.put("judges", new ArrayList<>(judges));
         }
@@ -342,6 +356,7 @@ public class BattleService {
                 objectMapper.writeValueAsString(currentPair.getRightBattler().getMembers()));
             s.setIsFinal(currentIsFinal);
             s.setBattlePhase(battlePhase);
+            s.setChampion(champion);
             synchronized (judges) {
                 s.setJudgesJson(objectMapper.writeValueAsString(new ArrayList<>(judges)));
             }
@@ -373,6 +388,7 @@ public class BattleService {
                 : new ArrayList<>());
             currentIsFinal = Boolean.TRUE.equals(s.getIsFinal());
             battlePhase = s.getBattlePhase() != null ? s.getBattlePhase() : "IDLE";
+            champion = s.getChampion();
             synchronized (judges) {
                 judges.clear();
                 if (s.getJudgesJson() != null) {
@@ -398,6 +414,7 @@ public class BattleService {
         currentPair.getRightBattler().setMembers(new ArrayList<>());
         currentIsFinal = false;
         battlePhase = "IDLE";
+        champion = null;
         synchronized (judges) { judges.clear(); }
     }
 

--- a/BES/src/main/java/com/example/BES/services/CheckinPreviewService.java
+++ b/BES/src/main/java/com/example/BES/services/CheckinPreviewService.java
@@ -1,0 +1,34 @@
+package com.example.BES.services;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CheckinPreviewService {
+
+    private final Map<String, Set<Long>> activePreviews = new ConcurrentHashMap<>();
+
+    public void setPreview(String eventName, Long participantId) {
+        activePreviews
+            .computeIfAbsent(eventName, k -> ConcurrentHashMap.newKeySet())
+            .add(participantId);
+    }
+
+    public void clearPreview(String eventName, Long participantId) {
+        Set<Long> previews = activePreviews.get(eventName);
+        if (previews != null) {
+            previews.remove(participantId);
+            if (previews.isEmpty()) {
+                activePreviews.remove(eventName);
+            }
+        }
+    }
+
+    public Set<Long> getActivePreviews(String eventName) {
+        return activePreviews.getOrDefault(eventName, Collections.emptySet());
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -118,6 +118,9 @@ public class EventGenreParticpantService {
     public void getAllAuditionNumsViaQR(Long participantId, Long eventId) {
         List<EventGenreParticipant> entries =
             repo.findByEventIdAndParticipantId(eventId, participantId);
+        if (entries.stream().allMatch(e -> e.getAuditionNumber() != null)) {
+            throw new IllegalStateException("already_checked_in");
+        }
         for (EventGenreParticipant entry : entries) {
             AddParticipantToEventGenreDto dto = new AddParticipantToEventGenreDto();
             dto.participantId = participantId;

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -118,7 +118,7 @@ public class EventGenreParticpantService {
     public void getAllAuditionNumsViaQR(Long participantId, Long eventId) {
         List<EventGenreParticipant> entries =
             repo.findByEventIdAndParticipantId(eventId, participantId);
-        if (entries.stream().allMatch(e -> e.getAuditionNumber() != null)) {
+        if (!entries.isEmpty() && entries.stream().allMatch(e -> e.getAuditionNumber() != null)) {
             throw new IllegalStateException("already_checked_in");
         }
         for (EventGenreParticipant entry : entries) {

--- a/BES/src/main/java/com/example/BES/services/EventService.java
+++ b/BES/src/main/java/com/example/BES/services/EventService.java
@@ -41,6 +41,12 @@ public class EventService {
         emailTemplateService.createDefaultTemplate(saved);
     }
 
+    public String getEventNameById(Long eventId) {
+        return repo.findById(eventId)
+            .map(Event::getEventName)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+    }
+
     public AddEventDto findEventbyNameSerivce(String eventName){
         Event event = repo.findByEventName(eventName).orElse(null);
         if(event != null){

--- a/BES/src/main/resources/db/migration/V28__add_battle_state_persistence.sql
+++ b/BES/src/main/resources/db/migration/V28__add_battle_state_persistence.sql
@@ -1,0 +1,30 @@
+-- Battle state persistence tables for genre division switching and restart recovery
+-- Stores the state of each active battle (bracket, pair, phase, judges) scoped per (event, genre)
+
+CREATE TABLE battle_genre_state (
+    id                          BIGSERIAL    PRIMARY KEY,
+    event_name                  VARCHAR(255) NOT NULL,
+    genre_name                  VARCHAR(255) NOT NULL,
+    bracket_json                TEXT,
+    top_size                    INTEGER,
+    current_round_index         INTEGER      DEFAULT 0,
+    current_pair_left           VARCHAR(255),
+    current_pair_left_members   TEXT,
+    current_pair_right          VARCHAR(255),
+    current_pair_right_members  TEXT,
+    is_final                    BOOLEAN      DEFAULT FALSE,
+    battle_phase                VARCHAR(20)  DEFAULT 'IDLE',
+    judges_json                 TEXT,
+    updated_at                  TIMESTAMP    DEFAULT NOW(),
+    UNIQUE (event_name, genre_name)
+);
+
+-- Singleton table tracking which event+genre is currently live on the backend
+-- Always contains exactly one row with id=1; updated by genre switch and @PostConstruct
+CREATE TABLE battle_active_genre (
+    id         INTEGER PRIMARY KEY DEFAULT 1,
+    event_name VARCHAR(255),
+    genre_name VARCHAR(255)
+);
+
+INSERT INTO battle_active_genre (id, event_name, genre_name) VALUES (1, NULL, NULL);

--- a/BES/src/main/resources/db/migration/V29__add_champion_to_battle_genre_state.sql
+++ b/BES/src/main/resources/db/migration/V29__add_champion_to_battle_genre_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE battle_genre_state ADD COLUMN champion VARCHAR(255);

--- a/BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java
@@ -348,4 +348,47 @@ public class BattleControllerIntegrationTest {
                         .content(body))
                 .andExpect(status().is4xxClientError());
     }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void testSetAndGetActiveGenre() throws Exception {
+        String json = objectMapper.writeValueAsString(
+            Map.of("eventName", "TestEvent", "genreName", "Breaking Top 16")
+        );
+        mockMvc.perform(post("/api/v1/battle/active-genre")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Active genre set"));
+
+        mockMvc.perform(get("/api/v1/battle/active-genre"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventName").value("TestEvent"))
+                .andExpect(jsonPath("$.genreName").value("Breaking Top 16"));
+    }
+
+    @Test
+    @WithMockUser
+    public void testGetBattleStateEmptyWhenNoActiveGenre() throws Exception {
+        mockMvc.perform(get("/api/v1/battle/state"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    public void testGetBattleStateAfterSettingActiveGenre() throws Exception {
+        String json = objectMapper.writeValueAsString(
+            Map.of("eventName", "EventA", "genreName", "Popping")
+        );
+        mockMvc.perform(post("/api/v1/battle/active-genre")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/battle/state"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventName").value("EventA"))
+                .andExpect(jsonPath("$.genreName").value("Popping"))
+                .andExpect(jsonPath("$.battlePhase").exists());
+    }
 }

--- a/BES/src/test/java/com/example/BES/controllers/EventControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/EventControllerIntegrationTest.java
@@ -41,6 +41,7 @@ import com.example.BES.models.EventGenreParticipant;
 import com.example.BES.models.EventParticipant;
 import com.example.BES.models.Genre;
 import com.example.BES.models.Participant;
+import com.example.BES.services.CheckinPreviewService;
 import com.example.BES.services.EventGenreParticpantService;
 import com.example.BES.services.EventGenreService;
 import com.example.BES.services.EventParticpantService;
@@ -81,6 +82,8 @@ public class EventControllerIntegrationTest {
     private JudgeService judgeService;
     @MockBean
     private ScoreService scoreService;
+    @MockBean
+    private CheckinPreviewService checkinPreviewService;
 
     @Test
     @WithMockUser

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -239,7 +239,7 @@ class BattleServiceTest {
     }
 
     @Test
-    void resetJudgeVotes_setsAllVotesToMinusOneAndBroadcasts() {
+    void resetJudgeVotes_setsAllVotesToMinusThreeAndBroadcasts() {
         Judge j = new Judge();
         j.setJudgeId(5L);
         j.setName("Alex");
@@ -256,7 +256,7 @@ class BattleServiceTest {
 
         service.resetJudgeVotesService();
 
-        assertThat(service.getJudges().get(0).getVote()).isEqualTo(-1);
+        assertThat(service.getJudges().get(0).getVote()).isEqualTo(-3);
         verify(messagingTemplate, atLeastOnce()).convertAndSend(
             eq("/topic/battle/judges"), any(Map.class));
     }

--- a/docs/superpowers/plans/2026-06-02-battle-division-state-persistence.md
+++ b/docs/superpowers/plans/2026-06-02-battle-division-state-persistence.md
@@ -1,0 +1,1448 @@
+# Battle Division State Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist battle state (bracket, pair, round, phase, judges) per event+genre in DB so all four battle views restore correctly after a page refresh or backend restart.
+
+**Architecture:** Thin persistence layer (Approach A from spec). Backend gains two new DB tables (`battle_genre_state`, `battle_active_genre`), three new REST endpoints, and calls a private `persistActiveState()` after every mutation. Frontend views call `GET /api/v1/battle/state` on mount and subscribe to `/topic/battle/state` for cross-client genre switches.
+
+**Tech Stack:** Spring Boot (JPA/Hibernate, Spring Data, Jackson, STOMP WebSocket), Vue 3 (Composition API, STOMP client), PostgreSQL (prod), H2 (tests), Flyway (migrations), JUnit 5 + MockMvc (backend tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-02-battle-division-state-persistence-design.md`
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Create | `BES/src/main/resources/db/migration/V17__add_battle_state_persistence.sql` |
+| Create | `BES/src/main/java/com/example/BES/models/BattleGenreState.java` |
+| Create | `BES/src/main/java/com/example/BES/models/BattleActiveGenre.java` |
+| Create | `BES/src/main/java/com/example/BES/respositories/BattleGenreStateRepository.java` |
+| Create | `BES/src/main/java/com/example/BES/respositories/BattleActiveGenreRepository.java` |
+| Create | `BES/src/main/java/com/example/BES/dtos/battle/SetActiveGenreDto.java` |
+| Modify | `BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java` |
+| Modify | `BES/src/main/java/com/example/BES/services/BattleService.java` |
+| Modify | `BES/src/main/java/com/example/BES/controllers/BattleController.java` |
+| Modify | `BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java` |
+| Modify | `BES-frontend/src/utils/api.js` |
+| Modify | `BES-frontend/src/views/BattleControl.vue` |
+| Modify | `BES-frontend/src/views/BracketVisualization.vue` |
+| Modify | `BES-frontend/src/views/BattleOverlay.vue` |
+| Modify | `BES-frontend/src/views/BattleJudge.vue` |
+
+---
+
+## Task 1: DB Migration
+
+**Files:**
+- Create: `BES/src/main/resources/db/migration/V17__add_battle_state_persistence.sql`
+
+- [ ] **Step 1: Create migration file**
+
+```sql
+CREATE TABLE battle_genre_state (
+    id                          BIGSERIAL    PRIMARY KEY,
+    event_name                  VARCHAR(255) NOT NULL,
+    genre_name                  VARCHAR(255) NOT NULL,
+    bracket_json                TEXT,
+    top_size                    INTEGER,
+    current_round_index         INTEGER      DEFAULT 0,
+    current_pair_left           VARCHAR(255),
+    current_pair_left_members   TEXT,
+    current_pair_right          VARCHAR(255),
+    current_pair_right_members  TEXT,
+    is_final                    BOOLEAN      DEFAULT FALSE,
+    battle_phase                VARCHAR(20)  DEFAULT 'IDLE',
+    judges_json                 TEXT,
+    updated_at                  TIMESTAMP    DEFAULT NOW(),
+    UNIQUE (event_name, genre_name)
+);
+
+CREATE TABLE battle_active_genre (
+    id         INTEGER PRIMARY KEY DEFAULT 1,
+    event_name VARCHAR(255),
+    genre_name VARCHAR(255)
+);
+
+INSERT INTO battle_active_genre (id, event_name, genre_name) VALUES (1, NULL, NULL);
+```
+
+- [ ] **Step 2: Verify migration applies cleanly**
+
+```bash
+cd BES && mvn flyway:migrate -Dflyway.url=jdbc:postgresql://localhost:5433/bes -Dflyway.user=bes -Dflyway.password=bes 2>&1 | tail -5
+```
+
+Expected: `Successfully applied 1 migration` (or confirm via Docker logs if running in Docker).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/resources/db/migration/V17__add_battle_state_persistence.sql
+git commit -m "feat: add battle_genre_state and battle_active_genre DB tables (V17)"
+```
+
+---
+
+## Task 2: JPA Models
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/models/BattleGenreState.java`
+- Create: `BES/src/main/java/com/example/BES/models/BattleActiveGenre.java`
+
+- [ ] **Step 1: Create `BattleGenreState.java`**
+
+```java
+package com.example.BES.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "battle_genre_state", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"event_name", "genre_name"})
+})
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BattleGenreState {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_name")
+    private String eventName;
+
+    @Column(name = "genre_name")
+    private String genreName;
+
+    @Column(name = "bracket_json", columnDefinition = "TEXT")
+    private String bracketJson;
+
+    @Column(name = "top_size")
+    private Integer topSize;
+
+    @Column(name = "current_round_index")
+    private Integer currentRoundIndex;
+
+    @Column(name = "current_pair_left")
+    private String currentPairLeft;
+
+    @Column(name = "current_pair_left_members", columnDefinition = "TEXT")
+    private String currentPairLeftMembers;
+
+    @Column(name = "current_pair_right")
+    private String currentPairRight;
+
+    @Column(name = "current_pair_right_members", columnDefinition = "TEXT")
+    private String currentPairRightMembers;
+
+    @Column(name = "is_final")
+    private Boolean isFinal;
+
+    @Column(name = "battle_phase")
+    private String battlePhase;
+
+    @Column(name = "judges_json", columnDefinition = "TEXT")
+    private String judgesJson;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}
+```
+
+- [ ] **Step 2: Create `BattleActiveGenre.java`**
+
+```java
+package com.example.BES.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "battle_active_genre")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BattleActiveGenre {
+
+    @Id
+    private Integer id;
+
+    @Column(name = "event_name")
+    private String eventName;
+
+    @Column(name = "genre_name")
+    private String genreName;
+}
+```
+
+- [ ] **Step 3: Compile to verify models are valid**
+
+```bash
+cd BES && mvn compile -q 2>&1 | tail -5
+```
+
+Expected: no output (clean compile).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/models/BattleGenreState.java \
+        BES/src/main/java/com/example/BES/models/BattleActiveGenre.java
+git commit -m "feat: add BattleGenreState and BattleActiveGenre JPA models"
+```
+
+---
+
+## Task 3: JPA Repositories
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/respositories/BattleGenreStateRepository.java`
+- Create: `BES/src/main/java/com/example/BES/respositories/BattleActiveGenreRepository.java`
+
+- [ ] **Step 1: Create `BattleGenreStateRepository.java`**
+
+```java
+package com.example.BES.respositories;
+
+import com.example.BES.models.BattleGenreState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface BattleGenreStateRepository extends JpaRepository<BattleGenreState, Long> {
+    Optional<BattleGenreState> findByEventNameAndGenreName(String eventName, String genreName);
+}
+```
+
+- [ ] **Step 2: Create `BattleActiveGenreRepository.java`**
+
+```java
+package com.example.BES.respositories;
+
+import com.example.BES.models.BattleActiveGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BattleActiveGenreRepository extends JpaRepository<BattleActiveGenre, Integer> {}
+```
+
+- [ ] **Step 3: Compile to verify**
+
+```bash
+cd BES && mvn compile -q 2>&1 | tail -5
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/respositories/BattleGenreStateRepository.java \
+        BES/src/main/java/com/example/BES/respositories/BattleActiveGenreRepository.java
+git commit -m "feat: add BattleGenreStateRepository and BattleActiveGenreRepository"
+```
+
+---
+
+## Task 4: DTOs
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/dtos/battle/SetActiveGenreDto.java`
+- Modify: `BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java`
+
+- [ ] **Step 1: Create `SetActiveGenreDto.java`**
+
+```java
+package com.example.BES.dtos.battle;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class SetActiveGenreDto {
+
+    @NotBlank
+    private String eventName;
+
+    @NotBlank
+    private String genreName;
+
+    public String getEventName() { return eventName; }
+    public void setEventName(String eventName) { this.eventName = eventName; }
+    public String getGenreName() { return genreName; }
+    public void setGenreName(String genreName) { this.genreName = genreName; }
+}
+```
+
+- [ ] **Step 2: Add `currentRoundIndex` to `SetBracketStateDto.java`**
+
+Open `BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java` and add the field + getter/setter:
+
+```java
+package com.example.BES.dtos.battle;
+
+public class SetBracketStateDto {
+    private String topSize;
+    private Object rounds;
+    private Integer currentRoundIndex;
+
+    public String getTopSize() { return topSize; }
+    public void setTopSize(String topSize) { this.topSize = topSize; }
+    public Object getRounds() { return rounds; }
+    public void setRounds(Object rounds) { this.rounds = rounds; }
+    public Integer getCurrentRoundIndex() { return currentRoundIndex; }
+    public void setCurrentRoundIndex(Integer currentRoundIndex) { this.currentRoundIndex = currentRoundIndex; }
+}
+```
+
+- [ ] **Step 3: Compile to verify**
+
+```bash
+cd BES && mvn compile -q 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/battle/SetActiveGenreDto.java \
+        BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java
+git commit -m "feat: add SetActiveGenreDto and currentRoundIndex to SetBracketStateDto"
+```
+
+---
+
+## Task 5: BattleService — Persistence Layer
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/BattleService.java`
+
+This is the core task. Add repos, new fields, `persistActiveState()`, `switchActiveGenreService()`, `loadGenreStateIntoMemory()`, `@PostConstruct`, and `getBattleStateService()`. Also make `BattleJudge` a static inner class (required for Jackson deserialization).
+
+- [ ] **Step 1: Write the failing integration test for `POST /api/v1/battle/active-genre`**
+
+Add to `BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java`:
+
+```java
+@Test
+@WithMockUser(roles = {"ADMIN"})
+public void testSetAndGetActiveGenre() throws Exception {
+    String json = objectMapper.writeValueAsString(
+        Map.of("eventName", "TestEvent", "genreName", "Breaking Top 16")
+    );
+    mockMvc.perform(post("/api/v1/battle/active-genre")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("Active genre set"));
+
+    mockMvc.perform(get("/api/v1/battle/active-genre"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.eventName").value("TestEvent"))
+            .andExpect(jsonPath("$.genreName").value("Breaking Top 16"));
+}
+
+@Test
+@WithMockUser
+public void testGetBattleStateEmptyWhenNoActiveGenre() throws Exception {
+    // Reset active genre by calling switch to a fresh genre
+    mockMvc.perform(get("/api/v1/battle/state"))
+            .andExpect(status().isOk());
+    // State may be empty ({}) or contain a previous test's genre — just verify 200
+}
+
+@Test
+@WithMockUser(roles = {"ADMIN"})
+public void testGetBattleStateAfterSettingActiveGenre() throws Exception {
+    String json = objectMapper.writeValueAsString(
+        Map.of("eventName", "EventA", "genreName", "Popping")
+    );
+    mockMvc.perform(post("/api/v1/battle/active-genre")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+            .andExpect(status().isOk());
+
+    mockMvc.perform(get("/api/v1/battle/state"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.eventName").value("EventA"))
+            .andExpect(jsonPath("$.genreName").value("Popping"))
+            .andExpect(jsonPath("$.battlePhase").exists());
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail (endpoints don't exist yet)**
+
+```bash
+cd BES && mvn test -Dtest=BattleControllerIntegrationTest#testSetAndGetActiveGenre -q 2>&1 | tail -10
+```
+
+Expected: FAIL — `404` or `405` (endpoint doesn't exist).
+
+- [ ] **Step 3: Replace the full `BattleService.java` with the updated version**
+
+Full file — add all imports at the top, make `BattleJudge` static, add repos + objectMapper, add new fields, add all new methods:
+
+```java
+package com.example.BES.services;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.BES.dtos.battle.ChampionRevealDto;
+import com.example.BES.dtos.battle.SetActiveGenreDto;
+import com.example.BES.dtos.battle.SetBattleModeDto;
+import com.example.BES.dtos.battle.SetBattlerPairDto;
+import com.example.BES.dtos.battle.SetBracketStateDto;
+import com.example.BES.dtos.battle.SetJudgeDto;
+import com.example.BES.dtos.battle.SetOverlayConfigDto;
+import com.example.BES.dtos.battle.SetSmokeBattlersDto;
+import com.example.BES.dtos.battle.SetVoteDto;
+import com.example.BES.models.BattleActiveGenre;
+import com.example.BES.models.BattleGenreState;
+import com.example.BES.models.Judge;
+import com.example.BES.respositories.BattleActiveGenreRepository;
+import com.example.BES.respositories.BattleGenreStateRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+
+@Service
+public class BattleService {
+
+    @Autowired
+    JudgeService judgeService;
+
+    @Autowired
+    SimpMessagingTemplate messagingTemplate;
+
+    @Autowired
+    BattleGenreStateRepository battleGenreStateRepository;
+
+    @Autowired
+    BattleActiveGenreRepository battleActiveGenreRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    // ── Mode ─────────────────────────────────────────────────────────
+    private List<String> modes = Arrays.asList("Top32", "Top16", "7-to-Smoke");
+    private String selectedMode;
+
+    // ── Battle state (in-memory) ──────────────────────────────────────
+    private Object bracketState = null;
+    private Integer currentRoundIndex = 0;
+    private List<Battler> battlers = new ArrayList<>();
+    private String battlePhase = "IDLE";
+    private boolean currentIsFinal = false;
+    private Map<String, Object> overlayConfig = new HashMap<>(Map.of(
+        "showImages", true,
+        "leftColor",  "#dc2626",
+        "rightColor", "#2563eb"
+    ));
+    private BattlePair currentPair;
+    private final List<BattleJudge> judges = Collections.synchronizedList(new ArrayList<>());
+    private String status;
+
+    // ── Active genre tracking ─────────────────────────────────────────
+    private String activeEventName;
+    private String activeGenreName;
+
+    BattleService() {
+        selectedMode = "";
+        currentPair = new BattlePair();
+        Battler left = new Battler();
+        Battler right = new Battler();
+        currentPair.leftBattler = left;
+        currentPair.rightBattler = right;
+    }
+
+    // ── Startup: restore active genre from DB ─────────────────────────
+    @PostConstruct
+    public void loadStateFromDb() {
+        battleActiveGenreRepository.findById(1).ifPresent(active -> {
+            if (active.getEventName() != null && active.getGenreName() != null) {
+                activeEventName = active.getEventName();
+                activeGenreName = active.getGenreName();
+                loadGenreStateIntoMemory(activeEventName, activeGenreName);
+            }
+        });
+    }
+
+    // ── Smoke ─────────────────────────────────────────────────────────
+    public List<Battler> getSmokeBattlersService() { return battlers; }
+
+    public void setSmokeBattlersService(SetSmokeBattlersDto dto) {
+        battlers = new ArrayList<>();
+        for (Battler battler : dto.getBattlers()) battlers.add(battler);
+        messagingTemplate.convertAndSend("/topic/battle/smoke", Map.of("battlers", battlers));
+    }
+
+    // ── Pair ──────────────────────────────────────────────────────────
+    public void setBattlerPairService(SetBattlerPairDto dto) {
+        getCurrentPair().leftBattler.setName(dto.getLeftBattler());
+        getCurrentPair().leftBattler.setScore(0);
+        getCurrentPair().leftBattler.setMembers(dto.getLeftMembers());
+        getCurrentPair().rightBattler.setName(dto.getRightBattler());
+        getCurrentPair().rightBattler.setScore(0);
+        getCurrentPair().rightBattler.setMembers(dto.getRightMembers());
+        currentIsFinal = dto.isFinal();
+        messagingTemplate.convertAndSend("/topic/battle/battle-pair", Map.of(
+            "left",         currentPair.getLeftBattler().getName(),
+            "leftScore",    currentPair.getLeftBattler().getScore(),
+            "leftMembers",  currentPair.getLeftBattler().getMembers(),
+            "right",        currentPair.getRightBattler().getName(),
+            "rightScore",   currentPair.getRightBattler().getScore(),
+            "rightMembers", currentPair.getRightBattler().getMembers(),
+            "isFinal",      currentIsFinal
+        ));
+        battlePhase = "LOCKED";
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        persistActiveState();
+    }
+
+    // ── Score ─────────────────────────────────────────────────────────
+    public Integer setScoreService(boolean isFinal) {
+        List<Integer> score = new ArrayList<>();
+        Integer res = -100;
+        synchronized (judges) {
+            if (judges.size() == 0) { res = -2; }
+            for (BattleJudge judge : judges) score.add(judge.getVote());
+        }
+        if (Collections.frequency(score, 0) == Collections.frequency(score, 1)) {
+            if (isFinal) return -3;
+            res = -1;
+        } else if (Collections.frequency(score, 0) > Collections.frequency(score, 1)) {
+            currentPair.getLeftBattler().setScore(currentPair.leftBattler.getScore() + 1);
+            res = 0;
+        } else {
+            currentPair.getRightBattler().setScore(currentPair.rightBattler.getScore() + 1);
+            res = 1;
+        }
+        messagingTemplate.convertAndSend("/topic/battle/score", Map.of(
+            "message", res,
+            "left",    currentPair.getLeftBattler().getScore(),
+            "right",   currentPair.getRightBattler().getScore()
+        ));
+        if (res == 0 || res == 1) {
+            battlePhase = "REVEALED";
+            messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+            persistActiveState();
+        }
+        return res;
+    }
+
+    // ── Judges ────────────────────────────────────────────────────────
+    public Integer removeBattleJudgeService(SetJudgeDto dto) {
+        judges.removeIf(judge -> Objects.equals(judge.getId(), dto.getId()));
+        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+        persistActiveState();
+        return dto.getId().intValue();
+    }
+
+    public Integer setBattleJudgeService(SetJudgeDto dto) {
+        Judge judge = judgeService.getJudgeById(dto.getId());
+        Integer code = -50;
+        if (judge != null) {
+            Boolean exists = judges.stream().anyMatch(j -> j.getName().equals(judge.getName()));
+            if (exists) return 0;
+            BattleJudge battleJudge = new BattleJudge();
+            battleJudge.setName(judge.getName());
+            battleJudge.setVote(-1);
+            battleJudge.setId(dto.getId());
+            judges.add(battleJudge);
+            code = dto.getId().intValue();
+        } else {
+            return -1;
+        }
+        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+        persistActiveState();
+        return code;
+    }
+
+    public Integer setVoteService(SetVoteDto dto) {
+        Integer code = -50;
+        Optional<BattleJudge> battleJude = judges.stream()
+            .filter(j -> j.getId().equals(dto.getId())).findFirst();
+        if (battleJude.isPresent()) {
+            battleJude.get().setVote(dto.getVote());
+        } else {
+            return -2;
+        }
+        code = dto.getVote();
+        messagingTemplate.convertAndSend(
+            String.format("/topic/battle/vote/%d", dto.getId()),
+            Map.of("vote", code, "judge", dto.getId())
+        );
+        persistActiveState();
+        return code;
+    }
+
+    public void resetJudgeVotesService() {
+        synchronized (judges) {
+            for (BattleJudge judge : judges) judge.setVote(-1);
+        }
+        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
+        persistActiveState();
+    }
+
+    // ── Bracket ───────────────────────────────────────────────────────
+    public Object getBracketState() { return bracketState; }
+
+    public void setBracketStateService(SetBracketStateDto dto) {
+        Map<String, Object> state = new HashMap<>();
+        state.put("topSize", dto.getTopSize());
+        state.put("rounds", dto.getRounds());
+        this.bracketState = state;
+        if (dto.getCurrentRoundIndex() != null) {
+            this.currentRoundIndex = dto.getCurrentRoundIndex();
+        }
+        messagingTemplate.convertAndSend("/topic/battle/bracket", state);
+        persistActiveState();
+    }
+
+    // ── Phase ─────────────────────────────────────────────────────────
+    public String getBattlePhase() { return battlePhase; }
+
+    public void setBattlePhaseService(String phase) {
+        if ("REVEALED".equals(phase)) return;
+        battlePhase = phase;
+        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of("phase", battlePhase));
+        persistActiveState();
+    }
+
+    // ── Overlay config ────────────────────────────────────────────────
+    public Map<String, Object> getOverlayConfig() { return overlayConfig; }
+
+    public void setOverlayConfigService(SetOverlayConfigDto dto) {
+        Map<String, Object> newConfig = new HashMap<>();
+        newConfig.put("showImages", dto.isShowImages());
+        newConfig.put("leftColor",  dto.getLeftColor());
+        newConfig.put("rightColor", dto.getRightColor());
+        overlayConfig = newConfig;
+        messagingTemplate.convertAndSend("/topic/battle/overlay-config", newConfig);
+    }
+
+    // ── Champion reveal ───────────────────────────────────────────────
+    public void broadcastChampionReveal(ChampionRevealDto dto) {
+        if (dto.isDismiss()) {
+            messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of("dismiss", true));
+        } else {
+            messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of(
+                "dismiss",       false,
+                "genreName",     dto.getGenreName()    != null ? dto.getGenreName()    : "",
+                "championName",  dto.getChampionName() != null ? dto.getChampionName() : ""
+            ));
+        }
+    }
+
+    // ── Active genre switch ───────────────────────────────────────────
+    @Transactional
+    public void switchActiveGenreService(SetActiveGenreDto dto) {
+        // 1. Persist current in-memory state under old genre
+        persistActiveState();
+
+        // 2. Update singleton in DB
+        BattleActiveGenre active = battleActiveGenreRepository.findById(1)
+            .orElse(new BattleActiveGenre(1, null, null));
+        active.setEventName(dto.getEventName());
+        active.setGenreName(dto.getGenreName());
+        battleActiveGenreRepository.save(active);
+
+        // 3. Update in-memory active genre
+        activeEventName = dto.getEventName();
+        activeGenreName = dto.getGenreName();
+
+        // 4. Load new genre state from DB
+        loadGenreStateIntoMemory(activeEventName, activeGenreName);
+
+        // 5. Broadcast full state snapshot to all clients
+        broadcastStateSnapshot();
+    }
+
+    // ── Full state snapshot ───────────────────────────────────────────
+    public Map<String, Object> getBattleStateService() {
+        if (activeEventName == null || activeGenreName == null) return new HashMap<>();
+        Map<String, Object> state = new HashMap<>();
+        state.put("eventName", activeEventName);
+        state.put("genreName", activeGenreName);
+        state.put("bracket", bracketState);
+        state.put("currentRoundIndex", currentRoundIndex);
+        Map<String, Object> pair = new HashMap<>();
+        pair.put("left",         currentPair.getLeftBattler().getName());
+        pair.put("leftMembers",  currentPair.getLeftBattler().getMembers());
+        pair.put("right",        currentPair.getRightBattler().getName());
+        pair.put("rightMembers", currentPair.getRightBattler().getMembers());
+        pair.put("isFinal",      currentIsFinal);
+        state.put("currentPair", pair);
+        state.put("battlePhase", battlePhase);
+        synchronized (judges) {
+            state.put("judges", new ArrayList<>(judges));
+        }
+        return state;
+    }
+
+    public String getActiveEventName() { return activeEventName; }
+    public String getActiveGenreName() { return activeGenreName; }
+
+    // ── Persist ───────────────────────────────────────────────────────
+    private void persistActiveState() {
+        if (activeEventName == null || activeGenreName == null) return;
+        try {
+            BattleGenreState s = battleGenreStateRepository
+                .findByEventNameAndGenreName(activeEventName, activeGenreName)
+                .orElse(new BattleGenreState());
+            s.setEventName(activeEventName);
+            s.setGenreName(activeGenreName);
+            s.setBracketJson(bracketState != null ? objectMapper.writeValueAsString(bracketState) : null);
+            if (bracketState instanceof Map) {
+                Object ts = ((Map<?, ?>) bracketState).get("topSize");
+                if (ts != null) {
+                    try { s.setTopSize(Integer.parseInt(ts.toString())); }
+                    catch (NumberFormatException ignored) {}
+                }
+            }
+            s.setCurrentRoundIndex(currentRoundIndex);
+            s.setCurrentPairLeft(currentPair.getLeftBattler().getName());
+            s.setCurrentPairLeftMembers(
+                objectMapper.writeValueAsString(currentPair.getLeftBattler().getMembers()));
+            s.setCurrentPairRight(currentPair.getRightBattler().getName());
+            s.setCurrentPairRightMembers(
+                objectMapper.writeValueAsString(currentPair.getRightBattler().getMembers()));
+            s.setIsFinal(currentIsFinal);
+            s.setBattlePhase(battlePhase);
+            synchronized (judges) {
+                s.setJudgesJson(objectMapper.writeValueAsString(new ArrayList<>(judges)));
+            }
+            s.setUpdatedAt(LocalDateTime.now());
+            battleGenreStateRepository.save(s);
+        } catch (Exception e) {
+            System.err.println("Failed to persist battle state: " + e.getMessage());
+        }
+    }
+
+    private void loadGenreStateIntoMemory(String eventName, String genreName) {
+        Optional<BattleGenreState> stateOpt =
+            battleGenreStateRepository.findByEventNameAndGenreName(eventName, genreName);
+        if (stateOpt.isEmpty()) { resetToDefaults(); return; }
+        BattleGenreState s = stateOpt.get();
+        try {
+            bracketState = s.getBracketJson() != null
+                ? objectMapper.readValue(s.getBracketJson(), Map.class) : null;
+            currentRoundIndex = s.getCurrentRoundIndex() != null ? s.getCurrentRoundIndex() : 0;
+            currentPair.getLeftBattler().setName(s.getCurrentPairLeft() != null ? s.getCurrentPairLeft() : "");
+            currentPair.getLeftBattler().setScore(0);
+            currentPair.getLeftBattler().setMembers(s.getCurrentPairLeftMembers() != null
+                ? objectMapper.readValue(s.getCurrentPairLeftMembers(), new TypeReference<List<String>>(){})
+                : new ArrayList<>());
+            currentPair.getRightBattler().setName(s.getCurrentPairRight() != null ? s.getCurrentPairRight() : "");
+            currentPair.getRightBattler().setScore(0);
+            currentPair.getRightBattler().setMembers(s.getCurrentPairRightMembers() != null
+                ? objectMapper.readValue(s.getCurrentPairRightMembers(), new TypeReference<List<String>>(){})
+                : new ArrayList<>());
+            currentIsFinal = Boolean.TRUE.equals(s.getIsFinal());
+            battlePhase = s.getBattlePhase() != null ? s.getBattlePhase() : "IDLE";
+            synchronized (judges) {
+                judges.clear();
+                if (s.getJudgesJson() != null) {
+                    List<BattleJudge> restored =
+                        objectMapper.readValue(s.getJudgesJson(), new TypeReference<List<BattleJudge>>(){});
+                    judges.addAll(restored);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load genre state from DB: " + e.getMessage());
+            resetToDefaults();
+        }
+    }
+
+    private void resetToDefaults() {
+        bracketState = null;
+        currentRoundIndex = 0;
+        currentPair.getLeftBattler().setName("");
+        currentPair.getLeftBattler().setScore(0);
+        currentPair.getLeftBattler().setMembers(new ArrayList<>());
+        currentPair.getRightBattler().setName("");
+        currentPair.getRightBattler().setScore(0);
+        currentPair.getRightBattler().setMembers(new ArrayList<>());
+        currentIsFinal = false;
+        battlePhase = "IDLE";
+        synchronized (judges) { judges.clear(); }
+    }
+
+    private void broadcastStateSnapshot() {
+        messagingTemplate.convertAndSend("/topic/battle/state", getBattleStateService());
+    }
+
+    // ── Mode / Judges accessors (unchanged) ───────────────────────────
+    public List<String> getModes() { return modes; }
+    public String getSelectedMode() { return selectedMode; }
+    public void setSelectedMode(SetBattleModeDto dto) { this.selectedMode = dto.getMode(); }
+    public BattlePair getCurrentPair() { return currentPair; }
+    public void setCurrentPair(BattlePair currentPair) { this.currentPair = currentPair; }
+    public List<BattleJudge> getJudges() { return judges; }
+    public void setJudges(List<BattleJudge> judges) {
+        synchronized (this.judges) { this.judges.clear(); this.judges.addAll(judges); }
+    }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public boolean isCurrentFinal() { return currentIsFinal; }
+
+    // ── Inner classes ─────────────────────────────────────────────────
+    // BattleJudge is static so Jackson can deserialize it from judgesJson
+    public static class BattleJudge {
+        private Long id;
+        private String name;
+        private Integer vote;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public Integer getVote() { return vote; }
+        public void setVote(Integer vote) { this.vote = vote; }
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+    }
+
+    public static class Battler {
+        private String name;
+        private Integer score;
+        private List<String> members = new ArrayList<>();
+        Battler() { name = ""; score = 0; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public Integer getScore() { return score; }
+        public void setScore(Integer score) { this.score = score; }
+        public List<String> getMembers() { return members; }
+        public void setMembers(List<String> members) {
+            this.members = members != null ? members : new ArrayList<>();
+        }
+    }
+
+    public class BattlePair {
+        private Battler leftBattler;
+        private Battler rightBattler;
+        public Battler getLeftBattler() { return leftBattler; }
+        public Battler getRightBattler() { return rightBattler; }
+        public void setLeftBattler(Battler leftBattler) { this.leftBattler = leftBattler; }
+        public void setRightBattler(Battler rightBattler) { this.rightBattler = rightBattler; }
+    }
+}
+```
+
+- [ ] **Step 4: Compile**
+
+```bash
+cd BES && mvn compile -q 2>&1 | tail -10
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run existing battle tests to ensure no regressions**
+
+```bash
+cd BES && mvn test -Dtest=BattleControllerIntegrationTest -q 2>&1 | tail -15
+```
+
+Expected: tests that don't involve the new endpoints pass; new tests fail with 404.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/BattleService.java \
+        BES/src/test/java/com/example/BES/controllers/BattleControllerIntegrationTest.java
+git commit -m "feat: add persistence layer to BattleService (persistActiveState, switchActiveGenre, @PostConstruct)"
+```
+
+---
+
+## Task 6: BattleController — New Endpoints
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/controllers/BattleController.java`
+
+- [ ] **Step 1: Add three new endpoints to `BattleController.java`**
+
+Add after the existing `@GetMapping("/overlay-config")` block (before the closing brace):
+
+```java
+@PostMapping("/active-genre")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> setActiveGenre(@Valid @RequestBody SetActiveGenreDto dto) {
+    battleService.switchActiveGenreService(dto);
+    return ResponseEntity.ok(Map.of("message", "Active genre set"));
+}
+
+@GetMapping("/active-genre")
+public ResponseEntity<?> getActiveGenre() {
+    return ResponseEntity.ok(Map.of(
+        "eventName", battleService.getActiveEventName() != null ? battleService.getActiveEventName() : "",
+        "genreName", battleService.getActiveGenreName() != null ? battleService.getActiveGenreName() : ""
+    ));
+}
+
+@GetMapping("/state")
+public ResponseEntity<?> getBattleState() {
+    return ResponseEntity.ok(battleService.getBattleStateService());
+}
+```
+
+Also add the import at the top of the file (it's already imported via wildcard if using `com.example.BES.dtos.battle.*` — verify and add if missing):
+
+```java
+import com.example.BES.dtos.battle.SetActiveGenreDto;
+```
+
+- [ ] **Step 2: Compile**
+
+```bash
+cd BES && mvn compile -q 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Run the new tests**
+
+```bash
+cd BES && mvn test -Dtest=BattleControllerIntegrationTest#testSetAndGetActiveGenre+testGetBattleStateAfterSettingActiveGenre -q 2>&1 | tail -15
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 4: Run the full battle test suite**
+
+```bash
+cd BES && mvn test -Dtest=BattleControllerIntegrationTest -q 2>&1 | tail -10
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/controllers/BattleController.java
+git commit -m "feat: add POST/GET /api/v1/battle/active-genre and GET /api/v1/battle/state endpoints"
+```
+
+---
+
+## Task 7: Frontend API Utility Functions
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js`
+
+- [ ] **Step 1: Add `currentRoundIndex` parameter to `setBracketState`**
+
+Find the existing `setBracketState` function (line ~555) and replace it:
+
+```js
+export const setBracketState = async (rounds, topSize, currentRoundIndex = 0) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/bracket`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rounds, topSize: String(topSize), currentRoundIndex })
+    })
+  } catch (e) { console.error(e) }
+}
+```
+
+- [ ] **Step 2: Add the three new battle API functions after `getBracketState`**
+
+```js
+export const setActiveGenre = async (eventName, genreName) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/active-genre`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventName, genreName })
+    })
+  } catch (e) { console.error(e) }
+}
+
+export const getActiveGenre = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/active-genre`, { credentials: 'include' })
+    return res.ok ? await res.json() : null
+  } catch (_e) { return null }
+}
+
+export const getBattleState = async () => {
+  try {
+    const res = await fetch(`${domain}/api/v1/battle/state`, { credentials: 'include' })
+    return res.ok ? await res.json() : null
+  } catch (_e) { return null }
+}
+```
+
+- [ ] **Step 3: Verify the frontend builds**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -10
+```
+
+Expected: `✓ built in` — no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat: add setActiveGenre, getActiveGenre, getBattleState API functions; add currentRoundIndex to setBracketState"
+```
+
+---
+
+## Task 8: BattleControl.vue — Genre Switch + Mount Recovery
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue`
+
+- [ ] **Step 1: Add `setActiveGenre` and `getBattleState` to the import line**
+
+Find the line that imports from `@/utils/api` near the top of the `<script setup>` block and add `setActiveGenre` and `getBattleState` to it. Example — the existing import likely looks like:
+
+```js
+import { ..., setBracketState, getBracketState, ... } from '@/utils/api'
+```
+
+Add `setActiveGenre` and `getBattleState` to that same import.
+
+- [ ] **Step 2: Update `broadcastBracket` to pass `currentRound.value`**
+
+Find:
+```js
+const broadcastBracket = () => setBracketState(toRaw(rounds.value), topSize.value)
+```
+
+Replace with:
+```js
+const broadcastBracket = () => setBracketState(toRaw(rounds.value), topSize.value, currentRound.value)
+```
+
+- [ ] **Step 3: Add recovery banner reactive state** (add near the top of the script setup, alongside the other `ref` declarations):
+
+```js
+const showRecoveryBanner = ref(false)
+const recoveryState      = ref(null)
+```
+
+- [ ] **Step 4: Add `jumpToRecoveredPair` handler**
+
+Add this function after `restoreAndBroadcastGenreBattle`:
+
+```js
+const jumpToRecoveredPair = async () => {
+  if (!recoveryState.value) return
+  showRecoveryBanner.value = false
+  currentRound.value = recoveryState.value.currentRoundIndex ?? 0
+  await restoreAndBroadcastGenreBattle(selectedGenre.value)
+}
+```
+
+- [ ] **Step 5: Update `watch(selectedGenre)` to call `setActiveGenre` on genre switch**
+
+Find the `watch(selectedGenre, ...)` handler. Inside the `if (newVal)` block, the current code is:
+
+```js
+if (oldVal) {
+  saveGenreBattleState(oldVal)
+  await restoreAndBroadcastGenreBattle(newVal)
+}
+```
+
+Change it to:
+
+```js
+if (oldVal) {
+  saveGenreBattleState(oldVal)
+  await setActiveGenre(selectedEvent.value, newVal)
+}
+broadcastBracket()
+if (oldVal) {
+  await restoreAndBroadcastGenreBattle(newVal)
+}
+```
+
+**Important:** Also remove the standalone `broadcastBracket()` call that currently appears BEFORE the `if (oldVal)` block (there should now be only one `broadcastBracket()` call in the watch handler, inside the `if (newVal)` block, after the `setActiveGenre` call).
+
+The updated `if (newVal)` section of the watch should read:
+
+```js
+if (newVal) {
+  const genreNeedsSmoke = newVal.toLowerCase().includes('7 to smoke') || newVal.toLowerCase().includes('7tosmoke')
+  if (genreNeedsSmoke && Number(topSize.value) !== 7) {
+    topSize.value = 7
+    localStorage.setItem('topSize', '7')
+  } else if (!genreNeedsSmoke && Number(topSize.value) === 7) {
+    topSize.value = 16
+    localStorage.setItem('topSize', '16')
+  }
+  localStorage.setItem("selectedGenre", newVal)
+  const storedRounds = localStorage.getItem(`Top${topSize.value}${newVal}Rounds`)
+  rounds.value = JSON.parse(storedRounds) || initRounds()
+  pickupCrews.value = await getPickupCrews(selectedEvent.value, newVal)
+  placeGuestsInBracket()
+  if (oldVal) {
+    saveGenreBattleState(oldVal)
+    await setActiveGenre(selectedEvent.value, newVal)
+  }
+  broadcastBracket()
+  if (oldVal) {
+    await restoreAndBroadcastGenreBattle(newVal)
+  }
+  if (mountJudgeSyncDone && oldVal) await syncJudgesForGenre(newVal, oldVal)
+} else {
+  pickupCrews.value = []
+}
+```
+
+- [ ] **Step 6: Add recovery banner logic to `onMounted`**
+
+In the existing `onMounted`, after `mountJudgeSyncDone = true` and before the WS setup, add:
+
+```js
+// Restore current round index + show recovery banner if a battle was in progress
+const battleState = await getBattleState()
+if (battleState?.battlePhase && battleState.battlePhase !== 'IDLE'
+    && battleState.currentPair?.left) {
+  currentRound.value = battleState.currentRoundIndex ?? 0
+  recoveryState.value = battleState
+  showRecoveryBanner.value = true
+}
+```
+
+- [ ] **Step 7: Add recovery banner to the template**
+
+Add the following right after the opening `<div>` of the root template element (or after the top-level toolbar/header — wherever is visible without scrolling):
+
+```html
+<Transition name="banner-fade">
+  <div v-if="showRecoveryBanner && recoveryState" class="recovery-banner">
+    <span class="recovery-dot"></span>
+    <span class="recovery-msg">
+      IN PROGRESS: ROUND {{ (recoveryState.currentRoundIndex ?? 0) + 1 }} —
+      {{ recoveryState.currentPair?.left }} VS {{ recoveryState.currentPair?.right }}
+    </span>
+    <button class="recovery-btn recovery-btn-jump" @click="jumpToRecoveredPair">JUMP TO PAIR</button>
+    <button class="recovery-btn recovery-btn-dismiss" @click="showRecoveryBanner = false">DISMISS</button>
+  </div>
+</Transition>
+```
+
+- [ ] **Step 8: Add recovery banner styles**
+
+Add to the `<style scoped>` section:
+
+```css
+/* ── Recovery banner ─────────────────────────────────────────── */
+.recovery-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: rgba(245, 158, 11, 0.08);
+  border-left: 3px solid rgba(245, 158, 11, 0.8);
+  font-family: 'Anton SC', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+  flex-wrap: wrap;
+}
+.recovery-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: rgba(245, 158, 11, 0.9);
+  box-shadow: 0 0 8px rgba(245, 158, 11, 0.7);
+  flex-shrink: 0;
+  animation: recoveryPulse 1.6s ease-in-out infinite;
+}
+.recovery-msg { flex: 1; min-width: 0; }
+.recovery-btn {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
+  padding: 4px 12px; border: none; cursor: pointer;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+}
+.recovery-btn-jump {
+  background: rgba(245, 158, 11, 0.25);
+  color: rgba(255, 255, 255, 0.9);
+}
+.recovery-btn-jump:hover { background: rgba(245, 158, 11, 0.4); }
+.recovery-btn-dismiss {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.4);
+}
+.recovery-btn-dismiss:hover { color: rgba(255, 255, 255, 0.7); }
+
+.banner-fade-enter-active, .banner-fade-leave-active { transition: opacity 0.25s ease; }
+.banner-fade-enter-from, .banner-fade-leave-to { opacity: 0; }
+
+@keyframes recoveryPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.65); }
+}
+```
+
+- [ ] **Step 9: Verify no lint errors**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -10
+```
+
+Expected: `✓ built in` — no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: BattleControl — genre switch calls setActiveGenre, mount restores round index + shows recovery banner"
+```
+
+---
+
+## Task 9: BracketVisualization.vue — Mount Restore + State Subscription
+
+**Files:**
+- Modify: `BES-frontend/src/views/BracketVisualization.vue`
+
+- [ ] **Step 1: Add `getBattleState` to the import**
+
+Find:
+```js
+import { getBracketState, getOverlayConfig } from '@/utils/api'
+```
+
+Replace with:
+```js
+import { getBracketState, getOverlayConfig, getBattleState } from '@/utils/api'
+```
+
+- [ ] **Step 2: Replace the `getBracketState()` call in `onMounted` with `getBattleState()`**
+
+Find in `onMounted`:
+```js
+const state = await getBracketState()
+if (state && (state.topSize || state.rounds)) bracketState.value = state
+```
+
+Replace with:
+```js
+const state = await getBattleState()
+if (state?.bracket && (state.bracket.topSize || state.bracket.rounds)) {
+  bracketState.value = state.bracket
+}
+if (state?.currentPair?.left) {
+  activePair.value = { left: state.currentPair.left, right: state.currentPair.right }
+}
+if (state?.genreName) {
+  currentGenre.value = state.genreName
+}
+```
+
+- [ ] **Step 3: Add `/topic/battle/state` subscription inside `wsClient.onConnect`**
+
+Inside the `wsClient.onConnect = () => { ... }` block, add after the existing subscriptions:
+
+```js
+wsClient.subscribe('/topic/battle/state', (msg) => {
+  const data = JSON.parse(msg.body)
+  if (data?.bracket && (data.bracket.topSize || data.bracket.rounds)) {
+    if (animRunning) {
+      pendingBracket.value = data.bracket
+    } else {
+      bracketState.value = data.bracket
+    }
+  }
+  if (data?.currentPair?.left) {
+    activePair.value = { left: data.currentPair.left, right: data.currentPair.right }
+  }
+  if (data?.genreName) {
+    currentGenre.value = data.genreName
+  }
+})
+```
+
+- [ ] **Step 4: Build to verify**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/BracketVisualization.vue
+git commit -m "feat: BracketVisualization — restore bracket/pair/genre from getBattleState on mount; subscribe to /topic/battle/state"
+```
+
+---
+
+## Task 10: BattleOverlay.vue — Mount Restore + State Subscription
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleOverlay.vue`
+
+- [ ] **Step 1: Add `getBattleState` to the import**
+
+Find:
+```js
+import { getBattleJudges, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
+```
+
+Replace with:
+```js
+import { getBattleJudges, getCurrentBattlePair, getImage, getOverlayConfig, getBattleState } from '@/utils/api';
+```
+
+- [ ] **Step 2: Replace the `getBattleJudges` + `getCurrentBattlePair` calls in `onMounted` with `getBattleState`**
+
+In `onMounted`, the non-smoke branch currently reads:
+```js
+if (!isSmoke.value) {
+  battleJudges.value = await getBattleJudges()
+  const res = await getCurrentBattlePair()
+  if (res) await updateBattlePair(res)
+  ...
+}
+```
+
+Replace the `getBattleJudges` and `getCurrentBattlePair` calls with `getBattleState`. Also restore `battlePhase` (currently the overlay doesn't fetch it on mount):
+
+```js
+if (!isSmoke.value) {
+  const state = await getBattleState()
+  if (state?.battlePhase) battlePhase.value = state.battlePhase
+  if (state?.judges?.length) {
+    battleJudges.value = { judges: state.judges }
+  } else {
+    battleJudges.value = await getBattleJudges()
+  }
+  const pair = state?.currentPair?.left ? state.currentPair : await getCurrentBattlePair()
+  if (pair) await updateBattlePair(pair)
+  ...
+}
+```
+
+Keep the WS subscriptions (`subscribeToChannel(cPair2, ...)` etc.) unchanged after this block.
+
+- [ ] **Step 3: Add `/topic/battle/state` subscription for cross-machine genre switches**
+
+After the `subscribeToChannel(cOverlay, '/topic/battle/overlay-config', ...)` block, add:
+
+```js
+const cState = createClient(); clients.push(cState)
+subscribeToChannel(cState, '/topic/battle/state', async (msg) => {
+  if (isSmoke.value) return
+  if (msg?.battlePhase) battlePhase.value = msg.battlePhase
+  if (msg?.currentPair?.left) await updateBattlePair(msg.currentPair)
+  if (msg?.judges?.length) updateBattleJudge({ judges: msg.judges })
+})
+```
+
+- [ ] **Step 4: Build to verify**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleOverlay.vue
+git commit -m "feat: BattleOverlay — restore phase/pair/judges from getBattleState on mount; subscribe to /topic/battle/state"
+```
+
+---
+
+## Task 11: BattleJudge.vue — Vote Restore from Backend
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleJudge.vue`
+
+- [ ] **Step 1: Update vote restore logic in `onMounted` (Step 5)**
+
+Find the existing vote restore block:
+```js
+// 5. Restore vote from localStorage (backend WS overrides if different)
+if (battlePhase.value === 'VOTING') {
+  const stored = restoreVoteFromStorage()
+  if (stored !== null) confirmedVote.value = stored
+}
+```
+
+Replace with:
+```js
+// 5. Restore vote — backend DB is authoritative (survives restarts), localStorage is fallback
+if (battlePhase.value === 'VOTING' && judgeId.value != null) {
+  const backendJudge = (battleJudges.value?.judges ?? []).find(j => j.id === judgeId.value)
+  const backendVote  = backendJudge?.vote
+  if (backendVote === 0 || backendVote === 1 || backendVote === -1) {
+    confirmedVote.value = backendVote
+  } else {
+    const stored = restoreVoteFromStorage()
+    if (stored !== null) confirmedVote.value = stored
+  }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Run full backend test suite to confirm no regressions**
+
+```bash
+cd BES && mvn test -q 2>&1 | tail -15
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleJudge.vue
+git commit -m "feat: BattleJudge — restore confirmed vote from backend judges list (DB-authoritative after restart)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec Requirement | Task |
+|-----------------|------|
+| `battle_genre_state` table | Task 1, 2, 3 |
+| `battle_active_genre` singleton table | Task 1, 2, 3 |
+| `POST/GET /api/v1/battle/active-genre` | Task 6 |
+| `GET /api/v1/battle/state` | Task 6 |
+| `/topic/battle/state` WS broadcast | Task 5 (`broadcastStateSnapshot`) |
+| `persistActiveState()` on every mutation | Task 5 |
+| `@PostConstruct` restart recovery | Task 5 |
+| `currentRoundIndex` persisted via `SetBracketStateDto` | Tasks 4, 5, 7, 8 |
+| BattleControl genre switch calls `setActiveGenre` | Task 8 |
+| BattleControl mount recovery prompt | Task 8 |
+| BracketVisualization mount restore + genre ticker fix | Task 9 |
+| BattleOverlay mount restore + phase recovery | Task 10 |
+| BattleJudge vote restore from backend | Task 11 |
+| Judge votes persisted in `judges_json` | Task 5 (`persistActiveState`) |
+
+All spec requirements are covered. ✓

--- a/docs/superpowers/plans/2026-06-02-checkin-concurrency.md
+++ b/docs/superpowers/plans/2026-06-02-checkin-concurrency.md
@@ -1,0 +1,883 @@
+# Check-in Concurrency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix concurrent check-in race conditions: duplicate guard (409), per-slot independent animations on AuditionNumber display, cancel signal for ghost previews, double-confirm guard, and Reset Scores access code gate.
+
+**Architecture:** Backend adds a 409 guard in `EventGenreParticpantService` and a `cancelled` field on `CheckinPreviewDto`. Frontend replaces AuditionNumber's single `currentPerson` model with an `activeSlots` array where each slot owns its animation queue, keyed by `slotId-genreName` to allow parallel animations.
+
+**Tech Stack:** Spring Boot (Java), Vue 3 (Composition API), STOMP WebSocket
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java` | Add `cancelled` boolean field |
+| `BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java` | Throw `IllegalStateException("already_checked_in")` if all genres already have numbers |
+| `BES/src/main/java/com/example/BES/controllers/EventController.java` | Catch `IllegalStateException` → 409 on `registerParticipantAllGenres` |
+| `BES-frontend/src/views/AuditionNumber.vue` | Full refactor: `activeSlots` array, per-slot queues, parallel animation |
+| `BES-frontend/src/views/EventDetails.vue` | Double-confirm guard, 409 error state, cancel preview on dialog close |
+| `BES-frontend/src/views/AuditionList.vue` | Access code gate before Reset Scores executes |
+
+---
+
+## Task 1: Add `cancelled` field to `CheckinPreviewDto`
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java`
+
+- [ ] **Open the file and add the field**
+
+Replace the entire file with:
+
+```java
+package com.example.BES.dtos;
+
+import java.util.List;
+
+public class CheckinPreviewDto {
+    public Long participantId;
+    public String name;
+    public String refCode;
+    public Boolean cancelled;
+    public List<String> memberNames;
+    public List<GenreEntry> genres;
+
+    public static class GenreEntry {
+        public String genreName;
+        public Integer auditionNumber;
+    }
+}
+```
+
+- [ ] **Build to confirm no compile errors**
+
+```bash
+cd BES && mvn compile -q
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
+git commit -m "feat: add cancelled field to CheckinPreviewDto"
+```
+
+---
+
+## Task 2: Backend — 409 duplicate check-in guard
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java`
+- Modify: `BES/src/main/java/com/example/BES/controllers/EventController.java`
+
+- [ ] **Add duplicate check at the top of `getAllAuditionNumsViaQR` in the service**
+
+In `EventGenreParticpantService.java`, find the `getAllAuditionNumsViaQR` method (currently at line ~118) and add the already-assigned check as the first thing it does:
+
+```java
+public void getAllAuditionNumsViaQR(Long participantId, Long eventId) {
+    List<EventGenreParticipant> entries =
+        repo.findByEventIdAndParticipantId(eventId, participantId);
+    // Guard: if every entry already has a number, this is a duplicate check-in
+    boolean allAssigned = !entries.isEmpty() &&
+        entries.stream().allMatch(e -> e.getAuditionNumber() != null);
+    if (allAssigned) {
+        throw new IllegalStateException("already_checked_in");
+    }
+    for (EventGenreParticipant entry : entries) {
+        AddParticipantToEventGenreDto dto = new AddParticipantToEventGenreDto();
+        dto.participantId = participantId;
+        dto.eventId = eventId;
+        dto.eventGenreId = entry.getEventGenre().getId();
+        int attempts = 0;
+        while (true) {
+            try {
+                getAuditionNumViaQR(dto);
+                break;
+            } catch (Exception e) {
+                if (++attempts >= 3) throw e;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Update the controller to return 409 for `IllegalStateException`**
+
+In `EventController.java`, find `registerParticipantAllGenres` (currently at line ~445) and split the catch:
+
+```java
+@GetMapping("/register-participant/{participantId}/{eventId}")
+public ResponseEntity<String> registerParticipantAllGenres(
+        @PathVariable Long participantId,
+        @PathVariable Long eventId) {
+    try {
+        eventGenreParticipantService.getAllAuditionNumsViaQR(participantId, eventId);
+        return new ResponseEntity<>("registered", HttpStatus.CREATED);
+    } catch (IllegalStateException e) {
+        if ("already_checked_in".equals(e.getMessage())) {
+            return new ResponseEntity<>("already_checked_in", HttpStatus.CONFLICT);
+        }
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    } catch (Exception e) {
+        return new ResponseEntity<>("Something is null", HttpStatus.BAD_REQUEST);
+    }
+}
+```
+
+- [ ] **Build to confirm no compile errors**
+
+```bash
+cd BES && mvn compile -q
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java \
+        BES/src/main/java/com/example/BES/controllers/EventController.java
+git commit -m "feat: return 409 when participant already has all audition numbers"
+```
+
+---
+
+## Task 3: EventDetails.vue — double-confirm guard + cancel preview + 409 handling
+
+**Files:**
+- Modify: `BES-frontend/src/views/EventDetails.vue`
+
+- [ ] **Add `confirming` ref near the other checkin refs (around line 750)**
+
+```js
+const checkingInId = ref(null)
+const confirming = ref(false)   // ← add this line
+```
+
+- [ ] **Update `confirmCheckIn` to guard against double-submit and handle 409**
+
+Find `confirmCheckIn` (around line 800) and replace it entirely:
+
+```js
+const confirmCheckIn = async () => {
+  const p = checkinConfirm.value.participant
+  if (!p || confirming.value) return
+
+  confirming.value = true
+  p.genres.forEach(g => { g.auditionNumber = null; g.rolling = false })
+  dialogNumberQueue.length = 0
+  Object.values(dialogRollingIntervals).forEach(clearInterval)
+  for (const k in dialogRollingIntervals) delete dialogRollingIntervals[k]
+  dialogFakeNums.value = {}
+
+  checkinConfirm.value.phase = 'generating'
+  checkinConfirm.value.refCode = null
+
+  try {
+    await checkIn(p)
+
+    // 409 — already checked in by another desk
+    if (checkingInId.value === null && checkinConfirm.value.phase === 'generating') {
+      // checkIn sets checkingInId back to null; inspect participants for the result
+    }
+
+    const refEntry = verifiedDbParticipants.value.find(ep => ep.participantId === p.participantId)
+    checkinConfirm.value.refCode = refEntry?.referenceCode || null
+
+    const freshParticipant = checkinList.value.find(ep => ep.participantId === p.participantId)
+    if (freshParticipant) {
+      for (const ug of freshParticipant.genres) {
+        if (ug.auditionNumber != null) {
+          dialogNumberQueue.push({ genre: ug.genreName, auditionNumber: ug.auditionNumber })
+        }
+      }
+    }
+
+    if (dialogNumberQueue.length === 0) {
+      checkinConfirm.value.phase = 'done'
+    } else {
+      processNextDialogNumber()
+    }
+  } finally {
+    confirming.value = false
+  }
+}
+```
+
+- [ ] **Update `checkIn` to surface 409 as a distinct error state**
+
+Find `checkIn` (around line 739) and replace it:
+
+```js
+const checkIn = async (p) => {
+  checkingInId.value = p.participantId
+  try {
+    const res = await checkInParticipant(p.participantId, p.eventId)
+    if (res?.status === 409) {
+      checkinConfirm.value.phase = 'error'
+      checkinConfirm.value.errorMessage = 'Already checked in at another desk.'
+      return
+    }
+    await Promise.all([fetchCheckinList(), refreshFromDb()])
+  } catch (e) {
+    console.error(e)
+  }
+  checkingInId.value = null
+}
+```
+
+- [ ] **Add `errorMessage` to `checkinConfirm` initial shape and the error phase to the template**
+
+Find the `checkinConfirm` ref (around line 750):
+
+```js
+const checkinConfirm = ref({ show: false, participant: null, phase: 'confirm', refCode: null, errorMessage: '' })
+```
+
+In the template, find the `<!-- Actions -->` section of the check-in dialog and add an error phase between generating and done:
+
+```html
+<!-- Error phase -->
+<div v-else-if="checkinConfirm.phase === 'error'"
+  class="flex-1 py-2 flex flex-col items-center gap-3">
+  <div class="flex items-center gap-2 type-label text-red-400">
+    <i class="pi pi-exclamation-circle text-sm"></i>
+    {{ checkinConfirm.errorMessage }}
+  </div>
+  <button @click="checkinConfirm.show = false"
+    class="para-chip-sm px-4 py-2 type-label text-content-muted hover:text-content-primary transition-colors">
+    Close
+  </button>
+</div>
+```
+
+Also update the dialog header to cover the error phase:
+
+```html
+{{ checkinConfirm.phase === 'confirm' ? 'Confirm Check-In'
+   : checkinConfirm.phase === 'generating' ? 'Generating…'
+   : checkinConfirm.phase === 'error' ? 'Check-In Failed'
+   : 'Check-In Complete' }}
+```
+
+- [ ] **Disable confirm button while confirming**
+
+Find the confirm button in the template and update:
+
+```html
+<button @click="confirmCheckIn"
+  :disabled="confirming"
+  class="flex-1 py-2 para-chip type-label text-white transition-all disabled:opacity-50"
+  style="background:rgba(255,255,255,0.12);box-shadow:0 0 12px var(--accent-subtle)"
+>
+  <i class="pi pi-check mr-1.5 text-xs"></i> Confirm
+</button>
+```
+
+- [ ] **Send cancel preview when dialog closes in `confirm` phase**
+
+Find the close button in the check-in dialog header (the `×` button) and update its handler:
+
+```html
+<button v-if="checkinConfirm.phase !== 'generating'" @click="closeCheckinDialog"
+  class="p-1 text-content-muted hover:text-content-primary transition-colors">
+  <i class="pi pi-times text-sm" />
+</button>
+```
+
+Add `closeCheckinDialog` near the other checkin functions:
+
+```js
+const closeCheckinDialog = () => {
+  if (checkinConfirm.value.phase === 'confirm' && checkinConfirm.value.participant) {
+    sendCheckinPreview(eventName.value, {
+      participantId: checkinConfirm.value.participant.participantId,
+      cancelled: true
+    })
+  }
+  checkinConfirm.value.show = false
+}
+```
+
+Also update the backdrop click handler to use `closeCheckinDialog`:
+
+```html
+@click="checkinConfirm.phase !== 'generating' && closeCheckinDialog()"
+```
+
+- [ ] **Commit**
+
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "feat: double-confirm guard, 409 error state, cancel preview on dialog close"
+```
+
+---
+
+## Task 4: AuditionNumber.vue — multi-slot refactor
+
+**Files:**
+- Modify: `BES-frontend/src/views/AuditionNumber.vue`
+
+This is a full rewrite of the `<script setup>` logic and template. Work through it section by section.
+
+- [ ] **Replace all state declarations**
+
+Remove the old `currentPerson`, `auditionQueue`, `queueRunning`, `fakeNums`, `rollingIntervals` declarations and replace with:
+
+```js
+// Each slot: { slotId, person, queue, running }
+// slotId = String(participantId ?? name)
+const activeSlots = ref([])
+const history = ref([])
+const revealingRef = ref(null)
+
+// Keyed by `${slotId}-${genreName}` to allow parallel animations across slots
+const fakeNums = ref({})
+const rollingIntervals = {}
+
+const modalTitle = ref('')
+const modalMessage = ref('')
+const showModal = ref(false)
+
+const wsClients = []
+```
+
+- [ ] **Replace all helper functions**
+
+Remove `flushCurrentToHistory`, `startRolling`, `stopRolling`, `processNextInQueue`, `animateAuditionNumber` and add:
+
+```js
+const slotKey = (participantId, name) => String(participantId ?? name)
+
+const flushSlotToHistory = (slotId) => {
+  const idx = activeSlots.value.findIndex(s => s.slotId === slotId)
+  if (idx === -1) return
+  const slot = activeSlots.value[idx]
+  history.value.unshift({ ...slot.person })
+  activeSlots.value.splice(idx, 1)
+}
+
+function startRolling(slotId, genreName) {
+  const key = `${slotId}-${genreName}`
+  clearInterval(rollingIntervals[key])
+  rollingIntervals[key] = setInterval(() => {
+    fakeNums.value = { ...fakeNums.value, [key]: Math.floor(Math.random() * 99) + 1 }
+  }, 80)
+}
+
+function stopRolling(slotId, genreName) {
+  const key = `${slotId}-${genreName}`
+  clearInterval(rollingIntervals[key])
+  delete rollingIntervals[key]
+  const next = { ...fakeNums.value }
+  delete next[key]
+  fakeNums.value = next
+}
+
+function checkSlotComplete(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
+  const allDone = slot.person.genres.every(g => g.auditionNumber !== null)
+  if (allDone && slot.queue.length === 0) {
+    setTimeout(() => flushSlotToHistory(slotId), 1500)
+  }
+}
+
+function processSlotQueue(slotId) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot || slot.queue.length === 0) {
+    if (slot) slot.running = false
+    checkSlotComplete(slotId)
+    return
+  }
+  slot.running = true
+  const msg = slot.queue.shift()
+  animateSlot(slotId, msg)
+}
+
+function animateSlot(slotId, msg) {
+  const slot = activeSlots.value.find(s => s.slotId === slotId)
+  if (!slot) return
+
+  if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+
+  let genre = slot.person.genres.find(g => g.genreName === msg.genre)
+  if (!genre) {
+    genre = { genreName: msg.genre, auditionNumber: null, rolling: false }
+    slot.person.genres.push(genre)
+  }
+
+  genre.rolling = true
+  startRolling(slotId, msg.genre)
+  setTimeout(() => {
+    stopRolling(slotId, msg.genre)
+    const s = activeSlots.value.find(s => s.slotId === slotId)
+    const g = s?.person.genres.find(g => g.genreName === msg.genre)
+    if (g) { g.rolling = false; g.auditionNumber = msg.auditionNumber }
+    processSlotQueue(slotId)
+  }, 2000)
+}
+```
+
+- [ ] **Replace WS handlers**
+
+Remove `isSamePerson`, `onPreview`, `onReceiveAuditionNumber` and replace with:
+
+```js
+const isSamePerson = (slot, msg) => {
+  if (!slot || !msg) return false
+  const sid = slot.person.participantId
+  const mid = msg.participantId
+  return (sid != null && mid != null) ? sid === mid : slot.person.name === msg.name
+}
+
+const findSlot = (msg) =>
+  activeSlots.value.find(s => isSamePerson(s, msg))
+
+const onPreview = (msg) => {
+  // Cancel signal — remove the matching slot
+  if (msg.cancelled) {
+    const idx = activeSlots.value.findIndex(s => isSamePerson(s, msg))
+    if (idx !== -1) {
+      const slot = activeSlots.value[idx]
+      // Stop any running animations for this slot
+      slot.person.genres.forEach(g => stopRolling(slot.slotId, g.genreName))
+      activeSlots.value.splice(idx, 1)
+    }
+    return
+  }
+
+  const existing = findSlot(msg)
+  if (existing) {
+    // Merge new genres into existing slot without overwriting
+    if (msg.refCode && !existing.person.refCode) existing.person.refCode = msg.refCode
+    const existingNames = new Set(existing.person.genres.map(g => g.genreName))
+    for (const g of (msg.genres ?? [])) {
+      if (!existingNames.has(g.genreName)) {
+        existing.person.genres.push({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false })
+      }
+    }
+  } else {
+    // New slot
+    const slotId = slotKey(msg.participantId, msg.name)
+    activeSlots.value.push({
+      slotId,
+      person: {
+        participantId: msg.participantId ?? null,
+        name: msg.name,
+        refCode: msg.refCode ?? null,
+        memberNames: msg.memberNames ?? [],
+        genres: (msg.genres ?? []).map(g => ({ genreName: g.genreName, auditionNumber: g.auditionNumber ?? null, rolling: false }))
+      },
+      queue: [],
+      running: false
+    })
+  }
+}
+
+const onReceiveAuditionNumber = (msg) => {
+  const slot = findSlot(msg)
+  if (slot) {
+    // Ensure genre row exists in pending state
+    if (!slot.person.genres.find(g => g.genreName === msg.genre)) {
+      slot.person.genres.push({ genreName: msg.genre, auditionNumber: null, rolling: false })
+    }
+    if (msg.refCode && !slot.person.refCode) slot.person.refCode = msg.refCode
+    slot.queue.push(msg)
+    if (!slot.running) processSlotQueue(slot.slotId)
+  } else {
+    // Late message — update history directly
+    const historyEntry = history.value.find(h =>
+      msg.participantId != null ? h.participantId === msg.participantId : h.name === msg.name
+    )
+    if (historyEntry) {
+      const hGenre = historyEntry.genres.find(g => g.genreName === msg.genre)
+      if (hGenre) hGenre.auditionNumber = msg.auditionNumber
+    }
+  }
+}
+
+const onRepeatAudition = (msg) => {
+  const judgeLabel = msg.judge ? ` · Judge: ${msg.judge}` : ''
+  modalTitle.value = `Hey ${msg.name}!`
+  modalMessage.value = `Your audition number is ${msg.genre} #${msg.audition}${judgeLabel}`
+  showModal.value = true
+}
+
+const clearHistory = () => { history.value = [] }
+```
+
+- [ ] **Update `onBeforeUnmount` to clear all slot intervals**
+
+```js
+onBeforeUnmount(() => {
+  Object.values(rollingIntervals).forEach(clearInterval)
+  wsClients.forEach(c => deactivateClient(c))
+})
+```
+
+(The keys changed but `Object.values(rollingIntervals)` still works — no change needed here.)
+
+- [ ] **Replace the entire `<template>`**
+
+```html
+<template>
+  <div class="page-container">
+    <div class="color-bleed"></div>
+
+    <!-- ── Live Previews ──────────────────────────────────────────────────── -->
+    <div class="section-rule mb-4">
+      <span class="section-rule-label">Live Previews</span>
+      <div class="section-rule-line"></div>
+    </div>
+
+    <!-- Idle state -->
+    <div v-if="activeSlots.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
+      <div class="para-chip-sm w-16 h-16 flex items-center justify-center mb-4">
+        <i class="pi pi-qrcode text-content-muted text-2xl"></i>
+      </div>
+      <p class="type-body text-content-secondary">Waiting for check-in…</p>
+      <p class="type-label text-content-muted mt-1">Check in a participant on the Event Details page</p>
+    </div>
+
+    <!-- Slot grid: up to 3 per row -->
+    <div
+      v-else
+      class="grid gap-4 mb-6"
+      :style="{ gridTemplateColumns: `repeat(${Math.min(activeSlots.length, 3)}, 1fr)` }"
+    >
+      <div
+        v-for="slot in activeSlots"
+        :key="slot.slotId"
+        class="card-hover p-4 relative"
+      >
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
+
+        <!-- Name row -->
+        <div class="flex items-start justify-between gap-3 mb-1">
+          <div class="flex-1 min-w-0">
+            <p class="type-label text-content-muted mb-1">Good Luck</p>
+            <p class="type-page-title text-content-primary leading-tight truncate" style="font-size:clamp(1.1rem,3vw,1.8rem)">
+              {{ slot.person.name }}
+            </p>
+          </div>
+          <!-- Ref code chip -->
+          <div
+            v-if="slot.person.refCode"
+            class="flex-shrink-0 para-chip-sm px-3 py-2 cursor-pointer select-none flex flex-col items-end gap-0.5"
+            @mousedown="revealingRef = slot.slotId" @mouseup="revealingRef = null" @mouseleave="revealingRef = null"
+            @touchstart="revealingRef = slot.slotId" @touchend="revealingRef = null" @touchcancel="revealingRef = null"
+          >
+            <span class="type-label text-content-muted">Ref Code</span>
+            <span v-if="revealingRef === slot.slotId" class="font-source tracking-widest text-accent" style="font-size:0.9rem;letter-spacing:0.2em">
+              {{ slot.person.refCode }}
+            </span>
+            <span v-else class="type-label text-content-muted/40">Hold to reveal</span>
+          </div>
+          <div v-else-if="slot.person.genres.some(g => g.auditionNumber === null)" class="flex-shrink-0 para-chip-sm px-2 py-1.5 flex items-center gap-1">
+            <i class="pi pi-spin pi-spinner text-content-muted text-xs"></i>
+            <span class="type-label text-content-muted">Assigning…</span>
+          </div>
+        </div>
+
+        <!-- Team members -->
+        <div v-if="slot.person.memberNames?.length" class="flex items-center gap-1.5 type-label text-content-muted mb-2">
+          <i class="pi pi-users" style="font-size:0.65rem"></i>
+          <span class="truncate">{{ slot.person.memberNames.join(' · ') }}</span>
+        </div>
+
+        <!-- Divisions -->
+        <div class="section-rule my-2">
+          <span class="section-rule-label">Divisions</span>
+          <div class="section-rule-line"></div>
+        </div>
+
+        <div class="space-y-1.5">
+          <div
+            v-for="g in slot.person.genres"
+            :key="g.genreName"
+            class="flex items-center gap-2 para-chip-sm px-2.5 py-2"
+            :style="g.auditionNumber !== null ? { borderColor: 'var(--accent-muted)', background: 'var(--accent-subtle)' } : {}"
+          >
+            <span
+              class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+              :style="g.auditionNumber !== null
+                ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
+                : g.rolling
+                  ? 'background:rgba(245,158,11,0.7);box-shadow:0 0 6px rgba(245,158,11,0.5)'
+                  : 'background:rgba(255,255,255,0.15)'"
+            ></span>
+            <span class="type-body text-content-primary flex-1 truncate">{{ g.genreName }}</span>
+            <div class="flex items-baseline gap-0.5 tabular-nums min-w-[4rem] justify-end">
+              <template v-if="g.rolling">
+                <span class="type-label text-amber-400/60 text-xs">Drawing</span>
+                <span class="type-stat text-amber-400" style="font-size:1.4rem">
+                  {{ fakeNums[`${slot.slotId}-${g.genreName}`] ?? '—' }}
+                </span>
+              </template>
+              <template v-else-if="g.auditionNumber !== null">
+                <span class="type-label text-accent/60 text-xs">#</span>
+                <span class="type-stat text-accent" style="font-size:1.4rem">{{ g.auditionNumber }}</span>
+              </template>
+              <template v-else>
+                <span class="type-stat text-content-muted/20" style="font-size:1.4rem">—</span>
+              </template>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── History ──────────────────────────────────────────────────────── -->
+    <template v-if="history.length > 0">
+      <div class="section-rule mb-3">
+        <span class="section-rule-label">History</span>
+        <div class="section-rule-line"></div>
+        <button @click="clearHistory" class="para-chip-sm px-2 py-0.5 type-label text-content-muted hover:text-content-primary transition-colors ml-3 flex-shrink-0">
+          Clear
+        </button>
+      </div>
+
+      <div class="space-y-2">
+        <div
+          v-for="(person, i) in history"
+          :key="(person.participantId ?? person.name) + i"
+          class="para-chip-sm px-3 py-2.5 flex items-center gap-3 flex-wrap"
+          :class="i === 0 ? 'border-white/15' : 'opacity-50'"
+        >
+          <span class="type-body text-content-primary shrink-0 min-w-[6rem]">{{ person.name }}</span>
+          <div class="flex flex-wrap gap-1.5 flex-1 min-w-0">
+            <span
+              v-for="g in person.genres"
+              :key="g.genreName"
+              class="inline-flex items-center gap-1 badge-neutral capitalize"
+            >
+              <span class="text-content-muted">{{ g.genreName }}</span>
+              <span class="text-accent">#{{ g.auditionNumber }}</span>
+            </span>
+          </div>
+          <span
+            v-if="person.refCode"
+            class="relative ml-auto shrink-0 inline-flex items-center gap-1.5 para-chip-sm px-2.5 py-1 type-label cursor-pointer select-none transition-colors"
+            :class="revealingRef === (person.participantId ?? person.name) + i ? 'text-accent' : 'text-content-muted hover:text-accent'"
+            @click="revealingRef = revealingRef === (person.participantId ?? person.name) + i ? null : (person.participantId ?? person.name) + i"
+          >
+            <i class="pi pi-eye" style="font-size:0.6rem"></i>
+            <template v-if="revealingRef === (person.participantId ?? person.name) + i">
+              <span class="font-source tracking-widest" style="font-size:0.75rem;letter-spacing:0.2em">{{ person.refCode }}</span>
+            </template>
+            <template v-else>Ref</template>
+          </span>
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <ActionDoneModal
+    :show="showModal"
+    :title="modalTitle"
+    variant="info"
+    @accept="() => { showModal = false }"
+    @close="() => { showModal = false }"
+  >
+    <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+  </ActionDoneModal>
+</template>
+```
+
+- [ ] **Verify the dev server starts with no errors**
+
+```bash
+cd BES-frontend && npm run dev
+```
+
+Open `http://localhost:5173/event/audition-number` — should show "Waiting for check-in…" idle state.
+
+- [ ] **Commit**
+
+```bash
+git add BES-frontend/src/views/AuditionNumber.vue
+git commit -m "feat: multi-slot parallel animation in AuditionNumber display"
+```
+
+---
+
+## Task 5: AuditionList.vue — Reset Scores access code gate
+
+**Files:**
+- Modify: `BES-frontend/src/views/AuditionList.vue`
+
+- [ ] **Add access code gate state near the other modal refs (around line 30)**
+
+```js
+const resetConfirmCode = ref('')
+const resetCodeError = ref('')
+const resetCodeChecking = ref(false)
+```
+
+- [ ] **Replace `confirmReset` to use the two-step gate**
+
+Find `confirmReset` (around line 87) and replace:
+
+```js
+const confirmReset = (title, message) => {
+  resetConfirmCode.value = ''
+  resetCodeError.value = ''
+  modalTitle.value = title
+  modalMessage.value = message
+  modalVariant.value = 'warning'
+  showModal.value = true
+  // dynamicCallBack now handles code validation before reset
+  dynamicCallBack.value = async () => {
+    if (!resetConfirmCode.value.trim()) {
+      resetCodeError.value = 'Enter the event access code to confirm.'
+      return
+    }
+    const activeEvent = getActiveEvent()
+    if (!activeEvent?.id) {
+      resetCodeError.value = 'Could not resolve event ID.'
+      return
+    }
+    resetCodeChecking.value = true
+    try {
+      const res = await verifyEventAccessCode(activeEvent.id, resetConfirmCode.value.trim())
+      if (!res?.valid) {
+        resetCodeError.value = 'Incorrect access code.'
+        resetCodeChecking.value = false
+        return
+      }
+    } catch {
+      resetCodeError.value = 'Could not verify access code.'
+      resetCodeChecking.value = false
+      return
+    }
+    resetCodeChecking.value = false
+    showModal.value = false
+    await resetScore()
+  }
+}
+```
+
+- [ ] **Add `verifyEventAccessCode` and `getActiveEvent` to the imports at the top of the file**
+
+Find the existing import line and add `verifyEventAccessCode`:
+
+```js
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, verifyEventAccessCode } from '@/utils/api';
+```
+
+And add `getActiveEvent` to the auth import:
+
+```js
+import { getActiveEvent } from '@/utils/auth';
+```
+
+- [ ] **Add the access code input to `ActionDoneModal` in the template**
+
+Find the `ActionDoneModal` at the bottom of the template (around line 862) and replace it:
+
+```html
+<ActionDoneModal
+  :show="showModal"
+  :title="modalTitle"
+  :variant="modalVariant"
+  @accept="() => { dynamicCallBack() }"
+  @close="() => { showModal = false; resetCodeError = '' }"
+>
+  <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+  <!-- Access code gate — only shown for reset (warning variant) -->
+  <template v-if="modalVariant === 'warning'">
+    <div class="mt-4 space-y-2">
+      <label class="type-label text-content-muted">Event Access Code</label>
+      <input
+        v-model="resetConfirmCode"
+        type="text"
+        placeholder="Enter access code…"
+        class="input-base w-full"
+        @keyup.enter="dynamicCallBack()"
+      />
+      <p v-if="resetCodeError" class="type-label text-red-400">{{ resetCodeError }}</p>
+      <p v-if="resetCodeChecking" class="type-label text-content-muted">Verifying…</p>
+    </div>
+  </template>
+</ActionDoneModal>
+```
+
+- [ ] **Verify the reset flow in the browser**
+
+Start the dev server, navigate to `/event/audition-list`, select Judge role and a genre. Click Reset — the modal should now show the access code input. Entering the wrong code should show an error. Entering the correct code should execute the reset.
+
+- [ ] **Commit**
+
+```bash
+git add BES-frontend/src/views/AuditionList.vue
+git commit -m "feat: require access code before Reset Scores executes"
+```
+
+---
+
+## Task 6: Full build verification
+
+- [ ] **Build the backend**
+
+```bash
+cd BES && mvn clean package -DskipTests
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Build the frontend**
+
+```bash
+cd BES-frontend && npm run build
+```
+
+Expected: no errors, `dist/` generated
+
+- [ ] **Run frontend linter**
+
+```bash
+cd BES-frontend && npm run lint 2>/dev/null || npx eslint src/views/AuditionNumber.vue src/views/EventDetails.vue src/views/AuditionList.vue
+```
+
+Expected: no errors
+
+- [ ] **Final commit if any lint fixes were made, then push**
+
+```bash
+git add -A
+git status  # confirm only expected files
+git commit -m "chore: lint fixes for checkin-concurrency changes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|-----------------|------|
+| 409 duplicate check-in guard | Task 2 |
+| Cancel signal via `cancelled: true` on existing topic | Tasks 1, 3 |
+| Multi-slot grid (3-per-row) | Task 4 |
+| Per-slot independent animation queue | Task 4 |
+| `fakeNums`/`rollingIntervals` keyed by `slotId-genreName` | Task 4 |
+| Preview fires on dialog open (unchanged) | Task 3 (no change to `askCheckIn`) |
+| Cancel on dialog close (confirm phase only) | Task 3 |
+| Double-confirm guard | Task 3 |
+| Reset Scores access code gate | Task 5 |
+| `/topic/audition/` message format unchanged | Task 4 (only internal processing changed) |
+| `EventDetails`, `AuditionList`, `AuditionAdjust` unaffected | Tasks 1–3 only touch their own files |
+
+**No placeholders:** All code blocks are complete and runnable.
+
+**Type consistency:** `slotId` is always `String(participantId ?? name)` via `slotKey()`. `fakeNums` and `rollingIntervals` keys are always `${slotId}-${genreName}`. `flushSlotToHistory` takes `slotId` string throughout.

--- a/docs/superpowers/specs/2026-06-02-battle-division-state-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-02-battle-division-state-persistence-design.md
@@ -1,0 +1,306 @@
+# Battle Division State Persistence — Design Spec
+**Date:** 2026-06-02  
+**Status:** Approved  
+**GitHub Issue:** #42  
+
+---
+
+## Goal
+
+Allow operators to switch between divisions (genres) mid-event and recover from page refreshes without losing battle progress. All four battle views — `BattleControl`, `BracketVisualization`, `BattleOverlay`, `BattleJudge` — must restore to the exact correct state on a cold page load, including after a backend restart.
+
+---
+
+## Design Decisions Summary
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Persistence approach | Option A — thin backend persistence layer | Minimal blast radius; localStorage stays as warm cache |
+| State scope | Per (eventName, genreName) | Matches existing frontend localStorage key structure |
+| Backend state model | Active-genre singleton + per-genre state rows | Keeps existing API endpoints unchanged |
+| Restart recovery | DB-backed (`@PostConstruct` reload) | Backend restart mid-event must be recoverable |
+| Cross-client sync | New `/topic/battle/state` WS topic + `GET /api/v1/battle/state` REST | Single snapshot serves all clients on mount and genre switch |
+| Recovery UX | Confirmation prompt in BattleControl; flexible manual navigation always available | Operator can dismiss prompt and navigate to any pair manually |
+| Judge vote recovery | Votes persisted in DB; restored via `GET /api/v1/battle/state` on mount | Judges see their confirmed vote immediately on refresh without re-voting |
+
+---
+
+## 1. Database Schema
+
+Two new tables. Next migration: `V17`.
+
+### `battle_genre_state`
+
+One row per `(event_name, genre_name)`. Upserted on every significant state mutation.
+
+```sql
+CREATE TABLE battle_genre_state (
+  id                        BIGSERIAL PRIMARY KEY,
+  event_name                VARCHAR(255) NOT NULL,
+  genre_name                VARCHAR(255) NOT NULL,
+  bracket_json              TEXT,
+  top_size                  INTEGER,
+  current_round_index       INTEGER      DEFAULT 0,
+  current_pair_left         VARCHAR(255),
+  current_pair_left_members TEXT,
+  current_pair_right        VARCHAR(255),
+  current_pair_right_members TEXT,
+  is_final                  BOOLEAN      DEFAULT FALSE,
+  battle_phase              VARCHAR(20)  DEFAULT 'IDLE',
+  judges_json               TEXT,
+  updated_at                TIMESTAMP    DEFAULT NOW(),
+  UNIQUE (event_name, genre_name)
+);
+```
+
+- `bracket_json` — serialised `{ topSize, rounds }` object (matches `SetBracketStateDto` shape)
+- `current_pair_left_members` / `current_pair_right_members` — JSON arrays of member name strings
+- `judges_json` — JSON array of `{ id, name, vote }` objects; votes included so judge view restores confirmed votes after a backend restart
+- Upsert key: `(event_name, genre_name)` — `ON CONFLICT DO UPDATE SET ...`
+
+### `battle_active_genre`
+
+Singleton (always one row, `id = 1`) tracking which event+genre is currently live.
+
+```sql
+CREATE TABLE battle_active_genre (
+  id         INTEGER PRIMARY KEY DEFAULT 1,
+  event_name VARCHAR(255),
+  genre_name VARCHAR(255)
+);
+
+INSERT INTO battle_active_genre (id, event_name, genre_name) VALUES (1, NULL, NULL);
+```
+
+---
+
+## 2. Backend — New Endpoints
+
+All added to `BattleController`. Existing endpoints are **unchanged**.
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `POST` | `/api/v1/battle/active-genre` | Admin, Organiser | Switch active event+genre; saves current in-memory state to DB, loads DB state for new genre, broadcasts full snapshot |
+| `GET`  | `/api/v1/battle/active-genre` | Public | Returns `{ eventName, genreName }` |
+| `GET`  | `/api/v1/battle/state`        | Public | Returns full state snapshot for the active genre |
+
+### `GET /api/v1/battle/state` response shape
+
+```json
+{
+  "eventName": "Spring Jam 2026",
+  "genreName": "Breaking Top 16",
+  "bracket": { "topSize": 16, "rounds": { "Top16": [...], "Top8": [...] } },
+  "currentRoundIndex": 2,
+  "currentPair": {
+    "left": "Alpha", "leftMembers": [],
+    "right": "Bravo", "rightMembers": [],
+    "isFinal": false
+  },
+  "battlePhase": "LOCKED",
+  "judges": [
+    { "id": 1, "name": "Judge A", "vote": 0 },
+    { "id": 2, "name": "Judge B", "vote": -1 }
+  ]
+}
+```
+
+Returns `{}` if no active genre is set.
+
+### New WS topic: `/topic/battle/state`
+
+Broadcast whenever `POST /api/v1/battle/active-genre` is called. Payload is the same shape as `GET /api/v1/battle/state`. All clients subscribing to this topic can react to genre switches without polling.
+
+---
+
+## 3. Backend — `BattleService` Changes
+
+### New in-memory fields
+
+```java
+private String activeEventName;
+private String activeGenreName;
+private Integer currentRoundIndex = 0;
+```
+
+`currentRoundIndex` is updated by `BattleControl.vue` via the existing `POST /api/v1/battle/bracket` call — the bracket DTO already includes `topSize` and `rounds`; `currentRoundIndex` is added to `SetBracketStateDto` so the frontend can pass it explicitly whenever it advances a round. `persistActiveState()` then writes it to DB as part of every `setBracketStateService` call.
+
+### New method: `switchActiveGenreService(String eventName, String genreName)`
+
+1. Persist current in-memory state to `battle_genre_state` for `(activeEventName, activeGenreName)` (skip if either is null)
+2. Update `battle_active_genre` singleton to `(eventName, genreName)`
+3. Load `battle_genre_state` row for `(eventName, genreName)` from DB — if no row exists, start fresh (IDLE, empty bracket, no pair)
+4. Populate in-memory fields from loaded row
+5. Broadcast full state snapshot to `/topic/battle/state`
+
+### New private method: `persistActiveState()`
+
+Upserts the current in-memory state into `battle_genre_state` for `(activeEventName, activeGenreName)`. Called at the end of every existing mutation:
+- `setBracketStateService`
+- `setBattlerPairService`
+- `setBattlePhaseService`
+- `setBattleJudgeService`
+- `removeBattleJudgeService`
+- `resetJudgeVotesService`
+- `setScoreService` (on successful score, after phase auto-transition)
+
+Skip persist if `activeEventName` or `activeGenreName` is null.
+
+### `@PostConstruct` startup reload
+
+On Spring startup, read `battle_active_genre` singleton. If `event_name` and `genre_name` are set, load the corresponding `battle_genre_state` row into memory. This restores all in-memory state after a backend restart.
+
+---
+
+## 4. New DTOs
+
+### `SetActiveGenreDto`
+```java
+@NotBlank String eventName;
+@NotBlank String genreName;
+```
+
+### `BattleStateDto` (response)
+```java
+String eventName;
+String genreName;
+Object bracket;           // { topSize, rounds }
+Integer currentRoundIndex;
+CurrentPairDto currentPair;
+String battlePhase;
+List<JudgeStateDto> judges;
+```
+
+---
+
+## 5. Frontend — Per-View Changes
+
+### 5.1 BattleControl.vue
+
+**Genre switch (existing `watch(selectedGenre)`):**
+
+After the existing localStorage save + `broadcastBracket()` + `restoreAndBroadcastGenreBattle()` calls, add:
+```js
+await setActiveGenre(selectedEvent.value, newVal)  // POST /api/v1/battle/active-genre
+```
+This triggers the backend to save old genre state, load new genre state from DB, and broadcast the full snapshot to `BracketVisualization` and `BattleOverlay` on other machines.
+
+**On mount — restore current round + recovery prompt:**
+
+After `initialiseDropdown()` and before wiring WS subscriptions, call `GET /api/v1/battle/state`. If `state.battlePhase !== 'IDLE'` and `state.currentPair.left`:
+
+1. Set `currentRound.value = state.currentRoundIndex`
+2. Show a dismissable recovery banner at the top of BattleControl:
+
+   > **"IN PROGRESS: Round [X] — [Left] vs [Right]"**  `[Jump to pair]`  `[Dismiss]`
+
+   "Jump to pair" sets the bracket selection to that pair (same logic as `restoreAndBroadcastGenreBattle` but using backend-sourced values).  
+   "Dismiss" hides the banner. The bracket grid is already correct from localStorage warm cache; the operator can navigate to any pair manually.
+
+The `if (oldVal)` guard in `restoreAndBroadcastGenreBattle` is left unchanged — it handles genre-switch restores. Mount restore goes through the new backend-state path above.
+
+---
+
+### 5.2 BracketVisualization.vue
+
+**On mount:** Replace the existing `getBracketState()` call with `GET /api/v1/battle/state`:
+```js
+const state = await getBattleState()
+if (state?.bracket) bracketState.value = state.bracket
+if (state?.currentPair?.left) activePair.value = { left: state.currentPair.left, right: state.currentPair.right }
+if (state?.genreName) currentGenre.value = state.genreName
+```
+
+This also fixes the broken genre ticker (currently `currentGenre` is only updated via `/topic/battle/genre` which has no publisher).
+
+**New WS subscription (inside `wsClient.onConnect`):** Subscribe to `/topic/battle/state`. On receipt, replace `bracketState`, `activePair`, and `currentGenre` from the snapshot. This handles genre switches from the operator on another machine.
+
+Keep existing fine-grained subscriptions (`/topic/battle/bracket`, `/topic/battle/battle-pair`, `/topic/battle/score`, `/topic/battle/champion-reveal`, `/topic/battle/overlay-config`) — they continue to handle live match updates within the active genre.
+
+---
+
+### 5.3 BattleOverlay.vue
+
+**On mount:** After fetching `getOverlayConfig()`, call `GET /api/v1/battle/state`:
+```js
+const state = await getBattleState()
+if (state?.battlePhase) battlePhase.value = state.battlePhase
+if (state?.currentPair?.left) await updateBattlePair(state.currentPair)
+if (state?.judges?.length) updateBattleJudge({ judges: state.judges })
+```
+
+This fixes: overlay refreshing during VOTING showing IDLE until next broadcast.
+
+**New WS subscription:** Subscribe to `/topic/battle/state`. On receipt, call `updateBattlePair` with the new pair. This handles cross-machine genre switches — overlay resets to the new genre's current pair automatically.
+
+---
+
+### 5.4 BattleJudge.vue
+
+**Step 5 on mount (vote restore) — change priority order:**
+
+```js
+// After step 4 (getBattleJudges + resolveJudgeIdentity):
+if (battlePhase.value === 'VOTING' && judgeId.value != null) {
+  const backendJudge = battleJudges.value?.judges?.find(j => j.id === judgeId.value)
+  const backendVote  = backendJudge?.vote
+  if (backendVote === 0 || backendVote === 1 || backendVote === -1) {
+    confirmedVote.value = backendVote   // backend is authoritative after restart
+  } else {
+    const stored = restoreVoteFromStorage()
+    if (stored !== null) confirmedVote.value = stored  // localStorage fallback
+  }
+}
+```
+
+Backend vote (`judges_json` restored from DB) takes priority. localStorage fallback handles the window where the vote was just cast but the DB hasn't been written yet (race condition between WS broadcast and DB persist is < 1 ms in practice).
+
+No change to the existing real-time vote subscription (`/topic/battle/vote/${judgeId}`).
+
+---
+
+## 6. New Frontend API Function
+
+Add to `utils/api.js`:
+
+```js
+export const setActiveGenre = async (eventName, genreName) => {
+  return await fetch(`${domain}/api/v1/battle/active-genre`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventName, genreName })
+  })
+}
+
+export const getBattleState = async () => {
+  const res = await fetch(`${domain}/api/v1/battle/state`, { credentials: 'include' })
+  if (!res.ok) return null
+  return await res.json()
+}
+
+export const getActiveGenre = async () => {
+  const res = await fetch(`${domain}/api/v1/battle/active-genre`, { credentials: 'include' })
+  if (!res.ok) return null
+  return await res.json()
+}
+```
+
+---
+
+## 7. Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| `GET /api/v1/battle/state` returns `{}` (no active genre) | All views render in empty/idle state — same as today |
+| DB unavailable on startup | Log error, continue with empty in-memory state — degrade gracefully |
+| `persistActiveState()` fails | Log error, do not block the mutation or WS broadcast |
+| Genre switch while a match is VOTING | Persist current state first (including in-flight votes), then switch — operator must manage this deliberately |
+| Backend restart during VOTING | Phase restored to VOTING from DB; judges' existing votes restored; judges who haven't voted yet can still vote |
+
+---
+
+## 8. Out of Scope (tracked in #42 comment)
+
+- **Option B** — removing frontend localStorage entirely; backend as sole source of truth
+- **Option C** — scoping all battle endpoints by event+genre in the request body

--- a/docs/superpowers/specs/2026-06-02-checkin-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-02-checkin-concurrency-design.md
@@ -1,0 +1,180 @@
+# Check-in Concurrency & Display Design
+
+**Date:** 2026-06-02
+**Branch:** `fix/checkin-concurrency`
+**Scope:** EventDetails.vue check-in flow · AuditionNumber.vue display · AuditionList.vue reset gate
+
+---
+
+## Problem
+
+3–4 operators run the check-in desk simultaneously. Several race conditions exist:
+
+1. **Double check-in** — stale list (30s poll) lets two operators check in the same person. Backend has no duplicate guard.
+2. **Preview-then-cancel stuck** — `sendCheckinPreview` fires on dialog open (not confirm). Cancelling leaves AuditionNumber permanently showing a ghost preview with no numbers.
+3. **Serial animation blocks concurrent check-ins** — the global `auditionQueue` processes one genre animation at a time across all participants. Two simultaneous confirmations queue serially instead of animating in parallel.
+4. **AuditionNumber single-slot design** — new person's preview immediately flushes current person to history, losing their animation if their numbers haven't arrived yet.
+5. **Reset Scores too easy to trigger accidentally** — no friction before wiping all judge scores for a genre.
+6. **Double-confirm** — confirm button has no debounce; rapid double-tap fires two check-in requests.
+
+---
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| 1 | Backend returns **409** if participant already has all audition numbers assigned. Frontend shows "Already checked in at another desk." |
+| 2 | Preview fires **on dialog open** (existing behaviour kept) — important for the display screen to show the person before the number is generated. Cancel sends an explicit cancel signal. |
+| 3 | AuditionNumber moves to a **multi-slot grid** — up to 3 slots per row, wrapping to a second row. Each slot is independent. |
+| 4 | Each slot has its **own animation queue** — parallel animations across slots. `fakeNums` and `rollingIntervals` keyed by `slotId-genreName` to avoid collision when two slots share the same genre name. |
+| 5 | Cancel sends a WS cancel signal on the **existing `/topic/checkin-preview/`** channel with `cancelled: true`. Only `AuditionNumber.vue` subscribes to this channel — no other consumers affected. |
+| 6 | Reset Scores requires **re-entering the event access code** before executing. |
+| 7 | Confirm button **disabled after first click**, re-enabled only on error response. |
+
+---
+
+## Architecture
+
+### AuditionNumber.vue — multi-slot state model
+
+Replace `currentPerson` (single ref) with `activeSlots` (array):
+
+```js
+// Before
+const currentPerson = ref(null)
+const auditionQueue = []       // global, serial
+let queueRunning = false
+const fakeNums = ref({})       // keyed by genreName
+const rollingIntervals = {}    // keyed by genreName
+
+// After
+const activeSlots = ref([])
+// Each slot: {
+//   slotId,          // participantId (or name fallback)
+//   person,          // { participantId, name, refCode, memberNames, genres[] }
+//   queue: [],       // per-slot pending number messages
+//   running: false,  // per-slot animation flag
+// }
+const fakeNums = ref({})       // keyed by `${slotId}-${genreName}`
+const rollingIntervals = {}    // keyed by `${slotId}-${genreName}`
+```
+
+`history` stays unchanged — completed slots move to history exactly as before.
+
+### WS message handling (AuditionNumber.vue only)
+
+**`/topic/checkin-preview/` → `onPreview(msg)`**
+
+```
+if msg.cancelled:
+  remove slot matching msg.participantId → done
+
+if slot exists for msg.participantId:
+  merge new genres into existing slot (same-person duplicate preview)
+else:
+  add new slot to activeSlots
+```
+
+No flushing, no queue clearing. Each slot is created/removed independently.
+
+**`/topic/audition/` → `onReceiveAuditionNumber(msg)`**
+
+```
+find slot matching msg.participantId:
+  if found:
+    push msg to slot.queue
+    if !slot.running: processSlotQueue(slotId)
+  else:
+    check history → patch directly (late message, no animation)
+```
+
+`processSlotQueue(slotId)` runs the 2-second slot-machine animation using `fakeNums[slotId-genre]` and `rollingIntervals[slotId-genre]`. When slot's queue empties and all genres have numbers, move slot to history after a short pause (1.5s so the audience sees the final numbers).
+
+### Channel safety — `/topic/audition/` subscribers
+
+The message format broadcast on `/topic/audition/` does **not change**. Only `AuditionNumber.vue`'s internal processing logic changes. The other three subscribers are unaffected:
+
+| File | What it does with `/topic/audition/` | Impact |
+|------|--------------------------------------|--------|
+| `EventDetails.vue` | Patches `checkinList[participant].genre.auditionNumber` | None |
+| `AuditionList.vue` | Adds/updates participant rows | None |
+| `AuditionAdjust.vue` | Patches `checkinList` via `applyAuditionMsg` | None |
+
+### Cancel signal — backend
+
+Extend the existing `POST /api/v1/event/{eventName}/checkin-preview` endpoint — add an optional `cancelled` boolean to the request body:
+
+```json
+{ "participantId": 123, "cancelled": true }
+```
+
+Backend checks `cancelled` and broadcasts the same payload on `/topic/checkin-preview/`. No new route needed.
+
+`AuditionNumber.vue` checks `msg.cancelled` first in `onPreview` before any other logic — if true, remove the matching slot and return.
+
+**EventDetails.vue:** call `sendCheckinPreview(eventName, { participantId, cancelled: true })` when the confirm dialog closes while still in `confirm` phase (not `generating`, not `done`). No call needed if the dialog closes after confirming — the slot moves to history naturally once numbers arrive.
+
+### Backend — duplicate check-in guard
+
+In the service method called by `GET /api/v1/event/register-participant/{participantId}/{eventId}`:
+
+- Before assigning numbers, check if all `EventGenreParticipant` rows for this participant+event already have `auditionNumber != null`.
+- If yes → return `409 Conflict` with body `"already_checked_in"`.
+- Frontend `checkIn()` catches 409 → sets `checkinConfirm.phase = 'error'` → shows "Already checked in at another desk." with a close button.
+
+### EventDetails.vue — double-confirm guard
+
+```js
+// confirmCheckIn()
+const confirmCheckIn = async () => {
+  if (confirming.value) return   // guard
+  confirming.value = true
+  try {
+    // ... existing logic
+  } finally {
+    confirming.value = false
+  }
+}
+```
+
+Confirm button: `:disabled="checkinConfirm.phase !== 'confirm' || confirming"`.
+
+### AuditionList.vue — Reset Scores gate
+
+Replace the current single-confirm modal with a two-step flow:
+
+1. Operator clicks Reset → warning modal appears explaining consequences.
+2. Modal shows an input: "Enter event access code to confirm".
+3. Frontend calls existing `GET /api/v1/event/{eventName}` (or a dedicated endpoint) to validate the access code.
+4. Only on match → execute `resetJudgeScores` + `resetJudgeFeedback`.
+
+The access code is already stored on the `Event` entity and visible to organisers on EventDetails. No new data model needed.
+
+---
+
+## Grid layout (AuditionNumber.vue template)
+
+```
+1 slot  → single full-width card
+2 slots → 2-column grid
+3 slots → 3-column grid
+4 slots → 3-column grid (row 1: 3, row 2: 1)
+5 slots → 3-column grid (row 1: 3, row 2: 2)
+```
+
+CSS: `grid-template-columns: repeat(min(activeSlots.length, 3), 1fr)` — Vue computed from slot count.
+
+Each slot card shows: operator tag · status dot (pending amber / rolling amber-pulse / done white) · participant name · member names · per-genre rows with number area.
+
+Slot auto-moves to history after animation completes + 1.5s display pause.
+
+---
+
+## What does NOT change
+
+- `/topic/audition/` message format — untouched
+- `/topic/checkin-preview/` message format for normal previews — untouched (cancel adds a new optional field)
+- `history` display in AuditionNumber — untouched
+- `onRepeatAudition` (`/topic/error/`) — untouched
+- All other EventDetails functionality (walk-in, genre adjust, payment verify, etc.)
+- AuditionList scoring, feedback, and emcee view


### PR DESCRIPTION
## Summary

- Adds DB-backed persistence for battle state (`battle_genre_state` + `battle_active_genre` tables, V28 migration) so BattleControl, BattleOverlay, and BattleJudge survive page refresh
- Auto-restores active pair, phase, bracket, and judges on refresh without operator action — shows a RESTORED banner
- SAVING/SAVED/ERROR indicator next to phase badge in Live Match section
- Per-match "Start Here" button to begin a TopN round from any pair, not forced to pair #1
- BattleJudge no longer re-asks "who are you" on every BattleControl refresh
- Real-time check-in button lock when a participant is being checked in by another operator (merged from `fix/checkin-concurrency`)
- Real-time smoke queue overlay — Chart.vue updates as operator assigns participants to slots, not only on Start Round
- Queue position labels (#1, #2, …) for participants waiting in the 7-to-Smoke queue
- Fixed bracket loss on page refresh: `watch(topSize)` was reading localStorage with the wrong key (`Top{size}{genre}Rounds`) while all writes use `Top{size}{event}{genre}Rounds` — key mismatch caused `initRounds()` to clear the bracket whenever topSize changed programmatically during genre switch
- Guarded `broadcastBracket()` in `watch(topSize)` against the initial fire (before genre is known), which was sending empty rounds to the backend DB and corrupting the stored bracket
- Added missing localStorage save to `applyToFirstRound` smoke-format path so 7-to-Smoke bracket seeding survives refresh

## Test plan

- [ ] Refresh BattleControl mid-battle — active pair, phase, and bracket should restore automatically with RESTORED banner
- [ ] SAVING/SAVED indicator appears next to phase badge during pair/phase changes
- [ ] Click "Start Here" on any bracket match to start from that specific pair
- [ ] BattleJudge retains judge identity after BattleControl refresh; real-time judge add/remove still works
- [ ] Select a smoke genre in BattleControl → drag participants to queue slots → verify `/battle/overlay?isSmoke=true` updates live with queue position labels (#1, #2, …)
- [ ] Refresh smoke overlay mid-session — queue state should restore from backend
- [ ] Two operators: check in a participant from one — the check-in button locks on the other's screen in real-time
- [ ] **Bracket persistence on refresh**: seed bracket via Random/By Rank on a genre with a non-default topSize (e.g. Top8 when another genre uses Top16), refresh page — bracket should still be filled
- [ ] **Smoke bracket persistence on refresh**: seed 7-to-Smoke slots via Random, refresh page — slot assignments should survive
- [ ] **No DB corruption on refresh**: seed bracket, refresh, switch genre away and back — bracket should remain intact (not wiped by initial `broadcastBracket()`)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)