### PR TITLE
chore: detect unmerged sibling branches in session-start and local-docker-verify

### DIFF
--- a/.claude/skills/local-docker-verify/SKILL.md
+++ b/.claude/skills/local-docker-verify/SKILL.md
@@ -108,6 +108,45 @@ If the local build **passes**: proceed to Step 3.
 
 ---
 
+## Step 2b — Verify no unmerged sibling branches will be dropped
+
+Before rebuilding, confirm the current branch includes all in-progress sibling branches. If any sibling branch has commits ahead of the default and no merged PR, a rebuild from the current branch will silently exclude that work.
+
+```bash
+DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "master")
+CURRENT=$(git branch --show-current)
+
+git for-each-ref --format='%(refname:short)' refs/heads/ \
+  | grep -vE "^(master|main|${CURRENT})$" \
+  | while read branch; do
+      AHEAD=$(git log origin/${DEFAULT}.."$branch" --oneline 2>/dev/null | wc -l | tr -d ' ')
+      if [ "$AHEAD" -gt 0 ]; then
+        MERGED=$(gh pr list --head "$branch" --state merged --limit 1 2>/dev/null | wc -l | tr -d ' ')
+        NOT_IN_CURRENT=$(git log HEAD.."$branch" --oneline 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$MERGED" -eq 0 ] && [ "$NOT_IN_CURRENT" -gt 0 ]; then
+          echo "  ⚠️  $branch — $AHEAD commits ahead of ${DEFAULT}, not merged into ${CURRENT}"
+        fi
+      fi
+    done
+```
+
+If any are found, **stop and warn before rebuilding**:
+```
+⚠️ Docker rebuild blocked — unmerged sibling branches detected:
+  feat/some-feature   (12 commits ahead of master, not in current branch)
+
+Rebuilding now will drop their changes from the running containers.
+Options:
+  1. git merge {branch} — include the work in this branch first
+  2. Confirm you intentionally want to rebuild without it
+```
+
+Do not proceed to Step 3 until the user either merges the sibling branches or explicitly confirms they want to rebuild without them.
+
+If no unmerged siblings are found: proceed to Step 3 silently.
+
+---
+
 ## Step 3 — Rebuild Affected Docker Containers
 
 **Targeted rebuild (preferred — faster)**

--- a/.claude/skills/local-docker-verify/SKILL.md
+++ b/.claude/skills/local-docker-verify/SKILL.md
@@ -136,12 +136,17 @@ If any are found, **stop and warn before rebuilding**:
   feat/some-feature   (12 commits ahead of master, not in current branch)
 
 Rebuilding now will drop their changes from the running containers.
-Options:
-  1. git merge {branch} — include the work in this branch first
-  2. Confirm you intentionally want to rebuild without it
+
+Recommended: get each sibling branch merged to {DEFAULT} via PR first, then:
+  git fetch origin && git rebase origin/{DEFAULT}
+
+Do not rebuild until sibling branches are merged to {DEFAULT} and this branch
+has been rebased onto the updated origin/{DEFAULT}.
 ```
 
-Do not proceed to Step 3 until the user either merges the sibling branches or explicitly confirms they want to rebuild without them.
+Do NOT use `git merge {sibling-branch}` — always keep history linear via rebase.
+
+Do not proceed to Step 3 until all sibling branches are resolved or the user explicitly confirms they want to rebuild without them.
 
 If no unmerged siblings are found: proceed to Step 3 silently.
 

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -45,11 +45,47 @@ git status --short | grep -v "^??" | head -20
 
 Report any uncommitted changes. Ask the user whether to continue with them or stash first.
 
-## Step 5 — Report
+## Step 5 — Check for unmerged sibling branches
+
+Before starting work, detect local branches that carry commits not yet in the default branch and have no merged PR. If the current branch was created from `origin/master` without including these, a Docker rebuild will silently drop their changes.
+
+```bash
+DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "master")
+CURRENT=$(git branch --show-current)
+
+git for-each-ref --format='%(refname:short)' refs/heads/ \
+  | grep -vE "^(master|main|${CURRENT})$" \
+  | while read branch; do
+      AHEAD=$(git log origin/${DEFAULT}.."$branch" --oneline 2>/dev/null | wc -l | tr -d ' ')
+      if [ "$AHEAD" -gt 0 ]; then
+        MERGED=$(gh pr list --head "$branch" --state merged --limit 1 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$MERGED" -eq 0 ]; then
+          IN_CURRENT=$(git log "$branch"..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
+          ALREADY=$(git log HEAD.."$branch" --oneline 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$ALREADY" -gt 0 ]; then
+            echo "  ⚠️  $branch — $AHEAD commits ahead of ${DEFAULT}, NOT in current branch (no merged PR)"
+          fi
+        fi
+      fi
+    done
+```
+
+If any sibling branches are found, warn:
+```
+⚠️ The following branches have unmerged work not included in `{CURRENT}`:
+  feat/some-feature   (12 commits ahead, no merged PR)
+
+A Docker rebuild on this branch will not contain their changes.
+Merge them in before rebuilding? Or continue without them?
+```
+
+If none are found, proceed silently.
+
+## Step 6 — Report
 
 Output a one-line status:
 ```
-✅ Branch: <name> | No stash | Migrations committed | Working tree clean
+✅ Branch: <name> | No stash | Migrations committed | Working tree clean | No unmerged siblings
 ```
 or flag any issues found.
 

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -76,8 +76,15 @@ If any sibling branches are found, warn:
   feat/some-feature   (12 commits ahead, no merged PR)
 
 A Docker rebuild on this branch will not contain their changes.
-Merge them in before rebuilding? Or continue without them?
+
+Recommended: get each sibling branch merged to {DEFAULT} via PR first, then:
+  git fetch origin && git rebase origin/{DEFAULT}
+
+Do not proceed with a Docker rebuild until sibling branches are merged to {DEFAULT}
+and this branch has been rebased onto the updated origin/{DEFAULT}.
 ```
+
+Do NOT use `git merge {sibling-branch}` — always keep history linear via rebase.
 
 If none are found, proceed silently.
 


### PR DESCRIPTION
## Summary

Closes #43

- **session-start**: Added Step 5 — scans local branches that are ahead of the default branch with no merged PR and are not included in the current branch. Warns before work begins so the developer knows to rebase and include missing sibling work.
- **local-docker-verify**: Added Step 2b — same detection, but blocks the Docker rebuild and asks for explicit confirmation if unmerged siblings are found. Prevents silent feature drops when rebuilding from a freshly-branched worktree.
- **git-scope-guard** (user-level skill, not in repo): Added B3b — after creating a new branch, scans for sibling branches and warns that the correct resolution is `git fetch origin && git rebase origin/{DEFAULT}` after merging siblings via PR, not direct `git merge`.

All three skills consistently enforce: **never `git merge {sibling-branch}` directly — always keep history linear via fetch + rebase after the sibling is merged to the default branch via PR.**

## Test plan
- [ ] CI passes (skill file changes are markdown only — no code changes)
- [ ] session-start skill visually reviewed for correctness
- [ ] local-docker-verify skill visually reviewed for correctness