### PR TITLE
feat: mobile & tablet responsiveness improvements (issue #59)

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -203,7 +203,7 @@ onUnmounted(() => {
             <button
               v-if="activeEvent"
               @click="panelOpen = !panelOpen"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[140px] md:max-w-[200px]"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[200px] md:max-w-[240px]"
             >
               <span class="truncate">{{ activeEvent.name }}</span>
               <i class="pi pi-chevron-right text-[10px] flex-shrink-0 opacity-50 transition-transform duration-200"

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -906,6 +906,49 @@ html.theme-transition *::after {
 }
 
 /* ─────────────────────────────────────────
+   Mobile Touch Targets (< 640px)
+   All interactive chip elements meet 44px minimum height on small screens.
+   Span-based chips (draggable pool items) are handled per-component.
+───────────────────────────────────────── */
+@media (max-width: 639px) {
+  button.para-chip,
+  button.para-chip-sm,
+  a.para-chip,
+  a.para-chip-sm {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  select.para-chip-sm {
+    min-height: 44px;
+  }
+  /* Ensure type-label font stays legible on mobile — bump to 13px */
+  button.para-chip .type-label,
+  button.para-chip-sm .type-label,
+  button.para-chip,
+  button.para-chip-sm {
+    font-size: 13px;
+  }
+}
+
+/* Tablet (640px–1023px): 36px touch targets, slightly larger than desktop */
+@media (min-width: 640px) and (max-width: 1023px) {
+  button.para-chip,
+  button.para-chip-sm,
+  a.para-chip,
+  a.para-chip-sm {
+    min-height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  select.para-chip-sm {
+    min-height: 36px;
+  }
+}
+
+/* ─────────────────────────────────────────
    Reduced Motion
 ───────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -48,9 +48,19 @@ const direction   = ref('left')
 const goNext = () => { if (currentRound.value < totalRounds.value)  { direction.value = 'left';  currentRound.value++ } }
 const goPrev = () => { if (currentRound.value > 1)                  { direction.value = 'right'; currentRound.value-- } }
 
-const onTouchStart = (e) => { touchStartX.value = e.touches[0].clientX; isDragging.value = true; dragOffset.value = 0 }
-const onTouchMove  = (e) => { if (!isDragging.value) return; dragOffset.value = e.touches[0].clientX - touchStartX.value }
-const onTouchEnd   = () => {
+const onPointerDown = (e) => {
+  e.currentTarget.setPointerCapture(e.pointerId)
+  touchStartX.value = e.clientX
+  isDragging.value  = true
+  dragOffset.value  = 0
+}
+
+const onPointerMove = (e) => {
+  if (!isDragging.value) return
+  dragOffset.value = e.clientX - touchStartX.value
+}
+
+const onPointerUp = () => {
   if (!isDragging.value) return
   isDragging.value = false
   if      (dragOffset.value < -60) goNext()
@@ -146,11 +156,12 @@ const swipeHint = computed(() => {
           <div
             :key="currentRound"
             :style="cardStyle"
-            @touchstart.passive="onTouchStart"
-            @touchmove.passive="onTouchMove"
-            @touchend="onTouchEnd"
-            class="card-hover p-0 relative select-none touch-pan-y"
-            style="box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 8px 32px rgba(0,0,0,0.6);"
+            @pointerdown="onPointerDown"
+            @pointermove="onPointerMove"
+            @pointerup="onPointerUp"
+            @pointercancel="onPointerUp"
+            class="card-hover p-0 relative select-none"
+            style="box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 8px 32px rgba(0,0,0,0.6); touch-action: none;"
           >
             <div class="corner-bar-tl"></div>
             <div class="flex items-center justify-between px-3 pt-2 pb-1.5 border-b border-white/8">

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -66,6 +66,7 @@ onMounted(async () => {
 
 function handleSwitchEvent(event) {
   setActiveEvent(event.id, event.name)
+  emit('close')
 }
 </script>
 

--- a/BES-frontend/src/utils/__tests__/EventPanel.test.js
+++ b/BES-frontend/src/utils/__tests__/EventPanel.test.js
@@ -183,12 +183,12 @@ describe('EventPanel.vue — zones', () => {
     expect(setActiveEvent).toHaveBeenCalledWith(2, 'Street Jam Vol.3')
   })
 
-  it('panel stays open after switching event (no close emit)', async () => {
+  it('emits close after switching event', async () => {
     const w = mountPanel('ROLE_ADMIN')
     await new Promise(r => setTimeout(r, 0))
     await w.vm.$nextTick()
     const row = w.findAll('button').find(b => b.text().includes('Street Jam Vol.3'))
     await row.trigger('click')
-    expect(w.emitted('close')).toBeFalsy()
+    expect(w.emitted('close')).toBeTruthy()
   })
 })

--- a/BES-frontend/src/utils/__tests__/pointerDnd.test.js
+++ b/BES-frontend/src/utils/__tests__/pointerDnd.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { parseDropKey } from '../pointerDnd'
+
+describe('parseDropKey', () => {
+  describe('smoke keys', () => {
+    it('parses smoke-0', () => {
+      expect(parseDropKey('smoke-0')).toEqual({ type: 'smoke', idx: 0 })
+    })
+    it('parses smoke-7', () => {
+      expect(parseDropKey('smoke-7')).toEqual({ type: 'smoke', idx: 7 })
+    })
+    it('returns null for malformed smoke key', () => {
+      expect(parseDropKey('smoke-')).toBeNull()
+      expect(parseDropKey('smoke-abc')).toBeNull()
+    })
+  })
+
+  describe('bracket keys', () => {
+    it('parses Top8 bracket key slot 0', () => {
+      expect(parseDropKey('bracket-Top8-0-0')).toEqual({
+        type: 'bracket', roundKey: 'Top8', matchIdx: 0, slotIdx: 0,
+      })
+    })
+    it('parses Top8 bracket key slot 1', () => {
+      expect(parseDropKey('bracket-Top8-2-1')).toEqual({
+        type: 'bracket', roundKey: 'Top8', matchIdx: 2, slotIdx: 1,
+      })
+    })
+    it('parses Top16 bracket key', () => {
+      expect(parseDropKey('bracket-Top16-3-0')).toEqual({
+        type: 'bracket', roundKey: 'Top16', matchIdx: 3, slotIdx: 0,
+      })
+    })
+    it('parses Top32 bracket key', () => {
+      expect(parseDropKey('bracket-Top32-15-1')).toEqual({
+        type: 'bracket', roundKey: 'Top32', matchIdx: 15, slotIdx: 1,
+      })
+    })
+    it('returns null for too-short bracket key', () => {
+      expect(parseDropKey('bracket-Top8-0')).toBeNull()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns null for null input', () => {
+      expect(parseDropKey(null)).toBeNull()
+    })
+    it('returns null for empty string', () => {
+      expect(parseDropKey('')).toBeNull()
+    })
+    it('returns null for unknown prefix', () => {
+      expect(parseDropKey('pool-Alice')).toBeNull()
+    })
+  })
+})

--- a/BES-frontend/src/utils/dropdown.js
+++ b/BES-frontend/src/utils/dropdown.js
@@ -1,14 +1,14 @@
-import { ref } from "vue";
-import { getActiveEvent } from "@/utils/auth";
+import { ref, computed } from "vue";
+import { useAuthStore } from "@/utils/auth";
 
 export function useDropdowns(){
-    const selectedEvent = ref(null)
+    const authStore = useAuthStore()
+    // Reactive: updates automatically when the active event changes in the store
+    const selectedEvent = computed(() => authStore.activeEvent?.name || localStorage.getItem("selectedEvent") || "")
     const selectedGenre = ref(null)
     const selectedJudge = ref(null)
 
-    const initialiseDropdown = ()=>{
-        const active = getActiveEvent()
-        selectedEvent.value = active?.name || localStorage.getItem("selectedEvent") || ""
+    const initialiseDropdown = () => {
         selectedGenre.value = localStorage.getItem("selectedGenre") || "All"
     }
     return {selectedEvent, selectedGenre, selectedJudge, initialiseDropdown}

--- a/BES-frontend/src/utils/pointerDnd.js
+++ b/BES-frontend/src/utils/pointerDnd.js
@@ -1,0 +1,29 @@
+/**
+ * Parse a data-drop-key attribute value into a typed drop target descriptor.
+ *
+ * Bracket keys: "bracket-Top8-0-1"  → { type: 'bracket', roundKey: 'Top8', matchIdx: 0, slotIdx: 1 }
+ * Smoke keys:   "smoke-3"           → { type: 'smoke', idx: 3 }
+ * Anything else: null
+ */
+export function parseDropKey(key) {
+  if (!key) return null
+
+  if (key.startsWith('smoke-')) {
+    const idx = parseInt(key.slice(6), 10)
+    if (isNaN(idx)) return null
+    return { type: 'smoke', idx }
+  }
+
+  if (key.startsWith('bracket-')) {
+    const inner = key.slice(8)           // e.g. "Top8-0-1"
+    const parts = inner.split('-')       // ["Top8", "0", "1"]
+    if (parts.length < 3) return null
+    const slotIdx  = parseInt(parts[parts.length - 1], 10)
+    const matchIdx = parseInt(parts[parts.length - 2], 10)
+    const roundKey = parts.slice(0, parts.length - 2).join('-')  // "Top8"
+    if (isNaN(slotIdx) || isNaN(matchIdx) || !roundKey) return null
+    return { type: 'bracket', roundKey, matchIdx, slotIdx }
+  }
+
+  return null
+}

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -649,9 +649,10 @@ onMounted(async () => {
       </div>
       <button
         @click="showFilters = !showFilters"
-        class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-all"
+        class="para-chip-sm px-3 py-2.5 sm:px-2 sm:py-1 type-label text-content-muted hover:text-content-primary transition-all flex-shrink-0"
+        style="min-width:44px"
       >
-        <i class="pi pi-sliders-h text-xs"></i>
+        <i class="pi pi-sliders-h text-sm sm:text-xs"></i>
       </button>
     </div>
 
@@ -682,76 +683,89 @@ onMounted(async () => {
       leave-to-class="opacity-0 -translate-y-2"
     >
       <div v-if="showFilters || !hasActiveSession" class="card p-5" :class="hasActiveSession ? 'fixed left-0 right-0 z-40 mx-4' : 'mb-6'" :style="hasActiveSession ? { top: '138px', background: '#1a1a1a', borderColor: 'rgba(255,255,255,0.12)', boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 20px 60px rgba(0,0,0,0.9)', clipPath: 'none' } : { clipPath: 'none' }">
-        <div class="flex flex-wrap items-center gap-3">
+        <!-- Mobile: vertical stack; Tablet+: horizontal wrap -->
+        <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-4 sm:gap-3">
           <!-- Event name -->
           <span class="type-body text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
-          <span class="text-surface-600 select-none">|</span>
+          <span class="text-surface-600 select-none hidden sm:inline">|</span>
 
           <!-- Role toggle -->
-          <div class="flex gap-1">
-            <button
-              v-for="r in roles"
-              :key="r"
-              @click="selectedRole = r"
-              class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
-              :class="selectedRole === r
-                ? 'text-accent border-[color:var(--accent-muted)]'
-                : 'text-content-muted hover:text-content-primary'"
-            >{{ r }}</button>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
+            <span class="section-rule-label sm:hidden">Role</span>
+            <div class="flex flex-wrap gap-2 sm:gap-1">
+              <button
+                v-for="r in roles"
+                :key="r"
+                @click="selectedRole = r"
+                class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1 type-label transition-all duration-150"
+                :class="selectedRole === r
+                  ? 'text-accent border-[color:var(--accent-muted)]'
+                  : 'text-content-muted hover:text-content-primary'"
+              >{{ r }}</button>
+            </div>
           </div>
-          <span class="text-surface-600 select-none">|</span>
+          <span class="text-surface-600 select-none hidden sm:inline">|</span>
 
           <!-- Genre toggle -->
-          <div class="flex gap-1">
-            <button
-              v-for="g in uniqueGenres"
-              :key="g"
-              @click="switchGenre(g)"
-              class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
-              :class="selectedGenre === g
-                ? 'text-accent border-[color:var(--accent-muted)]'
-                : 'text-content-muted hover:text-content-primary'"
-            >{{ g }}</button>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
+            <span class="section-rule-label sm:hidden">Genre</span>
+            <div class="flex flex-wrap gap-2 sm:gap-1">
+              <button
+                v-for="g in uniqueGenres"
+                :key="g"
+                @click="switchGenre(g)"
+                class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1 type-label transition-all duration-150"
+                :class="selectedGenre === g
+                  ? 'text-accent border-[color:var(--accent-muted)]'
+                  : 'text-content-muted hover:text-content-primary'"
+              >{{ g }}</button>
+            </div>
           </div>
 
           <!-- Type toggle (conditional) -->
           <template v-if="hasTeamAndSoloMix">
-            <span class="text-surface-600 select-none">|</span>
-            <div class="flex gap-1">
-              <button
-                v-for="t in ['Teams', 'Solo']"
-                :key="t"
-                @click="selectedEntryType = t"
-                class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
-                :class="selectedEntryType === t
-                  ? 'text-accent border-[color:var(--accent-muted)]'
-                  : 'text-content-muted hover:text-content-primary'"
-              >{{ t }}</button>
+            <span class="text-surface-600 select-none hidden sm:inline">|</span>
+            <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
+              <span class="section-rule-label sm:hidden">Type</span>
+              <div class="flex gap-2 sm:gap-1">
+                <button
+                  v-for="t in ['Teams', 'Solo']"
+                  :key="t"
+                  @click="selectedEntryType = t"
+                  class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1 type-label transition-all duration-150"
+                  :class="selectedEntryType === t
+                    ? 'text-accent border-[color:var(--accent-muted)]'
+                    : 'text-content-muted hover:text-content-primary'"
+                >{{ t }}</button>
+              </div>
             </div>
           </template>
 
           <!-- Judging mode toggle (admin only) -->
           <template v-if="isAdmin && selectedEvent">
-            <span class="text-surface-600 select-none">|</span>
-            <div class="flex gap-1">
-              <button
-                v-for="m in ['SOLO', 'PAIR']"
-                :key="m"
-                @click="judgingMode = m; setJudgingMode(selectedEvent, m)"
-                class="para-chip-sm px-3 py-1 type-label transition-all duration-150"
-                :class="judgingMode === m
-                  ? 'text-accent border-[color:var(--accent-muted)]'
-                  : 'text-content-muted hover:text-content-primary'"
-              >{{ m }}</button>
+            <span class="text-surface-600 select-none hidden sm:inline">|</span>
+            <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
+              <span class="section-rule-label sm:hidden">Mode</span>
+              <div class="flex gap-2 sm:gap-1">
+                <button
+                  v-for="m in ['SOLO', 'PAIR']"
+                  :key="m"
+                  @click="judgingMode = m; setJudgingMode(selectedEvent, m)"
+                  class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1 type-label transition-all duration-150"
+                  :class="judgingMode === m
+                    ? 'text-accent border-[color:var(--accent-muted)]'
+                    : 'text-content-muted hover:text-content-primary'"
+                >{{ m }}</button>
+              </div>
             </div>
           </template>
 
-          <!-- Judge filter + identity dropdowns pushed to the right -->
-          <div class="ml-auto flex items-center gap-3">
-            <div v-if="hasJudge" class="w-48">
+          <!-- Judge filter + identity dropdowns: full-width on mobile, right-aligned on sm+ -->
+          <div class="flex flex-col sm:flex-row sm:ml-auto sm:items-center gap-3 w-full sm:w-auto">
+            <div v-if="hasJudge" class="w-full sm:w-48">
               <ReusableDropdown v-model="filteredJudge" labelId="Judge" :options="allJudges" />
             </div>
-            <div v-if="selectedRole === 'Judge'" class="min-w-[12rem] max-w-[16rem]">
+            <div v-if="selectedRole === 'Judge'" class="w-full sm:min-w-[12rem] sm:max-w-[16rem]">
               <ReusableDropdown v-model="currentJudge" labelId="You are judging as" :options="allJudges" />
             </div>
           </div>

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -7,15 +7,16 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
 import FeedbackPopout from '@/components/FeedbackPopout.vue';
-import { getActiveEvent } from '@/utils/auth';
+import { useAuthStore } from '@/utils/auth';
 import SwipeableCardsV2 from '@/components/SwipeableCardsV2.vue';
 import PairScoreCards from '@/components/PairScoreCards.vue';
 import EmceeRoundView from '@/components/EmceeRoundView.vue';
 import MiniScoreMenu from '@/components/MiniScoreMenu.vue';
 import 'primeicons/primeicons.css'
 
+const authStore = useAuthStore()
 const roles = ref(["Emcee", "Judge"])
-const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem("selectedEvent") || "")
+const selectedEvent = computed(() => authStore.activeEvent?.name || localStorage.getItem("selectedEvent") || "")
 const selectedRole = ref(localStorage.getItem("selectedRole") || "")
 const selectedGenre = ref(localStorage.getItem("selectedGenre") || "")
 const selectedEntryType = ref('Teams') // 'Teams' | 'Solo'

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -104,7 +104,7 @@ const confirmReset = (title, message) => {
     }
     resetCodeChecking.value = true
     resetCodeError.value = ""
-    const activeEvent = getActiveEvent()
+    const activeEvent = authStore.activeEvent
     if (!activeEvent) {
       resetCodeError.value = "No active event found."
       resetCodeChecking.value = false

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2349,15 +2349,15 @@ onUnmounted(() => {
               <div
                 v-for="(match, mIdx) in rounds[`Top${size}`]"
                 :key="mIdx"
-                class="card-hover p-3 relative flex items-stretch min-h-[44px]"
+                class="card-hover p-3 relative flex flex-col sm:flex-row items-stretch"
                 :style="isActivePair(match) && effectivePhase !== 'IDLE'
                   ? 'border-left: 3px solid var(--accent-color); background: var(--accent-subtle); box-shadow: 0 0 0 1px var(--accent-muted), 0 0 18px var(--accent-subtle);'
                   : ''"
               >
                 <div class="corner-bar-tl"></div>
-                <!-- Slot 0 — left -->
+                <!-- Slot 0 — full-width on mobile, left half on sm+ -->
                 <div
-                  class="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-1.5 px-2 py-1.5 transition-all duration-150"
+                  class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-2 transition-all duration-150"
                   :data-drop-key="`bracket-Top${size}-${mIdx}-0`"
                   :class="[
                     match[2] === match[0] && match[0] ? 'bg-emerald-500/10' : '',
@@ -2366,19 +2366,19 @@ onUnmounted(() => {
                       : dragOverKey === `Top${size}-${mIdx}-0` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
                   ]"
                 >
-                  <!-- Name + members (draggable) -->
+                  <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[0] && match[0] ? 'text-amber-400' : 'text-surface-600'"></i>
+                  <!-- Name + members: stacked on mobile, inline on sm+ -->
                   <div v-if="match[0]"
                     @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 0 }, e)"
-                    class="flex-1 min-w-0 select-none"
+                    class="flex-1 min-w-0 select-none flex flex-col sm:flex-row sm:items-center sm:flex-wrap gap-0.5 sm:gap-x-1.5"
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[0] && match[0] ? 'text-emerald-400' : 'text-content-primary']"
                     style="touch-action: none;"
                   >
                     <div class="flex items-center gap-1 min-w-0">
-                      <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[0] && match[0] ? 'text-amber-400' : 'text-surface-600'"></i>
-                      <span class="type-body truncate">{{ match[0] }}</span>
+                      <span class="type-body break-words">{{ match[0] }}</span>
                       <span v-if="isGuestSlot(match[0])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
-                    <div v-if="getMembersFor(match[0]).length" class="flex flex-wrap gap-1 mt-1">
+                    <div v-if="getMembersFor(match[0]).length" class="flex flex-wrap gap-1">
                       <span
                         v-for="m in getMembersFor(match[0])" :key="m"
                         class="inline-block px-2 py-0.5 normal-case flex-shrink-0"
@@ -2387,30 +2387,29 @@ onUnmounted(() => {
                       >{{ m }}</span>
                     </div>
                   </div>
-                  <div v-else class="flex-1 flex items-center gap-1">
-                    <i class="pi pi-crown text-xs flex-shrink-0 text-surface-600"></i>
-                    <span class="type-body text-surface-600/60 italic">Drop here</span>
-                  </div>
-                  <!-- Action buttons -->
-                  <div class="flex items-center gap-1 justify-end sm:justify-start flex-shrink-0">
-                    <button v-if="!setupLocked && match[0] && !isGuestSlot(match[0])" @click="clearSlot(`Top${size}`, mIdx, 0)" class="px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
-                    <button
-                      :disabled="!match[0]"
-                      @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 0, match[0])"
-                      class="w-10 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
-                      :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
-                    >{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
-                  </div>
+                  <span v-else class="flex-1 type-body text-surface-600/60 italic">Drop here</span>
+                  <button v-if="!setupLocked && match[0] && !isGuestSlot(match[0])" @click="clearSlot(`Top${size}`, mIdx, 0)" class="flex-shrink-0 px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
+                  <button
+                    :disabled="!match[0]"
+                    @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 0, match[0])"
+                    class="flex-shrink-0 w-10 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+                  >{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
                 </div>
 
-                <!-- VS badge (vertical divider) -->
-                <div class="flex items-center justify-center w-7 shrink-0 border-x border-surface-600/30 bg-surface-900/50">
-                  <span class="text-[9px] font-black text-surface-600 tracking-widest rotate-0">VS</span>
+                <!-- VS: horizontal line on mobile, vertical divider on sm+ -->
+                <div class="sm:hidden flex items-center gap-2 px-2 py-0.5">
+                  <div class="flex-1 h-px bg-surface-600/30"></div>
+                  <span class="text-[9px] font-black text-surface-600 tracking-widest">VS</span>
+                  <div class="flex-1 h-px bg-surface-600/30"></div>
+                </div>
+                <div class="hidden sm:flex items-center justify-center w-7 shrink-0 border-x border-surface-600/30 bg-surface-900/50">
+                  <span class="text-[9px] font-black text-surface-600 tracking-widest">VS</span>
                 </div>
 
-                <!-- Slot 1 — right -->
+                <!-- Slot 1 — full-width on mobile, right half on sm+ -->
                 <div
-                  class="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-1.5 px-2 py-1.5 transition-all duration-150"
+                  class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-2 transition-all duration-150"
                   :data-drop-key="`bracket-Top${size}-${mIdx}-1`"
                   :class="[
                     match[2] === match[1] && match[1] ? 'bg-emerald-500/10' : '',
@@ -2419,19 +2418,19 @@ onUnmounted(() => {
                       : dragOverKey === `Top${size}-${mIdx}-1` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
                   ]"
                 >
-                  <!-- Name + members (draggable) -->
+                  <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[1] && match[1] ? 'text-amber-400' : 'text-surface-600'"></i>
+                  <!-- Name + members: stacked on mobile, inline on sm+ -->
                   <div v-if="match[1]"
                     @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 1 }, e)"
-                    class="flex-1 min-w-0 select-none"
+                    class="flex-1 min-w-0 select-none flex flex-col sm:flex-row sm:items-center sm:flex-wrap gap-0.5 sm:gap-x-1.5"
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[1] && match[1] ? 'text-emerald-400' : 'text-content-primary']"
                     style="touch-action: none;"
                   >
                     <div class="flex items-center gap-1 min-w-0">
-                      <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[1] && match[1] ? 'text-amber-400' : 'text-surface-600'"></i>
-                      <span class="type-body truncate">{{ match[1] }}</span>
+                      <span class="type-body break-words">{{ match[1] }}</span>
                       <span v-if="isGuestSlot(match[1])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
-                    <div v-if="getMembersFor(match[1]).length" class="flex flex-wrap gap-1 mt-1">
+                    <div v-if="getMembersFor(match[1]).length" class="flex flex-wrap gap-1">
                       <span
                         v-for="m in getMembersFor(match[1])" :key="m"
                         class="inline-block px-2 py-0.5 normal-case flex-shrink-0"
@@ -2440,26 +2439,20 @@ onUnmounted(() => {
                       >{{ m }}</span>
                     </div>
                   </div>
-                  <div v-else class="flex-1 flex items-center gap-1">
-                    <i class="pi pi-crown text-xs flex-shrink-0 text-surface-600"></i>
-                    <span class="type-body text-surface-600/60 italic">Drop here</span>
-                  </div>
-                  <!-- Action buttons -->
-                  <div class="flex items-center gap-1 justify-end sm:justify-start flex-shrink-0">
-                    <button v-if="!setupLocked && match[1] && !isGuestSlot(match[1])" @click="clearSlot(`Top${size}`, mIdx, 1)" class="px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
-                    <button
-                      :disabled="!match[1]"
-                      @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 1, match[1])"
-                      class="w-10 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
-                      :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
-                    >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
-                  </div>
+                  <span v-else class="flex-1 type-body text-surface-600/60 italic">Drop here</span>
+                  <button v-if="!setupLocked && match[1] && !isGuestSlot(match[1])" @click="clearSlot(`Top${size}`, mIdx, 1)" class="flex-shrink-0 px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
+                  <button
+                    :disabled="!match[1]"
+                    @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 1, match[1])"
+                    class="flex-shrink-0 w-10 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+                  >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
                 </div>
-                <!-- Start from this match — only when round is idle, all slots filled, and match has no winner yet -->
+                <!-- Start from this match — desktop only, mobile has the global Start Round button -->
                 <button
                   v-if="match[0] && match[1] && !match[2] && isActiveRoundFilled && effectivePhase === 'IDLE'"
                   @click="requestStartAt(`Top${size}`, rounds[`Top${size}`], mIdx)"
-                  class="flex-shrink-0 flex items-center justify-center w-10 ml-1.5 self-stretch rounded text-accent border border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)] hover:bg-[color:var(--accent-muted)] transition-colors"
+                  class="hidden sm:flex flex-shrink-0 items-center justify-center w-10 ml-1.5 self-stretch rounded text-accent border border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)] hover:bg-[color:var(--accent-muted)] transition-colors"
                   title="Start round from this match"
                 ><i class="pi pi-play text-[10px]"></i></button>
               </div>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2373,8 +2373,8 @@ onUnmounted(() => {
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[0] && match[0] ? 'text-emerald-400' : 'text-content-primary']"
                     style="touch-action: none;"
                   >
-                    <div class="flex items-center gap-1.5 flex-shrink-0">
-                      <span class="type-body">{{ match[0] }}</span>
+                    <div class="flex items-center gap-1 min-w-0 overflow-hidden">
+                      <span class="type-body truncate">{{ match[0] }}</span>
                       <span v-if="isGuestSlot(match[0])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
                     <div v-if="getMembersFor(match[0]).length" class="hidden sm:flex flex-wrap gap-1 flex-1 min-w-0">
@@ -2391,7 +2391,7 @@ onUnmounted(() => {
                   <button
                     :disabled="!match[0]"
                     @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 0, match[0])"
-                    class="flex-shrink-0 w-11 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    class="flex-shrink-0 w-8 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
                     :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
                   >{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
                 </div>
@@ -2419,8 +2419,8 @@ onUnmounted(() => {
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[1] && match[1] ? 'text-emerald-400' : 'text-content-primary']"
                     style="touch-action: none;"
                   >
-                    <div class="flex items-center gap-1.5 flex-shrink-0">
-                      <span class="type-body">{{ match[1] }}</span>
+                    <div class="flex items-center gap-1 min-w-0 overflow-hidden">
+                      <span class="type-body truncate">{{ match[1] }}</span>
                       <span v-if="isGuestSlot(match[1])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
                     <div v-if="getMembersFor(match[1]).length" class="hidden sm:flex flex-wrap gap-1 flex-1 min-w-0">
@@ -2437,7 +2437,7 @@ onUnmounted(() => {
                   <button
                     :disabled="!match[1]"
                     @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 1, match[1])"
-                    class="flex-shrink-0 w-11 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    class="flex-shrink-0 w-8 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
                     :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
                   >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
                 </div>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2357,7 +2357,7 @@ onUnmounted(() => {
                 <div class="corner-bar-tl"></div>
                 <!-- Slot 0 — left -->
                 <div
-                  class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
+                  class="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-1.5 px-2 py-1.5 transition-all duration-150"
                   :data-drop-key="`bracket-Top${size}-${mIdx}-0`"
                   :class="[
                     match[2] === match[0] && match[0] ? 'bg-emerald-500/10' : '',
@@ -2366,18 +2366,19 @@ onUnmounted(() => {
                       : dragOverKey === `Top${size}-${mIdx}-0` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
                   ]"
                 >
-                  <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[0] && match[0] ? 'text-amber-400' : 'text-surface-600'"></i>
+                  <!-- Name + members (draggable) -->
                   <div v-if="match[0]"
                     @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 0 }, e)"
-                    class="flex-1 min-w-0 select-none flex items-center gap-3"
+                    class="flex-1 min-w-0 select-none"
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[0] && match[0] ? 'text-emerald-400' : 'text-content-primary']"
                     style="touch-action: none;"
                   >
-                    <div class="flex items-center gap-1 min-w-0 overflow-hidden">
+                    <div class="flex items-center gap-1 min-w-0">
+                      <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[0] && match[0] ? 'text-amber-400' : 'text-surface-600'"></i>
                       <span class="type-body truncate">{{ match[0] }}</span>
                       <span v-if="isGuestSlot(match[0])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
-                    <div v-if="getMembersFor(match[0]).length" class="hidden sm:flex flex-wrap gap-1 flex-1 min-w-0">
+                    <div v-if="getMembersFor(match[0]).length" class="flex flex-wrap gap-1 mt-1">
                       <span
                         v-for="m in getMembersFor(match[0])" :key="m"
                         class="inline-block px-2 py-0.5 normal-case flex-shrink-0"
@@ -2386,14 +2387,20 @@ onUnmounted(() => {
                       >{{ m }}</span>
                     </div>
                   </div>
-                  <span v-else class="flex-1 type-body text-surface-600/60 italic">Drop here</span>
-                  <button v-if="!setupLocked && match[0] && !isGuestSlot(match[0])" @click="clearSlot(`Top${size}`, mIdx, 0)" class="flex-shrink-0 px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
-                  <button
-                    :disabled="!match[0]"
-                    @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 0, match[0])"
-                    class="flex-shrink-0 w-8 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
-                    :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
-                  >{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
+                  <div v-else class="flex-1 flex items-center gap-1">
+                    <i class="pi pi-crown text-xs flex-shrink-0 text-surface-600"></i>
+                    <span class="type-body text-surface-600/60 italic">Drop here</span>
+                  </div>
+                  <!-- Action buttons -->
+                  <div class="flex items-center gap-1 justify-end sm:justify-start flex-shrink-0">
+                    <button v-if="!setupLocked && match[0] && !isGuestSlot(match[0])" @click="clearSlot(`Top${size}`, mIdx, 0)" class="px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
+                    <button
+                      :disabled="!match[0]"
+                      @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 0, match[0])"
+                      class="w-10 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                      :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+                    >{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
+                  </div>
                 </div>
 
                 <!-- VS badge (vertical divider) -->
@@ -2403,7 +2410,7 @@ onUnmounted(() => {
 
                 <!-- Slot 1 — right -->
                 <div
-                  class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
+                  class="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-1.5 px-2 py-1.5 transition-all duration-150"
                   :data-drop-key="`bracket-Top${size}-${mIdx}-1`"
                   :class="[
                     match[2] === match[1] && match[1] ? 'bg-emerald-500/10' : '',
@@ -2412,18 +2419,19 @@ onUnmounted(() => {
                       : dragOverKey === `Top${size}-${mIdx}-1` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
                   ]"
                 >
-                  <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[1] && match[1] ? 'text-amber-400' : 'text-surface-600'"></i>
+                  <!-- Name + members (draggable) -->
                   <div v-if="match[1]"
                     @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 1 }, e)"
-                    class="flex-1 min-w-0 select-none flex items-center gap-3"
+                    class="flex-1 min-w-0 select-none"
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[1] && match[1] ? 'text-emerald-400' : 'text-content-primary']"
                     style="touch-action: none;"
                   >
-                    <div class="flex items-center gap-1 min-w-0 overflow-hidden">
+                    <div class="flex items-center gap-1 min-w-0">
+                      <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[1] && match[1] ? 'text-amber-400' : 'text-surface-600'"></i>
                       <span class="type-body truncate">{{ match[1] }}</span>
                       <span v-if="isGuestSlot(match[1])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
-                    <div v-if="getMembersFor(match[1]).length" class="hidden sm:flex flex-wrap gap-1 flex-1 min-w-0">
+                    <div v-if="getMembersFor(match[1]).length" class="flex flex-wrap gap-1 mt-1">
                       <span
                         v-for="m in getMembersFor(match[1])" :key="m"
                         class="inline-block px-2 py-0.5 normal-case flex-shrink-0"
@@ -2432,14 +2440,20 @@ onUnmounted(() => {
                       >{{ m }}</span>
                     </div>
                   </div>
-                  <span v-else class="flex-1 type-body text-surface-600/60 italic">Drop here</span>
-                  <button v-if="!setupLocked && match[1] && !isGuestSlot(match[1])" @click="clearSlot(`Top${size}`, mIdx, 1)" class="flex-shrink-0 px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
-                  <button
-                    :disabled="!match[1]"
-                    @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 1, match[1])"
-                    class="flex-shrink-0 w-8 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
-                    :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
-                  >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
+                  <div v-else class="flex-1 flex items-center gap-1">
+                    <i class="pi pi-crown text-xs flex-shrink-0 text-surface-600"></i>
+                    <span class="type-body text-surface-600/60 italic">Drop here</span>
+                  </div>
+                  <!-- Action buttons -->
+                  <div class="flex items-center gap-1 justify-end sm:justify-start flex-shrink-0">
+                    <button v-if="!setupLocked && match[1] && !isGuestSlot(match[1])" @click="clearSlot(`Top${size}`, mIdx, 1)" class="px-1.5 py-1 text-surface-400 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors" title="Clear slot"><i class="pi pi-times text-[10px]"></i></button>
+                    <button
+                      :disabled="!match[1]"
+                      @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 1, match[1])"
+                      class="w-10 sm:w-11 text-center rounded text-[10px] sm:text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                      :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+                    >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
+                  </div>
                 </div>
                 <!-- Start from this match — only when round is idle, all slots filled, and match has no winner yet -->
                 <button

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2372,7 +2372,7 @@ onUnmounted(() => {
                       <span class="type-body">{{ match[0] }}</span>
                       <span v-if="isGuestSlot(match[0])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
-                    <div v-if="getMembersFor(match[0]).length" class="flex flex-wrap gap-1 flex-1 min-w-0">
+                    <div v-if="getMembersFor(match[0]).length" class="hidden sm:flex flex-wrap gap-1 flex-1 min-w-0">
                       <span
                         v-for="m in getMembersFor(match[0])" :key="m"
                         class="inline-block px-2 py-0.5 normal-case flex-shrink-0"
@@ -2418,7 +2418,7 @@ onUnmounted(() => {
                       <span class="type-body">{{ match[1] }}</span>
                       <span v-if="isGuestSlot(match[1])" class="flex-shrink-0 inline-flex items-center gap-0.5 px-1.5 py-px text-amber-400 bg-amber-500/20 border border-amber-500/50 rounded" style="font-size:9px;font-weight:700;letter-spacing:0.1em"><i class="pi pi-star" style="font-size:7px"></i>GUEST</span>
                     </div>
-                    <div v-if="getMembersFor(match[1]).length" class="flex flex-wrap gap-1 flex-1 min-w-0">
+                    <div v-if="getMembersFor(match[1]).length" class="hidden sm:flex flex-wrap gap-1 flex-1 min-w-0">
                       <span
                         v-for="m in getMembersFor(match[1])" :key="m"
                         class="inline-block px-2 py-0.5 normal-case flex-shrink-0"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2373,6 +2373,7 @@ onUnmounted(() => {
           </span>
           <span
             v-for="p in poolParticipants" :key="p.name"
+            :data-drag-name="p.name"
             @pointerdown="(e) => onPointerDragStart('pool', p.name, e)"
             class="para-chip-sm px-2.5 py-1 type-label text-content-primary cursor-grab active:cursor-grabbing select-none inline-flex items-center gap-1.5"
             :class="poolDragName === p.name ? 'opacity-40' : ''"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1980,14 +1980,14 @@ onUnmounted(() => {
     </Transition>
 
     <!-- Genre switcher — page-level selector, above both panels -->
-    <div class="card px-5 py-3 flex flex-wrap items-center gap-2 mb-3">
+    <div class="card px-4 sm:px-5 py-3 flex flex-wrap items-center gap-2 mb-3">
       <span class="type-label text-content-muted" style="font-size:10px;letter-spacing:0.18em">GENRE</span>
       <div class="flex flex-wrap gap-2">
         <button
           v-for="g in uniqueGenres"
           :key="g"
           @click="requestGenreChange(g)"
-          class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150 inline-flex items-center gap-1.5"
+          class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label transition-all duration-150 inline-flex items-center gap-1.5"
           :class="[
             selectedGenre === g
               ? 'text-accent border-[color:var(--accent-muted)]'
@@ -2062,7 +2062,7 @@ onUnmounted(() => {
               v-for="s in sizes.filter(s => s !== 7)"
               :key="s"
               @click="requestSizeChange(s)"
-              class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150"
+              class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label transition-all duration-150"
               :class="topSize === s
                 ? 'text-accent border-[color:var(--accent-muted)]'
                 : 'text-content-muted hover:text-content-primary'"
@@ -2085,7 +2085,7 @@ onUnmounted(() => {
               v-for="j in sortedJudgesForToggle"
               :key="j.name"
               @click="toggleBattleJudge(j.name)"
-              class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1.5 transition-all duration-150 cursor-pointer select-none"
+              class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label inline-flex items-center gap-1.5 transition-all duration-150 cursor-pointer select-none"
               :class="j.active
                 ? 'text-accent border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)]'
                 : 'text-content-muted/40 hover:text-content-muted border-surface-600/30'"
@@ -2133,31 +2133,31 @@ onUnmounted(() => {
         <div class="section-rule-line"></div>
       </div>
 
-      <div class="flex flex-wrap items-center gap-2 mt-4 mb-5">
+      <!-- Seeding controls: stacked on mobile, inline on sm+ -->
+      <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3 sm:gap-2 mt-4 mb-5">
         <!-- Pickup crew sort toggle (mixed bracket only) -->
         <template v-if="isMixedBracket">
-          <div class="flex gap-1">
+          <div class="flex gap-2 sm:gap-1">
             <button
               @click="crewSortMode = 'leader'"
-              class="para-chip-sm px-2.5 py-1.5 type-label transition-all"
+              class="para-chip-sm px-3 sm:px-2.5 py-3 sm:py-1.5 type-label transition-all flex-1 sm:flex-none"
               :class="crewSortMode === 'leader' ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
               title="Sort pickup crews by their leader's individual audition score"
             >Leader</button>
             <button
               @click="crewSortMode = 'avg'"
-              class="para-chip-sm px-2.5 py-1.5 type-label transition-all"
+              class="para-chip-sm px-3 sm:px-2.5 py-3 sm:py-1.5 type-label transition-all flex-1 sm:flex-none"
               :class="crewSortMode === 'avg' ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
               title="Sort pickup crews by average score of all members"
             >Avg</button>
           </div>
-          <span class="text-surface-600 select-none">|</span>
+          <span class="text-surface-600 select-none hidden sm:inline">|</span>
         </template>
 
-        <div class="flex flex-wrap gap-1">
+        <div class="flex flex-wrap gap-2 sm:gap-1">
           <button
             @click="autoFillSeeds"
-            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 transition-all"
-            :class="rankAsc ? 'text-content-muted hover:text-content-primary' : 'text-content-muted hover:text-content-primary'"
+            class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label inline-flex items-center gap-1 transition-all text-content-muted hover:text-content-primary"
             :title="rankAsc ? 'Lowest score first' : 'Highest score first'"
           >
             <i :class="rankAsc ? 'pi pi-sort-amount-up' : 'pi pi-sort-amount-down'" class="text-xs"></i>
@@ -2171,7 +2171,7 @@ onUnmounted(() => {
           <button
             @click="highVsLowFill"
             :disabled="guestsForCurrentGenre.length > 0"
-            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 transition-all"
+            class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label inline-flex items-center gap-1 transition-all"
             :class="guestsForCurrentGenre.length > 0 ? 'opacity-30 cursor-not-allowed text-content-muted' : 'text-content-muted hover:text-content-primary'"
             :title="guestsForCurrentGenre.length > 0 ? 'Disabled: bracket has pinned guests' : 'Pair highest with lowest (1st vs last, 2nd vs 2nd-last...)'"
           >
@@ -2180,7 +2180,7 @@ onUnmounted(() => {
           </button>
           <button
             @click="randomFill"
-            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 text-content-muted hover:text-content-primary transition-all"
+            class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label inline-flex items-center gap-1 text-content-muted hover:text-content-primary transition-all"
             title="Random shuffle"
           >
             <i class="pi pi-refresh text-xs"></i>
@@ -2189,7 +2189,7 @@ onUnmounted(() => {
           <button
             v-if="isMixedBracket"
             @click="splitBracketFill"
-            class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1 text-accent transition-all"
+            class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label inline-flex items-center gap-1 text-accent transition-all"
             title="Pre-formed teams on left half, pickup crews on right half"
           >
             <i class="pi pi-table text-xs"></i>
@@ -2291,21 +2291,22 @@ onUnmounted(() => {
           <div class="section-rule-line"></div>
         </div>
 
-        <div class="flex flex-wrap gap-1.5 mt-3 min-h-[28px]">
-          <span v-if="!poolParticipants.length" class="type-label text-content-muted">
+        <!-- Mobile: 2-col grid for easy tap; Tablet+: flex wrap -->
+        <div class="grid grid-cols-2 sm:flex sm:flex-wrap gap-2 sm:gap-1.5 mt-3 min-h-[28px]">
+          <span v-if="!poolParticipants.length" class="col-span-2 type-label text-content-muted">
             {{ isSmoke ? `All ${bracketSize - guestsForCurrentGenre.length} queue slots filled` : `All top ${bracketSize - guestsForCurrentGenre.length} participants placed in bracket` }}
           </span>
           <span
             v-for="p in poolParticipants" :key="p.name"
             :data-drag-name="p.name"
             @pointerdown="(e) => onPointerDragStart('pool', p.name, e)"
-            class="para-chip-sm px-2.5 py-1 type-label text-content-primary cursor-grab active:cursor-grabbing select-none inline-flex items-center gap-1.5"
+            class="para-chip-sm px-3 sm:px-2.5 py-3 sm:py-1 type-label text-content-primary cursor-grab active:cursor-grabbing select-none inline-flex items-center justify-between gap-1.5"
             :class="poolDragName === p.name ? 'opacity-40' : ''"
             :title="p.name"
-            style="touch-action: none; user-select: none;"
+            style="touch-action: none; user-select: none; min-height: 44px;"
           >
-            <span>{{ p.name }}</span>
-            <span class="text-content-muted" style="font-size:10px;letter-spacing:0.05em;opacity:0.7">{{ p.score % 1 === 0 ? p.score : p.score.toFixed(1) }}</span>
+            <span class="truncate">{{ p.name }}</span>
+            <span class="text-content-muted flex-shrink-0" style="font-size:11px;letter-spacing:0.05em;opacity:0.7">{{ p.score % 1 === 0 ? p.score : p.score.toFixed(1) }}</span>
           </span>
         </div>
       </div>
@@ -2319,12 +2320,12 @@ onUnmounted(() => {
       <!-- ── Standard bracket ──────────────────────────── -->
       <div v-if="Number(topSize) !== 7" class="mt-3">
         <!-- Round tabs -->
-        <div class="flex flex-wrap gap-1 mb-4">
+        <div class="flex flex-wrap gap-2 sm:gap-1 mb-4">
           <button
             v-for="(size, idx) in roundSizes"
             :key="idx"
             @click="requestRoundChange(idx)"
-            class="para-chip-sm px-4 py-1.5 type-label transition-all duration-150 inline-flex items-center gap-1.5"
+            class="para-chip-sm px-4 py-3 sm:py-1.5 type-label transition-all duration-150 inline-flex items-center gap-1.5 flex-1 sm:flex-none justify-center sm:justify-start"
             :class="{
               'text-accent border-[color:var(--accent-muted)]': activeRoundIdx === idx,
               'text-emerald-400/70 border-emerald-500/30': activeRoundIdx !== idx && roundTabStatus(idx) === 'done',
@@ -2462,14 +2463,14 @@ onUnmounted(() => {
               v-if="effectivePhase === 'IDLE' && !setupLocked"
               :disabled="!isActiveRoundFilled"
               @click="initiateBattlePair(`Top${size}`, rounds[`Top${size}`])"
-              class="w-full py-2 para-chip type-label transition-all duration-200"
+              class="w-full py-4 sm:py-2 para-chip type-label transition-all duration-200"
               :class="isActiveRoundFilled ? 'bg-accent' : 'bg-surface-700 text-content-muted cursor-not-allowed'"
               :title="isActiveRoundFilled ? '' : 'All slots must be filled and the previous round must be completed'"
             >
               <i class="pi pi-play text-xs mr-1.5"></i>
               Start Round
             </button>
-            <div v-else class="w-full py-2 text-center type-label text-content-muted">
+            <div v-else class="w-full py-4 sm:py-2 text-center type-label text-content-muted">
               <template v-if="currentTop === `Top${size}`">Active battle in Top{{ size }}</template>
               <template v-else-if="rounds[`Top${size}`]?.every(m => Array.isArray(m) && m[2])">Round complete</template>
             </div>
@@ -2905,12 +2906,12 @@ onUnmounted(() => {
       </div>
 
       <!-- Action buttons — only for the active round -->
-      <div v-if="isActiveBattleInThisRound" class="flex flex-wrap gap-2">
+      <div v-if="isActiveBattleInThisRound" class="flex flex-wrap gap-3 sm:gap-2">
         <!-- LOCKED: open voting -->
         <button
           v-if="battlePhase === 'LOCKED'"
           @click="openVoting"
-          class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+          class="bg-accent para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 transition-all flex-1 sm:flex-none justify-center"
         >
           <i class="pi pi-lock-open text-xs"></i>
           Open Voting
@@ -2922,21 +2923,20 @@ onUnmounted(() => {
           :disabled="!allJudgesVoted"
           @click="submitGetScore"
           :class="allJudgesVoted
-            ? 'bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all'
-            : 'bg-surface-700/30 para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all cursor-not-allowed opacity-50'"
+            ? 'bg-accent para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 transition-all flex-1 sm:flex-none justify-center'
+            : 'bg-surface-700/30 para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 transition-all cursor-not-allowed opacity-50 flex-1 sm:flex-none justify-center'"
           :title="allJudgesVoted ? '' : 'Waiting for all judges to vote'"
         >
           <i class="pi pi-bolt text-xs"></i>
           {{ (Number(currentWinner) === -1 && !isSmoke) ? 'Rematch' : 'Get Score' }}
         </button>
 
-        <!-- VOTING + final + all judges voted → Lock Champion.
-             Enabled when clear winner, disabled on tie (listens in real-time). -->
+        <!-- VOTING + final + all judges voted → Lock Champion. -->
         <button
           v-if="battlePhase === 'VOTING' && isFinalInProgress && allJudgesVoted"
           :disabled="!showFinalReveal"
           @click="lockChampion"
-          class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+          class="para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 transition-all flex-1 sm:flex-none justify-center"
           :class="showFinalReveal
             ? 'border-amber-400/50 text-amber-400 bg-amber-400/10 hover:bg-amber-400/20'
             : 'border-gray-500/30 text-content-muted bg-surface-700/30 cursor-not-allowed'"
@@ -2951,7 +2951,7 @@ onUnmounted(() => {
           <button
             v-if="!revealActive"
             @click="revealChampionForGenre"
-            class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all"
+            class="para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 border-accent transition-all flex-1 sm:flex-none justify-center"
           >
             <i class="pi pi-star text-xs"></i>
             Reveal Champion
@@ -2959,14 +2959,14 @@ onUnmounted(() => {
           <button
             v-if="revealActive"
             @click="dismissReveal"
-            class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+            class="para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 transition-all flex-1 sm:flex-none justify-center"
           >
             <i class="pi pi-times text-xs"></i>
             Dismiss Reveal
           </button>
           <button
             @click="unlockChampion"
-            class="para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 text-content-muted hover:text-content-primary transition-all"
+            class="para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 text-content-muted hover:text-content-primary transition-all flex-1 sm:flex-none justify-center"
           >
             <i class="pi pi-unlock text-xs"></i>
             Unlock
@@ -2977,7 +2977,7 @@ onUnmounted(() => {
         <template v-if="battlePhase === 'REVEALED'">
           <button
             @click="nextPair"
-            class="bg-accent para-chip-sm px-4 py-2 type-label inline-flex items-center gap-1.5 transition-all"
+            class="bg-accent para-chip-sm px-5 sm:px-4 py-3.5 sm:py-2 type-label inline-flex items-center gap-1.5 transition-all flex-1 sm:flex-none justify-center"
           >
             Next
             <i class="pi pi-chevron-right text-xs"></i>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -6,6 +6,7 @@ import { useDropdowns } from '@/utils/dropdown'
 import { useEventUtils } from '@/utils/eventUtils'
 import { useBattleLogic } from '@/utils/battleLogic'
 import { createClient, deactivateClient } from '@/utils/websocket'
+import { parseDropKey } from '@/utils/pointerDnd'
 
 const { selectedEvent, selectedGenre, initialiseDropdown } = useDropdowns()
 const { allJudges, fetchAllJudges, participants } = useEventUtils()
@@ -821,6 +822,126 @@ const onSmokeDrop = (tgtIdx) => {
   if (rounds.value[tgtIdx]) rounds.value[tgtIdx] = { ...rounds.value[tgtIdx], name: srcName ?? null }
   localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
+}
+
+// ── Pointer-events DnD (replaces HTML5 drag API — works on touch + desktop) ──
+
+let _ghostEl = null
+let _ptrMoveHandler = null
+let _ptrUpHandler = null
+
+const _removePtrListeners = () => {
+  if (_ptrMoveHandler) { document.removeEventListener('pointermove', _ptrMoveHandler); _ptrMoveHandler = null }
+  if (_ptrUpHandler)   { document.removeEventListener('pointerup',   _ptrUpHandler);   _ptrUpHandler   = null }
+  document.removeEventListener('pointercancel', _ptrUpHandler ?? (() => {}))
+}
+
+const _cleanupDrag = () => {
+  if (_ghostEl) { document.body.removeChild(_ghostEl); _ghostEl = null }
+  _removePtrListeners()
+  dragSource.value  = null
+  poolDragName.value = null
+  dragOverKey.value  = null
+}
+
+const onPointerDragStart = (type, payload, e) => {
+  if (setupLocked.value) return
+  e.preventDefault()
+
+  // Set existing drag-state refs (drives existing highlight CSS — no template class changes)
+  if (type === 'pool') {
+    poolDragName.value = payload          // payload = name string
+    dragSource.value   = null
+  } else if (type === 'bracket') {
+    dragSource.value   = payload          // payload = { roundKey, matchIdx, slotIdx }
+    poolDragName.value = null
+  } else if (type === 'smoke') {
+    dragSource.value   = { smokeIdx: payload }   // payload = mIdx (number)
+    poolDragName.value = null
+  }
+
+  // Resolve display name for ghost label
+  let ghostName = ''
+  if (type === 'pool') {
+    ghostName = payload
+  } else if (type === 'bracket') {
+    ghostName = rounds.value[payload.roundKey]?.[payload.matchIdx]?.[payload.slotIdx] ?? ''
+  } else if (type === 'smoke') {
+    ghostName = rounds.value[payload]?.name ?? ''
+  }
+
+  // Create ghost element
+  _ghostEl = document.createElement('div')
+  _ghostEl.textContent = ghostName
+  Object.assign(_ghostEl.style, {
+    position:      'fixed',
+    left:          `${e.clientX + 12}px`,
+    top:           `${e.clientY + 12}px`,
+    padding:       '5px 14px',
+    background:    '#1a1a1a',
+    border:        `1.5px solid ${type === 'pool' ? 'rgba(255,255,255,0.25)' : 'rgba(248,113,113,0.65)'}`,
+    borderRadius:  '8px',
+    fontSize:      '12px',
+    fontWeight:    '600',
+    color:         '#f0f0f0',
+    boxShadow:     '0 10px 28px rgba(0,0,0,0.7)',
+    whiteSpace:    'nowrap',
+    pointerEvents: 'none',
+    zIndex:        '9999',
+  })
+  document.body.appendChild(_ghostEl)
+
+  _ptrMoveHandler = (ev) => {
+    _ghostEl.style.left = `${ev.clientX + 12}px`
+    _ghostEl.style.top  = `${ev.clientY + 12}px`
+
+    // Find drop target under pointer (hide ghost first so it doesn't intercept)
+    _ghostEl.style.display = 'none'
+    const el = document.elementFromPoint(ev.clientX, ev.clientY)
+    _ghostEl.style.display = ''
+    const dropEl = el?.closest('[data-drop-key]')
+    if (dropEl) {
+      const parsed = parseDropKey(dropEl.dataset.dropKey)
+      if (parsed?.type === 'bracket') {
+        dragOverKey.value = `${parsed.roundKey}-${parsed.matchIdx}-${parsed.slotIdx}`
+      } else if (parsed?.type === 'smoke') {
+        dragOverKey.value = `smoke-${parsed.idx}`
+      } else {
+        dragOverKey.value = null
+      }
+    } else {
+      dragOverKey.value = null
+    }
+  }
+
+  _ptrUpHandler = (ev) => {
+    _removePtrListeners()
+
+    // Hide ghost before elementFromPoint so it doesn't intercept the hit test
+    if (_ghostEl) _ghostEl.style.display = 'none'
+    const el = document.elementFromPoint(ev.clientX, ev.clientY)
+    if (_ghostEl) { document.body.removeChild(_ghostEl); _ghostEl = null }
+
+    const dropKeyEl = el?.closest('[data-drop-key]')
+    const parsed = dropKeyEl ? parseDropKey(dropKeyEl.dataset.dropKey) : null
+
+    if (parsed && !setupLocked.value) {
+      if (parsed.type === 'bracket') {
+        onDrop(parsed.roundKey, parsed.matchIdx, parsed.slotIdx)
+      } else if (parsed.type === 'smoke') {
+        onSmokeDrop(parsed.idx)
+      }
+    } else {
+      // No valid drop — clear state manually (onDrop/onSmokeDrop would have done this)
+      dragSource.value   = null
+      poolDragName.value = null
+      dragOverKey.value  = null
+    }
+  }
+
+  document.addEventListener('pointermove',  _ptrMoveHandler)
+  document.addEventListener('pointerup',    _ptrUpHandler)
+  document.addEventListener('pointercancel', _ptrUpHandler)
 }
 
 const clearSmokeSlot = (idx) => {
@@ -1850,6 +1971,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  _cleanupDrag()
   for (const sub of Object.values(judgeVoteSubscriptions)) sub.unsubscribe?.()
   deactivateClient(wsClient.value)
 })
@@ -2251,12 +2373,11 @@ onUnmounted(() => {
           </span>
           <span
             v-for="p in poolParticipants" :key="p.name"
-            draggable="true"
-            @dragstart="(e) => onPoolDragStart(p.name, e)"
-            @dragend="onPoolDragEnd"
+            @pointerdown="(e) => onPointerDragStart('pool', p.name, e)"
             class="para-chip-sm px-2.5 py-1 type-label text-content-primary cursor-grab active:cursor-grabbing select-none inline-flex items-center gap-1.5"
             :class="poolDragName === p.name ? 'opacity-40' : ''"
             :title="p.name"
+            style="touch-action: none; user-select: none;"
           >
             <span>{{ p.name }}</span>
             <span class="text-content-muted" style="font-size:10px;letter-spacing:0.05em;opacity:0.7">{{ p.score % 1 === 0 ? p.score : p.score.toFixed(1) }}</span>
@@ -2312,23 +2433,20 @@ onUnmounted(() => {
                 <!-- Slot 0 — left -->
                 <div
                   class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
+                  :data-drop-key="`bracket-Top${size}-${mIdx}-0`"
                   :class="[
                     match[2] === match[0] && match[0] ? 'bg-emerald-500/10' : '',
                     dragSource?.roundKey === `Top${size}` && dragSource?.matchIdx === mIdx && dragSource?.slotIdx === 0
                       ? 'ring-2 ring-primary-400/80 bg-primary-400/12 shadow-inner'
                       : dragOverKey === `Top${size}-${mIdx}-0` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
                   ]"
-                  @dragover.prevent="!setupLocked && onDragOver(`Top${size}`, mIdx, 0)"
-                  @dragleave="dragOverKey = null"
-                  @drop.prevent="!setupLocked && onDrop(`Top${size}`, mIdx, 0)"
                 >
                   <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[0] && match[0] ? 'text-amber-400' : 'text-surface-600'"></i>
                   <div v-if="match[0]"
-                    :draggable="!setupLocked"
-                    @dragstart="!setupLocked && onDragStart(`Top${size}`, mIdx, 0, $event)"
-                    @dragend="!setupLocked && onDragEnd()"
+                    @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 0 }, e)"
                     class="flex-1 min-w-0 select-none flex items-center gap-3"
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[0] && match[0] ? 'text-emerald-400' : 'text-content-primary']"
+                    style="touch-action: none;"
                   >
                     <div class="flex items-center gap-1.5 flex-shrink-0">
                       <span class="type-body">{{ match[0] }}</span>
@@ -2348,7 +2466,7 @@ onUnmounted(() => {
                   <button
                     :disabled="!match[0]"
                     @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 0, match[0])"
-                    class="flex-shrink-0 w-9 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    class="flex-shrink-0 w-11 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
                     :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
                   >{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
                 </div>
@@ -2361,23 +2479,20 @@ onUnmounted(() => {
                 <!-- Slot 1 — right -->
                 <div
                   class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
+                  :data-drop-key="`bracket-Top${size}-${mIdx}-1`"
                   :class="[
                     match[2] === match[1] && match[1] ? 'bg-emerald-500/10' : '',
                     dragSource?.roundKey === `Top${size}` && dragSource?.matchIdx === mIdx && dragSource?.slotIdx === 1
                       ? 'ring-2 ring-primary-400/80 bg-primary-400/12 shadow-inner'
                       : dragOverKey === `Top${size}-${mIdx}-1` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
                   ]"
-                  @dragover.prevent="!setupLocked && onDragOver(`Top${size}`, mIdx, 1)"
-                  @dragleave="dragOverKey = null"
-                  @drop.prevent="!setupLocked && onDrop(`Top${size}`, mIdx, 1)"
                 >
                   <i class="pi pi-crown text-xs flex-shrink-0 transition-colors" :class="match[2] === match[1] && match[1] ? 'text-amber-400' : 'text-surface-600'"></i>
                   <div v-if="match[1]"
-                    :draggable="!setupLocked"
-                    @dragstart="!setupLocked && onDragStart(`Top${size}`, mIdx, 1, $event)"
-                    @dragend="!setupLocked && onDragEnd()"
+                    @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 1 }, e)"
                     class="flex-1 min-w-0 select-none flex items-center gap-3"
                     :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[1] && match[1] ? 'text-emerald-400' : 'text-content-primary']"
+                    style="touch-action: none;"
                   >
                     <div class="flex items-center gap-1.5 flex-shrink-0">
                       <span class="type-body">{{ match[1] }}</span>
@@ -2397,7 +2512,7 @@ onUnmounted(() => {
                   <button
                     :disabled="!match[1]"
                     @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 1, match[1])"
-                    class="flex-shrink-0 w-9 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+                    class="flex-shrink-0 w-11 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
                     :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
                   >{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
                 </div>
@@ -2405,7 +2520,7 @@ onUnmounted(() => {
                 <button
                   v-if="match[0] && match[1] && !match[2] && isActiveRoundFilled && effectivePhase === 'IDLE'"
                   @click="requestStartAt(`Top${size}`, rounds[`Top${size}`], mIdx)"
-                  class="flex-shrink-0 flex items-center justify-center w-8 ml-1.5 self-stretch rounded text-accent border border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)] hover:bg-[color:var(--accent-muted)] transition-colors"
+                  class="flex-shrink-0 flex items-center justify-center w-10 ml-1.5 self-stretch rounded text-accent border border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)] hover:bg-[color:var(--accent-muted)] transition-colors"
                   title="Start round from this match"
                 ><i class="pi pi-play text-[10px]"></i></button>
               </div>
@@ -2442,16 +2557,12 @@ onUnmounted(() => {
           <div
             v-for="(match, mIdx) in rounds"
             :key="mIdx"
-            :draggable="!!match.name && !setupLocked"
-            @dragstart="!setupLocked && onSmokeDragStart(mIdx, $event)"
-            @dragend="onDragEnd"
-            @dragover.prevent="!setupLocked && onSmokeDragOver(mIdx)"
-            @dragleave="dragOverKey = null"
-            @drop.prevent="!setupLocked && onSmokeDrop(mIdx)"
+            :data-drop-key="`smoke-${mIdx}`"
+            @pointerdown="(e) => !!match.name && onPointerDragStart('smoke', mIdx, e)"
             class="card-hover relative flex items-stretch overflow-hidden transition-all duration-150"
             :class="dragOverKey === `smoke-${mIdx}` ? 'ring-2 ring-inset ring-primary-500/70 bg-primary-500/10' :
                     (dragSource?.smokeIdx === mIdx ? 'ring-2 ring-primary-400/80 bg-primary-400/12' : '')"
-            style="padding:0"
+            style="padding:0; touch-action: none;"
           >
             <div class="corner-bar-tl"></div>
             <!-- position number -->

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -744,8 +744,11 @@ let _ptrUpHandler = null
 
 const _removePtrListeners = () => {
   if (_ptrMoveHandler) { document.removeEventListener('pointermove', _ptrMoveHandler); _ptrMoveHandler = null }
-  if (_ptrUpHandler)   { document.removeEventListener('pointerup',   _ptrUpHandler);   _ptrUpHandler   = null }
-  document.removeEventListener('pointercancel', _ptrUpHandler ?? (() => {}))
+  if (_ptrUpHandler) {
+    document.removeEventListener('pointerup',     _ptrUpHandler)
+    document.removeEventListener('pointercancel', _ptrUpHandler)
+    _ptrUpHandler = null
+  }
 }
 
 const _cleanupDrag = () => {
@@ -782,13 +785,15 @@ const onPointerDragStart = (type, payload, e) => {
     ghostName = rounds.value[payload]?.name ?? ''
   }
 
-  // Create ghost element
+  // Create ghost element — position above finger on touch, below-right of cursor on mouse
+  const _ghostOffX = e.pointerType === 'touch' ? -20 : 12
+  const _ghostOffY = e.pointerType === 'touch' ? -50 : 12
   _ghostEl = document.createElement('div')
   _ghostEl.textContent = ghostName
   Object.assign(_ghostEl.style, {
     position:      'fixed',
-    left:          `${e.clientX + 12}px`,
-    top:           `${e.clientY + 12}px`,
+    left:          `${e.clientX + _ghostOffX}px`,
+    top:           `${e.clientY + _ghostOffY}px`,
     padding:       '5px 14px',
     background:    '#1a1a1a',
     border:        `1.5px solid ${type === 'pool' ? 'rgba(255,255,255,0.25)' : 'rgba(248,113,113,0.65)'}`,
@@ -804,8 +809,10 @@ const onPointerDragStart = (type, payload, e) => {
   document.body.appendChild(_ghostEl)
 
   _ptrMoveHandler = (ev) => {
-    _ghostEl.style.left = `${ev.clientX + 12}px`
-    _ghostEl.style.top  = `${ev.clientY + 12}px`
+    const ox = ev.pointerType === 'touch' ? -20 : 12
+    const oy = ev.pointerType === 'touch' ? -50 : 12
+    _ghostEl.style.left = `${ev.clientX + ox}px`
+    _ghostEl.style.top  = `${ev.clientY + oy}px`
 
     // Find drop target under pointer (hide ghost first so it doesn't intercept)
     _ghostEl.style.display = 'none'

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1050,6 +1050,11 @@ const saveGenreBattleState = (genre) => {
 }
 
 const restoreAndBroadcastGenreBattle = async (genre) => {
+  // Always reset bracket grid for the current event before restoring state — prevents
+  // stale rounds from a previous event persisting when the genre name is the same across events.
+  const storedRounds = localStorage.getItem(`Top${topSize.value}${selectedEvent.value}${genre}Rounds`)
+  rounds.value = storedRounds ? JSON.parse(storedRounds) : initRounds()
+
   // At this point, switchActiveGenreService has already loaded this genre's state from DB
   // and broadcast it to all connected clients (overlay, bracket, judge). We only need
   // to restore local BattleControl UI state — no backend calls needed here.

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -654,42 +654,6 @@ function initRounds() {
 
 const broadcastBracket = () => setBracketState(toRaw(rounds.value), topSize.value, currentRound.value)
 
-const onDragStart = (roundKey, matchIdx, slotIdx, event) => {
-  dragSource.value = { roundKey, matchIdx, slotIdx }
-
-  const name = rounds.value[roundKey][matchIdx][slotIdx] || ''
-  const ghost = document.createElement('div')
-  ghost.textContent = name
-  Object.assign(ghost.style, {
-    position: 'fixed',
-    top: '-9999px',
-    left: '-9999px',
-    padding: '5px 14px',
-    background: '#1a1a1a',
-    border: '1.5px solid rgba(248,113,113,0.65)',
-    borderRadius: '8px',
-    fontSize: '12px',
-    fontWeight: '600',
-    color: '#f0f0f0',
-    boxShadow: '0 10px 28px rgba(0,0,0,0.7), 0 0 0 1px rgba(229,57,53,0.15)',
-    whiteSpace: 'nowrap',
-    pointerEvents: 'none',
-  })
-  document.body.appendChild(ghost)
-  event.dataTransfer.setDragImage(ghost, ghost.offsetWidth / 2, ghost.offsetHeight / 2)
-  requestAnimationFrame(() => document.body.removeChild(ghost))
-}
-
-const onDragOver = (roundKey, matchIdx, slotIdx) => {
-  if (!dragSource.value && !poolDragName.value) return
-  dragOverKey.value = `${roundKey}-${matchIdx}-${slotIdx}`
-}
-
-const onDragEnd = () => {
-  dragSource.value = null
-  dragOverKey.value = null
-}
-
 // Re-broadcast the current battle pair to the overlay if a bracket drag/drop changed
 // its slots. Called after onDrop / onSmokeDrop so currentBattlePair already reflects
 // the updated rounds.
@@ -742,58 +706,6 @@ const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
   localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
   if (tgtIsCurrent || srcIsCurrent) reBroadcastCurrentPairIfActive()
-}
-
-const onPoolDragStart = (name, event) => {
-  poolDragName.value = name
-  const ghost = document.createElement('div')
-  ghost.textContent = name
-  Object.assign(ghost.style, {
-    position: 'fixed',
-    top: '-9999px',
-    left: '-9999px',
-    padding: '5px 14px',
-    background: '#1a1a1a',
-    border: '1.5px solid rgba(255,255,255,0.25)',
-    borderRadius: '8px',
-    fontSize: '12px',
-    fontWeight: '600',
-    color: '#f0f0f0',
-    boxShadow: '0 10px 28px rgba(0,0,0,0.7)',
-    whiteSpace: 'nowrap',
-    pointerEvents: 'none',
-  })
-  document.body.appendChild(ghost)
-  event.dataTransfer.setDragImage(ghost, ghost.offsetWidth / 2, ghost.offsetHeight / 2)
-  requestAnimationFrame(() => document.body.removeChild(ghost))
-}
-
-const onPoolDragEnd = () => {
-  poolDragName.value = null
-  dragOverKey.value = null
-}
-
-const onSmokeDragStart = (idx, event) => {
-  const name = rounds.value[idx]?.name
-  if (!name) return
-  dragSource.value = { smokeIdx: idx }
-  const ghost = document.createElement('div')
-  ghost.textContent = name
-  Object.assign(ghost.style, {
-    position: 'fixed', top: '-9999px', left: '-9999px',
-    padding: '5px 14px', background: '#1a1a1a',
-    border: '1.5px solid rgba(248,113,113,0.65)', borderRadius: '8px',
-    fontSize: '12px', fontWeight: '600', color: '#f0f0f0',
-    boxShadow: '0 10px 28px rgba(0,0,0,0.7)', whiteSpace: 'nowrap', pointerEvents: 'none',
-  })
-  document.body.appendChild(ghost)
-  event.dataTransfer.setDragImage(ghost, ghost.offsetWidth / 2, ghost.offsetHeight / 2)
-  requestAnimationFrame(() => document.body.removeChild(ghost))
-}
-
-const onSmokeDragOver = (idx) => {
-  if (!dragSource.value && !poolDragName.value) return
-  dragOverKey.value = `smoke-${idx}`
 }
 
 const onSmokeDrop = (tgtIdx) => {

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -506,7 +506,12 @@ onUnmounted(() => {
 .judge-chip-clear {
   background: none; border: none; cursor: pointer;
   font-size: 10px; color: rgba(255,255,255,0.3);
-  padding: 0 2px; line-height: 1; transition: color 0.15s;
+  padding: 10px 8px;
+  margin: -10px -8px;
+  min-width: 44px; min-height: 44px;
+  display: flex; align-items: center; justify-content: center;
+  line-height: 1; transition: color 0.15s;
+  -webkit-tap-highlight-color: transparent;
 }
 .judge-chip-clear:hover { color: rgba(255,255,255,0.8); }
 
@@ -514,7 +519,7 @@ onUnmounted(() => {
   font-family: 'Inter', sans-serif;
   font-size: 9px; font-weight: 800;
   letter-spacing: 0.2em; text-transform: uppercase;
-  padding: 5px 12px; border-radius: 999px;
+  padding: 8px 16px; border-radius: 999px;
   background: rgba(255,255,255,0.08);
   border: 1px solid rgba(255,255,255,0.2);
   color: rgba(255,255,255,0.7);
@@ -787,13 +792,24 @@ onUnmounted(() => {
   50%       { box-shadow: inset 0 0 0 1.5px rgba(255,255,255,0.18); }
 }
 
-/* ── Tablet: center at max 480px ────────────────────────────── */
+/* Tablet portrait — wider layout */
 @media (min-width: 600px) {
   .judge-root {
-    max-width: 480px;
+    max-width: 640px;
     margin: 0 auto;
     border-left:  1px solid rgba(255,255,255,0.05);
     border-right: 1px solid rgba(255,255,255,0.05);
+  }
+}
+
+/* Tablet landscape — shorter header, taller tie row for thumb reach */
+@media (min-width: 600px) and (orientation: landscape) {
+  .judge-header {
+    height: 44px;
+  }
+  .tie-row {
+    height: 26%;
+    min-height: 72px;
   }
 }
 </style>

--- a/BES-frontend/src/views/CrewFormation.vue
+++ b/BES-frontend/src/views/CrewFormation.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
-import { getActiveEvent } from '@/utils/auth'
+import { useAuthStore } from '@/utils/auth'
 import { getParticipantScore } from '@/utils/api'
 import { getPickupCrews, createPickupCrew, deletePickupCrew } from '@/utils/api'
 import ReusableDropdown from '@/components/ReusableDropdown.vue'
 import ActionDoneModal from '@/views/ActionDoneModal.vue'
 
-const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem('selectedEvent') || '')
+const authStore = useAuthStore()
+const selectedEvent = computed(() => authStore.activeEvent?.name || localStorage.getItem('selectedEvent') || '')
 const selectedGenre = ref('')
 const participants = ref([])   // raw score entries for the genre
 const crews = ref([])

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1226,85 +1226,89 @@ onUnmounted(() => {
                 : 'border-l-[3px] border-l-amber-500'
               : div.participantCount > 0 ? 'border-l-[3px] border-l-emerald-500' : ''"
           >
-            <div class="flex items-center gap-2">
-              <!-- Division name (click to rename) -->
-              <template v-if="divRenameActive !== div.eventGenreId">
-                <button
-                  @click="divRenameActive = div.eventGenreId; divRenameInput = div.name"
-                  class="type-body text-content-secondary hover:text-accent text-left truncate flex-1 transition-colors"
-                >{{ div.name }}</button>
-              </template>
-              <template v-else>
-                <input
-                  v-model="divRenameInput"
-                  type="text"
-                  class="input-base flex-1 min-w-0"
-                  placeholder="Division name"
-                  @keyup.enter="saveDivisionName(div)"
-                  @keyup.escape="divRenameActive = null"
-                  @blur="saveDivisionName(div)"
-                />
-              </template>
+            <!-- Mobile: stacked (name row, then actions row); Tablet+: single inline row -->
+            <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-2">
+              <!-- Name + count badges row -->
+              <div class="flex items-center gap-2 flex-1 min-w-0">
+                <template v-if="divRenameActive !== div.eventGenreId">
+                  <button
+                    @click="divRenameActive = div.eventGenreId; divRenameInput = div.name"
+                    class="type-body text-content-secondary hover:text-accent text-left break-words min-w-0 flex-1 transition-colors"
+                    style="overflow-wrap:break-word;word-break:break-word"
+                  >{{ div.name }}</button>
+                </template>
+                <template v-else>
+                  <input
+                    v-model="divRenameInput"
+                    type="text"
+                    class="input-base flex-1 min-w-0"
+                    placeholder="Division name"
+                    @keyup.enter="saveDivisionName(div)"
+                    @keyup.escape="divRenameActive = null"
+                    @blur="saveDivisionName(div)"
+                  />
+                </template>
 
-              <!-- Match count badge: green = imported, amber = not yet imported -->
-              <div class="flex items-center gap-2 shrink-0">
-                <!-- Green: already in DB -->
-                <div v-if="div.participantCount > 0" class="flex items-center gap-1 text-emerald-400">
-                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
-                  <span class="type-label text-xs">{{ div.participantCount }}</span>
-                </div>
-                <!-- Amber: matched on sheet but not yet imported -->
-                <div
-                  v-if="sheetCategories.length > 0 && ((matchCounts[div.eventGenreId] || 0) - div.participantCount) > 0"
-                  class="flex items-center gap-1 text-amber-400"
-                >
-                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
-                  <span class="type-label text-xs">{{ (matchCounts[div.eventGenreId] || 0) - div.participantCount }}</span>
-                </div>
-                <!-- Amber with 0 when sheet connected but no matches at all -->
-                <div
-                  v-if="sheetCategories.length > 0 && (matchCounts[div.eventGenreId] || 0) === 0 && div.participantCount === 0"
-                  class="flex items-center gap-1 text-amber-400"
-                >
-                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
-                  <span class="type-label text-xs">0</span>
+                <!-- Match count badges -->
+                <div class="flex items-center gap-2 shrink-0">
+                  <div v-if="div.participantCount > 0" class="flex items-center gap-1 text-emerald-400">
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
+                    <span class="type-label text-xs">{{ div.participantCount }}</span>
+                  </div>
+                  <div
+                    v-if="sheetCategories.length > 0 && ((matchCounts[div.eventGenreId] || 0) - div.participantCount) > 0"
+                    class="flex items-center gap-1 text-amber-400"
+                  >
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
+                    <span class="type-label text-xs">{{ (matchCounts[div.eventGenreId] || 0) - div.participantCount }}</span>
+                  </div>
+                  <div
+                    v-if="sheetCategories.length > 0 && (matchCounts[div.eventGenreId] || 0) === 0 && div.participantCount === 0"
+                    class="flex items-center gap-1 text-amber-400"
+                  >
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
+                    <span class="type-label text-xs">0</span>
+                  </div>
                 </div>
               </div>
 
-              <!-- Format dropdown -->
-              <select
-                :value="div.format || ''"
-                @change="saveDivisionFormat(div, $event.target.value)"
-                class="shrink-0 text-xs px-2 py-1 para-chip-sm bg-transparent text-content-secondary"
-              >
-                <option value="">No format</option>
-                <template v-for="opt in divFormatOptions" :key="opt">
-                  <option v-if="opt" :value="opt">{{ opt }}</option>
-                </template>
-              </select>
+              <!-- Actions row: format dropdown + icon buttons -->
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <!-- Format dropdown -->
+                <select
+                  :value="div.format || ''"
+                  @change="saveDivisionFormat(div, $event.target.value)"
+                  class="shrink-0 text-xs px-2 py-1 para-chip-sm bg-transparent text-content-secondary"
+                >
+                  <option value="">No format</option>
+                  <template v-for="opt in divFormatOptions" :key="opt">
+                    <option v-if="opt" :value="opt">{{ opt }}</option>
+                  </template>
+                </select>
 
-              <!-- Alias toggle -->
-              <button
-                @click="divAliasExpanded = divAliasExpanded === div.eventGenreId ? null : div.eventGenreId"
-                class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-accent transition-colors"
-                title="Sheet aliases"
-              ><i class="pi pi-tags text-xs"></i></button>
+                <!-- Alias toggle -->
+                <button
+                  @click="divAliasExpanded = divAliasExpanded === div.eventGenreId ? null : div.eventGenreId"
+                  class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label text-content-muted hover:text-accent transition-colors"
+                  title="Sheet aliases"
+                ><i class="pi pi-tags text-xs"></i></button>
 
-              <!-- Solo allowed toggle — only for team formats (XvX where X > 1) -->
-              <button
-                v-if="div.format && /^\d+v\d+$/i.test(div.format) && div.format.toLowerCase() !== '1v1'"
-                @click="askToggleSolo(div)"
-                :class="div.soloAllowed ? 'text-content-muted hover:text-amber-400' : 'text-amber-400 hover:text-content-muted'"
-                class="para-chip-sm px-2 py-1 type-label transition-colors"
-                :title="div.soloAllowed ? 'Solo entries allowed' : 'Solo entries blocked'"
-              >{{ div.soloAllowed ? 'SOLO OK' : 'NO SOLO' }}</button>
+                <!-- Solo allowed toggle — only for team formats (XvX where X > 1) -->
+                <button
+                  v-if="div.format && /^\d+v\d+$/i.test(div.format) && div.format.toLowerCase() !== '1v1'"
+                  @click="askToggleSolo(div)"
+                  :class="div.soloAllowed ? 'text-content-muted hover:text-amber-400' : 'text-amber-400 hover:text-content-muted'"
+                  class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label transition-colors"
+                  :title="div.soloAllowed ? 'Solo entries allowed' : 'Solo entries blocked'"
+                >{{ div.soloAllowed ? 'SOLO OK' : 'NO SOLO' }}</button>
 
-              <!-- Remove -->
-              <button
-                @click="askRemoveDivision(div)"
-                class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-red-400 transition-colors"
-                title="Remove division"
-              ><i class="pi pi-times text-xs"></i></button>
+                <!-- Remove -->
+                <button
+                  @click="askRemoveDivision(div)"
+                  class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label text-content-muted hover:text-red-400 transition-colors"
+                  title="Remove division"
+                ><i class="pi pi-times text-xs"></i></button>
+              </div>
             </div>
 
             <!-- Alias chips (always visible if exist) -->
@@ -1325,10 +1329,10 @@ onUnmounted(() => {
                 v-model="divAliasInput"
                 type="text"
                 placeholder="Add alias…"
-                class="input-base flex-1 text-xs py-1"
+                class="input-base flex-1"
                 @keyup.enter="addAlias(div)"
               />
-              <button @click="addAlias(div)" class="para-chip-sm px-2 py-1 type-label text-accent"><i class="pi pi-plus text-xs"></i></button>
+              <button @click="addAlias(div)" class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label text-accent"><i class="pi pi-plus text-xs"></i></button>
             </div>
           </div>
         </div>
@@ -1336,7 +1340,7 @@ onUnmounted(() => {
         <!-- Add division to group -->
         <button
           @click="addDivisionToGroup(group.genreId, group.label)"
-          class="para-chip-sm px-3 py-1.5 type-label text-content-muted hover:text-accent transition-all"
+          class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label text-content-muted hover:text-accent transition-all"
         >+ Add {{ group.label }} division</button>
       </div>
     </div>

--- a/BES-frontend/src/views/EventSelector.vue
+++ b/BES-frontend/src/views/EventSelector.vue
@@ -64,7 +64,7 @@ const handleSubmit = async () => {
 <template>
   <div class="page-container flex items-start justify-center relative">
     <div class="color-bleed"></div>
-    <div class="relative z-10 w-full max-w-md mt-10">
+    <div class="relative z-10 w-full max-w-md mt-4 sm:mt-10">
       <div class="card p-8">
 
         <!-- Header -->
@@ -81,19 +81,19 @@ const handleSubmit = async () => {
               <span class="section-rule-label">Available Events</span>
               <div class="section-rule-line"></div>
             </div>
-            <div class="grid gap-2" :class="events.length > 4 ? 'grid-cols-2' : 'grid-cols-1'">
+            <div class="grid gap-2 event-grid" :class="events.length > 4 ? 'grid-cols-2' : 'grid-cols-1'">
               <button
                 v-for="event in events"
                 :key="event.id"
                 type="button"
                 @click="selectedEventId = event.id; accessCode = ''; error = ''"
                 :class="[
-                  'card-hover p-5 text-left relative group w-full',
+                  'card-hover p-4 sm:p-5 text-left relative group w-full',
                   selectedEventId === event.id ? 'border-[color:var(--accent-muted)]' : ''
                 ]"
               >
                 <div class="corner-bar-tl"></div>
-                <div class="type-body mb-1">{{ event.name }}</div>
+                <div class="type-body mb-1 event-card-name">{{ event.name }}</div>
                 <div
                   v-if="isAdmin && event.accessCode"
                   class="type-label text-content-muted"
@@ -151,3 +151,18 @@ const handleSubmit = async () => {
     </div>
   </div>
 </template>
+
+<style scoped>
+/* Prevent long event names from clipping in the 2-col grid */
+.event-card-name {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+/* On very narrow phones fall back to 1-col to avoid squashed cards */
+@media (max-width: 360px) {
+  .event-grid {
+    grid-template-columns: 1fr !important;
+  }
+}
+</style>

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -2,10 +2,10 @@
 import { ref, computed, watch } from 'vue';
 import { getParticipantScore, getParticipantFeedback, getResultsStatus, releaseResults, getParticipantRefs, getScoringCriteria } from '@/utils/api';
 import DynamicTable from '@/components/DynamicTable.vue';
-import { getActiveEvent } from '@/utils/auth';
 import { useAuthStore } from '@/utils/auth';
 
-const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem("selectedEvent") || "")
+const authStore = useAuthStore()
+const selectedEvent = computed(() => authStore.activeEvent?.name || localStorage.getItem("selectedEvent") || "")
 const selectedGenre = ref(localStorage.getItem("selectedGenre") || "All")
 const selectedTabulation = ref(localStorage.getItem("selectedTabMethod") || "")
 const selectedTopN = ref("All")
@@ -15,7 +15,6 @@ const tabulationMethod = ref(["By Total", "By Judge"])
 const topNOptions = ["All", "Top 8", "Top 16", "Top 32"]
 
 // Auth
-const authStore = useAuthStore()
 const userRole = computed(() => authStore.user?.role?.[0]?.authority)
 const isAdminOrOrganiser = computed(() => ['ROLE_ADMIN', 'ROLE_ORGANISER'].includes(userRole.value))
 

--- a/BES-frontend/src/views/UpdateEventDetails.vue
+++ b/BES-frontend/src/views/UpdateEventDetails.vue
@@ -3,9 +3,10 @@ import DynamicTable from '@/components/DynamicTable.vue';
 import { onMounted, ref, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue'
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getActiveEvent } from '@/utils/auth';
+import { useAuthStore } from '@/utils/auth';
 import CreateParticipantForm from '@/components/CreateParticipantForm.vue';
-const selectedEvent = ref(getActiveEvent()?.name || localStorage.getItem("selectedEvent") || "")
+const authStore = useAuthStore()
+const selectedEvent = computed(() => authStore.activeEvent?.name || localStorage.getItem("selectedEvent") || "")
 const selectedGenre = ref(localStorage.getItem("selectedGenre") || "All")
 const participants = ref([])
 const allJudges = ref([])

--- a/docs/superpowers/plans/2026-06-04-mobile-tablet-responsiveness.md
+++ b/docs/superpowers/plans/2026-06-04-mobile-tablet-responsiveness.md
@@ -1,0 +1,901 @@
+# Mobile & Tablet Responsiveness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix touch drag-and-drop in BattleControl, add tablet layout to BattleJudge, enable desktop swipe in EmceeRoundView, and prevent EventSelector grid overflow on narrow phones — closing issue #59.
+
+**Architecture:** All changes are frontend-only. BattleControl and EmceeRoundView replace HTML5/touch-only event handlers with the Pointer Events API (works on touch + mouse + trackpad). BattleJudge adds CSS `@media` breakpoints. EventSelector adds overflow protection and a narrow-phone grid fallback. No backend changes, no new dependencies.
+
+**Tech Stack:** Vue 3 (Composition API), Tailwind CSS, Vitest + Vue Test Utils
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `BES-frontend/src/views/BattleControl.vue` | Extract `parseDropKey` util; replace HTML5 drag with pointer events; add `data-drop-key` on drop targets; add `@pointerdown` on drag sources |
+| `BES-frontend/src/utils/pointerDnd.js` | New file — `parseDropKey(key)` pure helper, tested in isolation |
+| `BES-frontend/src/utils/__tests__/pointerDnd.test.js` | New file — unit tests for `parseDropKey` |
+| `BES-frontend/src/components/EmceeRoundView.vue` | Replace `@touchstart/touchmove/touchend` with `@pointerdown/pointermove/pointerup`; add `pointercancel`; fix `touch-action` |
+| `BES-frontend/src/views/BattleJudge.vue` | Add tablet `@media` breakpoints; fix tap targets on ✕ button and SELECT JUDGE button |
+| `BES-frontend/src/views/EventSelector.vue` | Fix event name overflow in 2-col grid; add `max-w-[360px]` fallback to 1-col; reduce top margin on small screens |
+
+---
+
+## Task 1: Extract `parseDropKey` and write tests
+
+This is the only testable unit of pure logic in the DnD refactor — everything else is DOM interaction. Extract it first so the test exists before Task 2 wires it in.
+
+**Files:**
+- Create: `BES-frontend/src/utils/pointerDnd.js`
+- Create: `BES-frontend/src/utils/__tests__/pointerDnd.test.js`
+
+- [ ] **Step 1.1: Create the utility file**
+
+Create `BES-frontend/src/utils/pointerDnd.js`:
+
+```js
+/**
+ * Parse a data-drop-key attribute value into a typed drop target descriptor.
+ *
+ * Bracket keys: "bracket-Top8-0-1"  → { type: 'bracket', roundKey: 'Top8', matchIdx: 0, slotIdx: 1 }
+ * Smoke keys:   "smoke-3"           → { type: 'smoke', idx: 3 }
+ * Anything else: null
+ */
+export function parseDropKey(key) {
+  if (!key) return null
+
+  if (key.startsWith('smoke-')) {
+    const idx = parseInt(key.slice(6), 10)
+    if (isNaN(idx)) return null
+    return { type: 'smoke', idx }
+  }
+
+  if (key.startsWith('bracket-')) {
+    const inner = key.slice(8)           // e.g. "Top8-0-1"
+    const parts = inner.split('-')       // ["Top8", "0", "1"]
+    if (parts.length < 3) return null
+    const slotIdx  = parseInt(parts[parts.length - 1], 10)
+    const matchIdx = parseInt(parts[parts.length - 2], 10)
+    const roundKey = parts.slice(0, parts.length - 2).join('-')  // "Top8"
+    if (isNaN(slotIdx) || isNaN(matchIdx) || !roundKey) return null
+    return { type: 'bracket', roundKey, matchIdx, slotIdx }
+  }
+
+  return null
+}
+```
+
+- [ ] **Step 1.2: Write the tests**
+
+Create `BES-frontend/src/utils/__tests__/pointerDnd.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { parseDropKey } from '../pointerDnd'
+
+describe('parseDropKey', () => {
+  describe('smoke keys', () => {
+    it('parses smoke-0', () => {
+      expect(parseDropKey('smoke-0')).toEqual({ type: 'smoke', idx: 0 })
+    })
+    it('parses smoke-7', () => {
+      expect(parseDropKey('smoke-7')).toEqual({ type: 'smoke', idx: 7 })
+    })
+    it('returns null for malformed smoke key', () => {
+      expect(parseDropKey('smoke-')).toBeNull()
+      expect(parseDropKey('smoke-abc')).toBeNull()
+    })
+  })
+
+  describe('bracket keys', () => {
+    it('parses Top8 bracket key slot 0', () => {
+      expect(parseDropKey('bracket-Top8-0-0')).toEqual({
+        type: 'bracket', roundKey: 'Top8', matchIdx: 0, slotIdx: 0,
+      })
+    })
+    it('parses Top8 bracket key slot 1', () => {
+      expect(parseDropKey('bracket-Top8-2-1')).toEqual({
+        type: 'bracket', roundKey: 'Top8', matchIdx: 2, slotIdx: 1,
+      })
+    })
+    it('parses Top16 bracket key', () => {
+      expect(parseDropKey('bracket-Top16-3-0')).toEqual({
+        type: 'bracket', roundKey: 'Top16', matchIdx: 3, slotIdx: 0,
+      })
+    })
+    it('parses Top32 bracket key', () => {
+      expect(parseDropKey('bracket-Top32-15-1')).toEqual({
+        type: 'bracket', roundKey: 'Top32', matchIdx: 15, slotIdx: 1,
+      })
+    })
+    it('returns null for too-short bracket key', () => {
+      expect(parseDropKey('bracket-Top8-0')).toBeNull()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns null for null input', () => {
+      expect(parseDropKey(null)).toBeNull()
+    })
+    it('returns null for empty string', () => {
+      expect(parseDropKey('')).toBeNull()
+    })
+    it('returns null for unknown prefix', () => {
+      expect(parseDropKey('pool-Alice')).toBeNull()
+    })
+  })
+})
+```
+
+- [ ] **Step 1.3: Run tests to verify they pass**
+
+```bash
+cd BES-frontend && npm test -- pointerDnd --run
+```
+
+Expected: all 11 tests pass.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add BES-frontend/src/utils/pointerDnd.js BES-frontend/src/utils/__tests__/pointerDnd.test.js
+git commit -m "feat: add parseDropKey utility for pointer-events DnD (issue #59)"
+```
+
+---
+
+## Task 2: BattleControl — Replace HTML5 DnD with Pointer Events
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue`
+
+This task has two parts: (A) wire up the pointer-event drag engine in `<script setup>`, and (B) update the template to remove HTML5 drag attributes and add pointer event bindings + `data-drop-key` attributes.
+
+### Part A — Script changes
+
+- [ ] **Step 2.1: Import `parseDropKey` and add the pointer drag handler**
+
+In `BES-frontend/src/views/BattleControl.vue`, add the import at the top of `<script setup>` (after the existing imports):
+
+```js
+import { parseDropKey } from '@/utils/pointerDnd'
+```
+
+Then add this block after the existing `onSmokeDrop` function (around line 824):
+
+```js
+// ── Pointer-events DnD (replaces HTML5 drag API — works on touch + desktop) ──
+
+let _ghostEl = null
+let _ptrMoveHandler = null
+let _ptrUpHandler = null
+
+const _removePtrListeners = () => {
+  if (_ptrMoveHandler) { document.removeEventListener('pointermove', _ptrMoveHandler); _ptrMoveHandler = null }
+  if (_ptrUpHandler)   { document.removeEventListener('pointerup',   _ptrUpHandler);   _ptrUpHandler   = null }
+  document.removeEventListener('pointercancel', _ptrUpHandler ?? (() => {}))
+}
+
+const _cleanupDrag = () => {
+  if (_ghostEl) { document.body.removeChild(_ghostEl); _ghostEl = null }
+  _removePtrListeners()
+  dragSource.value  = null
+  poolDragName.value = null
+  dragOverKey.value  = null
+}
+
+const onPointerDragStart = (type, payload, e) => {
+  if (setupLocked.value) return
+  e.preventDefault()
+
+  // Set existing drag-state refs (drives existing highlight CSS — no template class changes)
+  if (type === 'pool') {
+    poolDragName.value = payload          // payload = name string
+    dragSource.value   = null
+  } else if (type === 'bracket') {
+    dragSource.value   = payload          // payload = { roundKey, matchIdx, slotIdx }
+    poolDragName.value = null
+  } else if (type === 'smoke') {
+    dragSource.value   = { smokeIdx: payload }   // payload = mIdx (number)
+    poolDragName.value = null
+  }
+
+  // Resolve display name for ghost label
+  let ghostName = ''
+  if (type === 'pool') {
+    ghostName = payload
+  } else if (type === 'bracket') {
+    ghostName = rounds.value[payload.roundKey]?.[payload.matchIdx]?.[payload.slotIdx] ?? ''
+  } else if (type === 'smoke') {
+    ghostName = rounds.value[payload]?.name ?? ''
+  }
+
+  // Create ghost element
+  _ghostEl = document.createElement('div')
+  _ghostEl.textContent = ghostName
+  Object.assign(_ghostEl.style, {
+    position:      'fixed',
+    left:          `${e.clientX + 12}px`,
+    top:           `${e.clientY + 12}px`,
+    padding:       '5px 14px',
+    background:    '#1a1a1a',
+    border:        `1.5px solid ${type === 'pool' ? 'rgba(255,255,255,0.25)' : 'rgba(248,113,113,0.65)'}`,
+    borderRadius:  '8px',
+    fontSize:      '12px',
+    fontWeight:    '600',
+    color:         '#f0f0f0',
+    boxShadow:     '0 10px 28px rgba(0,0,0,0.7)',
+    whiteSpace:    'nowrap',
+    pointerEvents: 'none',
+    zIndex:        '9999',
+  })
+  document.body.appendChild(_ghostEl)
+
+  _ptrMoveHandler = (ev) => {
+    _ghostEl.style.left = `${ev.clientX + 12}px`
+    _ghostEl.style.top  = `${ev.clientY + 12}px`
+
+    // Find drop target under pointer (hide ghost first so it doesn't intercept)
+    _ghostEl.style.display = 'none'
+    const el = document.elementFromPoint(ev.clientX, ev.clientY)
+    _ghostEl.style.display = ''
+    dragOverKey.value = el?.closest('[data-drop-key]')?.dataset.dropKey ?? null
+  }
+
+  _ptrUpHandler = (ev) => {
+    _removePtrListeners()
+
+    // Hide ghost before elementFromPoint so it doesn't intercept the hit test
+    if (_ghostEl) _ghostEl.style.display = 'none'
+    const el = document.elementFromPoint(ev.clientX, ev.clientY)
+    if (_ghostEl) { document.body.removeChild(_ghostEl); _ghostEl = null }
+
+    const dropKeyEl = el?.closest('[data-drop-key]')
+    const parsed = dropKeyEl ? parseDropKey(dropKeyEl.dataset.dropKey) : null
+
+    if (parsed && !setupLocked.value) {
+      if (parsed.type === 'bracket') {
+        onDrop(parsed.roundKey, parsed.matchIdx, parsed.slotIdx)
+      } else if (parsed.type === 'smoke') {
+        onSmokeDrop(parsed.idx)
+      }
+    } else {
+      // No valid drop — clear state manually (onDrop/onSmokeDrop would have done this)
+      dragSource.value   = null
+      poolDragName.value = null
+      dragOverKey.value  = null
+    }
+  }
+
+  document.addEventListener('pointermove',  _ptrMoveHandler)
+  document.addEventListener('pointerup',    _ptrUpHandler)
+  document.addEventListener('pointercancel', _ptrUpHandler)
+}
+```
+
+Also add cleanup to the existing `onUnmounted` hook (find it in the file and add `_cleanupDrag()` before the existing body):
+
+```js
+onUnmounted(() => {
+  _cleanupDrag()   // ← add this line
+  // ... existing cleanup ...
+})
+```
+
+### Part B — Template changes
+
+- [ ] **Step 2.2: Update pool chips**
+
+Find the pool chip `<span>` (around line 2252–2263). Replace:
+
+```html
+<span
+  v-for="p in poolParticipants" :key="p.name"
+  draggable="true"
+  @dragstart="(e) => onPoolDragStart(p.name, e)"
+  @dragend="onPoolDragEnd"
+  class="para-chip-sm px-2.5 py-1 type-label text-content-primary cursor-grab active:cursor-grabbing select-none inline-flex items-center gap-1.5"
+  :class="poolDragName === p.name ? 'opacity-40' : ''"
+  :title="p.name"
+>
+```
+
+With:
+
+```html
+<span
+  v-for="p in poolParticipants" :key="p.name"
+  @pointerdown="(e) => onPointerDragStart('pool', p.name, e)"
+  class="para-chip-sm px-2.5 py-1 type-label text-content-primary cursor-grab active:cursor-grabbing select-none inline-flex items-center gap-1.5"
+  :class="poolDragName === p.name ? 'opacity-40' : ''"
+  :title="p.name"
+  style="touch-action: none; user-select: none;"
+>
+```
+
+- [ ] **Step 2.3: Update bracket slot 0 containers and name divs**
+
+For each bracket slot 0 drop zone (the `<div class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 ...">` for slot 0), replace the drag-over/drop attrs and add `data-drop-key`:
+
+```html
+<div
+  class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
+  :data-drop-key="`bracket-Top${size}-${mIdx}-0`"
+  :class="[
+    match[2] === match[0] && match[0] ? 'bg-emerald-500/10' : '',
+    dragSource?.roundKey === `Top${size}` && dragSource?.matchIdx === mIdx && dragSource?.slotIdx === 0
+      ? 'ring-2 ring-primary-400/80 bg-primary-400/12 shadow-inner'
+      : dragOverKey === `Top${size}-${mIdx}-0` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
+  ]"
+>
+```
+
+(Remove `@dragover.prevent`, `@dragleave`, `@drop.prevent` from this div.)
+
+For the inner name `<div v-if="match[0]" ...>` inside slot 0, replace:
+
+```html
+<div v-if="match[0]"
+  :draggable="!setupLocked"
+  @dragstart="!setupLocked && onDragStart(`Top${size}`, mIdx, 0, $event)"
+  @dragend="!setupLocked && onDragEnd()"
+  class="flex-1 min-w-0 select-none flex items-center gap-3"
+  :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[0] && match[0] ? 'text-emerald-400' : 'text-content-primary']"
+>
+```
+
+With:
+
+```html
+<div v-if="match[0]"
+  @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 0 }, e)"
+  class="flex-1 min-w-0 select-none flex items-center gap-3"
+  :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[0] && match[0] ? 'text-emerald-400' : 'text-content-primary']"
+  style="touch-action: none;"
+>
+```
+
+- [ ] **Step 2.4: Update bracket slot 1 containers and name divs**
+
+For the slot 1 drop zone (`<div class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 ...">` for slot 1), replace:
+
+```html
+<div
+  class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
+  :class="[
+    match[2] === match[1] && match[1] ? 'bg-emerald-500/10' : '',
+    dragSource?.roundKey === `Top${size}` && dragSource?.matchIdx === mIdx && dragSource?.slotIdx === 1
+      ? 'ring-2 ring-primary-400/80 bg-primary-400/12 shadow-inner'
+      : dragOverKey === `Top${size}-${mIdx}-1` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
+  ]"
+  @dragover.prevent="!setupLocked && onDragOver(`Top${size}`, mIdx, 1)"
+  @dragleave="dragOverKey = null"
+  @drop.prevent="!setupLocked && onDrop(`Top${size}`, mIdx, 1)"
+>
+```
+
+With:
+
+```html
+<div
+  class="flex-1 min-w-0 flex items-center gap-1.5 px-2 py-1.5 transition-all duration-150"
+  :data-drop-key="`bracket-Top${size}-${mIdx}-1`"
+  :class="[
+    match[2] === match[1] && match[1] ? 'bg-emerald-500/10' : '',
+    dragSource?.roundKey === `Top${size}` && dragSource?.matchIdx === mIdx && dragSource?.slotIdx === 1
+      ? 'ring-2 ring-primary-400/80 bg-primary-400/12 shadow-inner'
+      : dragOverKey === `Top${size}-${mIdx}-1` ? 'bg-primary-500/15 ring-2 ring-inset ring-primary-500/70' : ''
+  ]"
+>
+```
+
+For the inner name `<div v-if="match[1]" ...>` inside slot 1, replace:
+
+```html
+<div v-if="match[1]"
+  :draggable="!setupLocked"
+  @dragstart="!setupLocked && onDragStart(`Top${size}`, mIdx, 1, $event)"
+  @dragend="!setupLocked && onDragEnd()"
+  class="flex-1 min-w-0 select-none flex items-center gap-3"
+  :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[1] && match[1] ? 'text-emerald-400' : 'text-content-primary']"
+>
+```
+
+With:
+
+```html
+<div v-if="match[1]"
+  @pointerdown="(e) => onPointerDragStart('bracket', { roundKey: `Top${size}`, matchIdx: mIdx, slotIdx: 1 }, e)"
+  class="flex-1 min-w-0 select-none flex items-center gap-3"
+  :class="[!setupLocked ? 'cursor-grab active:cursor-grabbing' : '', match[2] === match[1] && match[1] ? 'text-emerald-400' : 'text-content-primary']"
+  style="touch-action: none;"
+>
+```
+
+- [ ] **Step 2.5: Fix Win and Start button tap targets**
+
+The Win button is `w-9` (36px wide) and the Start button is `w-8` (32px wide) — both below 44px. Height is fine (they stretch to `min-h-[44px]` via the flex container). Widen both.
+
+Find the two Win buttons inside the match card (one per slot, near the `'Win'` text). Both have `class="flex-shrink-0 w-9 text-center rounded ..."`. Change `w-9` → `w-11` on both:
+
+```html
+<!-- Win button for slot 0 — change w-9 to w-11 -->
+<button
+  :disabled="!match[0]"
+  @click="match[2] === match[0] && match[0] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 0, match[0])"
+  class="flex-shrink-0 w-11 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+  :class="match[2] === match[0] && match[0] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+>{{ match[2] === match[0] && match[0] ? '✓' : 'Win' }}</button>
+```
+
+```html
+<!-- Win button for slot 1 — change w-9 to w-11 -->
+<button
+  :disabled="!match[1]"
+  @click="match[2] === match[1] && match[1] ? clearWinner(`Top${size}`, mIdx) : requestWin(`Top${size}`, mIdx, 1, match[1])"
+  class="flex-shrink-0 w-11 text-center rounded text-[11px] font-bold transition-all disabled:opacity-20 disabled:cursor-not-allowed leading-5"
+  :class="match[2] === match[1] && match[1] ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/40' : 'bg-surface-700 text-surface-400 border border-surface-600/50 hover:border-surface-500'"
+>{{ match[2] === match[1] && match[1] ? '✓' : 'Win' }}</button>
+```
+
+Find the Start button (has `w-8 ml-1.5`). Change `w-8` → `w-10`:
+
+```html
+<button
+  v-if="match[0] && match[1] && !match[2] && isActiveRoundFilled && effectivePhase === 'IDLE'"
+  @click="requestStartAt(`Top${size}`, rounds[`Top${size}`], mIdx)"
+  class="flex-shrink-0 flex items-center justify-center w-10 ml-1.5 self-stretch rounded text-accent border border-[color:var(--accent-muted)] bg-[color:var(--accent-subtle)] hover:bg-[color:var(--accent-muted)] transition-colors"
+  title="Start round from this match"
+><i class="pi pi-play text-[10px]"></i></button>
+```
+
+- [ ] **Step 2.7: Update smoke queue slots**
+
+Find the smoke slot `<div v-for="(match, mIdx) in rounds" ...>` (around line 2441–2454). Replace:
+
+```html
+<div
+  v-for="(match, mIdx) in rounds"
+  :key="mIdx"
+  :draggable="!!match.name && !setupLocked"
+  @dragstart="!setupLocked && onSmokeDragStart(mIdx, $event)"
+  @dragend="onDragEnd"
+  @dragover.prevent="!setupLocked && onSmokeDragOver(mIdx)"
+  @dragleave="dragOverKey = null"
+  @drop.prevent="!setupLocked && onSmokeDrop(mIdx)"
+  class="card-hover relative flex items-stretch overflow-hidden transition-all duration-150"
+  :class="dragOverKey === `smoke-${mIdx}` ? 'ring-2 ring-inset ring-primary-500/70 bg-primary-500/10' :
+          (dragSource?.smokeIdx === mIdx ? 'ring-2 ring-primary-400/80 bg-primary-400/12' : '')"
+  style="padding:0"
+>
+```
+
+With:
+
+```html
+<div
+  v-for="(match, mIdx) in rounds"
+  :key="mIdx"
+  :data-drop-key="`smoke-${mIdx}`"
+  @pointerdown="(e) => !!match.name && onPointerDragStart('smoke', mIdx, e)"
+  class="card-hover relative flex items-stretch overflow-hidden transition-all duration-150"
+  :class="dragOverKey === `smoke-${mIdx}` ? 'ring-2 ring-inset ring-primary-500/70 bg-primary-500/10' :
+          (dragSource?.smokeIdx === mIdx ? 'ring-2 ring-primary-400/80 bg-primary-400/12' : '')"
+  style="padding:0; touch-action: none;"
+>
+```
+
+- [ ] **Step 2.8: Manual test — drag-and-drop in browser**
+
+Run the dev server:
+```bash
+cd BES-frontend && npm run dev
+```
+
+Open Chrome DevTools → Toggle device toolbar → Select "iPad Air" (portrait).
+
+Navigate to `/battle/control`. Verify:
+1. Pool chips can be dragged to bracket slots with touch simulation
+2. Bracket slot names can be swapped by dragging one onto another
+3. Smoke queue slots can be reordered by drag
+4. Hover highlight (`dragOverKey`) appears on the target slot during drag
+5. No drag ghost lingers after drop or cancel
+6. Desktop mouse drag still works (disable device emulation and try again)
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: replace HTML5 DnD with pointer events in BattleControl (issue #59)"
+```
+
+---
+
+## Task 3: EmceeRoundView — Desktop Swipe via Pointer Events
+
+**Files:**
+- Modify: `BES-frontend/src/components/EmceeRoundView.vue`
+
+- [ ] **Step 3.1: Replace touch handlers in `<script setup>`**
+
+In `BES-frontend/src/components/EmceeRoundView.vue`, find the three touch handler functions (lines 51–58):
+
+```js
+const onTouchStart = (e) => { touchStartX.value = e.touches[0].clientX; isDragging.value = true; dragOffset.value = 0 }
+const onTouchMove  = (e) => { if (!isDragging.value) return; dragOffset.value = e.touches[0].clientX - touchStartX.value }
+const onTouchEnd   = () => {
+  if (!isDragging.value) return
+  isDragging.value = false
+  if      (dragOffset.value < -60) goNext()
+  else if (dragOffset.value >  60) goPrev()
+  dragOffset.value = 0
+}
+```
+
+Replace with:
+
+```js
+const onPointerDown = (e) => {
+  e.currentTarget.setPointerCapture(e.pointerId)
+  touchStartX.value = e.clientX
+  isDragging.value  = true
+  dragOffset.value  = 0
+}
+
+const onPointerMove = (e) => {
+  if (!isDragging.value) return
+  dragOffset.value = e.clientX - touchStartX.value
+}
+
+const onPointerUp = () => {
+  if (!isDragging.value) return
+  isDragging.value = false
+  if      (dragOffset.value < -60) goNext()
+  else if (dragOffset.value >  60) goPrev()
+  dragOffset.value = 0
+}
+```
+
+- [ ] **Step 3.2: Update the template bindings**
+
+Find the card `<div>` with the touch event listeners (around line 148–153):
+
+```html
+<div
+  :key="currentRound"
+  :style="cardStyle"
+  @touchstart.passive="onTouchStart"
+  @touchmove.passive="onTouchMove"
+  @touchend="onTouchEnd"
+  class="card-hover p-0 relative select-none touch-pan-y"
+  style="box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 8px 32px rgba(0,0,0,0.6);"
+>
+```
+
+Replace with:
+
+```html
+<div
+  :key="currentRound"
+  :style="cardStyle"
+  @pointerdown="onPointerDown"
+  @pointermove="onPointerMove"
+  @pointerup="onPointerUp"
+  @pointercancel="onPointerUp"
+  class="card-hover p-0 relative select-none"
+  style="box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 8px 32px rgba(0,0,0,0.6); touch-action: none;"
+>
+```
+
+Note: `touch-pan-y` class removed; `touch-action: none` set inline so the browser doesn't intercept touch scroll before our handler. `setPointerCapture` handles delivery of move/up events when the pointer leaves the element bounds.
+
+- [ ] **Step 3.3: Manual test in browser**
+
+Navigate to `/event/audition-list`, select Emcee role and a genre with participants.
+
+Verify:
+1. **Touch (device emulation):** swipe left → next round, swipe right → previous round. Threshold is 60px offset.
+2. **Mouse (desktop):** click-hold and drag left/right on the card → same navigation.
+3. **Trackpad:** two-finger horizontal swipe → same navigation (Chrome/Mac trackpad gesture).
+4. Swipe hint arrows (← / →) appear during drag as before.
+5. Round counter updates correctly.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add BES-frontend/src/components/EmceeRoundView.vue
+git commit -m "feat: replace touch-only swipe with pointer events in EmceeRoundView (issue #59)"
+```
+
+---
+
+## Task 4: BattleJudge — Tablet Layout + Tap Target Fixes
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleJudge.vue`
+
+- [ ] **Step 4.1: Update the portrait tablet breakpoint**
+
+In `BES-frontend/src/views/BattleJudge.vue`, find the existing `@media (min-width: 600px)` block (around line 791–798):
+
+```css
+@media (min-width: 600px) {
+  .judge-root {
+    max-width: 480px;
+    margin: 0 auto;
+    border-left:  1px solid rgba(255,255,255,0.05);
+    border-right: 1px solid rgba(255,255,255,0.05);
+  }
+}
+```
+
+Replace with:
+
+```css
+/* Tablet portrait — wider layout */
+@media (min-width: 600px) {
+  .judge-root {
+    max-width: 640px;
+    margin: 0 auto;
+    border-left:  1px solid rgba(255,255,255,0.05);
+    border-right: 1px solid rgba(255,255,255,0.05);
+  }
+}
+
+/* Tablet landscape — shorter header, taller tie row for thumb reach */
+@media (min-width: 600px) and (orientation: landscape) {
+  .judge-header {
+    height: 44px;
+  }
+  .tie-row {
+    height: 26%;
+    min-height: 72px;
+  }
+}
+```
+
+- [ ] **Step 4.2: Fix the judge chip ✕ tap target**
+
+Find `.judge-chip-clear` (around line 506–511):
+
+```css
+.judge-chip-clear {
+  background: none; border: none; cursor: pointer;
+  font-size: 10px; color: rgba(255,255,255,0.3);
+  padding: 0 2px; line-height: 1; transition: color 0.15s;
+}
+.judge-chip-clear:hover { color: rgba(255,255,255,0.8); }
+```
+
+Replace with:
+
+```css
+.judge-chip-clear {
+  background: none; border: none; cursor: pointer;
+  font-size: 10px; color: rgba(255,255,255,0.3);
+  padding: 10px 8px;
+  margin: -10px -8px;
+  min-width: 44px; min-height: 44px;
+  display: flex; align-items: center; justify-content: center;
+  line-height: 1; transition: color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+.judge-chip-clear:hover { color: rgba(255,255,255,0.8); }
+```
+
+- [ ] **Step 4.3: Fix the SELECT JUDGE button tap target**
+
+Find `.pick-judge-btn` (around line 513–524):
+
+```css
+.pick-judge-btn {
+  font-family: 'Inter', sans-serif;
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 0.2em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 999px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: rgba(255,255,255,0.7);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+```
+
+Replace `padding: 5px 12px` with `padding: 8px 16px`:
+
+```css
+.pick-judge-btn {
+  font-family: 'Inter', sans-serif;
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 0.2em; text-transform: uppercase;
+  padding: 8px 16px; border-radius: 999px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: rgba(255,255,255,0.7);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+```
+
+- [ ] **Step 4.4: Manual test in browser**
+
+Open `/battle/judge` in Chrome DevTools with device toolbar:
+
+1. **Phone portrait (375×667 "iPhone SE"):** Layout unchanged. Vote panels fill screen. ✕ button tap area is larger.
+2. **Tablet portrait (768×1024 "iPad Air"):** Page centers at max 640px. Vote panels use ~640px width instead of 480px. 
+3. **Tablet landscape (1024×768 "iPad Air" landscape):** Header is 44px height. Tie row is taller (~26% height). LR panels fill remaining height. Everything reachable with thumbs.
+4. Click the ✕ on the judge chip — confirm it triggers on first tap (no mis-tap).
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleJudge.vue
+git commit -m "feat: tablet layout and tap target fixes for BattleJudge (issue #59)"
+```
+
+---
+
+## Task 5: EventSelector — Narrow-Phone Grid Overflow Fix
+
+**Files:**
+- Modify: `BES-frontend/src/views/EventSelector.vue`
+
+- [ ] **Step 5.1: Add a `<style scoped>` block and narrow-phone override**
+
+`EventSelector.vue` currently has no `<style>` block. Add one at the end of the file:
+
+```html
+<style scoped>
+/* Prevent long event names from clipping in the 2-col grid */
+.event-card-name {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+/* On very narrow phones fall back to 1-col to avoid squashed cards */
+@media (max-width: 360px) {
+  .event-grid {
+    grid-template-columns: 1fr !important;
+  }
+}
+</style>
+```
+
+- [ ] **Step 5.2: Apply the classes in the template**
+
+Find the event grid `<div>` (around line 84):
+
+```html
+<div class="grid gap-2" :class="events.length > 4 ? 'grid-cols-2' : 'grid-cols-1'">
+```
+
+Add `event-grid` class:
+
+```html
+<div class="grid gap-2 event-grid" :class="events.length > 4 ? 'grid-cols-2' : 'grid-cols-1'">
+```
+
+Find the event name `<div class="type-body mb-1">{{ event.name }}</div>` (around line 96) and add `event-card-name`:
+
+```html
+<div class="type-body mb-1 event-card-name">{{ event.name }}</div>
+```
+
+- [ ] **Step 5.3: Reduce top margin on small screens**
+
+Find (around line 67):
+
+```html
+<div class="relative z-10 w-full max-w-md mt-10">
+```
+
+Replace `mt-10` with `mt-4 sm:mt-10`:
+
+```html
+<div class="relative z-10 w-full max-w-md mt-4 sm:mt-10">
+```
+
+- [ ] **Step 5.4: Reduce card padding in 2-col mode on small phones**
+
+Find the event button (around line 85–103):
+
+```html
+<button
+  ...
+  :class="[
+    'card-hover p-5 text-left relative group w-full',
+    selectedEventId === event.id ? 'border-[color:var(--accent-muted)]' : ''
+  ]"
+>
+```
+
+Change `p-5` to `p-4 sm:p-5`:
+
+```html
+<button
+  ...
+  :class="[
+    'card-hover p-4 sm:p-5 text-left relative group w-full',
+    selectedEventId === event.id ? 'border-[color:var(--accent-muted)]' : ''
+  ]"
+>
+```
+
+- [ ] **Step 5.5: Manual test in browser**
+
+Open `/event/select` in Chrome DevTools device toolbar:
+
+1. **iPhone SE (375px)** with 5+ events: 2-col grid renders. Long event names wrap instead of clipping. Cards have comfortable padding.
+2. **Galaxy S5 (360px)**: Confirm 1-col fallback applies (each event takes full width).
+3. **iPhone SE**: Confirm form sits higher (`mt-4` instead of `mt-10`).
+4. **Desktop (1280px)**: No change from before — form is centered at `max-w-md`.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add BES-frontend/src/views/EventSelector.vue
+git commit -m "feat: fix EventSelector 2-col grid overflow on narrow phones (issue #59)"
+```
+
+---
+
+## Task 6: Full regression check and PR
+
+- [ ] **Step 6.1: Run full test suite**
+
+```bash
+cd BES-frontend && npm test -- --run
+```
+
+Expected: all tests pass (including the new `pointerDnd` tests from Task 1).
+
+- [ ] **Step 6.2: Run the dev server and verify all four views**
+
+```bash
+cd BES-frontend && npm run dev
+```
+
+Checklist:
+- [ ] `/battle/control` — bracket drag works on simulated touch + desktop mouse
+- [ ] `/battle/control` — 7-to-smoke queue drag works on simulated touch + desktop mouse
+- [ ] `/battle/judge` — tablet portrait (768px): wider layout
+- [ ] `/battle/judge` — tablet landscape (1024×768): shorter header, taller tie row
+- [ ] `/battle/judge` — ✕ chip button tappable on first touch
+- [ ] `/event/audition-list` (Emcee) — mouse drag on "Now" card navigates rounds
+- [ ] `/event/audition-list` (Emcee) — touch swipe still works (device emulation)
+- [ ] `/event/select` — long event names wrap on 375px
+- [ ] `/event/select` — 1-col fallback at 360px
+- [ ] Desktop layouts unchanged on all four views
+
+- [ ] **Step 6.3: Push and open PR**
+
+```bash
+git push -u origin feat/mobile-touch-responsiveness
+gh pr create \
+  --title "feat: mobile & tablet responsiveness improvements (issue #59)" \
+  --body "$(cat <<'EOF'
+## Summary
+- **BattleControl**: Replace HTML5 DnD with Pointer Events API — bracket seeding and 7-to-smoke queue now work on touch devices
+- **BattleJudge**: Tablet portrait expands to 640px max-width; landscape gets shorter header + taller tie row; ✕ and SELECT JUDGE buttons meet 44px tap target
+- **EmceeRoundView**: Replace touch-only swipe handlers with Pointer Events — desktop mouse and trackpad can now navigate rounds
+- **EventSelector**: Long event names wrap in 2-col grid; fallback to 1-col at ≤360px; top margin reduced on small screens
+
+## Test plan
+- [ ] BattleControl bracket drag-and-drop works on iOS Safari / Android Chrome (use DevTools device emulation)
+- [ ] BattleControl 7-to-smoke queue reorder works on touch
+- [ ] Desktop drag-and-drop in BattleControl still works with mouse
+- [ ] BattleJudge portrait layout is wider on tablet viewport (768px+)
+- [ ] BattleJudge landscape layout on tablet (1024×768): header shorter, tie row taller
+- [ ] EmceeRoundView swipe works with mouse click-drag on desktop
+- [ ] EmceeRoundView swipe still works on touch (device emulation)
+- [ ] EventSelector long names don't overflow at 375px
+- [ ] All Vitest tests pass (`npm test -- --run`)
+
+Closes #59
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-06-04-mobile-tablet-responsiveness-design.md
+++ b/docs/superpowers/specs/2026-06-04-mobile-tablet-responsiveness-design.md
@@ -1,0 +1,260 @@
+# Mobile & Tablet Responsiveness — Design Spec
+
+**Issue:** #59
+**Branch:** `feat/mobile-touch-responsiveness`
+**Date:** 2026-06-04
+
+## Summary
+
+Four targeted fixes to make BES usable on phones and tablets:
+
+1. **BattleControl** — replace HTML5 drag-and-drop (touch-incompatible) with pointer events for bracket seeding and 7-to-smoke queue reordering
+2. **BattleJudge** — responsive tablet layout (portrait + landscape) with larger tap targets
+3. **EmceeRoundView** — replace touch-only swipe handlers with pointer events so desktop mouse/trackpad swipe works
+4. **EventSelector** — prevent long event names from overflowing in the 2-column grid on narrow phones
+
+---
+
+## 1 — BattleControl: Touch-Compatible Drag-and-Drop
+
+### Problem
+
+BattleControl uses the HTML5 `draggable` / `dragstart` / `dragover` / `drop` API. This API does not fire on touch screens (iOS Safari, Android Chrome). The bracket seeding drag-and-drop and the 7-to-smoke queue reordering are both broken on mobile.
+
+### Approach
+
+Replace HTML5 drag handlers with a pointer events implementation. No new library dependency.
+
+### Implementation
+
+**Shared drag state (new refs):**
+```js
+const pointerDragType   = ref(null)   // 'pool' | 'bracket' | 'smoke' | null
+const pointerDragName   = ref(null)   // string | null (for pool drags)
+const pointerDragSource = ref(null)   // { roundKey, matchIdx, slotIdx } | { smokeIdx } | null
+const pointerGhost      = ref(null)   // DOM element | null
+```
+
+**`data-drop-key` attributes on drop targets (template):**
+- Bracket slots: `data-drop-key="bracket-{roundKey}-{matchIdx}-{slotIdx}"` (e.g. `bracket-Top8-0-1`)
+- Smoke slots: `data-drop-key="smoke-{idx}"` (e.g. `smoke-3`)
+
+**`data-drag-name` attribute on pool name chips:**
+- Pool chips: `data-drag-name="{name}"` — read on pointerdown to identify what is being dragged
+
+**Drag lifecycle (document-level pointermove/pointerup):**
+
+1. `pointerdown` on a draggable element:
+   - Create ghost `<div>` (same styling as existing HTML5 ghost: dark chip, red border for bracket slots, white border for pool chips)
+   - Append ghost to `document.body` at pointer position
+   - Set `touch-action: none` on the dragged element during drag to prevent scroll interference
+   - Set `pointerDragType`, `pointerDragName` / `pointerDragSource`
+   - Register `pointermove` and `pointerup` listeners on `document`
+
+2. `pointermove` on document:
+   - Move ghost to `(e.clientX + 12, e.clientY + 12)` (offset so finger doesn't cover the ghost)
+   - Call `document.elementFromPoint(e.clientX, e.clientY)`, walk up via `.closest('[data-drop-key]')` to find the current drop target
+   - Set `dragOverKey` from the found key (drives existing hover highlight CSS — no template changes needed)
+
+3. `pointerup` on document:
+   - Remove ghost from DOM
+   - Resolve drop target via `elementFromPoint` + `closest('[data-drop-key]')`
+   - Parse key and invoke existing `onDrop(roundKey, matchIdx, slotIdx)` or `onSmokeDrop(idx)` — zero logic changes
+   - Clear all pointer drag state
+   - Remove document-level `pointermove` / `pointerup` listeners
+
+4. `pointercancel` on document: same cleanup as `pointerup`, no drop
+
+**Removing HTML5 attributes:**
+- Remove `draggable="true"` from all bracket slot elements, smoke slot elements, and pool name chips
+- Remove all `@dragstart`, `@dragover`, `@dragleave`, `@drop`, `@dragend` bindings
+- Replace with `@pointerdown` on each draggable element
+
+**Touch scroll guard:**
+- Add `touch-action: none` to draggable elements only while a drag is active (set/remove dynamically)
+- Non-draggable areas of the page retain normal scroll
+
+**Smoke queue (7-to-Smoke):**
+- Same pointer events pattern; `data-drop-key="smoke-{idx}"` on each queue slot
+- Pool → smoke slot and smoke slot → smoke slot swap both handled via existing `onSmokeDrop`
+
+### No logic changes
+
+`onDrop`, `onSmokeDrop`, `dragOverKey`, `dragSource`, `poolDragName` — all existing swap logic stays exactly as-is. Only the event plumbing changes.
+
+---
+
+## 2 — BattleJudge: Tablet Layout (Portrait + Landscape)
+
+### Problem
+
+BattleJudge caps at `max-width: 480px` on viewports ≥600px, wasting screen space on tablets. The judge chip "clear" (✕) button is ~10px — too small for reliable touch. No landscape adaptation exists.
+
+### Approach
+
+Expand max-width to 640px for tablet portrait. Add a landscape media query that makes the tie row taller for thumb reach. Fix tap target sizes.
+
+### Implementation
+
+**Portrait — wider layout (≥600px viewport width):**
+```css
+@media (min-width: 600px) {
+  .judge-root {
+    max-width: 640px;   /* was 480px */
+    margin: 0 auto;
+    border-left:  1px solid rgba(255,255,255,0.05);
+    border-right: 1px solid rgba(255,255,255,0.05);
+  }
+}
+```
+
+**Landscape — tablet-optimised (≥600px width + landscape orientation):**
+```css
+@media (min-width: 600px) and (orientation: landscape) {
+  .judge-header {
+    height: 44px;         /* shorter header frees space for panels */
+  }
+  .tie-row {
+    height: 26%;          /* taller tie row — reachable with thumbs at bottom */
+    min-height: 72px;
+  }
+}
+```
+
+The LR panels (`.lr-row`) remain `flex: 1` and fill remaining height naturally. No structural template changes required.
+
+**Tap target fixes:**
+
+Judge chip clear button — minimum 44×44px tap area via padding:
+```css
+.judge-chip-clear {
+  padding: 10px 8px;      /* was: 0 2px */
+  margin: -10px -8px;     /* negative margin keeps visual size unchanged */
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+SELECT JUDGE button — increase padding for easier tapping:
+```css
+.pick-judge-btn {
+  padding: 8px 16px;      /* was: 5px 12px */
+}
+```
+
+Sheet name chips (judge picker bottom sheet) — already `padding: 14px 8px`, no change needed.
+
+---
+
+## 3 — EmceeRoundView: Desktop Swipe (Mouse + Trackpad)
+
+### Problem
+
+The "Now on Stage" card in `EmceeRoundView.vue` only listens to `touchstart` / `touchmove` / `touchend`. Desktop users (emcees at a laptop, or an emcee using a USB trackpad) cannot swipe through rounds.
+
+### Approach
+
+Replace the three touch-only event handlers with pointer event equivalents. Pointer events unify touch, mouse, and trackpad input.
+
+### Implementation
+
+**Handler renames:**
+
+| Remove | Add |
+|--------|-----|
+| `@touchstart.passive="onTouchStart"` | `@pointerdown="onPointerDown"` |
+| `@touchmove.passive="onTouchMove"` | `@pointermove="onPointerMove"` |
+| `@touchend="onTouchEnd"` | `@pointerup="onPointerUp"` |
+
+Add `@pointercancel="onPointerUp"` to handle mid-gesture cancellation (e.g. incoming call on mobile).
+
+**Handler changes:**
+
+```js
+const onPointerDown = (e) => {
+  e.currentTarget.setPointerCapture(e.pointerId)
+  touchStartX.value = e.clientX
+  isDragging.value  = true
+  dragOffset.value  = 0
+}
+
+const onPointerMove = (e) => {
+  if (!isDragging.value) return
+  dragOffset.value = e.clientX - touchStartX.value
+}
+
+const onPointerUp = (e) => {
+  if (!isDragging.value) return
+  isDragging.value = false
+  if      (dragOffset.value < -60) goNext()
+  else if (dragOffset.value >  60) goPrev()
+  dragOffset.value = 0
+}
+```
+
+`setPointerCapture` ensures `pointermove` and `pointerup` are delivered to the card even when the pointer moves outside its bounds mid-swipe.
+
+**CSS change on the card element:**
+```
+touch-pan-y  →  touch-action: none
+```
+`touch-pan-y` was used to allow vertical scroll while capturing horizontal swipe. With pointer capture, the browser no longer needs the hint — `touch-action: none` prevents the browser from intercepting horizontal swipes before our handler fires.
+
+**Variable names unchanged:** `touchStartX`, `dragOffset`, `isDragging`, `swipeHint`, `cardStyle` — no other code needs to change.
+
+---
+
+## 4 — EventSelector: Narrow-Phone Grid Fix
+
+### Problem
+
+When 5+ events exist, EventSelector shows a `grid-cols-2` layout. On narrow phones (320–360px), each card is ~160px wide. Long event names (e.g. "KL Bboy Open 2026") can overflow or truncate unreadably inside the `p-5` card.
+
+### Approach
+
+Add `text-wrap: balance` and `min-h` so cards handle long names gracefully. On the narrowest phones (≤360px) fall back to a single column.
+
+### Implementation
+
+**Event card text:** add `break-words` / `overflow-wrap: break-word` to the event name element so long names wrap instead of clipping.
+
+**Narrow phone breakpoint:** switch from 2-col to 1-col on very narrow screens:
+```css
+@media (max-width: 360px) {
+  .event-grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+```
+Applied via a conditional class or scoped style on the grid `<div>`. The `:class` binding already targets `events.length > 4` — add a `max-w-[360px]` Tailwind responsive override or use a scoped `<style>` block since EventSelector has no existing `<style scoped>`.
+
+**Reduced card padding on small screens:** change `p-5` → `p-4` inside the 2-col grid only (via a Tailwind responsive modifier or scoped style targeting the 2-col case).
+
+**`mt-10` top margin:** change to `mt-4 sm:mt-10` so the form doesn't sit too low on small phones.
+
+---
+
+## Acceptance Criteria (mirrors issue #59 + bundled fix)
+
+- [ ] BattleControl bracket seeding drag-and-drop works on touch devices (iOS Safari, Android Chrome) — pool→slot and slot↔slot
+- [ ] BattleControl 7-to-smoke queue reordering works on touch devices
+- [ ] All interactive controls on BattleControl meet 48px minimum touch target (existing buttons reviewed — none added)
+- [ ] BattleJudge is comfortable on tablet portrait (≥600px) with wider layout
+- [ ] BattleJudge is comfortable on tablet landscape — tie row reachable with thumbs
+- [ ] BattleJudge judge chip ✕ and SELECT JUDGE button meet 44px minimum tap target
+- [ ] EmceeRoundView swipe works with mouse drag and trackpad swipe on desktop
+- [ ] EmceeRoundView swipe still works on touch (pointer events cover both)
+- [ ] EventSelector 2-col grid handles long event names without overflow on 320px phones
+- [ ] No regressions on existing desktop layouts for any of the four views
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `BES-frontend/src/views/BattleControl.vue` | Replace HTML5 DnD with pointer events; add `data-drop-key` attrs; add `data-drag-name` to pool chips |
+| `BES-frontend/src/views/BattleJudge.vue` | Update `@media` breakpoints; fix tap targets |
+| `BES-frontend/src/components/EmceeRoundView.vue` | Replace touch handlers with pointer event handlers |
+| `BES-frontend/src/views/EventSelector.vue` | Fix 2-col grid overflow; add narrow-phone fallback |


### PR DESCRIPTION
## Summary
- **BattleControl**: Replace HTML5 DnD with Pointer Events API — bracket seeding and 7-to-smoke queue work on touch devices; seeding pool chips switch to 2-col grid on mobile with 44px tap targets; all control buttons (genre, round, seeding, live action) use responsive padding (`py-3 sm:py-1.5`)
- **BattleJudge**: Tablet portrait expands to 640px max-width; landscape gets shorter header + taller tie row; ✕ and SELECT JUDGE buttons meet 44px tap target
- **EmceeRoundView**: Replace touch-only swipe with Pointer Events — desktop mouse and trackpad can now navigate rounds
- **EventSelector**: Long event names wrap in 2-col grid; fallback to 1-col at ≤360px; top margin reduced on small screens
- **EventDetails**: Division names no longer truncate on mobile — full name always visible via `break-words`; division row stacks into name row + actions row on mobile
- **AuditionList**: Filter panel stacks vertically on mobile with labeled groups (Role, Genre, Type, Mode); separators hidden on mobile; judge dropdowns full-width on mobile; context bar filter button meets 44px tap target
- **base.css**: Global standard — all `button.para-chip` / `button.para-chip-sm` get `min-height: 44px` on mobile (<640px) and `min-height: 36px` on tablet (640–1023px), covering every interactive chip button across the entire app

## Test plan
- [ ] BattleControl bracket drag-and-drop works on touch (iOS Safari / Android Chrome DevTools emulation)
- [ ] BattleControl 7-to-smoke queue reorder works on touch
- [ ] Desktop drag-and-drop in BattleControl still works with mouse
- [ ] BattleControl seed pool chips render as 2-col grid on mobile, flex-wrap on tablet+
- [ ] BattleControl live action buttons (Open Voting, Get Score, Next, Reveal) fill full row on mobile
- [ ] BattleJudge portrait layout is wider on tablet viewport (768px+)
- [ ] BattleJudge landscape layout on tablet (1024×768): header shorter, tie row taller
- [ ] EmceeRoundView swipe works with mouse click-drag on desktop
- [ ] EmceeRoundView swipe still works on touch (device emulation)
- [ ] EventSelector long names don't overflow at 375px
- [ ] EventDetails division names wrap instead of truncate on narrow screens
- [ ] EventDetails division action buttons are tappable on mobile (stacked below name)
- [ ] AuditionList filter panel stacks vertically on mobile with section labels
- [ ] AuditionList judge dropdowns go full-width on mobile
- [ ] All Vitest tests pass (`npm test -- --run`)
- [ ] Docker frontend build passes and serves HTTP 200

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)