### PR TITLE
ui: highlight active bracket pair with accent-color glow

### DIFF
--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -141,6 +141,12 @@ const currentBattlePair = computed(() => {
   return [left, right]
 })
 
+const isActivePair = (match) => {
+  if (!currentBattlePair.value || !match[0] || !match[1]) return false
+  const [a, b] = currentBattlePair.value
+  return (match[0] === a && match[1] === b) || (match[0] === b && match[1] === a)
+}
+
 const updateSmokePair = async () => {
   currentBattle.value = [rounds.value[0], rounds.value[1], rounds.value.slice(2)]
   await updateSmokeList(rounds.value)
@@ -2181,6 +2187,9 @@ onUnmounted(() => {
                 v-for="(match, mIdx) in rounds[`Top${size}`]"
                 :key="mIdx"
                 class="card-hover p-3 relative flex items-stretch min-h-[44px]"
+                :style="isActivePair(match) && effectivePhase !== 'IDLE'
+                  ? 'border-left: 3px solid var(--accent-color); background: var(--accent-subtle); box-shadow: 0 0 0 1px var(--accent-muted), 0 0 18px var(--accent-subtle);'
+                  : ''"
               >
                 <div class="corner-bar-tl"></div>
                 <!-- Slot 0 — left -->

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -782,7 +782,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   border-bottom: 1px solid var(--c-connector);
   pointer-events: none; z-index: 1;
 }
-.match-active.pair-group::after { border-color: rgba(255,255,255,0.3); }
+.match-active.pair-group::after { border-color: color-mix(in srgb, var(--accent-color) 45%, transparent); }
 
 .match-wrap { flex: 1; display: flex; align-items: center; padding: 0 2px; }
 
@@ -798,9 +798,9 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   transition: background 0.25s, border-color 0.25s, box-shadow 0.25s;
 }
 .match-active .battler-slot {
-  background: rgba(255,255,255,0.05);
-  border-color: rgba(255,255,255,0.18);
-  box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 0 14px rgba(255,255,255,0.08);
+  background: color-mix(in srgb, var(--accent-color) 6%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 35%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-color) 12%, transparent), 0 0 16px color-mix(in srgb, var(--accent-color) 18%, transparent);
 }
 .slot-active-left {
   background: color-mix(in srgb, var(--left-color) 18%, transparent) !important;
@@ -895,8 +895,8 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .final-match .battler-slot { height: var(--final-slot-h, 58px); }
 .final-match .battler-name { font-size: 17px; letter-spacing: 0.06em; }
 .final-match.match-active .battler-slot {
-  border-color: rgba(255,255,255,0.3);
-  box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 0 16px rgba(255,255,255,0.1);
+  border-color: color-mix(in srgb, var(--accent-color) 45%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-color) 14%, transparent), 0 0 20px color-mix(in srgb, var(--accent-color) 22%, transparent);
 }
 .final-vs {
   text-align: center;


### PR DESCRIPTION
## Summary
- `.match-active .battler-slot` border/background/box-shadow now uses `color-mix(in srgb, var(--accent-color) …, transparent)` instead of hardcoded white `rgba(255,255,255,…)` values
- `.match-active.pair-group::after` connector lines use accent color at 45% mix
- `.final-match.match-active .battler-slot` gets the same treatment with a slightly stronger glow (20px spread vs 16px)
- Individual slots still override with their side colors (`.slot-active-left`/`.slot-active-right`) — those are unchanged

## Test plan
- [ ] Open `/battle/bracket` with an active match running
- [ ] Verify the active match slots show the accent-colored border glow (not plain white)
- [ ] Verify the bracket connector lines for the active pair show accent color
- [ ] Verify changing the accent color in Admin updates the bracket glow live
- [ ] Verify non-active matches remain unstyled
- [ ] `npm run build` passes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)