### PR TITLE
feat: 7-to-smoke champion phase and state persistence (#55)

### DIFF
--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
-import { addBattleJudge, addBattleGuest, battleJudgeVote, clearBattlePair, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateJudgeWeightage, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, addBattleGuest, battleJudgeVote, clearBattlePair, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, getSmokeList, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateJudgeWeightage, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -997,6 +997,16 @@ const restoreAndBroadcastGenreBattle = async (genre) => {
       currentBattle.value = [resolvedIdx, pairList]
       saveGenreBattleState(genre)
     }
+  } else if (isSmoke.value) {
+    const smokeRes = await getSmokeList()
+    if (smokeRes?.list && Array.isArray(smokeRes.list)) {
+      rounds.value = smokeRes.list.map(b => ({ name: b.name, score: b.score }))
+      localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${genre}Rounds`, JSON.stringify(toRaw(rounds.value)))
+    }
+    if (state?.champion) {
+      genreChampions.value = { ...genreChampions.value, [genre]: state.champion }
+    }
+    saveGenreBattleState(genre)
   }
 }
 
@@ -1750,6 +1760,9 @@ onMounted(async () => {
       // switch can arrive after we've already switched back and set the correct phase.
       if (msg.genre && msg.genre !== selectedGenre.value) return
       battlePhase.value = msg.phase
+      if (msg.phase === 'DECIDED' && msg.champion) {
+        genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: msg.champion }
+      }
     })
     // NOTE: /topic/battle/judges is intentionally NOT subscribed here.
     // syncJudgesForGenre does multiple remove+add operations in sequence; each

--- a/BES/src/main/java/com/example/BES/models/BattleGenreState.java
+++ b/BES/src/main/java/com/example/BES/models/BattleGenreState.java
@@ -58,6 +58,9 @@ public class BattleGenreState {
     @Column(name = "champion")
     private String champion;
 
+    @Column(name = "smoke_list_json", columnDefinition = "TEXT")
+    private String smokeListJson;
+
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -106,6 +106,19 @@ public class BattleService {
         battlers = new ArrayList<>();
         for (Battler battler : dto.getBattlers()) battlers.add(battler);
         messagingTemplate.convertAndSend("/topic/battle/smoke", Map.of("battlers", battlers));
+        for (Battler battler : battlers) {
+            if (battler.getScore() != null && battler.getScore() >= 7) {
+                battlePhase = "DECIDED";
+                champion = battler.getName();
+                messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
+                    "phase", battlePhase,
+                    "genre", activeGenreName != null ? activeGenreName : "",
+                    "champion", champion
+                ));
+                break;
+            }
+        }
+        persistActiveState();
     }
 
     public void setBattlerPairService(SetBattlerPairDto dto) {
@@ -405,6 +418,7 @@ public class BattleService {
             s.setIsFinal(currentIsFinal);
             s.setBattlePhase(battlePhase);
             s.setChampion(champion);
+            s.setSmokeListJson(objectMapper.writeValueAsString(new ArrayList<>(battlers)));
             synchronized (judges) {
                 s.setJudgesJson(objectMapper.writeValueAsString(new ArrayList<>(judges)));
             }
@@ -437,6 +451,9 @@ public class BattleService {
             currentIsFinal = Boolean.TRUE.equals(s.getIsFinal());
             battlePhase = s.getBattlePhase() != null ? s.getBattlePhase() : "IDLE";
             champion = s.getChampion();
+            battlers = s.getSmokeListJson() != null
+                ? objectMapper.readValue(s.getSmokeListJson(), new TypeReference<List<Battler>>(){})
+                : new ArrayList<>();
             synchronized (judges) {
                 judges.clear();
                 if (s.getJudgesJson() != null) {
@@ -463,6 +480,7 @@ public class BattleService {
         currentIsFinal = false;
         battlePhase = "IDLE";
         champion = null;
+        battlers = new ArrayList<>();
         synchronized (judges) { judges.clear(); }
     }
 

--- a/BES/src/main/resources/db/migration/V30__add_smoke_list_to_battle_genre_state.sql
+++ b/BES/src/main/resources/db/migration/V30__add_smoke_list_to_battle_genre_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE battle_genre_state ADD COLUMN smoke_list_json TEXT;

--- a/docs/superpowers/specs/2026-06-03-smoke-champion-phase-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-03-smoke-champion-phase-persistence-design.md
@@ -1,0 +1,133 @@
+# 7-to-Smoke Champion Phase & State Persistence
+
+**Date:** 2026-06-03
+**Branch:** `feat/smoke-champion-phase-persistence`
+**Issue:** #55
+
+## Problem
+
+Two related gaps in the 7-to-smoke format:
+
+1. **No phase transition when a champion is crowned.** When a battler reaches 7 smokes, the backend never moves to `DECIDED`. The genre-switch guard checks `phase !== 'DECIDED'`, so switching genres while a smoke session is in progress always triggers the "battle in progress" warning even after a winner exists.
+
+2. **State not restored on genre switch-back.** The smoke battlers list (names + scores + queue order) is held in-memory on the backend but never persisted to `battle_genre_state`. On genre switch-back, BattleControl restores `rounds.value` from localStorage only — if localStorage is empty (new device, cleared storage, page reload), the queue shows blank.
+
+## Scope Constraint
+
+7-to-smoke uses a different code path from standard bracket formats (Top32/Top16). All changes are isolated to smoke-specific paths. `setScoreService()`, `setBattlerPairService()`, and the regular bracket flow are untouched.
+
+## What Is Not Changing
+
+- `Chart.vue` — already detects champion live (`score >= 7` in `updateList`) and restores from `getSmokeList()` on mount. No changes needed; it benefits automatically from backend persistence.
+- `BattleOverlay.vue`, `BracketVisualization.vue` — not touched.
+- The champion announcement flow — Chart.vue shows the overlay immediately when a battler hits 7. There is no "Reveal Champion" button for smoke; DECIDED is purely a state signal.
+- Regular bracket champion flow (`lockChampion`, `revealChampionForGenre`) — untouched.
+
+## Design
+
+### Backend
+
+#### V30 migration
+```sql
+ALTER TABLE battle_genre_state ADD COLUMN smoke_list_json TEXT;
+```
+
+#### `BattleGenreState.java`
+Add field:
+```java
+@Column(name = "smoke_list_json", columnDefinition = "TEXT")
+private String smokeListJson;
+```
+
+#### `BattleService.persistActiveState()`
+Serialize `battlers` alongside existing fields:
+```java
+s.setSmokeListJson(objectMapper.writeValueAsString(battlers));
+```
+
+#### `BattleService.loadGenreStateIntoMemory()`
+Restore `battlers` from `smokeListJson`; fall back to empty list if null:
+```java
+if (s.getSmokeListJson() != null) {
+    battlers = objectMapper.readValue(s.getSmokeListJson(), new TypeReference<List<Battler>>(){});
+} else {
+    battlers = new ArrayList<>();
+}
+```
+
+#### `BattleService.setSmokeBattlersService()`
+After updating `battlers` and broadcasting to `/topic/battle/smoke`, check for a champion:
+```java
+battlers.stream().filter(b -> b.getScore() >= 7).findFirst().ifPresent(champ -> {
+    champion = champ.getName();
+    battlePhase = "DECIDED";
+    messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
+        "phase", "DECIDED",
+        "genre", activeGenreName != null ? activeGenreName : "",
+        "champion", champion
+    ));
+    persistActiveState();
+});
+```
+
+The method already broadcasts the smoke list; this adds a conditional phase broadcast only when 7 smokes are reached. `persistActiveState()` is called to save both the champion name and the DECIDED phase.
+
+### Frontend — BattleControl.vue
+
+#### Phase WS handler (line ~1752)
+Extend to capture champion name when DECIDED arrives:
+```js
+battlePhase.value = msg.phase
+if (msg.phase === 'DECIDED' && msg.champion && selectedGenre.value) {
+    genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: msg.champion }
+}
+```
+The DECIDED panel (`{{ genreChampions[selectedGenre] ?? ... }}`) then displays the smoke winner's name immediately.
+
+#### `restoreAndBroadcastGenreBattle(genre)`
+Add a smoke branch alongside the existing standard bracket branch:
+```js
+} else if (isSmoke.value) {
+    const smokeList = await getSmokeList()
+    if (smokeList?.list?.length) {
+        rounds.value = smokeList.list
+        localStorage.setItem(
+            `Top${topSize.value}${selectedEvent.value}${genre}Rounds`,
+            JSON.stringify(smokeList.list)
+        )
+    }
+    if (state.champion) {
+        genreChampions.value = { ...genreChampions.value, [genre]: state.champion }
+    }
+}
+```
+This restores queue order and scores from the persisted backend list when localStorage is absent. The existing genre watcher defensive check (line 1551) already forces DECIDED if `genreChampions[newVal]` is populated.
+
+## Data Flow Summary
+
+### Live (smoke session in progress)
+1. Organiser clicks Get Score → BattleControl calls `update7toSmokeMatch(winner)` → `updateSmokeList(rounds.value)` → `POST /api/v1/battle/smoke`
+2. Backend `setSmokeBattlersService()`: updates `battlers`, broadcasts to `/topic/battle/smoke`
+3. **If any battler.score >= 7**: sets `champion`, `battlePhase=DECIDED`, broadcasts `{ phase, genre, champion }`, persists
+4. BattleControl phase WS handler: sets `battlePhase.value = 'DECIDED'`, sets `genreChampions[genre] = champion`
+5. Chart.vue `updateList()`: detects score >= 7, shows champion overlay
+
+### Genre switch-back
+1. Genre watcher fires `setActiveGenre()` → backend calls `loadGenreStateIntoMemory()` which now restores `battlers` from `smoke_list_json`
+2. `restoreAndBroadcastGenreBattle(genre)` smoke branch: calls `getSmokeList()`, populates `rounds.value` with correct scores + queue order
+3. If `state.battlePhase === 'DECIDED'` and `state.champion`: sets `battlePhase.value = 'DECIDED'`, sets `genreChampions[genre]`
+4. Genre watcher defensive check (line 1551): if `genreChampions[newVal]` present and phase != DECIDED, forces DECIDED
+
+### Chart.vue on mount / page reload
+1. `getSmokeList()` returns the persisted `battlers` (with correct scores)
+2. `smokeParticipants.value` populated with correct bar heights
+3. If any battler had score >= 7, `showChampion` fires immediately
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `BES/src/main/resources/db/migration/V30__add_smoke_list_to_battle_genre_state.sql` | New migration |
+| `BES/src/main/java/com/example/BES/models/BattleGenreState.java` | Add `smokeListJson` field |
+| `BES/src/main/java/com/example/BES/services/BattleService.java` | persist/restore battlers, champion detection in setSmokeBattlersService |
+| `BES-frontend/src/views/BattleControl.vue` | Phase WS handler + restoreAndBroadcastGenreBattle smoke branch |


### PR DESCRIPTION
## Summary
- Backend auto-transitions to `DECIDED` when a smoke battler reaches score ≥ 7, persisting champion name and broadcasting `{ phase, genre, champion }` via WebSocket
- New `smoke_list_json` column (V30 migration) persists the full smoke queue (names + scores + queue order) to `battle_genre_state` on every update — survives genre switches and backend restarts
- `BattleControl` genre switch-back now restores smoke queue from backend when localStorage is empty; phase WS handler captures champion name into `genreChampions` for the DECIDED panel display

## What is NOT changing
- `Chart.vue`, `BattleOverlay.vue`, `BracketVisualization.vue` — untouched
- Regular bracket flow (`setScoreService`, `setBattlerPairService`, `lockChampion`) — untouched
- Champion announcement: Chart.vue already shows the overlay immediately on score ≥ 7; no "Reveal Champion" button for smoke

## Test Plan
- [ ] Run smoke genre: confirm Chart.vue shows champion overlay the moment a battler hits 7
- [ ] Confirm BattleControl transitions to DECIDED and shows champion name in the glowing panel automatically
- [ ] Confirm genre-switch warning is suppressed after champion is crowned (phase = DECIDED)
- [ ] Switch away from smoke genre and back — confirm queue (scores + order) is fully restored
- [ ] Repeat switch-back in a new incognito tab (empty localStorage) — confirm backend restores state
- [ ] Run a regular Top16/Top32 bracket match end-to-end — confirm no regression
- [ ] 212 backend tests pass: `mvn test -f BES/pom.xml`

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)