### PR TITLE
fix: smooth 7-to-smoke column transitions and fix smoke-mode JSON display

### DIFF
--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -141,6 +141,15 @@ const currentBattlePair = computed(() => {
   return [left, right]
 })
 
+// Smoke mode pair entries are objects {name, score}; standard mode entries are strings.
+// This computed always returns [string|null, string|null] so templates are uniform.
+const currentBattlePairNames = computed(() => {
+  const pair = currentBattlePair.value
+  if (!pair) return [null, null]
+  const n = (p) => (p && typeof p === 'object') ? p.name : p
+  return [n(pair[0]), n(pair[1])]
+})
+
 const isActivePair = (match) => {
   if (!currentBattlePair.value || !match[0] || !match[1]) return false
   const [a, b] = currentBattlePair.value
@@ -2579,12 +2588,12 @@ onUnmounted(() => {
               v-else-if="judge.vote === 0"
               class="type-body"
               :style="{ fontSize: '13px', color: overlayConfig.leftColor }"
-            >{{ currentBattlePair?.[0] ?? 'LEFT' }}</div>
+            >{{ currentBattlePairNames?.[0] ?? 'LEFT' }}</div>
             <div
               v-else-if="judge.vote === 1"
               class="type-body"
               :style="{ fontSize: '13px', color: overlayConfig.rightColor }"
-            >{{ currentBattlePair?.[1] ?? 'RIGHT' }}</div>
+            >{{ currentBattlePairNames?.[1] ?? 'RIGHT' }}</div>
           </div>
         </div>
         <!-- Winner preview banner when all judges have voted -->
@@ -2598,7 +2607,7 @@ onUnmounted(() => {
         >
           <div class="type-label mb-2" style="font-size:9px;letter-spacing:0.18em" :style="{ color: tentativeWinner === 0 ? overlayConfig.leftColor : overlayConfig.rightColor }">WINNER PREVIEW (ORGANISER ONLY)</div>
           <div class="type-body" style="font-size:20px;letter-spacing:0.08em;font-weight:bold" :style="{ color: tentativeWinner === 0 ? overlayConfig.leftColor : overlayConfig.rightColor }">
-            {{ tentativeWinner === 0 ? (currentBattlePair?.[0] ?? 'LEFT') : (currentBattlePair?.[1] ?? 'RIGHT') }}
+            {{ tentativeWinner === 0 ? (currentBattlePairNames?.[0] ?? 'LEFT') : (currentBattlePairNames?.[1] ?? 'RIGHT') }}
           </div>
           <div class="type-label text-content-muted mt-1" style="font-size:13px;letter-spacing:0.06em">{{ voteWeightDisplay.left }} – {{ voteWeightDisplay.right }}</div>
         </div>

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -38,6 +38,19 @@ let unmounted = false
 const activeLeft  = computed(() => smokeParticipants.value[0] ?? null)
 const activeRight = computed(() => smokeParticipants.value[1] ?? null)
 
+// Flatten participants + stable spacer entries so TransitionGroup FLIP has a unique
+// key per DOM node — prevents vs-chip/queue-gap from sharing keys with their
+// surrounding participant and causing jitter during queue reorders.
+const chartItems = computed(() => {
+  const result = []
+  smokeParticipants.value.forEach((p, idx) => {
+    if (idx === 1) result.push({ _type: 'vs',  _key: '__vs__' })
+    if (idx === 2) result.push({ _type: 'gap', _key: '__gap__' })
+    result.push({ _type: 'col', _key: p.name, _idx: idx, name: p.name, score: p.score })
+  })
+  return result
+})
+
 // ── Score pop: watch for score increases ────────────────────────────────────
 watch(
   smokeParticipants,
@@ -202,21 +215,18 @@ onBeforeUnmount(() => {
     <!-- Bar chart -->
     <div class="smoke-chart">
       <TransitionGroup tag="div" name="col" class="smoke-cols">
-        <template v-for="(item, idx) in smokeParticipants" :key="item.name">
-          <!-- VS chip between position 0 and 1 -->
-          <div v-if="idx === 1" class="vs-chip" aria-hidden="true">VS</div>
-
-          <!-- Queue gap spacer between position 1 and 2 -->
-          <div v-if="idx === 2" class="queue-gap" aria-hidden="true"></div>
-
-          <!-- Fighter column -->
-          <div
-            class="smoke-col"
-            :class="{
-              'col-active-left':  idx === 0,
-              'col-active-right': idx === 1,
-            }"
-          >
+        <div
+          v-for="item in chartItems"
+          :key="item._key"
+          :class="
+            item._type === 'vs'  ? 'vs-chip' :
+            item._type === 'gap' ? 'queue-gap' :
+            ['smoke-col', { 'col-active-left': item._idx === 0, 'col-active-right': item._idx === 1 }]
+          "
+          :aria-hidden="item._type !== 'col' ? 'true' : undefined"
+        >
+          <template v-if="item._type === 'vs'">VS</template>
+          <template v-else-if="item._type === 'col'">
             <div class="bar-wrap">
               <div
                 class="bar"
@@ -226,17 +236,11 @@ onBeforeUnmount(() => {
               ></div>
             </div>
             <div class="dots-row" aria-hidden="true">
-              <div
-                v-for="d in 7"
-                :key="d"
-                class="dot"
-                :class="{ filled: d <= item.score }"
-              ></div>
+              <div v-for="d in 7" :key="d" class="dot" :class="{ filled: d <= item.score }"></div>
             </div>
             <div class="col-name">{{ item.name }}</div>
-            <div v-if="idx >= 2" class="queue-pos" aria-label="Queue position">#{{ idx - 1 }}</div>
-          </div>
-        </template>
+          </template>
+        </div>
       </TransitionGroup>
 
       <!-- Design B: ghost names behind chart -->
@@ -402,6 +406,7 @@ body.transparent-page #app {
   height: 100%;
   /* Cap columns so full bars (7/7) only graze the bottom quarter of the ghost names */
   max-height: 68%;
+  will-change: transform;
 }
 
 /* ── Bar wrap + bar ───────────────────────────────────── */
@@ -496,15 +501,6 @@ body.transparent-page #app {
 .col-active-right .col-name {
   color: color-mix(in srgb, var(--right-color) 50%, #fff);
   text-shadow: 0 0 12px color-mix(in srgb, var(--right-color) 80%, transparent);
-}
-
-/* ── Queue position label ─────────────────────────────── */
-.queue-pos {
-  font-size: clamp(8px, 0.9vw, 11px);
-  letter-spacing: 0.18em;
-  color: rgba(255,255,255,0.22);
-  text-align: center;
-  margin-top: 1px;
 }
 
 /* ── VS chip ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Fixes laggy/jittery column transitions in the 7-to-smoke chart when queue reorders (drag-drop) or a battle starts
- Removes `#1`/`#2` queue position labels from chart columns
- Fixes raw JSON object rendering in BattleControl judge vote display and winner preview banner during 7-to-smoke mode

## Root causes fixed

**Chart.vue — FLIP jitter:** `vs-chip` and `queue-gap` spacers were rendered inside `<template v-for :key="item.name">`, sharing the same key as their surrounding participant. Vue's TransitionGroup FLIP records positions per-key before and after a DOM update — when the spacers' keys changed on every reorder, FLIP got confused and applied transforms to the wrong elements, causing the visible snap/gap/jitter.

**Fix:** Flatten `smokeParticipants` + spacers into a single `chartItems` computed array where every DOM node has its own stable key (`__vs__`, `__gap__`, or `participantName`). Spacers never move so they don't interfere with FLIP. Added `will-change: transform` to `.smoke-col` for GPU compositing.

**BattleControl.vue — raw JSON:** In smoke mode `currentBattlePair` returns objects `{name, score}` but the judge-vote panel and winner preview banner interpolated `currentBattlePair?.[0]` directly, rendering `{ "NAME": "...", "SCORE": 0 }`. Added `currentBattlePairNames` computed that normalises both modes to plain strings.

## Test plan
- [ ] Open `/battle/chart` in 7-to-smoke mode with 4+ participants
- [ ] Drag queue participants in BattleControl — columns should slide smoothly with no gap/snap
- [ ] Start a battle round — active-left/right columns should animate smoothly into position
- [ ] Confirm no `#1`/`#2` labels appear under queue columns
- [ ] In BattleControl judge panel, after judges vote, confirm names display (not JSON) for voted side
- [ ] Winner preview banner shows participant name (not JSON object)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)