### PR TITLE
feat: slide-over event panel, remove Events from nav (issue #60)

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -4,6 +4,7 @@ import { logout, whoami, getAppConfig } from './utils/api'
 import { createClient, deactivateClient, subscribeToChannel } from './utils/websocket'
 import { useAuthStore } from './utils/auth'
 import ActionDoneModal from './views/ActionDoneModal.vue'
+import EventPanel from './components/EventPanel.vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -67,25 +68,34 @@ const logoutNow = async () => {
 }
 
 const activeEvent = computed(() => authStore.activeEvent)
-const eventMenuOpen = ref(false)
+const panelOpen = ref(false)
+
+function handleKeydown(e) {
+  if (e.key === 'Escape') panelOpen.value = false
+}
 
 function changeEvent() {
-  eventMenuOpen.value = false
+  panelOpen.value = false
   router.push({ name: 'EventSelector', query: { redirect: router.currentRoute.value.fullPath } })
 }
 
 function goToSection(routeName) {
-  eventMenuOpen.value = false
+  panelOpen.value = false
   router.push({ name: routeName })
 }
 
 function goToEventDetails() {
-  eventMenuOpen.value = false
+  panelOpen.value = false
   if (activeEvent.value) router.push({
     name: 'Event Details',
     params: { eventName: activeEvent.value.name },
     query: activeEvent.value.folderID ? { folderID: activeEvent.value.folderID } : {}
   })
+}
+
+function goToAllEvents() {
+  panelOpen.value = false
+  router.push({ name: 'Event' })
 }
 
 // ── Theme ───────────────────────────────────────────────────────────────────
@@ -112,7 +122,7 @@ function toggleTheme() {
 // ── Watchers ───────────────────────────────────────────────────────────────
 watch(route, () => {
   isOpen.value = false
-  eventMenuOpen.value = false
+  panelOpen.value = false
 })
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
@@ -135,10 +145,12 @@ onMounted(async () => {
   subscribeToChannel(c, '/topic/app-config', (msg) => {
     if (msg?.accentColor) applyAccent(msg.accentColor)
   })
+  document.addEventListener('keydown', handleKeydown)
 })
 
 onUnmounted(() => {
   deactivateClient(wsAccentClient.value)
+  document.removeEventListener('keydown', handleKeydown)
 })
 </script>
 
@@ -173,14 +185,6 @@ onUnmounted(() => {
                 : 'text-content-muted hover:text-content-primary'"
             >Home</span>
           </router-link>
-          <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
-            <span
-              class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
-              :class="isActive
-                ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
-                : 'text-content-muted hover:text-content-primary'"
-            >Events</span>
-          </router-link>
           <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
             <span
               class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
@@ -191,110 +195,61 @@ onUnmounted(() => {
           </router-link>
         </div>
 
-        <!-- Right: event chip + role + theme + logout -->
-        <div class="hidden md:flex items-center gap-2">
+        <!-- Right: always-visible chip + desktop utilities + mobile hamburger -->
+        <div class="flex items-center gap-2">
 
-          <!-- Active event dropdown -->
-          <div v-if="isAuthenticated && activeEvent" class="relative">
+          <!-- Event chip — visible on all screen sizes -->
+          <div v-if="isAuthenticated" class="relative">
             <button
-              @click="eventMenuOpen = !eventMenuOpen"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[200px]"
+              v-if="activeEvent"
+              @click="panelOpen = !panelOpen"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[140px] md:max-w-[200px]"
             >
               <span class="truncate">{{ activeEvent.name }}</span>
-              <i class="pi pi-chevron-down text-[10px] flex-shrink-0 opacity-50 transition-transform duration-200"
-                 :class="eventMenuOpen ? 'rotate-180' : ''"></i>
+              <i class="pi pi-chevron-right text-[10px] flex-shrink-0 opacity-50 transition-transform duration-200"
+                 :class="panelOpen ? 'rotate-90' : ''"></i>
             </button>
-
-            <Transition
-              enter-active-class="transition duration-150 ease-out"
-              enter-from-class="opacity-0 translate-y-1"
-              enter-to-class="opacity-100 translate-y-0"
-              leave-active-class="transition duration-100 ease-in"
-              leave-from-class="opacity-100 translate-y-0"
-              leave-to-class="opacity-0 translate-y-1"
+            <button
+              v-else
+              @click="router.push({ name: 'EventSelector' })"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-muted hover:text-content-primary border border-[color:var(--accent-muted)] transition-all duration-200"
             >
-              <div v-if="eventMenuOpen"
-                class="absolute right-0 top-full mt-2 w-52 z-50 bg-surface-800 border border-[rgba(255,255,255,0.07)] shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden"
-                style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
-                @click.stop>
-                <div class="corner-bar-tl"></div>
-                <div class="px-3 py-2.5 border-b border-[rgba(255,255,255,0.07)]">
-                  <p class="type-label text-content-muted mb-0.5">Current Event</p>
-                  <p class="type-body text-content-primary truncate">{{ activeEvent.name }}</p>
-                </div>
-                <div class="py-1">
-                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-                    @click="goToEventDetails"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
-                    Event Details
-                  </button>
-                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'"
-                    @click="goToSection('Audition List')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
-                    Audition
-                  </button>
-                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-                    @click="goToSection('Update Event Details')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
-                    Participants
-                  </button>
-                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'"
-                    @click="goToSection('Score')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
-                    Scoreboard
-                  </button>
-                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-                    @click="goToSection('Battle Control')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
-                    Battle
-                  </button>
-                  <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'"
-                    @click="goToSection('Audition Adjust')"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-secondary hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
-                    Adjust Numbers
-                  </button>
-                </div>
-                <div class="border-t border-[rgba(255,255,255,0.07)] py-1">
-                  <button @click="changeEvent"
-                    class="w-full flex items-center gap-2.5 px-3 py-2 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors">
-                    Change Event
-                  </button>
-                </div>
-              </div>
-            </Transition>
-            <div v-if="eventMenuOpen" class="fixed inset-0 z-40 bg-black/20" @click="eventMenuOpen = false"></div>
+              Select Event →
+            </button>
           </div>
 
-          <div v-if="isAuthenticated" class="h-4 w-px bg-[rgba(255,255,255,0.12)]"></div>
+          <!-- Desktop-only utilities -->
+          <div class="hidden md:flex items-center gap-2">
+            <div v-if="isAuthenticated" class="h-4 w-px bg-[rgba(255,255,255,0.12)]"></div>
 
-          <!-- Role badge -->
-          <span v-if="isAuthenticated && roleDisplay"
-            class="badge-neutral type-label px-2 py-0.5">
-            {{ roleDisplay.label }}
-          </span>
+            <span v-if="isAuthenticated && roleDisplay"
+              class="badge-neutral type-label px-2 py-0.5">
+              {{ roleDisplay.label }}
+            </span>
 
-          <!-- Theme toggle -->
-          <button @click="toggleTheme"
-            class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
-            <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
+            <button @click="toggleTheme"
+              class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
+              <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
+            </button>
+
+            <router-link v-if="!isAuthenticated" to="/login">
+              <span class="px-4 py-1.5 para-chip type-label text-surface-900 bg-accent cursor-pointer">Login</span>
+            </router-link>
+
+            <button v-if="isAuthenticated"
+              @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
+              class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200">
+              <i class="pi pi-sign-out text-sm"></i>
+            </button>
+          </div>
+
+          <!-- Mobile hamburger -->
+          <button @click="isOpen = !isOpen"
+            class="md:hidden inline-flex items-center justify-center w-9 h-9 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-colors focus:outline-none">
+            <i class="pi text-lg" :class="isOpen ? 'pi-times' : 'pi-bars'"></i>
           </button>
 
-          <router-link v-if="!isAuthenticated" to="/login">
-            <span class="px-4 py-1.5 para-chip type-label text-surface-900 bg-accent cursor-pointer">Login</span>
-          </router-link>
-
-          <button v-if="isAuthenticated"
-            @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
-            class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200">
-            <i class="pi pi-sign-out text-sm"></i>
-          </button>
         </div>
-
-        <!-- Mobile Hamburger -->
-        <button @click="isOpen = !isOpen"
-          class="md:hidden inline-flex items-center justify-center w-9 h-9 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-colors focus:outline-none">
-          <i class="pi text-lg" :class="isOpen ? 'pi-times' : 'pi-bars'"></i>
-        </button>
 
       </div>
     </div>
@@ -316,12 +271,6 @@ onUnmounted(() => {
               Home
             </span>
           </router-link>
-          <router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
-            <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
-              :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
-              Events
-            </span>
-          </router-link>
           <router-link v-if="role === 'ROLE_ADMIN'" to="/admin" v-slot="{ isActive }">
             <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
               :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
@@ -329,40 +278,6 @@ onUnmounted(() => {
             </span>
           </router-link>
 
-          <template v-if="isAuthenticated && activeEvent">
-            <div class="px-4 pt-3 pb-1 section-rule">
-              <span class="section-rule-label">Current Event — {{ activeEvent.name }}</span>
-              <div class="section-rule-line"></div>
-            </div>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToEventDetails"
-              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
-              Event Details
-            </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE'" @click="goToSection('Audition List')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
-              Audition
-            </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToSection('Update Event Details')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
-              Participants
-            </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE'" @click="goToSection('Score')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
-              Scoreboard
-            </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToSection('Battle Control')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
-              Battle
-            </button>
-            <button v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" @click="goToSection('Audition Adjust')"
-              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-secondary hover:text-content-primary transition-colors">
-              Adjust Numbers
-            </button>
-            <button @click="changeEvent"
-              class="w-full flex items-center gap-3 px-4 py-2.5 type-label text-content-muted hover:text-content-primary transition-colors">
-              Change Event
-            </button>
-          </template>
         </div>
 
         <div class="px-3 py-3 border-t border-[rgba(255,255,255,0.07)]">
@@ -384,6 +299,47 @@ onUnmounted(() => {
             <span class="flex items-center justify-center px-4 py-2.5 type-label para-chip text-surface-900 bg-accent w-full cursor-pointer">Login</span>
           </router-link>
         </div>
+      </div>
+    </Transition>
+
+    <!-- Backdrop -->
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="panelOpen"
+        class="fixed inset-0 z-40 bg-black/50"
+        @click="panelOpen = false"
+      ></div>
+    </Transition>
+
+    <!-- Slide-over panel -->
+    <Transition
+      enter-active-class="transition-transform duration-200 ease-out"
+      enter-from-class="translate-x-full"
+      enter-to-class="translate-x-0"
+      leave-active-class="transition-transform duration-150 ease-in"
+      leave-from-class="translate-x-0"
+      leave-to-class="translate-x-full"
+    >
+      <div
+        v-if="panelOpen"
+        class="fixed top-0 right-0 h-full w-full md:w-[300px] z-50 bg-surface-800 border-l border-[rgba(255,255,255,0.07)] overflow-hidden flex flex-col"
+      >
+        <EventPanel
+          :role="role"
+          :activeEvent="activeEvent"
+          @close="panelOpen = false"
+          @navigate="goToSection"
+          @goToEventDetails="goToEventDetails"
+          @goToAllEvents="goToAllEvents"
+          @changeEvent="changeEvent"
+        />
       </div>
     </Transition>
 

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -1,0 +1,147 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { fetchAllEvents } from '@/utils/api'
+import { setActiveEvent } from '@/utils/auth'
+
+const props = defineProps({
+  role:        { type: String, required: true },
+  activeEvent: { type: Object, default: null },
+})
+
+const emit = defineEmits([
+  'close',
+  'navigate',
+  'goToEventDetails',
+  'goToAllEvents',
+  'changeEvent',
+])
+
+const ALL_TILES = [
+  { key: 'details',      icon: 'pi-cog',      label: 'Details',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+  { key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
+  { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+  { key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'] },
+  { key: 'battle',       icon: 'pi-bolt',      label: 'Battle',       roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_JUDGE'] },
+  { key: 'numbers',      icon: 'pi-hashtag',   label: 'Numbers',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+]
+
+const TILE_ROUTES = {
+  audition:     'Audition List',
+  participants: 'Update Event Details',
+  score:        'Score',
+  battle:       'Battle Control',
+  numbers:      'Audition Adjust',
+}
+
+const isAdminOrOrganiser = computed(() =>
+  props.role === 'ROLE_ADMIN' || props.role === 'ROLE_ORGANISER'
+)
+
+const visibleTiles = computed(() =>
+  ALL_TILES.filter(t => t.roles.includes(props.role))
+)
+
+function handleTile(tile) {
+  if (tile.key === 'details') {
+    emit('goToEventDetails')
+  } else {
+    emit('navigate', TILE_ROUTES[tile.key])
+  }
+  emit('close')
+}
+
+const allEvents    = ref([])
+const search       = ref('')
+
+const filteredEvents = computed(() =>
+  allEvents.value.filter(e =>
+    e.name.toLowerCase().includes(search.value.toLowerCase())
+  )
+)
+
+onMounted(async () => {
+  if (!isAdminOrOrganiser.value) return
+  allEvents.value = await fetchAllEvents() ?? []
+})
+
+function handleSwitchEvent(event) {
+  setActiveEvent(event.id, event.name)
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+
+    <div class="flex items-center justify-between px-4 py-3 border-b border-[rgba(255,255,255,0.07)] flex-shrink-0">
+      <div class="corner-bar-tl"></div>
+      <span class="type-body truncate pr-4">
+        {{ activeEvent ? activeEvent.name : 'No Event Selected' }}
+      </span>
+      <button data-close @click="emit('close')"
+        class="flex-shrink-0 text-content-muted hover:text-accent transition-colors">
+        <i class="pi pi-times text-sm"></i>
+      </button>
+    </div>
+
+    <div class="p-3 grid grid-cols-2 gap-2 flex-shrink-0">
+      <button
+        v-for="tile in visibleTiles"
+        :key="tile.key"
+        data-tile
+        @click="handleTile(tile)"
+        class="card-hover flex flex-col items-center gap-2 py-4 transition-all duration-150 hover:bg-[rgba(255,255,255,0.06)]"
+        style="min-height:56px"
+      >
+        <i class="pi text-lg text-accent" :class="tile.icon"></i>
+        <span class="type-label">{{ tile.label }}</span>
+      </button>
+    </div>
+
+    <template v-if="isAdminOrOrganiser">
+      <div class="flex-1 overflow-y-auto border-t border-[rgba(255,255,255,0.07)] p-3">
+        <div class="section-rule mb-3">
+          <span class="section-rule-label">Manage Events</span>
+          <div class="section-rule-line"></div>
+        </div>
+        <input
+          v-model="search"
+          type="text"
+          placeholder="Search events..."
+          class="input-base w-full mb-2"
+        />
+        <div class="space-y-0.5 mb-2">
+          <button
+            v-for="event in filteredEvents"
+            :key="event.id"
+            @click="handleSwitchEvent(event)"
+            class="w-full flex items-center gap-2 px-2 py-2 type-label text-left transition-colors hover:bg-[rgba(255,255,255,0.04)]"
+            :class="event.id === activeEvent?.id ? 'text-accent' : 'text-content-secondary'"
+          >
+            <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors"
+              :class="event.id === activeEvent?.id ? 'bg-accent' : 'bg-transparent border border-surface-600'">
+            </span>
+            <span class="truncate">{{ event.name }}</span>
+          </button>
+        </div>
+        <button
+          @click="emit('goToAllEvents'); emit('close')"
+          class="w-full text-left type-label text-content-muted hover:text-content-primary transition-colors px-2 py-2"
+        >
+          All Events →
+        </button>
+      </div>
+    </template>
+
+    <template v-else>
+      <div class="mt-auto border-t border-[rgba(255,255,255,0.07)] px-4 py-3">
+        <button
+          @click="emit('changeEvent'); emit('close')"
+          class="w-full type-label text-content-muted hover:text-content-primary transition-colors text-center py-1"
+        >
+          ↻ Change Event
+        </button>
+      </div>
+    </template>
+
+  </div>
+</template>

--- a/BES-frontend/src/utils/__tests__/EventPanel.test.js
+++ b/BES-frontend/src/utils/__tests__/EventPanel.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import EventPanel from '@/components/EventPanel.vue'
 

--- a/BES-frontend/src/utils/__tests__/EventPanel.test.js
+++ b/BES-frontend/src/utils/__tests__/EventPanel.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EventPanel from '@/components/EventPanel.vue'
+
+vi.mock('@/utils/api', () => ({
+  fetchAllEvents: vi.fn().mockResolvedValue([
+    { id: 1, name: 'Dance Battle 2025' },
+    { id: 2, name: 'Street Jam Vol.3' },
+  ]),
+}))
+
+vi.mock('@/utils/auth', () => ({
+  setActiveEvent: vi.fn(),
+}))
+
+const activeEvent = { id: 1, name: 'Dance Battle 2025', folderID: null }
+
+function mountPanel(role) {
+  return mount(EventPanel, {
+    props: { role, activeEvent },
+  })
+}
+
+describe('EventPanel.vue — section tiles', () => {
+  describe('Admin role', () => {
+    it('shows all 6 tiles', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tiles = w.findAll('[data-tile]')
+      expect(tiles).toHaveLength(6)
+    })
+
+    it('shows Details, Audition, Participants, Score, Battle, Numbers tiles', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const labels = w.findAll('[data-tile]').map(t => t.text())
+      expect(labels).toEqual(
+        expect.arrayContaining(['Details', 'Audition', 'Participants', 'Score', 'Battle', 'Numbers'])
+      )
+    })
+  })
+
+  describe('Organiser role', () => {
+    it('shows all 6 tiles', async () => {
+      const w = mountPanel('ROLE_ORGANISER')
+      await w.vm.$nextTick()
+      expect(w.findAll('[data-tile]')).toHaveLength(6)
+    })
+  })
+
+  describe('Emcee role', () => {
+    it('shows only Audition and Score tiles', async () => {
+      const w = mountPanel('ROLE_EMCEE')
+      await w.vm.$nextTick()
+      const labels = w.findAll('[data-tile]').map(t => t.text())
+      expect(labels).toEqual(expect.arrayContaining(['Audition', 'Score']))
+      expect(labels).not.toContain('Details')
+      expect(labels).not.toContain('Battle')
+      expect(labels).not.toContain('Participants')
+      expect(labels).not.toContain('Numbers')
+    })
+  })
+
+  describe('Judge role', () => {
+    it('shows only Audition and Battle tiles', async () => {
+      const w = mountPanel('ROLE_JUDGE')
+      await w.vm.$nextTick()
+      const labels = w.findAll('[data-tile]').map(t => t.text())
+      expect(labels).toEqual(expect.arrayContaining(['Audition', 'Battle']))
+      expect(labels).not.toContain('Score')
+      expect(labels).not.toContain('Details')
+      expect(labels).not.toContain('Participants')
+    })
+  })
+
+  describe('tile interactions', () => {
+    it('emits navigate with correct route when Audition tile clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tile = w.findAll('[data-tile]').find(t => t.text().includes('Audition'))
+      await tile.trigger('click')
+      expect(w.emitted('navigate')).toEqual([['Audition List']])
+      expect(w.emitted('close')).toBeTruthy()
+    })
+
+    it('emits navigate with Score route when Score tile clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tile = w.findAll('[data-tile]').find(t => t.text().includes('Score'))
+      await tile.trigger('click')
+      expect(w.emitted('navigate')).toEqual([['Score']])
+    })
+
+    it('emits goToEventDetails (not navigate) when Details tile clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tile = w.findAll('[data-tile]').find(t => t.text().includes('Details'))
+      await tile.trigger('click')
+      expect(w.emitted('goToEventDetails')).toBeTruthy()
+      expect(w.emitted('navigate')).toBeFalsy()
+      expect(w.emitted('close')).toBeTruthy()
+    })
+
+    it('emits close when header close button clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      await w.find('[data-close]').trigger('click')
+      expect(w.emitted('close')).toBeTruthy()
+    })
+  })
+})
+
+describe('EventPanel.vue — zones', () => {
+  it('Admin sees Manage Events zone', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Manage Events')
+    expect(w.text()).not.toContain('Change Event')
+  })
+
+  it('Organiser sees Manage Events zone', async () => {
+    const w = mountPanel('ROLE_ORGANISER')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Manage Events')
+  })
+
+  it('Emcee sees Change Event link, not Manage Events zone', async () => {
+    const w = mountPanel('ROLE_EMCEE')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Change Event')
+    expect(w.text()).not.toContain('Manage Events')
+  })
+
+  it('Judge sees Change Event link, not Manage Events zone', async () => {
+    const w = mountPanel('ROLE_JUDGE')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Change Event')
+    expect(w.text()).not.toContain('Manage Events')
+  })
+
+  it('Admin panel lists fetched events', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Dance Battle 2025')
+    expect(w.text()).toContain('Street Jam Vol.3')
+  })
+
+  it('active event is marked with accent class', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const activeRow = w.findAll('button').find(b => b.text().includes('Dance Battle 2025'))
+    expect(activeRow?.classes()).toContain('text-accent')
+  })
+
+  it('emits changeEvent when Change Event clicked (Emcee)', async () => {
+    const w = mountPanel('ROLE_EMCEE')
+    await w.vm.$nextTick()
+    const btn = w.findAll('button').find(b => b.text().includes('Change Event'))
+    await btn.trigger('click')
+    expect(w.emitted('changeEvent')).toBeTruthy()
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('emits goToAllEvents and close when All Events clicked', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const btn = w.findAll('button').find(b => b.text().includes('All Events'))
+    await btn.trigger('click')
+    expect(w.emitted('goToAllEvents')).toBeTruthy()
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('calls setActiveEvent when an event in the list is clicked', async () => {
+    const { setActiveEvent } = await import('@/utils/auth')
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const row = w.findAll('button').find(b => b.text().includes('Street Jam Vol.3'))
+    await row.trigger('click')
+    expect(setActiveEvent).toHaveBeenCalledWith(2, 'Street Jam Vol.3')
+  })
+
+  it('panel stays open after switching event (no close emit)', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const row = w.findAll('button').find(b => b.text().includes('Street Jam Vol.3'))
+    await row.trigger('click')
+    expect(w.emitted('close')).toBeFalsy()
+  })
+})

--- a/docs/superpowers/plans/2026-06-04-nav-events-restructure.md
+++ b/docs/superpowers/plans/2026-06-04-nav-events-restructure.md
@@ -1,0 +1,811 @@
+# Nav + Events Restructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the navbar event dropdown with a slide-over panel that is role-filtered, mobile-friendly, and removes "Events" from the primary nav entirely.
+
+**Architecture:** Extract a new `EventPanel.vue` component that handles all event navigation (section tiles + Manage Events zone). `App.vue` owns panel open/close state and wires the component's emits to existing navigation functions. No backend changes needed.
+
+**Tech Stack:** Vue 3 (Composition API), Vue Router, Pinia (auth store), Vitest + Vue Test Utils, Tailwind CSS
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `BES-frontend/src/components/EventPanel.vue` | **Create** | Panel UI: role-filtered section tiles, Manage Events zone (Admin/Organiser), Change Event link (Emcee/Judge) |
+| `BES-frontend/src/utils/__tests__/EventPanel.test.js` | **Create** | Component tests: tile visibility per role, zone visibility, emits |
+| `BES-frontend/src/App.vue` | **Modify** | Wire EventPanel, replace dropdown markup, remove Events nav item, slim mobile hamburger, add "Select Event →" chip, add Escape key handler |
+
+---
+
+## Task 1: Create EventPanel.vue — section tiles with role filtering
+
+**Files:**
+- Create: `BES-frontend/src/components/EventPanel.vue`
+- Create: `BES-frontend/src/utils/__tests__/EventPanel.test.js`
+
+- [ ] **Step 1: Write failing tests for tile visibility**
+
+Create `BES-frontend/src/utils/__tests__/EventPanel.test.js`:
+
+```js
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EventPanel from '@/components/EventPanel.vue'
+
+vi.mock('@/utils/api', () => ({
+  fetchAllEvents: vi.fn().mockResolvedValue([
+    { id: 1, name: 'Dance Battle 2025' },
+    { id: 2, name: 'Street Jam Vol.3' },
+  ]),
+}))
+
+vi.mock('@/utils/auth', () => ({
+  setActiveEvent: vi.fn(),
+}))
+
+const activeEvent = { id: 1, name: 'Dance Battle 2025', folderID: null }
+
+function mountPanel(role) {
+  return mount(EventPanel, {
+    props: { role, activeEvent },
+  })
+}
+
+describe('EventPanel.vue — section tiles', () => {
+  describe('Admin role', () => {
+    it('shows all 6 tiles', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tiles = w.findAll('[data-tile]')
+      expect(tiles).toHaveLength(6)
+    })
+
+    it('shows Details, Audition, Participants, Score, Battle, Numbers tiles', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const labels = w.findAll('[data-tile]').map(t => t.text())
+      expect(labels).toEqual(
+        expect.arrayContaining(['DETAILS', 'AUDITION', 'PARTICIPANTS', 'SCORE', 'BATTLE', 'NUMBERS'])
+      )
+    })
+  })
+
+  describe('Organiser role', () => {
+    it('shows all 6 tiles', async () => {
+      const w = mountPanel('ROLE_ORGANISER')
+      await w.vm.$nextTick()
+      expect(w.findAll('[data-tile]')).toHaveLength(6)
+    })
+  })
+
+  describe('Emcee role', () => {
+    it('shows only Audition and Score tiles', async () => {
+      const w = mountPanel('ROLE_EMCEE')
+      await w.vm.$nextTick()
+      const labels = w.findAll('[data-tile]').map(t => t.text())
+      expect(labels).toEqual(expect.arrayContaining(['AUDITION', 'SCORE']))
+      expect(labels).not.toContain('DETAILS')
+      expect(labels).not.toContain('BATTLE')
+      expect(labels).not.toContain('PARTICIPANTS')
+      expect(labels).not.toContain('NUMBERS')
+    })
+  })
+
+  describe('Judge role', () => {
+    it('shows only Audition and Battle tiles', async () => {
+      const w = mountPanel('ROLE_JUDGE')
+      await w.vm.$nextTick()
+      const labels = w.findAll('[data-tile]').map(t => t.text())
+      expect(labels).toEqual(expect.arrayContaining(['AUDITION', 'BATTLE']))
+      expect(labels).not.toContain('SCORE')
+      expect(labels).not.toContain('DETAILS')
+    })
+  })
+
+  describe('tile interactions', () => {
+    it('emits navigate with correct route when Audition tile clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tile = w.findAll('[data-tile]').find(t => t.text().includes('AUDITION'))
+      await tile.trigger('click')
+      expect(w.emitted('navigate')).toEqual([['Audition List']])
+      expect(w.emitted('close')).toBeTruthy()
+    })
+
+    it('emits navigate with Score route when Score tile clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tile = w.findAll('[data-tile]').find(t => t.text().includes('SCORE'))
+      await tile.trigger('click')
+      expect(w.emitted('navigate')).toEqual([['Score']])
+    })
+
+    it('emits goToEventDetails (not navigate) when Details tile clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      const tile = w.findAll('[data-tile]').find(t => t.text().includes('DETAILS'))
+      await tile.trigger('click')
+      expect(w.emitted('goToEventDetails')).toBeTruthy()
+      expect(w.emitted('navigate')).toBeFalsy()
+      expect(w.emitted('close')).toBeTruthy()
+    })
+
+    it('emits close when header close button clicked', async () => {
+      const w = mountPanel('ROLE_ADMIN')
+      await w.vm.$nextTick()
+      await w.find('[data-close]').trigger('click')
+      expect(w.emitted('close')).toBeTruthy()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd BES-frontend && npm test -- --run EventPanel
+```
+
+Expected: FAIL — `Cannot find module '@/components/EventPanel.vue'`
+
+- [ ] **Step 3: Create EventPanel.vue with section tiles**
+
+Create `BES-frontend/src/components/EventPanel.vue`:
+
+```vue
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { fetchAllEvents } from '@/utils/api'
+import { setActiveEvent } from '@/utils/auth'
+
+const props = defineProps({
+  role:        { type: String, required: true },
+  activeEvent: { type: Object, default: null },
+})
+
+const emit = defineEmits([
+  'close',
+  'navigate',
+  'goToEventDetails',
+  'goToAllEvents',
+  'changeEvent',
+])
+
+const ALL_TILES = [
+  { key: 'details',      icon: 'pi-cog',      label: 'Details',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+  { key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
+  { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+  { key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'] },
+  { key: 'battle',       icon: 'pi-bolt',      label: 'Battle',       roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_JUDGE'] },
+  { key: 'numbers',      icon: 'pi-hashtag',   label: 'Numbers',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+]
+
+const TILE_ROUTES = {
+  audition:     'Audition List',
+  participants: 'Update Event Details',
+  score:        'Score',
+  battle:       'Battle Control',
+  numbers:      'Audition Adjust',
+}
+
+const isAdminOrOrganiser = computed(() =>
+  props.role === 'ROLE_ADMIN' || props.role === 'ROLE_ORGANISER'
+)
+
+const visibleTiles = computed(() =>
+  ALL_TILES.filter(t => t.roles.includes(props.role))
+)
+
+function handleTile(tile) {
+  if (tile.key === 'details') {
+    emit('goToEventDetails')
+  } else {
+    emit('navigate', TILE_ROUTES[tile.key])
+  }
+  emit('close')
+}
+
+// ── Manage Events zone ────────────────────────────────────────────────────────
+const allEvents    = ref([])
+const search       = ref('')
+
+const filteredEvents = computed(() =>
+  allEvents.value.filter(e =>
+    e.name.toLowerCase().includes(search.value.toLowerCase())
+  )
+)
+
+onMounted(async () => {
+  if (!isAdminOrOrganiser.value) return
+  allEvents.value = await fetchAllEvents() ?? []
+})
+
+function handleSwitchEvent(event) {
+  setActiveEvent(event.id, event.name)
+  // panel stays open — user picks a section next
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between px-4 py-3 border-b border-[rgba(255,255,255,0.07)] flex-shrink-0">
+      <div class="corner-bar-tl"></div>
+      <span class="type-body truncate pr-4">
+        {{ activeEvent ? activeEvent.name : 'No Event Selected' }}
+      </span>
+      <button data-close @click="emit('close')"
+        class="flex-shrink-0 text-content-muted hover:text-accent transition-colors">
+        <i class="pi pi-times text-sm"></i>
+      </button>
+    </div>
+
+    <!-- Section tiles -->
+    <div class="p-3 grid grid-cols-2 gap-2 flex-shrink-0">
+      <button
+        v-for="tile in visibleTiles"
+        :key="tile.key"
+        data-tile
+        @click="handleTile(tile)"
+        class="card-hover flex flex-col items-center gap-2 py-4 transition-all duration-150 hover:bg-[rgba(255,255,255,0.06)]"
+        style="min-height:56px"
+      >
+        <i class="pi text-lg text-accent" :class="tile.icon"></i>
+        <span class="type-label">{{ tile.label }}</span>
+      </button>
+    </div>
+
+    <!-- Manage Events zone (Admin + Organiser) -->
+    <template v-if="isAdminOrOrganiser">
+      <div class="flex-1 overflow-y-auto border-t border-[rgba(255,255,255,0.07)] p-3">
+        <div class="section-rule mb-3">
+          <span class="section-rule-label">Manage Events</span>
+          <div class="section-rule-line"></div>
+        </div>
+        <input
+          v-model="search"
+          type="text"
+          placeholder="Search events..."
+          class="input-base w-full mb-2"
+        />
+        <div class="space-y-0.5 mb-2">
+          <button
+            v-for="event in filteredEvents"
+            :key="event.id"
+            @click="handleSwitchEvent(event)"
+            class="w-full flex items-center gap-2 px-2 py-2 type-label text-left transition-colors hover:bg-[rgba(255,255,255,0.04)]"
+            :class="event.id === activeEvent?.id ? 'text-accent' : 'text-content-secondary'"
+          >
+            <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors"
+              :class="event.id === activeEvent?.id ? 'bg-accent' : 'bg-transparent border border-surface-600'">
+            </span>
+            <span class="truncate">{{ event.name }}</span>
+          </button>
+        </div>
+        <button
+          @click="emit('goToAllEvents'); emit('close')"
+          class="w-full text-left type-label text-content-muted hover:text-content-primary transition-colors px-2 py-2"
+        >
+          All Events →
+        </button>
+      </div>
+    </template>
+
+    <!-- Change Event (Emcee + Judge) -->
+    <template v-else>
+      <div class="mt-auto border-t border-[rgba(255,255,255,0.07)] px-4 py-3">
+        <button
+          @click="emit('changeEvent'); emit('close')"
+          class="w-full type-label text-content-muted hover:text-content-primary transition-colors text-center py-1"
+        >
+          ↻ Change Event
+        </button>
+      </div>
+    </template>
+
+  </div>
+</template>
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd BES-frontend && npm test -- --run EventPanel
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/components/EventPanel.vue BES-frontend/src/utils/__tests__/EventPanel.test.js
+git commit -m "feat: add EventPanel component with role-filtered section tiles"
+```
+
+---
+
+## Task 2: EventPanel — Manage Events zone + Change Event tests
+
+**Files:**
+- Modify: `BES-frontend/src/utils/__tests__/EventPanel.test.js`
+
+- [ ] **Step 1: Add failing tests for zone visibility and event switching**
+
+Append to `BES-frontend/src/utils/__tests__/EventPanel.test.js`:
+
+```js
+describe('EventPanel.vue — zones', () => {
+  it('Admin sees Manage Events zone', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('MANAGE EVENTS')
+    expect(w.text()).not.toContain('Change Event')
+  })
+
+  it('Organiser sees Manage Events zone', async () => {
+    const w = mountPanel('ROLE_ORGANISER')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('MANAGE EVENTS')
+  })
+
+  it('Emcee sees Change Event link, not Manage Events zone', async () => {
+    const w = mountPanel('ROLE_EMCEE')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Change Event')
+    expect(w.text()).not.toContain('MANAGE EVENTS')
+  })
+
+  it('Judge sees Change Event link, not Manage Events zone', async () => {
+    const w = mountPanel('ROLE_JUDGE')
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Change Event')
+    expect(w.text()).not.toContain('MANAGE EVENTS')
+  })
+
+  it('Admin panel lists fetched events', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0)) // flush onMounted async
+    await w.vm.$nextTick()
+    expect(w.text()).toContain('Dance Battle 2025')
+    expect(w.text()).toContain('Street Jam Vol.3')
+  })
+
+  it('active event is marked with accent class', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const activeRow = w.findAll('button').find(b => b.text().includes('Dance Battle 2025'))
+    expect(activeRow?.classes()).toContain('text-accent')
+  })
+
+  it('emits changeEvent when Change Event clicked (Emcee)', async () => {
+    const w = mountPanel('ROLE_EMCEE')
+    await w.vm.$nextTick()
+    const btn = w.findAll('button').find(b => b.text().includes('Change Event'))
+    await btn.trigger('click')
+    expect(w.emitted('changeEvent')).toBeTruthy()
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('emits goToAllEvents and close when All Events clicked', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const btn = w.findAll('button').find(b => b.text().includes('All Events'))
+    await btn.trigger('click')
+    expect(w.emitted('goToAllEvents')).toBeTruthy()
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('calls setActiveEvent when an event in the list is clicked', async () => {
+    const { setActiveEvent } = await import('@/utils/auth')
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const row = w.findAll('button').find(b => b.text().includes('Street Jam Vol.3'))
+    await row.trigger('click')
+    expect(setActiveEvent).toHaveBeenCalledWith(2, 'Street Jam Vol.3')
+  })
+
+  it('panel stays open after switching event (no close emit)', async () => {
+    const w = mountPanel('ROLE_ADMIN')
+    await new Promise(r => setTimeout(r, 0))
+    await w.vm.$nextTick()
+    const row = w.findAll('button').find(b => b.text().includes('Street Jam Vol.3'))
+    await row.trigger('click')
+    expect(w.emitted('close')).toBeFalsy()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — confirm new ones fail**
+
+```bash
+cd BES-frontend && npm test -- --run EventPanel
+```
+
+Expected: the new zone tests FAIL (zones not found / wrong text)
+
+- [ ] **Step 3: Verify existing implementation already covers these cases**
+
+The EventPanel.vue created in Task 1 already includes the Manage Events zone and Change Event link. Run:
+
+```bash
+cd BES-frontend && npm test -- --run EventPanel
+```
+
+Expected: ALL tests PASS (implementation was complete in Task 1)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/utils/__tests__/EventPanel.test.js
+git commit -m "test: add zone visibility and event-switching tests for EventPanel"
+```
+
+---
+
+## Task 3: App.vue — wire EventPanel, replace dropdown, add Escape handler
+
+**Files:**
+- Modify: `BES-frontend/src/App.vue`
+
+- [ ] **Step 1: Add imports and replace dropdown state**
+
+In the `<script setup>` of `BES-frontend/src/App.vue`, add the EventPanel import after the existing imports:
+
+```js
+import EventPanel from './components/EventPanel.vue'
+```
+
+Rename the `eventMenuOpen` ref to `panelOpen` (search and replace all 4 occurrences):
+
+```js
+// was: const eventMenuOpen = ref(false)
+const panelOpen = ref(false)
+```
+
+Update the `watch(route, ...)` block (it references `eventMenuOpen`):
+
+```js
+watch(route, () => {
+  isOpen.value = false
+  panelOpen.value = false
+})
+```
+
+Update `changeEvent()`:
+
+```js
+function changeEvent() {
+  panelOpen.value = false
+  router.push({ name: 'EventSelector', query: { redirect: router.currentRoute.value.fullPath } })
+}
+```
+
+Update `goToSection()`:
+
+```js
+function goToSection(routeName) {
+  panelOpen.value = false
+  router.push({ name: routeName })
+}
+```
+
+Update `goToEventDetails()`:
+
+```js
+function goToEventDetails() {
+  panelOpen.value = false
+  if (activeEvent.value) router.push({
+    name: 'Event Details',
+    params: { eventName: activeEvent.value.name },
+    query: activeEvent.value.folderID ? { folderID: activeEvent.value.folderID } : {}
+  })
+}
+```
+
+Add `goToAllEvents()` function:
+
+```js
+function goToAllEvents() {
+  panelOpen.value = false
+  router.push({ name: 'Event' })
+}
+```
+
+Add Escape key handler. Define the function at the **top level of `<script setup>`** (not inside `onMounted`) so `onUnmounted` can reference it:
+
+```js
+function handleKeydown(e) {
+  if (e.key === 'Escape') panelOpen.value = false
+}
+```
+
+Then in the existing `onMounted` block, add after existing setup:
+
+```js
+document.addEventListener('keydown', handleKeydown)
+```
+
+In the existing `onUnmounted` block, add:
+
+```js
+document.removeEventListener('keydown', handleKeydown)
+```
+
+- [ ] **Step 2: Remove the old dropdown markup from the template**
+
+In the `<template>`, locate the old chip button and its entire dropdown. The chip button currently reads `@click="eventMenuOpen = !eventMenuOpen"` — the rename in Step 1 already updated it to `panelOpen`, so the button itself is correct and stays. What you need to remove is:
+
+1. The `<Transition>` block containing the dropdown div (`v-if="eventMenuOpen"` → now `v-if="panelOpen"`) — delete it entirely
+2. The backdrop div immediately after: `<div v-if="eventMenuOpen" class="fixed inset-0 z-40 bg-black/20" ...>` — delete it
+
+Also update the chip button's chevron class to reflect the new panel direction (right arrow that rotates down):
+
+```html
+<i class="pi pi-chevron-right text-[10px] flex-shrink-0 opacity-50 transition-transform duration-200"
+   :class="panelOpen ? 'rotate-90' : ''"></i>
+```
+
+- [ ] **Step 3: Add slide-over panel + backdrop to template**
+
+Add the following just before the closing `</nav>` tag:
+
+```html
+<!-- Backdrop -->
+<Transition
+  enter-active-class="transition-opacity duration-200"
+  enter-from-class="opacity-0"
+  enter-to-class="opacity-100"
+  leave-active-class="transition-opacity duration-150"
+  leave-from-class="opacity-100"
+  leave-to-class="opacity-0"
+>
+  <div
+    v-if="panelOpen"
+    class="fixed inset-0 z-40 bg-black/50"
+    @click="panelOpen = false"
+  ></div>
+</Transition>
+
+<!-- Slide-over panel -->
+<Transition
+  enter-active-class="transition-transform duration-200 ease-out"
+  enter-from-class="translate-x-full"
+  enter-to-class="translate-x-0"
+  leave-active-class="transition-transform duration-150 ease-in"
+  leave-from-class="translate-x-0"
+  leave-to-class="translate-x-full"
+>
+  <div
+    v-if="panelOpen"
+    class="fixed top-0 right-0 h-full w-full md:w-[300px] z-50 bg-surface-800 border-l border-[rgba(255,255,255,0.07)] overflow-hidden flex flex-col"
+  >
+    <EventPanel
+      :role="role"
+      :activeEvent="activeEvent"
+      @close="panelOpen = false"
+      @navigate="goToSection"
+      @goToEventDetails="goToEventDetails"
+      @goToAllEvents="goToAllEvents"
+      @changeEvent="changeEvent"
+    />
+  </div>
+</Transition>
+```
+
+- [ ] **Step 4: Start dev server and verify panel opens/closes**
+
+```bash
+cd BES-frontend && npm run dev
+```
+
+- Open http://localhost:5173, log in
+- Click the event chip → panel should slide in from the right
+- Click the backdrop → panel closes
+- Press Escape → panel closes
+- Navigate via a section tile → panel closes and page changes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/App.vue
+git commit -m "feat: wire EventPanel into App.vue, replace dropdown with slide-over panel"
+```
+
+---
+
+## Task 4: App.vue — remove Events from primary nav, slim mobile hamburger, show event chip on mobile
+
+**Files:**
+- Modify: `BES-frontend/src/App.vue`
+
+- [ ] **Step 1: Remove "Events" from desktop primary nav**
+
+In the desktop center nav section (`<!-- Center: Primary nav -->`), remove the entire `<router-link>` block for `/events`:
+
+```html
+<!-- DELETE THIS ENTIRE BLOCK -->
+<router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
+  <span
+    class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
+    :class="isActive
+      ? 'text-accent border-b-2 border-[color:var(--accent-color)]'
+      : 'text-content-muted hover:text-content-primary'"
+  >Events</span>
+</router-link>
+```
+
+- [ ] **Step 2: Make event chip visible on mobile**
+
+The current right section is `class="hidden md:flex items-center gap-2"`. The mobile hamburger button sits outside this div. We need the event chip visible on mobile.
+
+Replace the entire right column (from `<!-- Right: event chip -->` to just before the mobile hamburger button `<!-- Mobile Hamburger -->`) with:
+
+```html
+<!-- Right: always-visible chip + desktop utilities + mobile hamburger -->
+<div class="flex items-center gap-2">
+
+  <!-- Event chip — visible on all screen sizes -->
+  <div v-if="isAuthenticated" class="relative">
+    <button
+      v-if="activeEvent"
+      @click="panelOpen = !panelOpen"
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[140px] md:max-w-[200px]"
+    >
+      <span class="truncate">{{ activeEvent.name }}</span>
+      <i class="pi pi-chevron-right text-[10px] flex-shrink-0 opacity-50 transition-transform duration-200"
+         :class="panelOpen ? 'rotate-90' : ''"></i>
+    </button>
+    <button
+      v-else
+      @click="router.push({ name: 'EventSelector' })"
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-muted hover:text-content-primary border border-[color:var(--accent-muted)] transition-all duration-200"
+    >
+      Select Event →
+    </button>
+  </div>
+
+  <!-- Desktop-only utilities -->
+  <div class="hidden md:flex items-center gap-2">
+    <div v-if="isAuthenticated" class="h-4 w-px bg-[rgba(255,255,255,0.12)]"></div>
+
+    <span v-if="isAuthenticated && roleDisplay"
+      class="badge-neutral type-label px-2 py-0.5">
+      {{ roleDisplay.label }}
+    </span>
+
+    <button @click="toggleTheme"
+      class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
+      <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>
+    </button>
+
+    <router-link v-if="!isAuthenticated" to="/login">
+      <span class="px-4 py-1.5 para-chip type-label text-surface-900 bg-accent cursor-pointer">Login</span>
+    </router-link>
+
+    <button v-if="isAuthenticated"
+      @click="openModal('Logout Confirmation', 'Are you sure you want to securely log out?')"
+      class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-red-400 hover:bg-red-950 transition-all duration-200">
+      <i class="pi pi-sign-out text-sm"></i>
+    </button>
+  </div>
+
+  <!-- Mobile hamburger -->
+  <button @click="isOpen = !isOpen"
+    class="md:hidden inline-flex items-center justify-center w-9 h-9 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-colors focus:outline-none">
+    <i class="pi text-lg" :class="isOpen ? 'pi-times' : 'pi-bars'"></i>
+  </button>
+
+</div>
+```
+
+Note: Task 3 kept the original chip button (only removing the dropdown below it). In this step you're restructuring the entire right column — the chip button from Task 3 is now re-written as part of this combined block.
+
+- [ ] **Step 3: Slim the mobile dropdown — remove Events link and all event section links**
+
+In the mobile dropdown (`v-show="isOpen"`), remove:
+
+1. The entire Events `<router-link>` block:
+```html
+<!-- DELETE -->
+<router-link v-if="role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER'" to="/events" v-slot="{ isActive }">
+  <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
+    :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
+    Events
+  </span>
+</router-link>
+```
+
+2. The entire `<template v-if="isAuthenticated && activeEvent">` block (section rule + all section buttons + Change Event button):
+```html
+<!-- DELETE the entire block from here... -->
+<template v-if="isAuthenticated && activeEvent">
+  <div class="px-4 pt-3 pb-1 section-rule">...</div>
+  <button ...>Event Details</button>
+  <button ...>Audition</button>
+  <button ...>Participants</button>
+  <button ...>Scoreboard</button>
+  <button ...>Battle</button>
+  <button ...>Adjust Numbers</button>
+  <button ...>Change Event</button>
+</template>
+<!-- ...to here -->
+```
+
+- [ ] **Step 4: Add theme toggle + logout to mobile dropdown footer**
+
+The mobile dropdown footer already has these. Verify the bottom of the mobile dropdown contains role badge, theme toggle, and logout button — these should be unchanged.
+
+- [ ] **Step 5: Verify in browser**
+
+```bash
+cd BES-frontend && npm run dev
+```
+
+**Desktop checks:**
+- Primary nav center shows only `Home` and `Admin` (Admin role) — no `Events`
+- Event chip visible in top-right, opens panel
+
+**Mobile checks (resize browser to < 768px):**
+- Event chip visible in navbar (not hidden)
+- Hamburger opens a slim menu: only Home + Admin links + role/theme/logout footer
+- Tapping event chip opens full-width panel with large tile targets
+
+**All roles:**
+- No active event → chip shows `Select Event →`, clicking goes to EventSelector
+- Active event → chip shows event name, clicking opens panel
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BES-frontend/src/App.vue
+git commit -m "feat: remove Events from nav, show event chip on mobile, slim hamburger"
+```
+
+---
+
+## Task 5: Run full test suite and verify acceptance criteria
+
+**Files:** none
+
+- [ ] **Step 1: Run full frontend test suite**
+
+```bash
+cd BES-frontend && npm test -- --run
+```
+
+Expected: all existing tests pass, EventPanel tests pass
+
+- [ ] **Step 2: Verify each acceptance criterion in the browser**
+
+Log in as each role and check:
+
+| Criterion | How to verify |
+|-----------|--------------|
+| "Events" not in nav | Check primary nav and hamburger for any role |
+| Chip opens panel on desktop | Click chip |
+| Chip opens panel on mobile | Resize to mobile, tap chip |
+| Tiles role-filtered | Log in as Emcee → see only Audition + Score; as Judge → Audition + Battle |
+| Tile height ≥ 56px | DevTools → inspect tile element, check computed height |
+| Admin panel has searchable event list | Log in as Admin, open panel, type in search box |
+| Switching event keeps panel open | Click a different event in the list → panel stays, header updates |
+| Emcee/Judge see "Change Event" | Log in as Emcee, open panel |
+| No active event shows "Select Event →" | Clear localStorage `activeEvent`, reload → chip shows prompt |
+| Backdrop closes panel | Click outside the panel |
+| Escape closes panel | Press Escape while panel open |
+| Route change closes panel | Open panel, click Home link |
+| Events page via "All Events →" | Open panel as Admin → click All Events → lands on /events |
+| Mobile hamburger: Home + Admin only | Resize to mobile, open hamburger |
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: nav + events restructure complete (issue #60)"
+```

--- a/docs/superpowers/specs/2026-06-04-nav-events-restructure-design.md
+++ b/docs/superpowers/specs/2026-06-04-nav-events-restructure-design.md
@@ -1,0 +1,111 @@
+# Nav + Events Restructure Design
+
+**Issue:** #60  
+**Date:** 2026-06-04  
+**Status:** Approved for implementation
+
+## Problem
+
+Users need multiple clicks to reach any event section from anywhere in the app. The Events page and the navbar event chip duplicate navigation concerns. On mobile the hamburger is heavy and slow for Emcees/Judges who only need 1–2 sections. The event chip disappears entirely when no event is active, leaving users with no clear next step.
+
+## Solution: Slide-Over Event Panel
+
+Replace the existing dropdown with a right-side slide-over panel opened by the event chip. The panel is role-filtered, has large touch targets for mobile, and includes an inline event switcher for Admin/Organiser. Remove "Events" from the primary nav entirely.
+
+## Approach
+
+**Chosen: Slide-over panel (Option B)**  
+Rejected: enhanced dropdown (good UX for desktop but poor mobile touch targets), persistent sub-bar (eats screen real estate on every page).
+
+## Design
+
+### 1. Navbar chip — revised behaviour
+
+**Active event:** chip shows truncated event name + chevron. Clicking toggles the panel.
+
+**No active event:** chip shows `Select Event →` in accent-outlined style (not solid). Clicking navigates to EventSelector. This replaces the current behaviour where the chip disappears entirely.
+
+**Primary nav center:** `Home · Admin` (Admin only) — "Events" removed for all roles. The panel is the new entry point for event navigation.
+
+**Mobile hamburger:** now only contains `Home · Admin`. Much lighter than today — the event panel is opened separately via the chip, not via the hamburger.
+
+### 2. Slide-over panel
+
+**Layout:** slides in from the right, overlaying page content. A semi-transparent dark backdrop covers the rest of the screen.
+
+**Width:** 280px on desktop; 100% viewport width on mobile.
+
+**Close triggers:** clicking any section tile (navigates then closes), clicking the backdrop, pressing Escape, or route change (already wired in `App.vue`).
+
+**Panel header:** current event name (prominent, Anton SC) + close button (✕) top-right.
+
+**Section tiles:** 2-column parallelogram grid with icon + label. Clicking a tile calls `router.push` to the relevant route and closes the panel.
+
+**Role-filtered tile sets:**
+
+| Tile | Admin | Organiser | Emcee | Judge |
+|------|-------|-----------|-------|-------|
+| Details (⚙) | ✓ | ✓ | — | — |
+| Audition (≡) | ✓ | ✓ | ✓ | ✓ |
+| Participants (👥) | ✓ | ✓ | — | — |
+| Score (📊) | ✓ | ✓ | ✓ | — |
+| Battle (⚡) | ✓ | ✓ | — | ✓ |
+| Numbers (#) | ✓ | ✓ | — | — |
+
+Tile height: minimum 56px to meet mobile touch target requirements.
+
+**Manage Events zone (Admin + Organiser only):** rendered below a section divider at the bottom of the panel. Contains:
+- Section label: `MANAGE EVENTS`
+- Search input (filters the list client-side by event name)
+- Scrollable list of all events — clicking any entry calls `setActiveEvent()`, updates the panel header to show the new event name, and **keeps the panel open** so the user can immediately tap a section tile. Panel does not close or navigate.
+- Active event is visually marked (accent dot or weight)
+- "All Events →" link below the list navigates to `/events` and closes the panel
+
+Emcee/Judge panels show a plain `Change Event` text link at the bottom instead of this zone (routes to EventSelector).
+
+### 3. Events page (`/events`)
+
+The page stays. It remains the best way to browse the full event grid and access card actions (create, edit access code).
+
+Access path changes:
+- **Previously:** "Events" top-level nav item
+- **Now:** "All Events →" link at the bottom of the Manage Events zone in the panel (Admin + Organiser only) — navigates to `/events` and closes the panel
+
+No changes to `Events.vue` or `EventCard.vue` are required by this spec.
+
+### 4. Animation
+
+Panel enter: slide-in from right, `transform: translateX(100%) → translateX(0)`, 200ms `ease-out`.  
+Panel leave: reverse, 150ms `ease-in`.  
+Backdrop enter: `opacity: 0 → 0.5`, 200ms. Leave: reverse, 150ms.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `App.vue` | Replace dropdown with slide-over panel component/section; update chip to show "Select Event →" when no event active; remove "Events" from primary nav and mobile hamburger; wire backdrop + Escape close |
+| `EventCard.vue` | No changes |
+| `Events.vue` | No changes |
+| `router/index.js` | No changes |
+
+The panel markup can live inline in `App.vue` (it is already a large component) or be extracted to `components/EventPanel.vue` — either is acceptable. Prefer extraction if the panel template exceeds ~80 lines.
+
+## Acceptance Criteria
+
+- [ ] "Events" no longer appears in the primary nav or mobile hamburger for any role
+- [ ] Event chip opens a slide-over panel on both desktop and mobile
+- [ ] Panel tiles are role-filtered per the table above
+- [ ] Panel tile height is ≥ 56px (mobile touch target)
+- [ ] Admin/Organiser panel shows a searchable event list that switches the active event
+- [ ] Emcee/Judge panel shows "Change Event" link at the bottom
+- [ ] No active event → chip shows "Select Event →" and routes to EventSelector
+- [ ] Backdrop click, Escape key, and route change all close the panel
+- [ ] Panel slides in/out with the specified animation
+- [ ] Events page remains accessible via the panel's "All Events" link (Admin/Organiser)
+- [ ] Mobile hamburger only contains Home + Admin links
+
+## Out of Scope
+
+- Account management / per-organiser event scoping (tracked in issues #39, #40)
+- Any changes to the Events page card layout or EventCard actions
+- Emcee/Judge session-link access model (future work)


### PR DESCRIPTION
## Summary
- Replaces the navbar event dropdown with a right-side slide-over panel (`EventPanel.vue`)
- Panel is role-filtered: Admin/Organiser see 6 section tiles; Emcee sees Audition + Score; Judge sees Audition + Battle
- Admin/Organiser panel includes a searchable event-switcher list — clicking an event updates the active event and keeps the panel open for immediate section navigation
- Removes "Events" from the primary nav and mobile hamburger entirely; event chip is now always visible on mobile
- No active event now shows a "Select Event →" chip instead of nothing

## Test Plan
- [ ] Log in as Admin — event chip opens panel with 6 tiles + searchable event list
- [ ] Log in as Emcee — panel shows only Audition + Score tiles + "Change Event" link
- [ ] Log in as Judge — panel shows only Audition + Battle tiles + "Change Event" link
- [ ] No active event set — chip shows "Select Event →", clicking routes to EventSelector
- [ ] Backdrop click, Escape key, and route change each close the panel
- [ ] Mobile (< 768px): chip visible in navbar, panel is full-width, hamburger only has Home + Admin
- [ ] "All Events →" in Admin panel navigates to `/events`
- [ ] All 83 frontend tests pass: `cd BES-frontend && npm test -- --run`

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)