### PR TITLE
feat: real-time judge vote transparency panel (issue #49)

### DIFF
--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -901,6 +901,14 @@ const showFinalReveal = computed(() =>
   tentativeWinner.value !== -1
 )
 
+const voteCountDisplay = computed(() => {
+  const judges = battleJudges.value?.judges ?? []
+  return {
+    left:  judges.filter(j => j.vote === 0).length,
+    right: judges.filter(j => j.vote === 1).length,
+  }
+})
+
 const allJudgeOptions = computed(() => ["", ...Object.values(allJudges.value).map(j => j.judgeName)])
 
 // Per-genre battle state persistence — saves which round/match was in progress so
@@ -2469,8 +2477,24 @@ onUnmounted(() => {
         >START REVOTE</button>
       </div>
 
-      <!-- Winner announcement -->
+      <!-- WINNER ANNOUNCEMENT -->
+      <!-- DECIDED: champion locked — show glowing champion name -->
       <div
+        v-if="battlePhase === 'DECIDED'"
+        class="px-4 py-3 mb-4"
+        style="border-left:4px solid #34d399;background:rgba(52,211,153,0.08)"
+      >
+        <span class="type-label text-emerald-400" style="font-size:9px;letter-spacing:0.22em">⭐ CHAMPION LOCKED</span>
+        <span class="type-body text-emerald-400 block mt-1" style="font-size:18px;font-weight:bold;text-shadow:0 0 12px rgba(52,211,153,0.4)">
+          {{ genreChampions[selectedGenre] ?? currentGenreChampion ?? '—' }}
+        </span>
+        <span v-if="!revealActive" class="type-label text-content-muted block mt-1" style="font-size:9px;letter-spacing:0.22em">
+          FINAL · ORGANISER ONLY — NOT REVEALED YET
+        </span>
+      </div>
+      <!-- All other phases: ongoing/wait/winner/tie announcement -->
+      <div
+        v-else
         class="px-4 py-3 mb-4"
         :class="{
           'semantic-chip-warning': winnerVariant === 'ongoing',
@@ -2485,6 +2509,70 @@ onUnmounted(() => {
           :style="winnerVariant === 'winner' ? 'box-shadow:0 0 8px rgba(52,211,153,0.8)' : winnerVariant === 'tie' ? '' : 'box-shadow:0 0 8px rgba(245,158,11,0.8)'"
         ></div>
         <span class="type-body text-content-primary">{{ winnerAnnouncement }}</span>
+      </div>
+
+      <!-- Judge vote panel — live per-judge votes, visible in all phases -->
+      <div v-if="battleJudges?.judges?.length" class="mb-4">
+        <div class="section-rule mb-3">
+          <span class="section-rule-label">JUDGES</span>
+          <div class="section-rule-line"></div>
+        </div>
+        <div
+          class="grid gap-2 mb-3"
+          :style="{ gridTemplateColumns: `repeat(${battleJudges.judges.length}, 1fr)` }"
+        >
+          <div
+            v-for="judge in battleJudges.judges"
+            :key="judge.id"
+            class="px-3 py-2 text-center"
+            :style="{
+              clipPath: 'polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)',
+              border: judge.vote === -3 ? '1px solid rgba(245,158,11,0.3)' : judge.vote === 0 ? '1px solid rgba(52,211,153,0.4)' : '1px solid rgba(59,130,246,0.4)',
+              background: judge.vote === -3 ? 'rgba(245,158,11,0.06)' : judge.vote === 0 ? 'rgba(52,211,153,0.08)' : 'rgba(59,130,246,0.08)',
+            }"
+          >
+            <span class="type-label text-content-muted block mb-1">{{ judge.judgeName }}</span>
+            <span
+              v-if="judge.vote === -3"
+              class="type-body text-amber-400"
+            >⏳ WAITING</span>
+            <span
+              v-else-if="judge.vote === 0"
+              class="type-body text-emerald-400"
+            >{{ currentBattlePair?.[0] ?? 'LEFT' }}</span>
+            <span
+              v-else-if="judge.vote === 1"
+              class="type-body text-blue-400"
+            >{{ currentBattlePair?.[1] ?? 'RIGHT' }}</span>
+          </div>
+        </div>
+        <!-- Winner preview banner when all judges have voted -->
+        <div
+          v-if="allJudgesVoted && tentativeWinner !== -1"
+          class="semantic-chip-success px-4 py-3"
+        >
+          <div class="type-label text-emerald-400 mb-1" style="font-size:9px;letter-spacing:0.18em">WINNER PREVIEW (ORGANISER ONLY)</div>
+          <div class="type-body text-emerald-400" style="font-size:13px">
+            {{ tentativeWinner === 0 ? (currentBattlePair?.[0] ?? 'LEFT') : (currentBattlePair?.[1] ?? 'RIGHT') }}
+          </div>
+          <div class="type-label text-content-muted mt-1" style="font-size:9px">{{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}</div>
+        </div>
+        <div
+          v-else-if="allJudgesVoted && tentativeWinner === -1"
+          class="px-4 py-3"
+          style="border-left:3px solid #6b7280;background:rgba(107,114,128,0.08)"
+        >
+          <div class="type-label mb-1" style="font-size:9px;letter-spacing:0.18em;color:#9ca3af">WINNER PREVIEW</div>
+          <div class="type-body" style="font-size:13px;color:#9ca3af">TIE — {{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}</div>
+          <div class="type-label text-content-muted mt-1" style="font-size:9px">Rematch required</div>
+        </div>
+      </div>
+      <div
+        v-else-if="!battleJudges?.judges?.length"
+        class="mb-4 px-3 py-2"
+        style="clip-path:polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%);border:1px solid rgba(255,255,255,0.07);background:rgba(255,255,255,0.04)"
+      >
+        <span class="type-label text-content-muted">No judges assigned for this battle</span>
       </div>
 
       <!-- Match pairs (standard) — only shown when viewing the active round -->
@@ -2557,8 +2645,12 @@ onUnmounted(() => {
         <!-- VOTING: non-final, not all voted, or tie → Get Score / Rematch -->
         <button
           v-if="battlePhase === 'VOTING' && !showFinalReveal"
+          :disabled="!allJudgesVoted"
           @click="submitGetScore"
-          class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+          :class="allJudgesVoted
+            ? 'bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all'
+            : 'bg-surface-700/30 para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all cursor-not-allowed opacity-50'"
+          :title="allJudgesVoted ? '' : 'Waiting for all judges to vote'"
         >
           <i class="pi pi-bolt text-xs"></i>
           {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -128,6 +128,8 @@ const nextBattlePair = computed(() => {
 })
 
 const resetJudgeVote = async () => {
+  // Reset locally first so the panel shows WAITING immediately, before WS echo arrives
+  ;(battleJudges.value?.judges ?? []).forEach(j => { j.vote = -3 })
   await Promise.all(battleJudges.value.judges.map(j => battleJudgeVote(j.id, -3)))
 }
 
@@ -2524,47 +2526,62 @@ onUnmounted(() => {
           <div
             v-for="judge in battleJudges.judges"
             :key="judge.id"
-            class="px-3 py-2 text-center"
+            class="px-3 py-3 text-center"
             :style="{
               clipPath: 'polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)',
-              border: judge.vote === -3 ? '1px solid rgba(245,158,11,0.3)' : judge.vote === 0 ? '1px solid rgba(52,211,153,0.4)' : '1px solid rgba(59,130,246,0.4)',
-              background: judge.vote === -3 ? 'rgba(245,158,11,0.06)' : judge.vote === 0 ? 'rgba(52,211,153,0.08)' : 'rgba(59,130,246,0.08)',
+              border: judge.vote === -3
+                ? '1px solid rgba(245,158,11,0.3)'
+                : judge.vote === 0
+                  ? `1px solid ${overlayConfig.leftColor}99`
+                  : `1px solid ${overlayConfig.rightColor}99`,
+              background: judge.vote === -3
+                ? 'rgba(245,158,11,0.06)'
+                : judge.vote === 0
+                  ? `${overlayConfig.leftColor}18`
+                  : `${overlayConfig.rightColor}18`,
             }"
           >
-            <span class="type-label text-content-muted block mb-1">{{ judge.judgeName }}</span>
-            <span
+            <div style="font-size:10px;letter-spacing:0.18em;color:rgba(255,255,255,0.55);margin-bottom:6px">{{ judge.name }}</div>
+            <div
               v-if="judge.vote === -3"
               class="type-body text-amber-400"
-            >⏳ WAITING</span>
-            <span
+              style="font-size:13px"
+            >⏳ WAITING</div>
+            <div
               v-else-if="judge.vote === 0"
-              class="type-body text-emerald-400"
-            >{{ currentBattlePair?.[0] ?? 'LEFT' }}</span>
-            <span
+              class="type-body"
+              :style="{ fontSize: '13px', color: overlayConfig.leftColor }"
+            >{{ currentBattlePair?.[0] ?? 'LEFT' }}</div>
+            <div
               v-else-if="judge.vote === 1"
-              class="type-body text-blue-400"
-            >{{ currentBattlePair?.[1] ?? 'RIGHT' }}</span>
+              class="type-body"
+              :style="{ fontSize: '13px', color: overlayConfig.rightColor }"
+            >{{ currentBattlePair?.[1] ?? 'RIGHT' }}</div>
           </div>
         </div>
         <!-- Winner preview banner when all judges have voted -->
         <div
           v-if="allJudgesVoted && tentativeWinner !== -1"
-          class="semantic-chip-success px-4 py-3"
+          class="px-4 py-3"
+          :style="{
+            borderLeft: `4px solid ${tentativeWinner === 0 ? overlayConfig.leftColor : overlayConfig.rightColor}`,
+            background: `${tentativeWinner === 0 ? overlayConfig.leftColor : overlayConfig.rightColor}18`,
+          }"
         >
-          <div class="type-label text-emerald-400 mb-1" style="font-size:9px;letter-spacing:0.18em">WINNER PREVIEW (ORGANISER ONLY)</div>
-          <div class="type-body text-emerald-400" style="font-size:13px">
+          <div class="type-label mb-2" style="font-size:9px;letter-spacing:0.18em" :style="{ color: tentativeWinner === 0 ? overlayConfig.leftColor : overlayConfig.rightColor }">WINNER PREVIEW (ORGANISER ONLY)</div>
+          <div class="type-body" style="font-size:20px;letter-spacing:0.08em;font-weight:bold" :style="{ color: tentativeWinner === 0 ? overlayConfig.leftColor : overlayConfig.rightColor }">
             {{ tentativeWinner === 0 ? (currentBattlePair?.[0] ?? 'LEFT') : (currentBattlePair?.[1] ?? 'RIGHT') }}
           </div>
-          <div class="type-label text-content-muted mt-1" style="font-size:9px">{{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}</div>
+          <div class="type-label text-content-muted mt-1" style="font-size:13px;letter-spacing:0.06em">{{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}</div>
         </div>
         <div
           v-else-if="allJudgesVoted && tentativeWinner === -1"
           class="px-4 py-3"
           style="border-left:3px solid #6b7280;background:rgba(107,114,128,0.08)"
         >
-          <div class="type-label mb-1" style="font-size:9px;letter-spacing:0.18em;color:#9ca3af">WINNER PREVIEW</div>
-          <div class="type-body" style="font-size:13px;color:#9ca3af">TIE — {{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}</div>
-          <div class="type-label text-content-muted mt-1" style="font-size:9px">Rematch required</div>
+          <div class="type-label mb-2" style="font-size:9px;letter-spacing:0.18em;color:#9ca3af">WINNER PREVIEW</div>
+          <div class="type-body" style="font-size:20px;letter-spacing:0.06em;font-weight:bold;color:#9ca3af">TIE — {{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}</div>
+          <div class="type-label text-content-muted mt-1" style="font-size:13px;letter-spacing:0.06em">Rematch required</div>
         </div>
       </div>
       <div
@@ -2729,7 +2746,7 @@ onUnmounted(() => {
           Reveal Champion
         </button>
         <button
-          v-if="revealActive"
+          v-if="revealActive && battlePhase !== 'DECIDED'"
           @click="dismissReveal"
           class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
         >

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -115,7 +115,8 @@ async function handleClick(side) {
 
 // ── WebSocket ───────────────────────────────────────────────────────────────
 const wsClients  = []
-let   voteClient = null
+let   voteClient      = null
+let   clearJudgeTimer = null
 
 function setupVoteSubscription() {
   if (judgeId.value == null || voteClient) return
@@ -195,12 +196,33 @@ onMounted(async () => {
     battleJudges.value = msg
     if (judgeId.value != null) {
       const still = (msg?.judges ?? []).find(j => j.id === judgeId.value)
-      if (!still) clearJudge()
+      if (still) {
+        clearTimeout(clearJudgeTimer)
+      } else {
+        // Judge absent — may be a temporary genre-sync remove+re-add. Debounce before clearing
+        // so the re-add has time to arrive. If still gone after 2.5s, clear for real.
+        if (clearJudgeTimer == null) {
+          clearJudgeTimer = setTimeout(() => {
+            clearJudgeTimer = null
+            const storedName = localStorage.getItem(LS_JUDGE_NAME)
+            const byName = storedName
+              ? (battleJudges.value?.judges ?? []).find(j => j.name === storedName)
+              : null
+            if (byName) {
+              judgeId.value = byName.id
+              localStorage.setItem(LS_JUDGE_ID, String(byName.id))
+            } else if (!(battleJudges.value?.judges ?? []).find(j => j.id === judgeId.value)) {
+              clearJudge()
+            }
+          }, 2500)
+        }
+      }
     }
   })
 })
 
 onUnmounted(() => {
+  clearTimeout(clearJudgeTimer)
   wsClients.forEach(c => deactivateClient(c))
 })
 </script>

--- a/docs/superpowers/plans/2026-06-03-battle-control-judge-transparency.md
+++ b/docs/superpowers/plans/2026-06-03-battle-control-judge-transparency.md
@@ -1,0 +1,420 @@
+# Battle Control Judge Vote Transparency Panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a real-time horizontal judge vote panel to `BattleControl.vue` that shows each judge's live vote, gates GET SCORE until all judges have voted, and upgrades the DECIDED-phase winner bar to a "CHAMPION LOCKED" display.
+
+**Architecture:** Frontend-only change to a single file (`BattleControl.vue`). All data already flows through `battleJudges` ref and per-judge WebSocket subscriptions (`/topic/battle/vote/{judgeId}`). One new computed property (`voteCountDisplay`) is added; everything else reads existing state.
+
+**Tech Stack:** Vue 3 (Composition API, `<script setup>`), Tailwind CSS, existing design system utilities (`para-chip-sm`, `semantic-chip-success`, `type-label`, `type-body`, `section-rule`)
+
+---
+
+## File Map
+
+| Action | Path | What changes |
+|--------|------|-------------|
+| Modify | `BES-frontend/src/views/BattleControl.vue` | New computed + 3 template changes |
+
+No new files. No backend changes.
+
+---
+
+### Task 1: Add `voteCountDisplay` computed
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue` (after line 902, inside `<script setup>`)
+
+- [ ] **Step 1: Locate insertion point**
+
+Open `BattleControl.vue`. Find the `showFinalReveal` computed ending at line 902:
+```js
+const showFinalReveal = computed(() =>
+  battlePhase.value === 'VOTING' &&
+  isFinalInProgress.value &&
+  allJudgesVoted.value &&
+  tentativeWinner.value !== -1
+)
+```
+The new computed goes immediately after this block.
+
+- [ ] **Step 2: Insert `voteCountDisplay` computed**
+
+After the closing `)` of `showFinalReveal` (line 902), add:
+```js
+
+const voteCountDisplay = computed(() => {
+  const judges = battleJudges.value?.judges ?? []
+  return {
+    left:  judges.filter(j => j.vote === 0).length,
+    right: judges.filter(j => j.vote === 1).length,
+  }
+})
+```
+
+- [ ] **Step 3: Verify no lint errors**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | grep -E "error|warn" | head -20
+```
+Expected: no errors referencing `voteCountDisplay`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: add voteCountDisplay computed for judge tally"
+```
+
+---
+
+### Task 2: Add judge vote panel template
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue` (template, after line 2488)
+
+The panel goes between the winner announcement bar and the match pairs grid. It is always rendered — no phase guard — so the organiser sees judge status regardless of phase.
+
+- [ ] **Step 1: Locate insertion point**
+
+Find this comment in the template (around line 2489):
+```html
+      <!-- Match pairs (standard) — only shown when viewing the active round -->
+```
+The new panel is inserted **immediately before** this comment.
+
+- [ ] **Step 2: Insert the judge vote panel**
+
+Paste the following block before `<!-- Match pairs (standard) -->`:
+```html
+      <!-- Judge vote panel — real-time via per-judge WS subscriptions, always visible -->
+      <div class="mb-4">
+        <div class="section-rule mb-3">
+          <span class="section-rule-label" style="font-size:9px;letter-spacing:0.22em">Judges</span>
+          <div class="section-rule-line"></div>
+        </div>
+
+        <!-- Judge cards grid -->
+        <template v-if="battleJudges?.judges?.length">
+          <div
+            class="grid gap-2 mb-3"
+            :style="`grid-template-columns: repeat(${battleJudges.judges.length}, 1fr)`"
+          >
+            <div
+              v-for="judge in battleJudges.judges"
+              :key="judge.id"
+              class="p-2 text-center"
+              style="clip-path:polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%);border-left:2px solid"
+              :style="judge.vote === -3
+                ? 'border-color:rgba(245,158,11,0.5);background:rgba(245,158,11,0.06)'
+                : judge.vote === 0
+                  ? 'border-color:rgba(52,211,153,0.5);background:rgba(52,211,153,0.06)'
+                  : 'border-color:rgba(59,130,246,0.5);background:rgba(59,130,246,0.06)'"
+            >
+              <div class="type-label text-content-muted mb-1" style="font-size:9px;letter-spacing:0.14em">
+                {{ judge.judgeName }}
+              </div>
+              <div
+                class="type-body"
+                style="font-size:10px;letter-spacing:0.06em"
+                :class="judge.vote === -3 ? 'text-amber-400' : judge.vote === 0 ? 'text-emerald-400' : 'text-blue-400'"
+              >
+                <template v-if="judge.vote === -3">⏳ WAITING</template>
+                <template v-else-if="judge.vote === 0">{{ currentBattlePair?.[0] ?? 'LEFT' }}</template>
+                <template v-else>{{ currentBattlePair?.[1] ?? 'RIGHT' }}</template>
+              </div>
+            </div>
+          </div>
+
+          <!-- Winner preview — shown when all judges have cast a vote -->
+          <template v-if="allJudgesVoted">
+            <!-- Clear winner -->
+            <div
+              v-if="tentativeWinner !== -1"
+              class="semantic-chip-success px-3 py-2"
+            >
+              <div class="type-label text-emerald-400 mb-1" style="font-size:9px;letter-spacing:0.18em">
+                WINNER PREVIEW (ORGANISER ONLY)
+              </div>
+              <div class="type-body text-emerald-400" style="font-size:13px">
+                {{ tentativeWinner === 0 ? (currentBattlePair?.[0] ?? 'LEFT') : (currentBattlePair?.[1] ?? 'RIGHT') }}
+              </div>
+              <div class="type-label text-content-muted mt-1" style="font-size:9px">
+                {{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}
+              </div>
+            </div>
+            <!-- Tie -->
+            <div
+              v-else
+              class="px-3 py-2"
+              style="border-left:3px solid #6b7280;background:rgba(107,114,128,0.08)"
+            >
+              <div class="type-label mb-1" style="font-size:9px;letter-spacing:0.18em;color:#9ca3af">
+                WINNER PREVIEW
+              </div>
+              <div class="type-body" style="font-size:13px;color:#9ca3af">
+                TIE — {{ voteCountDisplay.left }} – {{ voteCountDisplay.right }}
+              </div>
+              <div class="type-label text-content-muted mt-1" style="font-size:9px">Rematch required</div>
+            </div>
+          </template>
+        </template>
+
+        <!-- Empty state: no judges assigned -->
+        <div
+          v-else
+          class="type-label text-content-muted px-3 py-2"
+          style="font-size:10px;letter-spacing:0.14em;background:rgba(255,255,255,0.02);clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
+        >
+          No judges assigned for this battle
+        </div>
+      </div>
+```
+
+- [ ] **Step 3: Build to verify no template errors**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | grep -E "error|Error" | head -20
+```
+Expected: clean build with no errors.
+
+- [ ] **Step 4: Manual verify — start dev server and open BattleControl**
+
+```bash
+cd BES-frontend && npm run dev
+```
+Navigate to `/battle/control`. Check:
+- "JUDGES" section rule appears below the winner bar in the Live Match card
+- Judge cards are in a horizontal grid
+- If no judges assigned: "No judges assigned" muted row shows
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: add real-time judge vote panel to Live Match card"
+```
+
+---
+
+### Task 3: Gate GET SCORE button until all judges voted
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue` (template, around line 2558)
+
+- [ ] **Step 1: Locate the GET SCORE button**
+
+Find this block (around line 2557):
+```html
+        <!-- VOTING: non-final, not all voted, or tie → Get Score / Rematch -->
+        <button
+          v-if="battlePhase === 'VOTING' && !showFinalReveal"
+          @click="submitGetScore"
+          class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+        >
+          <i class="pi pi-bolt text-xs"></i>
+          {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}
+        </button>
+```
+
+- [ ] **Step 2: Replace with disabled-aware version**
+
+Replace the block above with:
+```html
+        <!-- VOTING: non-final → Get Score / Rematch (disabled until all judges voted) -->
+        <button
+          v-if="battlePhase === 'VOTING' && !showFinalReveal"
+          :disabled="!allJudgesVoted"
+          @click="submitGetScore"
+          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+          :class="allJudgesVoted
+            ? 'bg-accent'
+            : 'text-content-muted cursor-not-allowed opacity-50'"
+          :style="!allJudgesVoted ? 'background:rgba(255,255,255,0.04);border-color:rgba(255,255,255,0.08)' : ''"
+          :title="allJudgesVoted ? '' : 'Waiting for all judges to vote'"
+        >
+          <i class="pi pi-bolt text-xs"></i>
+          {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}
+        </button>
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | grep -E "error|Error" | head -20
+```
+Expected: clean build.
+
+- [ ] **Step 4: Manual verify**
+
+With dev server running, open `/battle/control` in VOTING phase:
+- Before all judges vote: GET SCORE button should be visually muted and unclickable (`:disabled` prevents click)
+- After all judges vote (watch the judge panel update in real-time): GET SCORE button should become active white
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: disable GET SCORE button until all judges have voted"
+```
+
+---
+
+### Task 4: Upgrade DECIDED-phase winner bar to champion locked display
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue` (template, lines 2472–2488)
+
+- [ ] **Step 1: Locate the winner announcement block**
+
+Find this block (around line 2472):
+```html
+      <!-- Winner announcement -->
+      <div
+        class="px-4 py-3 mb-4"
+        :class="{
+          'semantic-chip-warning': winnerVariant === 'ongoing',
+          'semantic-chip-warning': winnerVariant === 'wait',
+          'semantic-chip-success': winnerVariant === 'winner',
+          'border-l-3 border-gray-400 bg-gray-500/10': winnerVariant === 'tie',
+        }"
+      >
+        <div
+          class="w-2 h-2 rounded-full mb-1"
+          :class="winnerVariant === 'winner' ? 'bg-emerald-400' : winnerVariant === 'tie' ? 'bg-gray-400' : 'bg-amber-400'"
+          :style="winnerVariant === 'winner' ? 'box-shadow:0 0 8px rgba(52,211,153,0.8)' : winnerVariant === 'tie' ? '' : 'box-shadow:0 0 8px rgba(245,158,11,0.8)'"
+        ></div>
+        <span class="type-body text-content-primary">{{ winnerAnnouncement }}</span>
+      </div>
+```
+
+- [ ] **Step 2: Replace with phase-conditional champion display**
+
+Replace the entire block above with:
+```html
+      <!-- DECIDED: champion locked display -->
+      <div
+        v-if="battlePhase === 'DECIDED'"
+        class="px-4 py-3 mb-4"
+        style="border-left:4px solid #34d399;background:rgba(52,211,153,0.08)"
+      >
+        <div class="type-label text-emerald-400 mb-1" style="font-size:9px;letter-spacing:0.22em">
+          ⭐ CHAMPION LOCKED
+        </div>
+        <div
+          class="type-body text-emerald-400"
+          style="font-size:18px;letter-spacing:0.12em;font-weight:bold;text-shadow:0 0 12px rgba(52,211,153,0.4)"
+        >
+          {{ genreChampions[selectedGenre] ?? currentGenreChampion ?? '—' }}
+        </div>
+        <div
+          v-if="!revealActive"
+          class="type-label text-content-muted mt-1"
+          style="font-size:9px;letter-spacing:0.1em"
+        >
+          FINAL · ORGANISER ONLY — NOT REVEALED YET
+        </div>
+      </div>
+
+      <!-- Winner announcement — all phases except DECIDED -->
+      <div
+        v-else
+        class="px-4 py-3 mb-4"
+        :class="{
+          'semantic-chip-warning': winnerVariant === 'ongoing',
+          'semantic-chip-warning': winnerVariant === 'wait',
+          'semantic-chip-success': winnerVariant === 'winner',
+          'border-l-3 border-gray-400 bg-gray-500/10': winnerVariant === 'tie',
+        }"
+      >
+        <div
+          class="w-2 h-2 rounded-full mb-1"
+          :class="winnerVariant === 'winner' ? 'bg-emerald-400' : winnerVariant === 'tie' ? 'bg-gray-400' : 'bg-amber-400'"
+          :style="winnerVariant === 'winner' ? 'box-shadow:0 0 8px rgba(52,211,153,0.8)' : winnerVariant === 'tie' ? '' : 'box-shadow:0 0 8px rgba(245,158,11,0.8)'"
+        ></div>
+        <span class="type-body text-content-primary">{{ winnerAnnouncement }}</span>
+      </div>
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | grep -E "error|Error" | head -20
+```
+Expected: clean build.
+
+- [ ] **Step 4: Manual verify**
+
+With dev server running, trigger DECIDED phase on `/battle/control`:
+- Winner bar should show green left-border, "⭐ CHAMPION LOCKED" label, champion name with green glow, "NOT REVEALED YET" disclaimer
+- After clicking "Reveal Champion": disclaimer disappears (`revealActive` becomes true)
+- Navigating away from DECIDED (e.g. genre switch back to VOTING): normal amber/green winner bar returns
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: upgrade DECIDED phase winner bar to champion locked display"
+```
+
+---
+
+### Task 5: End-to-end smoke test + push
+
+- [ ] **Step 1: Full build check**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -5
+```
+Expected: `✓ built in Xs` with no errors.
+
+- [ ] **Step 2: Run existing tests**
+
+```bash
+cd BES-frontend && npm test 2>&1 | tail -20
+```
+Expected: all tests pass (no new tests were added — computed is trivial).
+
+- [ ] **Step 3: Manual E2E walkthrough**
+
+With dev server running (`npm run dev`), go through each phase on `/battle/control`:
+
+| Phase | What to check |
+|-------|--------------|
+| IDLE | Judge panel visible, all showing ⏳ WAITING; normal winner bar shows |
+| LOCKED | Same as IDLE |
+| VOTING (some pending) | Some judges show amber WAITING, voted judges show battler name; GET SCORE disabled |
+| VOTING (all voted, winner) | All judge cards show battler name; green winner preview banner shows; GET SCORE active |
+| VOTING (all voted, tie) | All judge cards show battler name; gray TIE banner shows; GET SCORE active |
+| REVEALED | Judge panel visible; votes from previous round may show |
+| DECIDED | Green "CHAMPION LOCKED" bar with glowing champion name; "NOT REVEALED YET" shown; after Reveal Champion clicked, disclaimer hidden |
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin feat/battle-division-state-persistence
+gh pr create \
+  --title "feat: real-time judge vote transparency panel in BattleControl" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds horizontal judge vote panel to Live Match card (always visible, all phases)
+- Shows each judge's vote as battler name (teal = left, blue = right, amber = waiting) in real time via existing per-judge WebSocket subscriptions
+- Displays winner preview banner (name + tally) when all judges have voted; gray TIE state when split evenly
+- Gates GET SCORE button — disabled with muted styling until `allJudgesVoted` is true
+- Upgrades DECIDED-phase winner bar to green "CHAMPION LOCKED" display with glowing champion name and "NOT REVEALED YET" disclaimer
+
+Closes #49
+
+## Test plan
+- [ ] IDLE/LOCKED: panel visible, all judges show WAITING
+- [ ] VOTING partial: pending judges show amber WAITING, voted judges show battler name; GET SCORE disabled
+- [ ] VOTING all voted (winner): winner preview banner appears with name + tally; GET SCORE enabled
+- [ ] VOTING all voted (tie): gray TIE banner appears; GET SCORE enabled
+- [ ] DECIDED: green champion locked bar, glowing name; disclaimer hides after Reveal Champion
+- [ ] Build passes: `npm run build` clean
+- [ ] Tests pass: `npm test` green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-06-03-battle-control-judge-transparency-design.md
+++ b/docs/superpowers/specs/2026-06-03-battle-control-judge-transparency-design.md
@@ -1,0 +1,185 @@
+# Design Spec: Real-time Judge Vote Transparency Panel
+**Issue:** #49  
+**Branch:** `feat/battle-division-state-persistence`  
+**Date:** 2026-06-03
+
+---
+
+## Overview
+
+Add a horizontal judge vote panel to the Live Match card in `BattleControl.vue` so the organiser can see each judge's vote in real time during a battle. The panel also drives GET SCORE gating and upgrades the champion display in DECIDED phase.
+
+No backend changes required. All data flows through the existing `battleJudges` ref and per-judge WebSocket subscriptions already in place.
+
+---
+
+## Scope
+
+Frontend only — `BattleControl.vue` is the only file that changes.
+
+---
+
+## Design Decisions (confirmed with user)
+
+| Decision | Choice |
+|----------|--------|
+| Panel layout | Horizontal grid — one card per judge |
+| Vote label | Battler **name** (not LEFT / RIGHT) |
+| Pending | Amber "⏳ WAITING" |
+| Left vote | Teal — `currentBattlePair[0]` name |
+| Right vote | Blue — `currentBattlePair[1]` name |
+| Winner preview | Green banner + name + tally when `allJudgesVoted`; gray "TIE" otherwise |
+| Champion display | Upgrade existing winner bar in DECIDED phase (Option A: green glow + star label) |
+| GET SCORE gate | Disabled until `allJudgesVoted === true` |
+| Phase visibility | Panel always visible (IDLE through DECIDED) |
+
+---
+
+## Data Model
+
+Existing refs/computeds used (no new state needed):
+
+| Source | Shape | Notes |
+|--------|-------|-------|
+| `battleJudges.value.judges` | `[{ id, judgeName, vote }]` | `vote`: `-3` = pending, `0` = left, `1` = right |
+| `currentBattlePair.value` | `[leftName, rightName]` | `undefined` when no active battle |
+| `allJudgesVoted` | `boolean` | Already computed; gates GET SCORE |
+| `tentativeWinner` | `-2 \| -1 \| 0 \| 1` | `-2` = pending, `-1` = tie, `0` = left, `1` = right |
+| `genreChampions[selectedGenre]` | `string \| undefined` | Champion name locked by `lockChampion()` |
+| `battlePhase` | `string` | IDLE / LOCKED / VOTING / REVEALED / DECIDED |
+| `revealActive` | `boolean` | True after organiser clicks Reveal Champion |
+
+### New derived computeds
+
+**`voteCountDisplay`** — for the winner preview tally (e.g. "2 – 1"):
+```js
+const voteCountDisplay = computed(() => {
+  const judges = battleJudges.value?.judges ?? []
+  const left  = judges.filter(j => j.vote === 0).length
+  const right = judges.filter(j => j.vote === 1).length
+  return { left, right }
+})
+```
+
+No other new computeds are needed — `allJudgesVoted`, `tentativeWinner`, and `currentBattlePair` already carry everything else.
+
+---
+
+## Template Changes
+
+### 1. Judge vote panel
+
+**Position:** Inside the Live Match card, inserted **after** the winner announcement bar and **before** the match-pairs grid. No `v-if` guard — always rendered when the Live Match card is visible.
+
+**Structure:**
+
+```
+[Judge A card] [Judge B card] [Judge C card]   ← grid-cols-N, N = judge count
+[Winner preview banner]                         ← shown only when allJudgesVoted
+```
+
+**Judge card states:**
+
+| State | Border | Label text | Label color |
+|-------|--------|-----------|-------------|
+| Pending (`vote === -3`) | `#f59e0b` (amber) | ⏳ WAITING | amber-400 |
+| Left voted (`vote === 0`) | `#34d399` (teal) | `currentBattlePair[0]` | emerald-400 |
+| Right voted (`vote === 1`) | `#3b82f6` (blue) | `currentBattlePair[1]` | blue-400 |
+
+When `currentBattlePair` is undefined (no active battle), fall back to "LEFT" / "RIGHT" as labels for voted judges.
+
+**Winner preview banner** (shown when `allJudgesVoted`):
+- Clear winner: green left-border chip, `tentativeWinner === 0 ? currentBattlePair[0] : currentBattlePair[1]`, tally `"${voteCountDisplay.left} – ${voteCountDisplay.right}"`
+- Tie: gray left-border chip, "TIE — N – N", "Rematch required"
+
+Empty state (no judges assigned): render a single muted row "No judges assigned for this battle."
+
+### 2. GET SCORE button — disable until all judges voted
+
+Existing button at line ~2558:
+```html
+<button v-if="battlePhase === 'VOTING' && !showFinalReveal" @click="submitGetScore" ...>
+```
+
+Add `:disabled="!allJudgesVoted"` and conditional styling:
+- **Enabled** (`allJudgesVoted`): current `bg-accent` style
+- **Disabled** (`!allJudgesVoted`): muted surface, `cursor-not-allowed`, `opacity-50`
+
+No change to the button's `v-if` condition — it still only appears in VOTING phase for non-final battles.
+
+### 3. Champion display — DECIDED phase winner bar upgrade
+
+The existing winner announcement bar (lines 2472–2488) renders for all phases. When `battlePhase === 'DECIDED'`, replace it with an upgraded "CHAMPION LOCKED" variant.
+
+**Condition:** `battlePhase === 'DECIDED'`  
+**Champion name:** `genreChampions[selectedGenre] ?? currentGenreChampion ?? '—'`
+
+Upgraded bar (Option A — green glow + star label):
+```
+┌─────────────────────────────────────────────────────┐
+│ ⭐ CHAMPION LOCKED                                   │ ← 9px, emerald-400, letter-spacing 3px
+│                                                     │
+│ CREW ALPHA                                          │ ← 18px, emerald-400, text-shadow glow
+│                                                     │
+│ FINAL · ORGANISER ONLY — NOT REVEALED YET           │ ← 9px, content-muted (hidden after reveal)
+└─────────────────────────────────────────────────────┘
+```
+
+Styling: `border-l-4 border-emerald-400 bg-emerald-400/10`, champion name `text-shadow: 0 0 12px rgba(52,211,153,0.4)`.
+
+After `revealActive` becomes true, the "NOT REVEALED YET" disclaimer is hidden.
+
+The normal winner announcement bar continues to render as-is for all other phases (IDLE, LOCKED, VOTING, REVEALED).
+
+---
+
+## Implementation Plan
+
+All changes are in a single section of `BattleControl.vue`.
+
+### Script additions (top of `<script setup>`)
+
+```js
+const voteCountDisplay = computed(() => {
+  const judges = battleJudges.value?.judges ?? []
+  return {
+    left:  judges.filter(j => j.vote === 0).length,
+    right: judges.filter(j => j.vote === 1).length,
+  }
+})
+```
+
+### Template additions
+
+**A.** After the winner announcement bar `</div>` (line ~2488), before `<!-- Match pairs (standard) -->` (line 2490):
+
+Insert the judge grid panel and winner preview banner.
+
+**B.** On the GET SCORE button (~line 2558):
+
+Add `:disabled="!allJudgesVoted"` and dynamic class for enabled/disabled styling.
+
+**C.** The winner announcement bar block (lines 2472–2488):
+
+Wrap in `<template v-else>` paired with a `<template v-if="battlePhase === 'DECIDED'">` that renders the upgraded champion display.
+
+---
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|---------|
+| No judges assigned | Panel shows "No judges assigned" muted row |
+| All judges voted but no active pair | Voted labels fall back to LEFT / RIGHT |
+| DECIDED phase, champion cleared (Unlock) | Falls back gracefully to `'—'` |
+| revealActive during DECIDED | "NOT REVEALED YET" disclaimer hidden |
+| Smoke format | Panel renders the same way (smoke uses same judge pool) |
+
+---
+
+## Non-Goals
+
+- No backend changes
+- No new files
+- No change to WebSocket subscription logic (already per-judge real-time)
+- No change to BattleOverlay, BattleJudge, or BracketVisualization


### PR DESCRIPTION
## Summary
- Adds horizontal judge vote panel to Live Match card in BattleControl — visible in all phases (IDLE through DECIDED)
- Each judge card shows their name + vote as battler name (left/right side colors from overlay config), amber ⏳ WAITING when pending
- Winner preview banner (name + tally) appears when all judges voted; gray TIE banner on split
- GET SCORE button disabled until all judges have voted, real-time via existing WS subscriptions
- DECIDED phase: upgrades winner bar to green "CHAMPION LOCKED" display with glowing champion name and "NOT REVEALED YET" disclaimer
- BattleJudge: debounce identity clear (2.5s) so judges are not prompted to re-identify on genre switch when both genres share the same judge set
- Fix: duplicate "Dismiss Reveal" button in DECIDED phase
- Fix: judge votes reset locally on next/prev match for immediate UI feedback

Closes #49

## Test plan
- [ ] IDLE/LOCKED: JUDGES panel visible, all cards show amber WAITING
- [ ] VOTING partial: voted judges show battler name in overlay color; GET SCORE disabled
- [ ] VOTING all voted (winner): green winner preview with name + tally; GET SCORE enabled
- [ ] VOTING all voted (tie): gray TIE banner; GET SCORE enabled
- [ ] Next match: judge cards immediately flip to WAITING
- [ ] DECIDED: green champion locked bar with glowing name; disclaimer hides after Reveal Champion
- [ ] Only one Dismiss Reveal button visible in DECIDED phase
- [ ] Switching genres with same judges: BattleJudge does not show identity picker
- [ ] `npm run build` and `npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)