### PR TITLE
feat: Two-tier account model — persistent Organiser accounts + session links for Emcee/Judge/Helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ BES-frontend/nginx/certs/*.key
 # Superpowers runtime
 .superpowers/
 
+# Codegraph index (local only)
+.codegraph/
+
 # Temp / scratch files
 *_body.txt
 test_output.txt

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -27,6 +27,11 @@ const role = computed(() =>
 
 const isAuthenticated = computed(() => authStore.isAuthenticated)
 
+const isJudgeRole = computed(() => role.value === 'ROLE_JUDGE')
+const isHelperRole = computed(() => role.value === 'ROLE_HELPER')
+const isJudgeSession = computed(() => !!authStore.judgeName && !!authStore.judgeId)
+const isHelperSession = computed(() => isHelperRole.value && !!authStore.activeEvent)
+
 /** Hide the navbar on full-screen / immersive routes */
 const hideNav = computed(() =>
   ['Login', 'StreamOverlay', 'Battle Judge', 'BracketVisualization'].includes(route.name)
@@ -46,7 +51,9 @@ const roleDisplay = computed(() => {
     ROLE_HELPER:    'Helper',
   }
   const label = labels[role.value]
-  return label ? { label } : null
+  if (!label) return null
+  const name = (role.value === 'ROLE_JUDGE' && authStore.judgeName) ? authStore.judgeName : null
+  return { label, name }
 })
 
 // ── Actions ────────────────────────────────────────────────────────────────
@@ -171,14 +178,14 @@ onUnmounted(() => {
       <div class="grid grid-cols-[auto_1fr_auto] items-center h-16 gap-4">
 
         <!-- Left: BES wordmark + glowing dot -->
-        <router-link to="/" class="flex items-center gap-2.5 group flex-shrink-0">
+        <router-link :to="isJudgeRole ? '/judge/session' : isHelperRole && activeEvent ? `/events/${activeEvent.name}` : '/'" class="flex items-center gap-2.5 group flex-shrink-0">
           <div class="glow-dot"></div>
           <span class="type-body text-[18px] tracking-[0.12em] text-content-primary">BES</span>
         </router-link>
 
         <!-- Center: Primary nav as parallelogram chips -->
         <div class="hidden md:flex items-center justify-center gap-2">
-          <router-link to="/" v-slot="{ isActive }">
+          <router-link v-if="!isJudgeRole && !isHelperRole" to="/" v-slot="{ isActive }">
             <span
               class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
               :class="isActive
@@ -201,8 +208,16 @@ onUnmounted(() => {
 
           <!-- Event chip — visible on all screen sizes -->
           <div v-if="isAuthenticated" class="relative">
+            <!-- Session judge/helper: event name is locked, displayed as static chip -->
+            <span
+              v-if="activeEvent && (isJudgeSession || isHelperSession)"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary max-w-[200px] md:max-w-[240px]"
+            >
+              <span class="truncate">{{ activeEvent.name }}</span>
+            </span>
+            <!-- Normal user: interactive event chip -->
             <button
-              v-if="activeEvent"
+              v-else-if="activeEvent && !isHelperSession"
               @click="panelOpen = !panelOpen"
               class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[200px] md:max-w-[240px]"
             >
@@ -224,8 +239,9 @@ onUnmounted(() => {
             <div v-if="isAuthenticated" class="h-4 w-px bg-[rgba(255,255,255,0.12)]"></div>
 
             <span v-if="isAuthenticated && roleDisplay"
-              class="badge-neutral type-label px-2 py-0.5">
-              {{ roleDisplay.label }}
+              class="badge-neutral type-label px-2 py-0.5 inline-flex items-center gap-1.5">
+              <span class="opacity-50">{{ roleDisplay.label }}</span>
+              <span v-if="roleDisplay.name" class="text-content-primary">{{ roleDisplay.name }}</span>
             </span>
 
             <button @click="toggleTheme"
@@ -266,7 +282,7 @@ onUnmounted(() => {
     >
       <div v-show="isOpen" class="md:hidden border-t border-[rgba(255,255,255,0.07)] bg-surface-900/98">
         <div class="px-3 py-3 space-y-0.5">
-          <router-link to="/" v-slot="{ isActive }">
+          <router-link v-if="!isJudgeRole && !isHelperRole" to="/" v-slot="{ isActive }">
             <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
               :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
               Home
@@ -284,7 +300,10 @@ onUnmounted(() => {
         <div class="px-3 py-3 border-t border-[rgba(255,255,255,0.07)]">
           <div v-if="isAuthenticated" class="flex items-center justify-between">
             <div class="flex items-center gap-2">
-              <span v-if="roleDisplay" class="badge-neutral type-label">{{ roleDisplay.label }}</span>
+              <span v-if="roleDisplay" class="badge-neutral type-label inline-flex items-center gap-1.5">
+                <span class="opacity-50">{{ roleDisplay.label }}</span>
+                <span v-if="roleDisplay.name" class="text-content-primary">{{ roleDisplay.name }}</span>
+              </span>
               <button @click="toggleTheme"
                 class="inline-flex items-center justify-center w-8 h-8 type-label text-content-muted hover:text-content-primary hover:bg-[rgba(255,255,255,0.06)] transition-all duration-200">
                 <i class="pi text-sm" :class="theme === 'dark' ? 'pi-sun' : 'pi-moon'"></i>

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -43,6 +43,7 @@ const roleDisplay = computed(() => {
     ROLE_ORGANISER: 'Organiser',
     ROLE_JUDGE:     'Judge',
     ROLE_EMCEE:     'Emcee',
+    ROLE_HELPER:    'Helper',
   }
   const label = labels[role.value]
   return label ? { label } : null

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -28,8 +28,10 @@ const role = computed(() =>
 const isAuthenticated = computed(() => authStore.isAuthenticated)
 
 const isJudgeRole = computed(() => role.value === 'ROLE_JUDGE')
+const isEmceeRole = computed(() => role.value === 'ROLE_EMCEE')
 const isHelperRole = computed(() => role.value === 'ROLE_HELPER')
 const isJudgeSession = computed(() => !!authStore.judgeName && !!authStore.judgeId)
+const isEmceeSession = computed(() => isEmceeRole.value && !!authStore.activeEvent)
 const isHelperSession = computed(() => isHelperRole.value && !!authStore.activeEvent)
 
 /** Hide the navbar on full-screen / immersive routes */
@@ -178,14 +180,14 @@ onUnmounted(() => {
       <div class="grid grid-cols-[auto_1fr_auto] items-center h-16 gap-4">
 
         <!-- Left: BES wordmark + glowing dot -->
-        <router-link :to="isJudgeRole ? '/judge/session' : isHelperRole && activeEvent ? `/events/${activeEvent.name}` : '/'" class="flex items-center gap-2.5 group flex-shrink-0">
+        <router-link :to="isJudgeRole ? '/judge/session' : isEmceeRole ? '/emcee/session' : isHelperRole ? '/helper/session' : '/'" class="flex items-center gap-2.5 group flex-shrink-0">
           <div class="glow-dot"></div>
           <span class="type-body text-[18px] tracking-[0.12em] text-content-primary">BES</span>
         </router-link>
 
         <!-- Center: Primary nav as parallelogram chips -->
         <div class="hidden md:flex items-center justify-center gap-2">
-          <router-link v-if="!isJudgeRole && !isHelperRole" to="/" v-slot="{ isActive }">
+          <router-link v-if="!isJudgeRole && !isEmceeRole && !isHelperRole" to="/" v-slot="{ isActive }">
             <span
               class="inline-flex items-center gap-1.5 px-3.5 py-1.5 type-label cursor-pointer transition-all duration-200"
               :class="isActive
@@ -208,16 +210,16 @@ onUnmounted(() => {
 
           <!-- Event chip — visible on all screen sizes -->
           <div v-if="isAuthenticated" class="relative">
-            <!-- Session judge/helper: event name is locked, displayed as static chip -->
+            <!-- Session roles (judge/emcee/helper): event name is locked, displayed as static chip -->
             <span
-              v-if="activeEvent && (isJudgeSession || isHelperSession)"
+              v-if="activeEvent && (isJudgeSession || isEmceeSession || isHelperSession)"
               class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary max-w-[200px] md:max-w-[240px]"
             >
               <span class="truncate">{{ activeEvent.name }}</span>
             </span>
             <!-- Normal user: interactive event chip -->
             <button
-              v-else-if="activeEvent && !isHelperSession"
+              v-else-if="activeEvent && !isEmceeSession && !isHelperSession"
               @click="panelOpen = !panelOpen"
               class="inline-flex items-center gap-1.5 px-3 py-1.5 type-label para-chip-sm text-content-secondary hover:text-content-primary transition-all duration-200 max-w-[200px] md:max-w-[240px]"
             >
@@ -282,7 +284,7 @@ onUnmounted(() => {
     >
       <div v-show="isOpen" class="md:hidden border-t border-[rgba(255,255,255,0.07)] bg-surface-900/98">
         <div class="px-3 py-3 space-y-0.5">
-          <router-link v-if="!isJudgeRole && !isHelperRole" to="/" v-slot="{ isActive }">
+          <router-link v-if="!isJudgeRole && !isEmceeRole && !isHelperRole" to="/" v-slot="{ isActive }">
             <span class="flex items-center gap-3 px-4 py-3 type-label cursor-pointer transition-colors duration-150"
               :class="isActive ? 'text-accent' : 'text-content-secondary hover:text-content-primary'">
               Home

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -19,7 +19,7 @@ const emit = defineEmits([
 const ALL_TILES = [
   { key: 'details',      icon: 'pi-cog',      label: 'Details',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
   { key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
-  { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+  { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'] },
   { key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'] },
   { key: 'battle',       icon: 'pi-bolt',      label: 'Battle',       roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_JUDGE'] },
   { key: 'numbers',      icon: 'pi-hashtag',   label: 'Numbers',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -48,6 +48,8 @@ const visibleTiles = computed(() =>
 function handleTile(tile) {
   if (tile.key === 'details') {
     emit('goToEventDetails')
+  } else if (tile.key === 'battle' && props.role === 'ROLE_JUDGE') {
+    emit('navigate', 'Battle Judge')
   } else {
     emit('navigate', TILE_ROUTES[tile.key])
   }

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -17,9 +17,9 @@ const emit = defineEmits([
 ])
 
 const ALL_TILES = [
-  { key: 'details',      icon: 'pi-cog',      label: 'Details',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
+  { key: 'details',      icon: 'pi-cog',      label: 'Details',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'] },
   { key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
-  { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'] },
+  { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
   { key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'] },
   { key: 'battle',       icon: 'pi-bolt',      label: 'Battle',       roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_JUDGE'] },
   { key: 'numbers',      icon: 'pi-hashtag',   label: 'Numbers',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
@@ -35,6 +35,10 @@ const TILE_ROUTES = {
 
 const isAdminOrOrganiser = computed(() =>
   props.role === 'ROLE_ADMIN' || props.role === 'ROLE_ORGANISER'
+)
+
+const isSessionRole = computed(() =>
+  ['ROLE_JUDGE', 'ROLE_EMCEE', 'ROLE_HELPER'].includes(props.role)
 )
 
 const visibleTiles = computed(() =>
@@ -134,7 +138,7 @@ function handleSwitchEvent(event) {
     </template>
 
     <template v-else>
-      <div class="mt-auto border-t border-[rgba(255,255,255,0.07)] px-4 py-3">
+      <div v-if="!isSessionRole" class="mt-auto border-t border-[rgba(255,255,255,0.07)] px-4 py-3">
         <button
           @click="emit('changeEvent'); emit('close')"
           class="w-full type-label text-content-muted hover:text-content-primary transition-colors text-center py-1"

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -43,7 +43,7 @@ const routes = [
             eventName: route.params.eventName,
             folderID: route.query.folderID
         }),
-        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] }
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'] }
     },
     {
         path: '/event/audition-number',
@@ -55,7 +55,7 @@ const routes = [
         path: '/event/update-event-details',
         name: 'Update Event Details',
         component: UpdateEventDetails,
-        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'], requiresEvent: true }
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'], requiresEvent: true }
     },
     {
         path: '/event/audition-list',

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -21,6 +21,8 @@ import AuditionAdjust from "@/views/AuditionAdjust.vue";
 import BracketVisualization from "@/views/BracketVisualization.vue";
 import TokenAuth from "@/views/TokenAuth.vue";
 import JudgeSessionView from "@/views/JudgeSessionView.vue";
+import EmceeSessionView from "@/views/EmceeSessionView.vue";
+import HelperSessionView from "@/views/HelperSessionView.vue";
 import { whoami } from "@/utils/api";
 import { getActiveEvent, useAuthStore } from "@/utils/auth";
 
@@ -149,6 +151,16 @@ const routes = [
         path: '/judge/session',
         name: 'JudgeSession',
         component: JudgeSessionView
+    },
+    {
+        path: '/emcee/session',
+        name: 'EmceeSession',
+        component: EmceeSessionView
+    },
+    {
+        path: '/helper/session',
+        name: 'HelperSession',
+        component: HelperSessionView
     }
 ]
 
@@ -157,7 +169,7 @@ const router = createRouter({
     routes
 })
 
-const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'JudgeSession']
+const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'JudgeSession', 'EmceeSession', 'HelperSession']
 
 router.beforeEach(async (to) => {
     if (PUBLIC_ROUTES.includes(to.name)) return true
@@ -175,16 +187,15 @@ router.beforeEach(async (to) => {
             return { name: 'Forbidden' }
         }
 
-        // Judges and Helpers land on their session hub, not the generic home
+        // Session roles land on their hub, not the generic home
         if (userRole === 'ROLE_JUDGE' && to.name === 'Main') {
             return { name: 'JudgeSession' }
         }
+        if (userRole === 'ROLE_EMCEE' && to.name === 'Main') {
+            return { name: 'EmceeSession' }
+        }
         if (userRole === 'ROLE_HELPER' && to.name === 'Main') {
-            const activeEvent = getActiveEvent()
-            if (activeEvent) {
-                return { name: 'Event Details', params: { eventName: activeEvent.name } }
-            }
-            return { name: 'Forbidden' }
+            return { name: 'HelperSession' }
         }
 
         if (to.meta?.requiresEvent && !getActiveEvent()) {

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -20,6 +20,7 @@ import CrewFormation from "@/views/CrewFormation.vue";
 import AuditionAdjust from "@/views/AuditionAdjust.vue";
 import BracketVisualization from "@/views/BracketVisualization.vue";
 import TokenAuth from "@/views/TokenAuth.vue";
+import JudgeSessionView from "@/views/JudgeSessionView.vue";
 import { whoami } from "@/utils/api";
 import { getActiveEvent, useAuthStore } from "@/utils/auth";
 
@@ -49,7 +50,7 @@ const routes = [
         path: '/event/audition-number',
         name: 'Audition Number',
         component: AuditionNumber,
-        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] }
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'] }
     },
     {
         path: '/event/update-event-details',
@@ -143,6 +144,11 @@ const routes = [
         path: '/auth/token',
         name: 'TokenAuth',
         component: TokenAuth
+    },
+    {
+        path: '/judge/session',
+        name: 'JudgeSession',
+        component: JudgeSessionView
     }
 ]
 
@@ -151,7 +157,7 @@ const router = createRouter({
     routes
 })
 
-const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth']
+const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'JudgeSession']
 
 router.beforeEach(async (to) => {
     if (PUBLIC_ROUTES.includes(to.name)) return true
@@ -166,6 +172,18 @@ router.beforeEach(async (to) => {
 
         const userRole = user.role?.[0]?.authority
         if (to.meta?.allowedRoles && !to.meta.allowedRoles.includes(userRole)) {
+            return { name: 'Forbidden' }
+        }
+
+        // Judges and Helpers land on their session hub, not the generic home
+        if (userRole === 'ROLE_JUDGE' && to.name === 'Main') {
+            return { name: 'JudgeSession' }
+        }
+        if (userRole === 'ROLE_HELPER' && to.name === 'Main') {
+            const activeEvent = getActiveEvent()
+            if (activeEvent) {
+                return { name: 'Event Details', params: { eventName: activeEvent.name } }
+            }
             return { name: 'Forbidden' }
         }
 

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -19,6 +19,7 @@ import ResultsQR from "@/views/ResultsQR.vue";
 import CrewFormation from "@/views/CrewFormation.vue";
 import AuditionAdjust from "@/views/AuditionAdjust.vue";
 import BracketVisualization from "@/views/BracketVisualization.vue";
+import TokenAuth from "@/views/TokenAuth.vue";
 import { whoami } from "@/utils/api";
 import { getActiveEvent, useAuthStore } from "@/utils/auth";
 
@@ -54,7 +55,7 @@ const routes = [
         path: '/event/update-event-details',
         name: 'Update Event Details',
         component: UpdateEventDetails,
-        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'], requiresEvent: true }
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'], requiresEvent: true }
     },
     {
         path: '/event/audition-list',
@@ -86,13 +87,14 @@ const routes = [
     {
         path: '/battle/judge',
         name: "Battle Judge",
-        component: BattleJudge
+        component: BattleJudge,
+        meta: { allowedRoles: ['ROLE_JUDGE', 'ROLE_ADMIN'] }
     },
     {
         path: '/battle/control',
         name: "Battle Control",
         component: BattleControl,
-        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'], requiresEvent: true }
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'], requiresEvent: true }
     },
     {
         path: '/battle/chart',
@@ -136,6 +138,11 @@ const routes = [
         name: 'Audition Adjust',
         component: AuditionAdjust,
         meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'], requiresEvent: true }
+    },
+    {
+        path: '/auth/token',
+        name: 'TokenAuth',
+        component: TokenAuth
     }
 ]
 
@@ -144,7 +151,7 @@ const router = createRouter({
     routes
 })
 
-const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Battle Judge', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization']
+const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth']
 
 router.beforeEach(async (to) => {
     if (PUBLIC_ROUTES.includes(to.name)) return true

--- a/BES-frontend/src/utils/__tests__/EventPanel.test.js
+++ b/BES-frontend/src/utils/__tests__/EventPanel.test.js
@@ -124,17 +124,17 @@ describe('EventPanel.vue — zones', () => {
     expect(w.text()).toContain('Manage Events')
   })
 
-  it('Emcee sees Change Event link, not Manage Events zone', async () => {
+  it('Emcee sees neither Change Event nor Manage Events (session role — locked event)', async () => {
     const w = mountPanel('ROLE_EMCEE')
     await w.vm.$nextTick()
-    expect(w.text()).toContain('Change Event')
+    expect(w.text()).not.toContain('Change Event')
     expect(w.text()).not.toContain('Manage Events')
   })
 
-  it('Judge sees Change Event link, not Manage Events zone', async () => {
+  it('Judge sees neither Change Event nor Manage Events (session role — locked event)', async () => {
     const w = mountPanel('ROLE_JUDGE')
     await w.vm.$nextTick()
-    expect(w.text()).toContain('Change Event')
+    expect(w.text()).not.toContain('Change Event')
     expect(w.text()).not.toContain('Manage Events')
   })
 
@@ -154,13 +154,11 @@ describe('EventPanel.vue — zones', () => {
     expect(activeRow?.classes()).toContain('text-accent')
   })
 
-  it('emits changeEvent when Change Event clicked (Emcee)', async () => {
+  it('does not show Change Event for session roles (locked identity)', async () => {
     const w = mountPanel('ROLE_EMCEE')
     await w.vm.$nextTick()
     const btn = w.findAll('button').find(b => b.text().includes('Change Event'))
-    await btn.trigger('click')
-    expect(w.emitted('changeEvent')).toBeTruthy()
-    expect(w.emitted('close')).toBeTruthy()
+    expect(btn).toBeUndefined()
   })
 
   it('emits goToAllEvents and close when All Events clicked', async () => {

--- a/BES-frontend/src/utils/adminApi.js
+++ b/BES-frontend/src/utils/adminApi.js
@@ -201,6 +201,27 @@ export const addFeedbackTag = async (groupId, label) => {
     } catch (_err) { /* network error — caller handles undefined return */ }
 }
 
+export const createOrganiser = async (username, password) => {
+    try {
+        const res = await fetch(`${domain}/api/v1/admin/organisers`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password })
+        })
+        return res
+    } catch (_err) { /* network error */ }
+}
+
+export const deleteOrganiser = async (accountId) => {
+    try {
+        return await fetch(`${domain}/api/v1/admin/organisers/${accountId}`, {
+            method: 'DELETE',
+            credentials: 'include'
+        })
+    } catch (_err) { /* network error */ }
+}
+
 export const getOrganisers = async () => {
     try {
         const res = await fetch(`${domain}/api/v1/admin/organisers`, { credentials: 'include' })

--- a/BES-frontend/src/utils/adminApi.js
+++ b/BES-frontend/src/utils/adminApi.js
@@ -201,6 +201,36 @@ export const addFeedbackTag = async (groupId, label) => {
     } catch (_err) { /* network error — caller handles undefined return */ }
 }
 
+export const getOrganisers = async () => {
+    try {
+        const res = await fetch(`${domain}/api/v1/admin/organisers`, { credentials: 'include' })
+        if (res.ok) return await res.json()
+        return []
+    } catch (_err) { return [] }
+}
+
+export const assignOrganiserToEvent = async (accountId, eventId) => {
+    try {
+        return await fetch(`${domain}/api/v1/admin/organisers/assign`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ accountId, eventId })
+        })
+    } catch (_err) { /* network error — caller handles undefined return */ }
+}
+
+export const removeOrganiserFromEvent = async (accountId, eventId) => {
+    try {
+        return await fetch(`${domain}/api/v1/admin/organisers/assign`, {
+            method: 'DELETE',
+            credentials: 'include',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ accountId, eventId })
+        })
+    } catch (_err) { /* network error — caller handles undefined return */ }
+}
+
 export const deleteFeedbackTag = async (id) => {
     try {
         return await fetch(`${domain}/api/v1/admin/feedback-tag`, {

--- a/BES-frontend/src/utils/adminApi.js
+++ b/BES-frontend/src/utils/adminApi.js
@@ -162,7 +162,7 @@ export const deleteImage = async(name)=>{
 
 export const getFeedbackGroups = async () => {
     try {
-        const res = await fetch(`${domain}/api/v1/admin/feedback-groups`, { credentials: 'include' })
+        const res = await fetch(`${domain}/api/v1/event/feedback-groups`, { credentials: 'include' })
         if (res.ok) return await res.json()
         return []
     } catch (_err) { return [] }

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -144,13 +144,10 @@ export const getVerifiedParticipantsByEvent = async(eventName) =>{
     const res = await fetch(`${domain}/api/v1/event/verified-participant/${eventName}`,{
       credentials: 'include'
     })
-    if(res.ok){
-        return await res.json()
-    }else if (res.status === 404) {
-        return []
-    }
+    return res.ok ? await res.json() : []
   }catch(e){
       console.log(e)
+      return []
   }
 }
 
@@ -159,13 +156,10 @@ export const getRegisteredParticipantsByEvent = async(eventName) =>{
     const res = await fetch(`${domain}/api/v1/event/participants/${eventName}`,{
       credentials: 'include',
     })
-    if(res.ok){
-        return await res.json()
-    }else if (res.status === 404) {
-        return []
-    }
+    return res.ok ? await res.json() : []
   }catch(e){
       console.log(e)
+      return []
   }
 }
 
@@ -206,6 +200,39 @@ export const removeEventJudge = async(eventName, judgeId) => {
       credentials: 'include'
     })
   } catch(err) { console.log(err) }
+}
+
+export const getJudgesByEvent = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/judges`, { credentials: 'include', headers: { 'Accept': 'application/json' } })
+    return res.ok ? await res.json() : []
+  } catch { return [] }
+}
+
+export const getJudgeDivisions = async (eventName, judgeId) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/judge/${judgeId}/divisions`, { credentials: 'include', headers: { 'Accept': 'application/json' } })
+    return res.ok ? await res.json() : []
+  } catch { return [] }
+}
+
+export const addJudgeToEvent = async (eventName, judgeName) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/judge`, {
+      method: 'POST', credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ judgeName })
+    })
+  } catch { return null }
+}
+
+export const assignJudgeToDivision = async (eventName, divisionId, judgeId) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/divisions/${divisionId}/assign-judge/${judgeId}`, {
+      method: 'POST', credentials: 'include',
+      headers: { 'Accept': 'application/json' }
+    })
+  } catch { return null }
 }
 
 export const getJudgesByDivision = async (eventName, divisionId) => {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1403,3 +1403,18 @@ export const generateToken = async (role, eventId, judgeId, expiresInDays = 7) =
     return res.ok ? await res.json() : null
   } catch (err) { console.error(err); return null }
 }
+
+export const getSessionTokens = async (eventId) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/auth/tokens?eventId=${eventId}`, { credentials: 'include' })
+    return res.ok ? await res.json() : []
+  } catch (err) { console.error(err); return [] }
+}
+
+export const revokeSessionToken = async (tokenId) => {
+  try {
+    return await fetch(`${domain}/api/v1/auth/tokens/${tokenId}`, {
+      method: 'DELETE', credentials: 'include'
+    })
+  } catch (err) { console.error(err) }
+}

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1381,3 +1381,25 @@ export const releaseAuditionNumbers = async (eventId, participantId) => {
     })
   } catch (e) { console.log(e) }
 }
+
+export const redeemToken = async (tokenId) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/auth/token`, {
+      method: 'POST', credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tokenId })
+    })
+    return res.ok ? await res.json() : null
+  } catch (err) { console.error(err); return null }
+}
+
+export const generateToken = async (role, eventId, judgeId, expiresInDays = 7) => {
+  try {
+    const params = new URLSearchParams({ role, eventId, expiresInDays })
+    if (judgeId) params.append('judgeId', judgeId)
+    const res = await fetch(`${domain}/api/v1/auth/generate-token?${params}`, {
+      method: 'POST', credentials: 'include'
+    })
+    return res.ok ? await res.json() : null
+  } catch (err) { console.error(err); return null }
+}

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1416,8 +1416,15 @@ export const redeemToken = async (tokenId) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tokenId })
     })
-    return res.ok ? await res.json() : null
-  } catch (err) { console.error(err); return null }
+    if (!res.ok) {
+      const body = await res.json().catch(() => null)
+      return { authenticated: false, error: body?.error || 'Invalid or expired link.' }
+    }
+    return await res.json()
+  } catch (err) {
+    console.error(err)
+    return { authenticated: false, error: 'Unable to reach server. Check your connection and try again.' }
+  }
 }
 
 export const generateToken = async (role, eventId, judgeId, expiresInDays = 7) => {

--- a/BES-frontend/src/utils/auth.js
+++ b/BES-frontend/src/utils/auth.js
@@ -47,17 +47,23 @@ export const useAuthStore = defineStore('auth',{
     state: ()=>({
         user: null,
         isAuthenticated: false,
-        activeEvent: getActiveEvent()
+        activeEvent: getActiveEvent(),
+        judgeId: null,
+        judgeName: null
     }),
     actions:{
         login(userData){
             this.user = userData
             this.isAuthenticated = userData["authenticated"]
+            this.judgeId = userData.judgeId ?? null
+            this.judgeName = userData.judgeName ?? null
         },
         logout(){
             this.user = null;
             this.isAuthenticated = false;
             this.activeEvent = null;
+            this.judgeId = null;
+            this.judgeName = null;
             clearVerifiedEvents();
             localStorage.removeItem('selectedEvent');
             localStorage.removeItem('selectedRole');

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -53,6 +53,33 @@ const addTagInputs = ref({})  // { [groupId]: string }
 const dynamicHandler = ref(() => {})
 
 const organisers = ref([])
+const newOrganiserUsername = ref('')
+const newOrganiserPassword = ref('')
+
+const submitCreateOrganiser = async () => {
+  if (checkInputNull(newOrganiserUsername.value) || checkInputNull(newOrganiserPassword.value)) {
+    openModal("Validation Error", "Username and password cannot be empty.", "error")
+    return
+  }
+  const res = await createOrganiser(newOrganiserUsername.value, newOrganiserPassword.value)
+  if (res?.ok) {
+    organisers.value = await getOrganisers() ?? []
+    newOrganiserUsername.value = ''
+    newOrganiserPassword.value = ''
+  }
+}
+
+const confirmDeleteOrganiser = (id, username) => {
+  modalTitle.value = 'Delete Organiser?'
+  modalMessage.value = `Are you sure you want to delete ${username}?`
+  modalVariant.value = 'warning'
+  showModal.value = true
+  dynamicHandler.value = async () => {
+    const res = await deleteOrganiser(id)
+    if (res?.ok) organisers.value = organisers.value.filter(o => o.id !== id)
+    showModal.value = false
+  }
+}
 
 const toggleOrganiserEvent = async (accountId, eventId, isAssigned) => {
   if (isAssigned) {
@@ -387,6 +414,24 @@ onMounted(async () => {
           <div class="section-rule-line"></div>
         </div>
 
+        <div class="flex gap-3 mb-5">
+          <input
+            v-model="newOrganiserUsername"
+            type="text"
+            placeholder="Username…"
+            class="input-base flex-1 max-w-xs"
+            @keyup.enter="submitCreateOrganiser"
+          />
+          <input
+            v-model="newOrganiserPassword"
+            type="password"
+            placeholder="Password…"
+            class="input-base flex-1 max-w-xs"
+            @keyup.enter="submitCreateOrganiser"
+          />
+          <button @click="submitCreateOrganiser" class="bg-accent para-chip-sm type-label text-surface-900 px-4 py-2">Create Account</button>
+        </div>
+
         <p class="type-label text-content-muted mb-4">Assign or remove events for each organiser.</p>
 
         <div class="space-y-3">
@@ -398,6 +443,13 @@ onMounted(async () => {
             <div class="corner-bar-tl"></div>
             <div class="flex items-center justify-between mb-3">
               <span class="type-body text-content-primary">{{ org.username }}</span>
+              <button
+                @click="confirmDeleteOrganiser(org.id, org.username)"
+                class="w-6 h-6 flex items-center justify-center text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"
+                title="Delete organiser"
+              >
+                <i class="pi pi-times text-xs"></i>
+              </button>
             </div>
 
             <div class="flex flex-wrap gap-2">
@@ -414,7 +466,7 @@ onMounted(async () => {
           </div>
 
           <p v-if="organisers.length === 0" class="type-label text-content-muted py-4">
-            No organiser accounts found
+            No organiser accounts yet. Use the form above to create one.
           </p>
         </div>
       </div>

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { addGenre, deleteGenre, deleteImage, deleteScore, getAllImages, updateGenre, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag, getOrganisers, assignOrganiserToEvent, removeOrganiserFromEvent } from '@/utils/adminApi';
+import { addGenre, deleteGenre, deleteImage, deleteScore, getAllImages, updateGenre, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag, getOrganisers, assignOrganiserToEvent, removeOrganiserFromEvent, createOrganiser, deleteOrganiser } from '@/utils/adminApi';
 import { checkInputNull } from '@/utils/utils';
 import { onMounted, ref } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { addGenre, deleteGenre, deleteImage, deleteScore, getAllImages, updateGenre, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag } from '@/utils/adminApi';
+import { addGenre, deleteGenre, deleteImage, deleteScore, getAllImages, updateGenre, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag, getOrganisers, assignOrganiserToEvent, removeOrganiserFromEvent } from '@/utils/adminApi';
 import { checkInputNull } from '@/utils/utils';
 import { onMounted, ref } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
@@ -52,9 +52,24 @@ const addGroupInput = ref('')
 const addTagInputs = ref({})  // { [groupId]: string }
 const dynamicHandler = ref(() => {})
 
+const organisers = ref([])
+
+const toggleOrganiserEvent = async (accountId, eventId, isAssigned) => {
+  if (isAssigned) {
+    await removeOrganiserFromEvent(accountId, eventId)
+  } else {
+    await assignOrganiserToEvent(accountId, eventId)
+  }
+  organisers.value = await getOrganisers() ?? []
+}
+
+const isEventAssigned = (organiser, eventId) => {
+  return organiser.assignedEventIds?.includes(eventId) ?? false
+}
+
 const accentInput = ref('#ffffff')
 const activeTab = ref('genres')
-const tabs = ref(['genres', 'scores', 'feedback', 'images', 'theme'])
+const tabs = ref(['genres', 'scores', 'feedback', 'images', 'theme', 'organisers'])
 
 const confirmResetScore = (id, title, message) => {
   modalTitle.value = title
@@ -153,6 +168,7 @@ onMounted(async () => {
   events.value = await fetchAllEvents() ?? []
   images.value = await getAllImages() ?? []
   feedbackGroups.value = await getFeedbackGroups() ?? []
+  organisers.value = await getOrganisers() ?? []
   const cfg = await getAppConfig()
   accentInput.value = cfg?.accentColor ?? '#ffffff'
 })
@@ -360,6 +376,46 @@ onMounted(async () => {
           <div v-if="images.length === 0" class="col-span-full type-label text-content-muted py-4">
             No images uploaded
           </div>
+        </div>
+      </div>
+
+      <!-- ── Organisers ────────────────────────────────────── -->
+      <div v-if="activeTab === 'organisers'">
+        <div class="section-rule mb-4">
+          <span class="section-rule-label">Organisers</span>
+          <span class="badge-neutral type-label px-2 py-0.5">{{ organisers.length }}</span>
+          <div class="section-rule-line"></div>
+        </div>
+
+        <p class="type-label text-content-muted mb-4">Assign or remove events for each organiser.</p>
+
+        <div class="space-y-3">
+          <div
+            v-for="org in organisers"
+            :key="org.id"
+            class="card-hover p-4 relative"
+          >
+            <div class="corner-bar-tl"></div>
+            <div class="flex items-center justify-between mb-3">
+              <span class="type-body text-content-primary">{{ org.username }}</span>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="e in events"
+                :key="e.id"
+                @click="toggleOrganiserEvent(org.id, e.id, isEventAssigned(org, e.id))"
+                class="para-chip-sm type-label px-3 py-1 transition-all duration-150"
+                :class="isEventAssigned(org, e.id) ? 'bg-accent text-surface-900' : 'text-content-muted hover:text-content-primary hover:border-[color:var(--accent-muted)]'"
+              >{{ e.name }}</button>
+            </div>
+
+            <p v-if="events.length === 0" class="type-label text-content-muted py-1">No events available</p>
+          </div>
+
+          <p v-if="organisers.length === 0" class="type-label text-content-muted py-4">
+            No organiser accounts found
+          </p>
         </div>
       </div>
 

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -61,11 +61,16 @@ const submitCreateOrganiser = async () => {
     openModal("Validation Error", "Username and password cannot be empty.", "error")
     return
   }
-  const res = await createOrganiser(newOrganiserUsername.value, newOrganiserPassword.value)
+  const username = newOrganiserUsername.value
+  const res = await createOrganiser(username, newOrganiserPassword.value)
   if (res?.ok) {
     organisers.value = await getOrganisers() ?? []
     newOrganiserUsername.value = ''
     newOrganiserPassword.value = ''
+    openModal("Account Created", `Organiser "${username}" created successfully.`, "info")
+  } else {
+    const body = await res?.json().catch(() => null)
+    openModal("Error", body?.message || "Failed to create organiser. Username may already exist.", "warning")
   }
 }
 
@@ -458,7 +463,7 @@ onMounted(async () => {
                 :key="e.id"
                 @click="toggleOrganiserEvent(org.id, e.id, isEventAssigned(org, e.id))"
                 class="para-chip-sm type-label px-3 py-1 transition-all duration-150"
-                :class="isEventAssigned(org, e.id) ? 'bg-accent text-surface-900' : 'text-content-muted hover:text-content-primary hover:border-[color:var(--accent-muted)]'"
+                :class="isEventAssigned(org, e.id) ? 'text-green-300 border-green-500/50 bg-green-500/15' : 'text-content-muted hover:text-content-primary hover:border-[color:var(--accent-muted)]'"
               >{{ e.name }}</button>
             </div>
 

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -48,6 +48,11 @@ const dynamicRole = async () => {
   } else if (authority === "ROLE_JUDGE") {
     roles.value = ["Judge"]
     selectedRole.value = "Judge"
+    const jName = authStore.judgeName
+    if (jName) {
+      currentJudge.value = jName
+      localStorage.setItem('currentJudge', jName)
+    }
   } else if (authority === "ROLE_ORGANISER") {
     roles.value = ["Emcee"]
     selectedRole.value = "Emcee"
@@ -805,7 +810,7 @@ onMounted(async () => {
 
     <!-- Judge: no identity selected -->
     <div
-      v-else-if="selectedRole === 'Judge' && !currentJudge"
+      v-else-if="selectedRole === 'Judge' && !currentJudge && isAdmin"
       class="flex flex-col items-center justify-center py-16 text-center gap-6 px-4"
     >
       <div>

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -4,7 +4,7 @@ import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipan
 import { getFeedbackGroups } from '@/utils/adminApi';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
-import { RouterLink } from 'vue-router';
+import { RouterLink, useRouter } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
 import FeedbackPopout from '@/components/FeedbackPopout.vue';
 import { useAuthStore } from '@/utils/auth';
@@ -27,6 +27,7 @@ const participants = ref([])
 const judgingMode = ref("SOLO")
 const eventDivisions = ref([]) // { eventGenreId, name } for current event — used to map division name → ID
 const isAdmin = ref(false)
+const isOrganiser = ref(false)
 
 const modalTitle = ref("")
 const modalMessage = ref("")
@@ -48,15 +49,16 @@ const dynamicRole = async () => {
   } else if (authority === "ROLE_JUDGE") {
     roles.value = ["Judge"]
     selectedRole.value = "Judge"
-    const jName = authStore.judgeName
+    const jName = res.judgeName || authStore.judgeName
     if (jName) {
       currentJudge.value = jName
       filteredJudge.value = jName
       localStorage.setItem('currentJudge', jName)
     }
   } else if (authority === "ROLE_ORGANISER") {
-    roles.value = ["Emcee"]
-    selectedRole.value = "Emcee"
+    roles.value = ["Emcee", "Judge"]
+    selectedRole.value = localStorage.getItem("selectedRole") || "Emcee"
+    isOrganiser.value = true
   } else if (authority === "ROLE_ADMIN") {
     roles.value = ["Emcee", "Judge"]
     selectedRole.value = localStorage.getItem("selectedRole") || ""
@@ -155,13 +157,21 @@ const confirmSubmit = async (title, message) => {
 
 const filteredParticipantsForJudge = computed({
   get() {
+    // For pure judges (not admin/organiser), the filter identity is always the current judge.
+    // Admin/organiser can set filteredJudge independently via a dropdown.
+    const effectiveJudge = (!isAdmin.value && !isOrganiser.value && currentJudge.value)
+      ? currentJudge.value
+      : filteredJudge.value
     return participants.value
-      .filter(p =>
-        p.genreName === selectedGenre.value &&
-        p.judgeName === (filteredJudge.value === "" ? null : filteredJudge.value) &&
-        p.auditionNumber !== null &&
-        matchesEntryType(p)
-      )
+      .filter(p => {
+        if (p.genreName !== selectedGenre.value) return false
+        if (p.auditionNumber === null) return false
+        if (!matchesEntryType(p)) return false
+        // If no participants have per-participant judge assignments, use event-genre scope
+        if (!hasJudge.value) return true
+        // Otherwise, filter by per-participant judgeName
+        return p.judgeName === (effectiveJudge === "" ? null : effectiveJudge)
+      })
       .sort((a, b) => a.auditionNumber - b.auditionNumber)
   },
   set(updatedList) {
@@ -209,7 +219,9 @@ const loadScoresFromDb = async (event, genre, judge) => {
 }
 
 const filteredParticipantsForEmceeView = computed(() => {
-  const base = filteredJudge.value === ""
+  // If no participants have per-participant judge assignments, use event-genre scope.
+  // Otherwise, respect the admin/org's judge filter dropdown.
+  const base = (!hasJudge.value || filteredJudge.value === "")
     ? participants.value.filter(p => p.genreName === selectedGenre.value && p.auditionNumber !== null && matchesEntryType(p))
     : participants.value.filter(p => p.genreName === selectedGenre.value && p.judgeName === filteredJudge.value && p.auditionNumber !== null && matchesEntryType(p))
   return base.sort((a, b) => a.auditionNumber - b.auditionNumber)
@@ -253,9 +265,20 @@ watch(selectedEvent, async (newVal, oldVal) => {
       currentJudge.value = ""
       localStorage.removeItem("currentJudge")
     }
-    filteredJudge.value = ""
+    if (!authStore.judgeName) filteredJudge.value = ""
     if (selectedEvent.value !== newVal) return
     participants.value = res.map((r, i) => ({ ...r, rowId: r.rowId ?? i, score: 0 }))
+    // Auto-select the first genre assigned to a session-link judge who has no genre selected yet
+    if (!selectedGenre.value && authStore.judgeName) {
+      const myGenre = res.find(p => p.judgeName === authStore.judgeName)?.genreName
+      if (myGenre) selectedGenre.value = myGenre
+    }
+    // Fallback: if still no genre selected, pick the first genre from participants or event divisions
+    if (!selectedGenre.value) {
+      const firstGenre = res.find(p => p.genreName)?.genreName
+        || (divRes && divRes.length > 0 ? divRes[0].name : null)
+      if (firstGenre) selectedGenre.value = firstGenre
+    }
     if (modeRes?.judgingMode) judgingMode.value = modeRes.judgingMode
     await loadScoresFromDb(newVal, selectedGenre.value, currentJudge.value)
   }
@@ -279,13 +302,19 @@ watch(selectedGenre, async (newVal) => {
       if (sessionJudge && judgeNames.includes(sessionJudge)) {
         currentJudge.value = sessionJudge
         localStorage.setItem('currentJudge', sessionJudge)
-      } else {
+      } else if (!sessionJudge || currentJudge.value !== sessionJudge) {
+        // Only clear if currentJudge doesn't match a session-linked judge identity.
+        // Session-linked judges keep their identity even if not in this division's explicit judge list.
         currentJudge.value = ""
         localStorage.removeItem("currentJudge")
       }
     }
     if (!judgeNames.includes(filteredJudge.value)) {
-      filteredJudge.value = (sessionJudge && judgeNames.includes(sessionJudge)) ? sessionJudge : ""
+      if (sessionJudge && judgeNames.includes(sessionJudge)) {
+        filteredJudge.value = sessionJudge
+      } else if (!sessionJudge || filteredJudge.value !== sessionJudge) {
+        filteredJudge.value = ""
+      }
     }
     await loadScoresFromDb(selectedEvent.value, newVal, currentJudge.value)
   } else {
@@ -530,6 +559,8 @@ watch([currentJudge, selectedGenre], loadFeedbackGiven)
 
 const showFilters = ref(false)
 const hasActiveSession = computed(() => !!selectedGenre.value && !!selectedRole.value)
+const router = useRouter()
+const isJudgeSession = computed(() => !!authStore.judgeName && !!authStore.judgeId)
 
 const wsClients = []
 
@@ -651,13 +682,19 @@ onMounted(async () => {
       class="para-chip px-4 py-2.5 mb-4 flex-shrink-0 flex items-center justify-between"
     >
       <div class="flex items-center gap-2 type-label text-content-muted flex-wrap">
+        <button
+          v-if="isJudgeSession"
+          @click="router.push({ name: 'JudgeSession' })"
+          class="text-accent hover:text-content-primary transition-colors whitespace-nowrap"
+        >← SESSION</button>
+        <span v-if="isJudgeSession" class="text-content-muted opacity-30">·</span>
         <span class="text-accent">{{ selectedEvent }}</span>
         <span class="text-content-muted opacity-30">·</span>
         <span>{{ selectedGenre }}</span>
         <span class="text-content-muted opacity-30">·</span>
         <span class="uppercase tracking-widest">{{ judgingMode }}</span>
-        <span class="text-content-muted opacity-30">·</span>
-        <span>{{ selectedRole }}</span>
+        <span v-if="!isJudgeSession" class="text-content-muted opacity-30">·</span>
+        <span v-if="!isJudgeSession">{{ selectedRole }}</span>
       </div>
       <button
         @click="showFilters = !showFilters"
@@ -697,12 +734,12 @@ onMounted(async () => {
       <div v-if="showFilters || !hasActiveSession" class="card p-5" :class="hasActiveSession ? 'fixed left-0 right-0 z-40 mx-4' : 'mb-6'" :style="hasActiveSession ? { top: '138px', background: '#1a1a1a', borderColor: 'rgba(255,255,255,0.12)', boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 20px 60px rgba(0,0,0,0.9)', clipPath: 'none' } : { clipPath: 'none' }">
         <!-- Mobile: vertical stack; Tablet+: horizontal wrap -->
         <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-4 sm:gap-3">
-          <!-- Event name -->
-          <span class="type-body text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
-          <span class="text-surface-600 select-none hidden sm:inline">|</span>
+          <!-- Event name (hidden for session judges — locked) -->
+          <span v-if="!isJudgeSession" class="type-body text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
+          <span v-if="!isJudgeSession" class="text-surface-600 select-none hidden sm:inline">|</span>
 
-          <!-- Role toggle -->
-          <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
+          <!-- Role toggle (hidden for session judges — locked to Judge) -->
+          <div v-if="!isJudgeSession" class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
             <span class="section-rule-label sm:hidden">Role</span>
             <div class="flex flex-wrap gap-2 sm:gap-1">
               <button
@@ -716,7 +753,7 @@ onMounted(async () => {
               >{{ r }}</button>
             </div>
           </div>
-          <span class="text-surface-600 select-none hidden sm:inline">|</span>
+          <span v-if="!isJudgeSession" class="text-surface-600 select-none hidden sm:inline">|</span>
 
           <!-- Genre toggle -->
           <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
@@ -774,10 +811,10 @@ onMounted(async () => {
 
           <!-- Judge filter + identity dropdowns: full-width on mobile, right-aligned on sm+ -->
           <div class="flex flex-col sm:flex-row sm:ml-auto sm:items-center gap-3 w-full sm:w-auto">
-            <div v-if="hasJudge && isAdmin" class="w-full sm:w-48">
+            <div v-if="hasJudge && (isAdmin || isOrganiser)" class="w-full sm:w-48">
               <ReusableDropdown v-model="filteredJudge" labelId="Judge" :options="allJudges" />
             </div>
-            <div v-if="selectedRole === 'Judge' && isAdmin" class="w-full sm:min-w-[12rem] sm:max-w-[16rem]">
+            <div v-if="selectedRole === 'Judge' && (isAdmin || isOrganiser)" class="w-full sm:min-w-[12rem] sm:max-w-[16rem]">
               <ReusableDropdown v-model="currentJudge" labelId="You are judging as" :options="allJudges" />
             </div>
           </div>
@@ -817,7 +854,7 @@ onMounted(async () => {
 
     <!-- Judge: no identity selected -->
     <div
-      v-else-if="selectedRole === 'Judge' && !currentJudge && isAdmin"
+      v-else-if="selectedRole === 'Judge' && !currentJudge"
       class="flex flex-col items-center justify-center py-16 text-center gap-6 px-4"
     >
       <div>
@@ -887,9 +924,34 @@ onMounted(async () => {
       />
     </template>
 
-    <!-- Empty state -->
+    <!-- Empty state: no participants in this genre -->
     <div
-      v-else-if="selectedRole && selectedGenre && currentJudge && filteredParticipantsForEmceeView.length === 0 && filteredParticipantsForJudge.length === 0"
+      v-else-if="selectedRole === 'Judge' && selectedGenre && currentJudge && filteredParticipantsForJudge.length === 0"
+      class="flex flex-col items-center justify-center h-full text-center"
+    >
+      <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
+        <i class="pi pi-user text-content-muted text-xl"></i>
+      </div>
+      <p class="type-body text-content-secondary">No participants in {{ selectedGenre }}</p>
+      <p class="type-label text-content-muted mt-1">
+        {{ currentJudge }} — {{ selectedGenre }}
+      </p>
+      <div class="mt-4 px-5 py-3 flex flex-col items-center gap-1" style="border-left:3px solid rgba(245,158,11,0.8);background:rgba(245,158,11,0.07);clip-path:polygon(8px 0%,100% 0%,calc(100% - 8px) 100%,0% 100%)">
+        <p class="type-label text-amber-300/80">
+          {{ participants.filter(p => p.genreName === selectedGenre).length }} total participants in {{ selectedGenre }}
+        </p>
+        <p class="type-label text-amber-300/80">
+          {{ participants.filter(p => p.genreName === selectedGenre && p.auditionNumber !== null).length }} have audition numbers
+        </p>
+      </div>
+      <p class="type-label text-content-muted mt-3 max-w-xs">
+        No participants found in this division. Try a different genre or ask an organiser to add participants.
+      </p>
+    </div>
+
+    <!-- Empty state: no participants in this genre (general) -->
+    <div
+      v-else-if="selectedRole && selectedGenre && filteredParticipantsForEmceeView.length === 0 && filteredParticipantsForJudge.length === 0"
       class="flex flex-col items-center justify-center h-full text-center"
     >
       <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
@@ -909,6 +971,18 @@ onMounted(async () => {
       </div>
       <p class="type-body text-content-secondary">Select your role to begin</p>
       <p class="type-label text-content-muted mt-1">Choose Emcee or Judge in the filter panel above</p>
+    </div>
+
+    <!-- Catch-all fallback: prevent blank page while data is loading -->
+    <div
+      v-else
+      class="flex flex-col items-center justify-center h-full text-center"
+    >
+      <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
+        <i class="pi pi-spinner pi-spin text-accent text-xl"></i>
+      </div>
+      <p class="type-body text-content-secondary">Loading…</p>
+      <p class="type-label text-content-muted mt-1">Fetching audition data for {{ selectedEvent }}</p>
     </div>
 
     </div>
@@ -955,7 +1029,7 @@ onMounted(async () => {
     :show="showJudgeConfirm"
     title="Confirm Identity"
     variant="info"
-    @accept="() => { currentJudge = pendingJudge; showJudgeConfirm = false; pendingJudge = null }"
+    @accept="() => { currentJudge = pendingJudge; filteredJudge = pendingJudge; showJudgeConfirm = false; pendingJudge = null }"
     @close="() => { showJudgeConfirm = false; pendingJudge = null }"
   >
     <p class="type-body text-content-secondary">

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -51,6 +51,7 @@ const dynamicRole = async () => {
     const jName = authStore.judgeName
     if (jName) {
       currentJudge.value = jName
+      filteredJudge.value = jName
       localStorage.setItem('currentJudge', jName)
     }
   } else if (authority === "ROLE_ORGANISER") {
@@ -273,12 +274,18 @@ watch(selectedGenre, async (newVal) => {
     const judges = await getJudgesByDivision(selectedEvent.value, division.eventGenreId)
     const judgeNames = judges.map(j => j.judgeName)
     allJudges.value = ["", ...judgeNames]
+    const sessionJudge = authStore.judgeName
     if (!judgeNames.includes(currentJudge.value)) {
-      currentJudge.value = ""
-      localStorage.removeItem("currentJudge")
+      if (sessionJudge && judgeNames.includes(sessionJudge)) {
+        currentJudge.value = sessionJudge
+        localStorage.setItem('currentJudge', sessionJudge)
+      } else {
+        currentJudge.value = ""
+        localStorage.removeItem("currentJudge")
+      }
     }
     if (!judgeNames.includes(filteredJudge.value)) {
-      filteredJudge.value = ""
+      filteredJudge.value = (sessionJudge && judgeNames.includes(sessionJudge)) ? sessionJudge : ""
     }
     await loadScoresFromDb(selectedEvent.value, newVal, currentJudge.value)
   } else {
@@ -767,10 +774,10 @@ onMounted(async () => {
 
           <!-- Judge filter + identity dropdowns: full-width on mobile, right-aligned on sm+ -->
           <div class="flex flex-col sm:flex-row sm:ml-auto sm:items-center gap-3 w-full sm:w-auto">
-            <div v-if="hasJudge" class="w-full sm:w-48">
+            <div v-if="hasJudge && isAdmin" class="w-full sm:w-48">
               <ReusableDropdown v-model="filteredJudge" labelId="Judge" :options="allJudges" />
             </div>
-            <div v-if="selectedRole === 'Judge'" class="w-full sm:min-w-[12rem] sm:max-w-[16rem]">
+            <div v-if="selectedRole === 'Judge' && isAdmin" class="w-full sm:min-w-[12rem] sm:max-w-[16rem]">
               <ReusableDropdown v-model="currentJudge" labelId="You are judging as" :options="allJudges" />
             </div>
           </div>

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -2,6 +2,7 @@
 import { battleJudgeVote, getBattleJudges, getBattlePhase, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
 import { onMounted, onUnmounted, ref } from 'vue'
+import { useAuthStore } from '@/utils/auth'
 
 // ── Overlay config ──────────────────────────────────────────────────────────
 const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
@@ -16,33 +17,16 @@ const battleJudges   = ref({ judges: [] })
 // ── Judge identity ──────────────────────────────────────────────────────────
 const judgeId         = ref(null)   // number | null
 const judgeName       = ref('')
-const showJudgePicker = ref(false)
+const notAssigned     = ref(false)
 
-const LS_JUDGE_ID   = 'battleJudgeId'
-const LS_JUDGE_NAME = 'battleJudgeName'
-
-function resolveJudgeIdentity(judges) {
-  const storedId = localStorage.getItem(LS_JUDGE_ID)
-  if (!storedId) { showJudgePicker.value = true; return }
-  const id = Number(storedId)
-  const match = judges.find(j => j.id === id)
-  if (!match) {
-    localStorage.removeItem(LS_JUDGE_ID)
-    localStorage.removeItem(LS_JUDGE_NAME)
-    showJudgePicker.value = true
-    return
-  }
-  judgeId.value   = id
+function loadJudgeIdentity(judges) {
+  const authStore = useAuthStore()
+  const sid = authStore.judgeId
+  if (!sid) { notAssigned.value = true; return }
+  const match = judges.find(j => j.id === Number(sid))
+  if (!match) { notAssigned.value = true; return }
+  judgeId.value   = match.id
   judgeName.value = match.name
-  setupVoteSubscription()
-}
-
-function selectJudge(j) {
-  judgeId.value   = j.id
-  judgeName.value = j.name
-  localStorage.setItem(LS_JUDGE_ID,   String(j.id))
-  localStorage.setItem(LS_JUDGE_NAME, j.name)
-  showJudgePicker.value = false
   setupVoteSubscription()
 }
 
@@ -50,9 +34,6 @@ function clearJudge() {
   clearVote()
   judgeId.value   = null
   judgeName.value = ''
-  localStorage.removeItem(LS_JUDGE_ID)
-  localStorage.removeItem(LS_JUDGE_NAME)
-  showJudgePicker.value = true
   if (voteClient) {
     deactivateClient(voteClient)
     const idx = wsClients.indexOf(voteClient)
@@ -149,7 +130,7 @@ onMounted(async () => {
 
   // 4. Judges + identity
   battleJudges.value = await getBattleJudges()
-  resolveJudgeIdentity(battleJudges.value?.judges ?? [])
+  loadJudgeIdentity(battleJudges.value?.judges ?? [])
 
   // 5. Restore vote from backend judges list if available, fall back to localStorage
   if (battlePhase.value === 'VOTING' && judgeId.value != null) {
@@ -204,13 +185,12 @@ onMounted(async () => {
         if (clearJudgeTimer == null) {
           clearJudgeTimer = setTimeout(() => {
             clearJudgeTimer = null
-            const storedName = localStorage.getItem(LS_JUDGE_NAME)
-            const byName = storedName
-              ? (battleJudges.value?.judges ?? []).find(j => j.name === storedName)
+            const authStore = useAuthStore()
+            const byName = authStore.judgeName
+              ? (battleJudges.value?.judges ?? []).find(j => j.name === authStore.judgeName)
               : null
             if (byName) {
               judgeId.value = byName.id
-              localStorage.setItem(LS_JUDGE_ID, String(byName.id))
             } else if (!(battleJudges.value?.judges ?? []).find(j => j.id === judgeId.value)) {
               clearJudge()
             }
@@ -255,11 +235,7 @@ onUnmounted(() => {
         <div v-if="judgeName" class="judge-chip">
           <span class="judge-chip-label">AS</span>
           <span class="judge-chip-name">{{ judgeName }}</span>
-          <button class="judge-chip-clear" @click="clearJudge" aria-label="Change judge">✕</button>
         </div>
-        <button v-else class="pick-judge-btn" @click="showJudgePicker = true">
-          SELECT JUDGE
-        </button>
       </div>
     </header>
 
@@ -395,30 +371,19 @@ onUnmounted(() => {
         </button>
       </div><!-- /tie-row -->
 
-    </div><!-- /panels-wrap -->
-
-    <!-- ── Judge picker bottom sheet ───────────────────────────── -->
-    <Transition name="sheet-slide">
-      <div
-        v-if="showJudgePicker"
-        class="sheet-backdrop"
-        role="dialog"
-        aria-label="Select your name"
-      >
-        <div class="bottom-sheet">
-          <div class="sheet-handle" aria-hidden="true"></div>
-          <p class="sheet-title">WHO ARE YOU?</p>
-          <div class="sheet-grid">
-            <button
-              v-for="j in (battleJudges?.judges ?? [])"
-              :key="j.id"
-              class="sheet-name-chip"
-              @click="selectJudge(j)"
-            >{{ j.name }}</button>
-          </div>
+      <!-- Not assigned overlay -->
+      <Transition name="phase-fade">
+        <div
+          v-if="notAssigned"
+          class="panels-blocker"
+          aria-live="polite"
+        >
+          <span class="blocker-icon">🚫</span>
+          <span class="blocker-text">NOT ASSIGNED TO THIS BATTLE</span>
         </div>
-      </div>
-    </Transition>
+      </Transition>
+
+    </div><!-- /panels-wrap -->
 
   </div>
 </template>

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -3,6 +3,9 @@ import { battleJudgeVote, getBattleJudges, getBattlePhase, getCurrentBattlePair,
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { useAuthStore } from '@/utils/auth'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
 
 // ── Overlay config ──────────────────────────────────────────────────────────
 const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
@@ -231,7 +234,13 @@ onUnmounted(() => {
         >{{ battlePhase }}</span>
       </div>
 
-      <div class="header-right">
+      <div class="header-right" style="display:flex;align-items:center;gap:8px;">
+        <button
+          v-if="judgeId"
+          @click="router.push('/judge/session')"
+          class="audition-nav-btn"
+          title="Go to Session Hub"
+        >HUB</button>
         <div v-if="judgeName" class="judge-chip">
           <span class="judge-chip-label">AS</span>
           <span class="judge-chip-name">{{ judgeName }}</span>
@@ -492,6 +501,20 @@ onUnmounted(() => {
   transition: background 0.15s, color 0.15s;
 }
 .pick-judge-btn:active { background: rgba(255,255,255,0.15); color: white; }
+
+.audition-nav-btn {
+  font-family: 'Inter', sans-serif;
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 0.2em; text-transform: uppercase;
+  padding: 5px 12px; border-radius: 999px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.5);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+.audition-nav-btn:active { background: rgba(255,255,255,0.12); color: rgba(255,255,255,0.9); }
 
 /* ── (names bar removed — names shown on panels) ───────────── */
 

--- a/BES-frontend/src/views/EmceeSessionView.vue
+++ b/BES-frontend/src/views/EmceeSessionView.vue
@@ -1,0 +1,258 @@
+<script setup>
+import { onMounted, ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/utils/auth'
+import { whoami } from '@/utils/api'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const eventName = computed(() => authStore.activeEvent?.name || '')
+const sessionReady = ref(false)
+const loading = ref(true)
+
+onMounted(async () => {
+  if (!authStore.user) {
+    try {
+      const user = await whoami()
+      if (user?.authenticated) authStore.login(user)
+    } catch { /* not authenticated */ }
+  }
+  loading.value = false
+  sessionReady.value = !!authStore.user && !!authStore.activeEvent
+})
+
+const LINKS = [
+  { key: 'audition', label: 'Audition List', route: 'Audition List', icon: 'pi-list' },
+  { key: 'score',    label: 'Score',         route: 'Score',         icon: 'pi-chart-bar' },
+  { key: 'battle',   label: 'Battle Control', route: 'Battle Control', icon: 'pi-bolt' },
+]
+
+function navigate(routeName) {
+  router.push({ name: routeName })
+}
+</script>
+
+<template>
+  <div class="session-root">
+    <div class="color-bleed"></div>
+
+    <!-- Not authenticated / session lost -->
+    <div v-if="!loading && !sessionReady" class="session-card">
+      <h1 class="session-title">SESSION NOT FOUND</h1>
+      <p class="empty-text">Your session could not be restored. Please use your invitation link again, or contact the event organiser for a new link.</p>
+    </div>
+
+    <!-- Main hub -->
+    <div v-else class="session-card session-card--wide">
+
+      <!-- Title -->
+      <h1 class="session-title">EMCEE SESSION</h1>
+
+      <!-- Identity block -->
+      <div class="info-grid">
+        <div class="info-block">
+          <span class="info-label">EVENT</span>
+          <span class="info-value">{{ eventName }}</span>
+        </div>
+        <div class="info-block">
+          <span class="info-label">ROLE</span>
+          <span class="info-value">Emcee</span>
+        </div>
+      </div>
+
+      <!-- Section header -->
+      <div class="section-header">
+        <span class="section-label">NAVIGATION</span>
+        <span class="section-rule"></span>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="loading-text">LOADING…</div>
+
+      <!-- Navigation grid -->
+      <div v-else class="nav-grid">
+        <button
+          v-for="link in LINKS"
+          :key="link.key"
+          @click="navigate(link.route)"
+          class="nav-btn"
+        >
+          <i class="pi nav-btn-icon" :class="link.icon"></i>
+          <span class="nav-btn-label">{{ link.label }}</span>
+        </button>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.session-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111111;
+  font-family: 'Anton SC', sans-serif;
+  text-transform: uppercase;
+  padding: 16px;
+}
+
+.color-bleed {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 60% 35% at 0% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 35% at 100% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%);
+}
+
+.session-card {
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  background: #1a1a1a;
+  border: 1px solid rgba(255,255,255,0.07);
+  padding: 48px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 380px;
+  max-width: 520px;
+  width: 90%;
+  position: relative;
+  z-index: 1;
+}
+
+.session-card--wide {
+  max-width: 640px;
+}
+
+.session-title {
+  font-size: 28px;
+  letter-spacing: 0.06em;
+  color: rgba(255,255,255,0.9);
+  text-shadow: 1px 1px 0 var(--accent-muted, rgba(255,255,255,0.08));
+  text-align: center;
+  margin: 0;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.info-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.info-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.4);
+}
+
+.info-value {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: rgba(255,255,255,0.85);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.section-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.4);
+  white-space: nowrap;
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: rgba(255,255,255,0.07);
+}
+
+.loading-text,
+.empty-text {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: rgba(255,255,255,0.35);
+  text-align: center;
+}
+
+.nav-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+
+.nav-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 24px 12px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.6);
+  font-family: 'Anton SC', sans-serif;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  min-height: 88px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nav-btn:hover,
+.nav-btn:active {
+  color: var(--accent-color, #fff);
+  border-color: var(--accent-muted, rgba(255,255,255,0.25));
+  background: var(--accent-subtle, rgba(255,255,255,0.04));
+}
+
+.nav-btn-icon {
+  font-size: 1.4rem;
+}
+
+.nav-btn-label {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-align: center;
+  line-height: 1.3;
+}
+
+/* Mobile: stack to single column */
+@media (max-width: 480px) {
+  .session-card {
+    padding: 32px 20px;
+    gap: 20px;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .session-card--wide {
+    max-width: 100%;
+  }
+
+  .nav-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .nav-btn {
+    flex-direction: row;
+    gap: 14px;
+    padding: 16px 20px;
+    min-height: 56px;
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -645,16 +645,6 @@ const loadJudgesForDivision = async (genre) => {
   if (!genre) return
   divisionJudges.value[genre.name] = await getJudgesByDivision(props.eventName, genre.eventGenreId)
 }
-
-const refreshAllJudges = async () => {
-  allEventJudges.value = await getJudgesByEvent(props.eventName) ?? []
-  // refresh visible division's judge list too
-  if (activeGenreTab.value) {
-    const genre = eventGenres.value.find(g => g.name === activeGenreTab.value)
-    if (genre) await loadJudgesForDivision(genre)
-  }
-}
-
 // Judges not yet assigned to a specific division
 const openAssignDropdown = ref(null)
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1588,7 +1588,7 @@ onUnmounted(() => {
           :disabled="generatingRole === 'EMCEE'"
           class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
         >
-          <i class="pi text-xs" :class="generatingRole === 'EMCEE' ? 'pi-spinner pi-spin' : 'pi-plus'" class="mr-1"></i>
+          <i class="pi text-xs mr-1" :class="generatingRole === 'EMCEE' ? 'pi-spinner pi-spin' : 'pi-plus'"></i>
           EMCEE
         </button>
         <button
@@ -1596,7 +1596,7 @@ onUnmounted(() => {
           :disabled="generatingRole === 'HELPER'"
           class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
         >
-          <i class="pi text-xs" :class="generatingRole === 'HELPER' ? 'pi-spinner pi-spin' : 'pi-plus'" class="mr-1"></i>
+          <i class="pi text-xs mr-1" :class="generatingRole === 'HELPER' ? 'pi-spinner pi-spin' : 'pi-plus'"></i>
           HELPER
         </button>
         <select
@@ -1614,7 +1614,7 @@ onUnmounted(() => {
           :disabled="generatingRole === 'JUDGE' || !selectedJudgeId"
           class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
         >
-          <i class="pi text-xs" :class="generatingRole === 'JUDGE' ? 'pi-spinner pi-spin' : 'pi-plus'" class="mr-1"></i>
+          <i class="pi text-xs mr-1" :class="generatingRole === 'JUDGE' ? 'pi-spinner pi-spin' : 'pi-plus'"></i>
           JUDGE
         </button>
       </div>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -5,6 +5,8 @@ import ActionDoneModal from './ActionDoneModal.vue';
 import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
+
+const authStore = useAuthStore()
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
 import CreateParticipantForm from '@/components/CreateParticipantForm.vue'
@@ -668,7 +670,6 @@ watch(activeGenreTab, async (tabName) => {
 // ───────────────────────────────────────────────────────────────────────────
 
 // ── Session Links ──────────────────────────────────────────────────────────
-const authStore = useAuthStore()
 const sessionLinksExpanded = ref(false)
 const sessionTokens = ref([])
 const sessionTokensLoading = ref(false)

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,8 +1,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted, watch, computed } from 'vue';
-import { RouterLink } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 
@@ -87,6 +86,11 @@ const askRemoveJudge = (g, j) => askConfirm(
   'Remove Judge?',
   `Remove ${j.judgeName} from ${g.name}?`,
   () => submitRemoveJudge(g.eventGenreId, j.judgeId)
+)
+const askRemoveJudgeGlobal = (j) => askConfirm(
+  'Remove Judge from Event?',
+  `Remove ${j.judgeName} from all divisions?`,
+  () => submitRemoveJudgeGlobal(j.judgeId)
 )
 const askToggleSolo = (div) => askConfirm(
   div.soloAllowed ? 'Block Solo Entries?' : 'Allow Solo Entries?',
@@ -632,24 +636,66 @@ const removeDivisionFromSection = async (divId) => {
 }
 // ───────────────────────────────────────────────────────────────────────────
 
-// ── Judges (per division) ──────────────────────────────────────────────────
+// ── Judges (global + per division) ───────────────────────────────────────
 const divisionJudges = ref({})
-const addJudgeInput = ref('')
+const allEventJudges = ref([])
+const globalJudgeInput = ref('')
 
 const loadJudgesForDivision = async (genre) => {
   if (!genre) return
   divisionJudges.value[genre.name] = await getJudgesByDivision(props.eventName, genre.eventGenreId)
 }
 
-const submitAddJudge = async (divisionId) => {
-  if (!addJudgeInput.value.trim()) return
-  const res = await addJudgeToDivision(props.eventName, divisionId, addJudgeInput.value.trim())
+const refreshAllJudges = async () => {
+  allEventJudges.value = await getJudgesByEvent(props.eventName) ?? []
+  // refresh visible division's judge list too
+  if (activeGenreTab.value) {
+    const genre = eventGenres.value.find(g => g.name === activeGenreTab.value)
+    if (genre) await loadJudgesForDivision(genre)
+  }
+}
+
+// Judges not yet assigned to a specific division
+const openAssignDropdown = ref(null)
+
+const toggleAssignDropdown = (id) => {
+  openAssignDropdown.value = openAssignDropdown.value === id ? null : id
+}
+
+const unassignedJudges = (genreName) => {
+  const assigned = divisionJudges.value[genreName] || []
+  const assignedIds = new Set(assigned.map(j => j.judgeId))
+  return allEventJudges.value.filter(j => !assignedIds.has(j.judgeId))
+}
+
+const submitAddJudgeGlobal = async () => {
+  if (!globalJudgeInput.value.trim()) return
+  const res = await addJudgeToEvent(props.eventName, globalJudgeInput.value.trim())
+  if (res?.ok) {
+    allEventJudges.value = await res.json()
+  }
+  globalJudgeInput.value = ''
+}
+
+const submitRemoveJudgeGlobal = async (judgeId) => {
+  const res = await removeEventJudge(props.eventName, judgeId)
+  if (res?.ok) {
+    allEventJudges.value = await res.json()
+    for (const genre of eventGenres.value) {
+      if (divisionJudges.value[genre.name]) {
+        divisionJudges.value[genre.name] = await getJudgesByDivision(props.eventName, genre.eventGenreId)
+      }
+    }
+  }
+}
+
+const submitAssignJudge = async (divisionId, judgeId) => {
+  const res = await assignJudgeToDivision(props.eventName, divisionId, judgeId)
   if (res?.ok) {
     const judges = await res.json()
     const genre = eventGenres.value.find(g => g.eventGenreId === divisionId)
     if (genre) divisionJudges.value[genre.name] = judges
   }
-  addJudgeInput.value = ''
 }
 
 const submitRemoveJudge = async (divisionId, judgeId) => {
@@ -658,6 +704,7 @@ const submitRemoveJudge = async (divisionId, judgeId) => {
     const judges = await res.json()
     const genre = eventGenres.value.find(g => g.eventGenreId === divisionId)
     if (genre) divisionJudges.value[genre.name] = judges
+    allEventJudges.value = await getJudgesByEvent(props.eventName) ?? []
   }
 }
 
@@ -686,6 +733,12 @@ const isHelper = computed(() => authStore.user?.role?.[0]?.authority === 'ROLE_H
 const allUniqueJudges = computed(() => {
   const seen = new Set()
   const result = []
+  for (const j of allEventJudges.value) {
+    if (!seen.has(j.judgeId)) {
+      seen.add(j.judgeId)
+      result.push(j)
+    }
+  }
   for (const judges of Object.values(divisionJudges.value)) {
     for (const j of judges) {
       if (!seen.has(j.judgeId)) {
@@ -723,8 +776,30 @@ const handleRevokeToken = async (tokenId) => {
   await loadSessionTokens()
 }
 
+function copyToClipboard(text) {
+  // Fallback path using execCommand — works on all browsers including mobile
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.style.position = 'fixed'
+  ta.style.left = '-9999px'
+  ta.style.top = '-9999px'
+  ta.setAttribute('readonly', '')
+  document.body.appendChild(ta)
+  ta.select()
+  ta.setSelectionRange(0, text.length)
+  document.execCommand('copy')
+  document.body.removeChild(ta)
+}
+
 const copyTokenLink = (url) => {
-  navigator.clipboard.writeText(window.location.origin + url)
+  copyToClipboard(window.location.origin + url)
+}
+
+const auditionLinkCopied = ref(false)
+function copyAuditionScreenLink() {
+  copyToClipboard(window.location.origin + '/event/audition-number')
+  auditionLinkCopied.value = true
+  setTimeout(() => { auditionLinkCopied.value = false }, 2000)
 }
 
 const formatExpiry = (expiresAt) => {
@@ -946,34 +1021,40 @@ watch(
 
 onMounted(async () => {
   onStartLoading.value = true
-  tableExist.value = checkTableExist(eventName, tableExist)
-  // folderID may be absent when navigating from the navbar dropdown or EventSelector redirect
-  let resolvedFolderID = props.folderID
-  if (!resolvedFolderID) {
-    const folderEvents = await fetchAllFolderEvents()
-    const match = folderEvents?.find(e => e.folderName === props.eventName)
-    resolvedFolderID = match?.folderID ?? null
-  }
-  activeFolderID.value = resolvedFolderID
-  fileId.value = await getFileId(resolvedFolderID)
-  const dbEvents = await fetchAllEvents() ?? []
-  const dbEvent = dbEvents.find(e => e.name === props.eventName)
-  if (dbEvent) {
-    dbEventId.value = dbEvent.id
-    setActiveEvent(dbEvent.id, dbEvent.name, resolvedFolderID)
-  }
-  genreOptions.value = await fetchAllGenres()
-  eventGenres.value = await getGenresByEvent(props.eventName)
-  if (eventGenres.value.length > 0) {
-    activeGenreTab.value = eventGenres.value[0].name
-    await loadJudgesForDivision(eventGenres.value[0])
-  }
-  await loadCriteriaForAllGenres(eventGenres.value)
-  if (tableExist.value) {
-    verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
-    verifiedFormParticipants.value = await getVerifiedParticipantsByEvent(eventName.value)
-    unverifiedParticipants.value = await getUnverifiedParticipantsDB(props.eventName)
-    await fetchCheckinList()
+  try {
+    await checkTableExist(eventName, tableExist)
+    // folderID may be absent when navigating from the navbar dropdown or EventSelector redirect
+    let resolvedFolderID = props.folderID
+    if (!resolvedFolderID) {
+      const folderEvents = await fetchAllFolderEvents()
+      const match = folderEvents?.find(e => e.folderName === props.eventName)
+      resolvedFolderID = match?.folderID ?? null
+    }
+    activeFolderID.value = resolvedFolderID
+    fileId.value = await getFileId(resolvedFolderID)
+    const dbEvents = await fetchAllEvents() ?? []
+    const dbEvent = dbEvents.find(e => e.name === props.eventName)
+    if (dbEvent) {
+      dbEventId.value = dbEvent.id
+      setActiveEvent(dbEvent.id, dbEvent.name, resolvedFolderID)
+    }
+    genreOptions.value = await fetchAllGenres()
+    eventGenres.value = await getGenresByEvent(props.eventName) ?? []
+    allEventJudges.value = await getJudgesByEvent(props.eventName) ?? []
+    if (eventGenres.value.length > 0) {
+      activeGenreTab.value = eventGenres.value[0].name
+      await loadJudgesForDivision(eventGenres.value[0])
+    }
+    await loadCriteriaForAllGenres(eventGenres.value)
+    if (tableExist.value) {
+      verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
+      verifiedFormParticipants.value = await getVerifiedParticipantsByEvent(eventName.value)
+      unverifiedParticipants.value = await getUnverifiedParticipantsDB(props.eventName)
+      await fetchCheckinList()
+      loadSessionTokens()
+    }
+  } catch (e) {
+    console.error('EventDetails mount error:', e)
   }
   await useDelay().wait(2500)
   onStartLoading.value = false
@@ -1047,14 +1128,16 @@ onUnmounted(() => {
           <i class="pi pi-sliders-h text-sm"></i>
           Genre Entries
         </button>
-        <RouterLink
-          to="/event/audition-number"
-          class="flex items-center gap-2 px-4 py-2 para-chip type-label border-accent"
-        >
-          <i class="pi pi-hashtag text-sm"></i>
-          Audition Screen
-        </RouterLink>
         <button
+          @click="copyAuditionScreenLink"
+          class="flex items-center gap-2 px-4 py-2 para-chip type-label border-accent transition-all duration-200"
+          :class="auditionLinkCopied ? 'text-emerald-400 border-emerald-400/40' : ''"
+        >
+          <i class="pi text-sm" :class="auditionLinkCopied ? 'pi-check' : 'pi-hashtag'"></i>
+          {{ auditionLinkCopied ? 'Link Copied!' : 'Audition Screen' }}
+        </button>
+        <button
+          v-if="!isHelper"
           @click="refreshParticipant"
           :disabled="loading"
           class="flex items-center gap-2 px-4 py-2 bg-accent para-chip type-label disabled:opacity-50 disabled:cursor-not-allowed"
@@ -1436,12 +1519,48 @@ onUnmounted(() => {
   </div>
 
   <!-- Genre Configuration — unified per-genre tabs (participants, format, criteria, judges) -->
-  <div v-if="tableExist && eventGenres.length > 0" class="card-hover p-4 relative mt-6">
+  <div v-if="tableExist && eventGenres.length > 0" class="card-hover p-4 relative mt-6" style="overflow: visible">
     <div class="corner-bar-tl"></div>
 
     <div class="section-rule mb-4">
       <span class="section-rule-label">Genre Configuration</span>
       <div class="section-rule-line"></div>
+    </div>
+
+    <!-- Global Judges -->
+    <div class="mb-5 p-4 para-chip">
+      <p class="type-label text-content-muted mb-3">Event Judges</p>
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <div
+          v-for="j in allEventJudges"
+          :key="j.judgeId"
+          class="flex items-center gap-2 para-chip px-2.5 py-1"
+        >
+          <i class="pi pi-user text-content-muted text-xs shrink-0"></i>
+          <span class="type-body text-content-secondary">{{ j.judgeName }}</span>
+          <button
+            @click="askRemoveJudgeGlobal(j)"
+            class="type-label text-content-muted hover:text-primary-400 transition-colors"
+            title="Remove from event"
+          ><i class="pi pi-times text-xs"></i></button>
+        </div>
+        <span v-if="allEventJudges.length === 0" class="type-body text-content-muted text-xs">No judges added yet.</span>
+      </div>
+      <div class="flex items-center gap-1.5 para-chip px-2.5 py-1 w-fit">
+        <input
+          v-model="globalJudgeInput"
+          type="text"
+          placeholder="Add judge to event…"
+          autocomplete="off"
+          class="bg-transparent type-body placeholder:text-content-muted focus:outline-none w-56"
+          @keyup.enter="submitAddJudgeGlobal()"
+        />
+        <button
+          @click="submitAddJudgeGlobal()"
+          class="type-label text-accent hover:opacity-80 transition-opacity shrink-0"
+          title="Add to all divisions"
+        ><i class="pi pi-plus text-xs"></i></button>
+      </div>
     </div>
 
     <!-- Genre tab bar -->
@@ -1543,23 +1662,28 @@ onUnmounted(() => {
               <button
                 @click="askRemoveJudge(g, j)"
                 class="type-label text-content-muted hover:text-content-primary transition-colors"
-                title="Remove"
+                title="Remove from division"
               ><i class="pi pi-times text-xs"></i></button>
             </div>
-            <div class="flex items-center gap-1.5 para-chip px-2.5 py-1">
-              <input
-                v-model="addJudgeInput"
-                type="text"
-                placeholder="Add judge…"
-                autocomplete="off"
-                class="bg-transparent type-body placeholder:text-content-muted focus:outline-none w-28"
-                @keyup.enter="submitAddJudge(g.eventGenreId)"
-              />
+
+            <!-- Assign from pool dropdown -->
+            <div v-if="unassignedJudges(g.name).length > 0" class="relative">
               <button
-                @click="submitAddJudge(g.eventGenreId)"
-                class="type-label text-accent hover:opacity-80 transition-opacity shrink-0"
-                title="Add"
-              ><i class="pi pi-plus text-xs"></i></button>
+                @click="toggleAssignDropdown(g.name)"
+                class="para-chip px-2 py-1 type-label text-accent hover:bg-[var(--accent-subtle)] transition-all"
+                title="Assign judge from pool"
+              ><i class="pi pi-plus text-xs"></i> Assign</button>
+              <div
+                v-if="openAssignDropdown === g.name"
+                class="absolute bottom-full left-0 mb-1 bg-surface-800 border border-surface-600 para-chip p-1.5 z-50 min-w-[180px] max-h-48 overflow-y-auto"
+              >
+                <button
+                  v-for="j in unassignedJudges(g.name)"
+                  :key="j.judgeId"
+                  @click="submitAssignJudge(g.eventGenreId, j.judgeId); openAssignDropdown = null"
+                  class="block w-full text-left px-3 py-1.5 type-body text-content-secondary hover:text-content-primary hover:bg-surface-700 transition-colors"
+                >+ {{ j.judgeName }}</button>
+              </div>
             </div>
           </div>
         </div>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -100,7 +100,7 @@ const showCriteriaModal = ref(false)
 // Walk-in form
 const showWalkInForm = ref(false)
 const revealingRef = ref(null) // name of participant whose ref code is being held/revealed
-const activeTab = ref('setup') // 'setup' | 'event-day'
+const activeTab = ref(authStore.user?.role?.[0]?.authority === 'ROLE_HELPER' ? 'event-day' : 'setup') // 'setup' | 'event-day'
 const activeGenreTab = ref(null)
 const poolTab = ref(null) // active division tab in number pool
 let refreshInterval = null
@@ -680,6 +680,8 @@ const isAdminOrOrganiser = computed(() => {
   return auth === 'ROLE_ADMIN' || auth === 'ROLE_ORGANISER'
 })
 
+const isHelper = computed(() => authStore.user?.role?.[0]?.authority === 'ROLE_HELPER')
+
 const allUniqueJudges = computed(() => {
   const seen = new Set()
   const result = []
@@ -1065,6 +1067,7 @@ onUnmounted(() => {
     <!-- Tab toggle -->
     <div class="flex gap-2 mb-6">
       <button
+        v-if="!isHelper"
         @click="activeTab = 'setup'"
         class="para-chip-sm px-5 py-2 type-label transition-all duration-150"
         :class="activeTab === 'setup'

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2,8 +2,8 @@
 import { ref, reactive, onMounted, onUnmounted, watch, computed } from 'vue';
 import { RouterLink } from 'vue-router';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories } from '@/utils/api';
-import { setActiveEvent } from '@/utils/auth';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByDivision, addJudgeToDivision, removeJudgeFromDivision, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken } from '@/utils/api';
+import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
@@ -664,6 +664,73 @@ watch(activeGenreTab, async (tabName) => {
     const genre = eventGenres.value.find(g => g.name === tabName)
     if (genre) await loadJudgesForDivision(genre)
   }
+})
+// ───────────────────────────────────────────────────────────────────────────
+
+// ── Session Links ──────────────────────────────────────────────────────────
+const authStore = useAuthStore()
+const sessionLinksExpanded = ref(false)
+const sessionTokens = ref([])
+const sessionTokensLoading = ref(false)
+const selectedJudgeId = ref('')
+const generatingRole = ref(null)
+
+const isAdminOrOrganiser = computed(() => {
+  const auth = authStore.user?.role?.[0]?.authority
+  return auth === 'ROLE_ADMIN' || auth === 'ROLE_ORGANISER'
+})
+
+const allUniqueJudges = computed(() => {
+  const seen = new Set()
+  const result = []
+  for (const judges of Object.values(divisionJudges.value)) {
+    for (const j of judges) {
+      if (!seen.has(j.judgeId)) {
+        seen.add(j.judgeId)
+        result.push(j)
+      }
+    }
+  }
+  return result
+})
+
+const loadSessionTokens = async () => {
+  if (!dbEventId.value) return
+  sessionTokensLoading.value = true
+  sessionTokens.value = await getSessionTokens(dbEventId.value)
+  sessionTokensLoading.value = false
+}
+
+const handleGenerateToken = async (role) => {
+  if (!dbEventId.value) return
+  let judgeId = null
+  if (role === 'JUDGE') {
+    judgeId = Number(selectedJudgeId.value)
+    if (!judgeId) return
+  }
+  generatingRole.value = role
+  await generateToken(role, dbEventId.value, judgeId)
+  generatingRole.value = null
+  selectedJudgeId.value = ''
+  await loadSessionTokens()
+}
+
+const handleRevokeToken = async (tokenId) => {
+  await revokeSessionToken(tokenId)
+  await loadSessionTokens()
+}
+
+const copyTokenLink = (url) => {
+  navigator.clipboard.writeText(window.location.origin + url)
+}
+
+const formatExpiry = (expiresAt) => {
+  const d = new Date(expiresAt)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+watch(sessionLinksExpanded, async (val) => {
+  if (val) await loadSessionTokens()
 })
 // ───────────────────────────────────────────────────────────────────────────
 
@@ -1495,6 +1562,95 @@ onUnmounted(() => {
 
       </div>
     </template>
+  </div>
+
+  <!-- Session Links -->
+  <div v-if="isAdminOrOrganiser && tableExist" class="card-hover p-4 relative mt-6">
+    <div class="corner-bar-tl"></div>
+    <button
+      @click="sessionLinksExpanded = !sessionLinksExpanded"
+      :aria-expanded="sessionLinksExpanded"
+      class="w-full flex items-center justify-between text-left"
+    >
+      <div class="flex items-center gap-3">
+        <i class="pi pi-link text-xs" style="color:var(--accent-color)"></i>
+        <span class="type-body text-content-secondary">Session Links</span>
+        <span class="badge-accent">{{ sessionTokens.length }}</span>
+      </div>
+      <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
+         :class="{ 'rotate-180': sessionLinksExpanded }"></i>
+    </button>
+    <div v-if="sessionLinksExpanded" class="mt-4 pt-4 border-t border-surface-600/30">
+      <!-- Generate row -->
+      <div class="flex flex-wrap items-center gap-2 mb-4">
+        <button
+          @click="handleGenerateToken('EMCEE')"
+          :disabled="generatingRole === 'EMCEE'"
+          class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
+        >
+          <i class="pi text-xs" :class="generatingRole === 'EMCEE' ? 'pi-spinner pi-spin' : 'pi-plus'" class="mr-1"></i>
+          EMCEE
+        </button>
+        <button
+          @click="handleGenerateToken('HELPER')"
+          :disabled="generatingRole === 'HELPER'"
+          class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
+        >
+          <i class="pi text-xs" :class="generatingRole === 'HELPER' ? 'pi-spinner pi-spin' : 'pi-plus'" class="mr-1"></i>
+          HELPER
+        </button>
+        <select
+          v-model="selectedJudgeId"
+          class="input-base type-label"
+          style="width:auto;min-width:7rem"
+        >
+          <option value="">Select judge…</option>
+          <option v-for="j in allUniqueJudges" :key="j.judgeId" :value="j.judgeId">
+            {{ j.judgeName }}
+          </option>
+        </select>
+        <button
+          @click="handleGenerateToken('JUDGE')"
+          :disabled="generatingRole === 'JUDGE' || !selectedJudgeId"
+          class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
+        >
+          <i class="pi text-xs" :class="generatingRole === 'JUDGE' ? 'pi-spinner pi-spin' : 'pi-plus'" class="mr-1"></i>
+          JUDGE
+        </button>
+      </div>
+
+      <!-- Token list -->
+      <div v-if="sessionTokensLoading" class="flex items-center gap-2 type-label text-content-muted py-4">
+        <i class="pi pi-spinner pi-spin text-xs"></i> Loading…
+      </div>
+      <div v-else-if="sessionTokens.length === 0" class="type-label text-content-muted py-4">
+        No active session links
+      </div>
+      <div v-else class="space-y-2">
+        <div
+          v-for="t in sessionTokens"
+          :key="t.tokenId"
+          class="para-chip px-3 py-2 flex items-center gap-3"
+        >
+          <span
+            class="badge-neutral text-xs shrink-0"
+            :class="t.role === 'JUDGE' ? 'badge-accent' : 'badge-neutral'"
+          >{{ t.role }}</span>
+          <span v-if="t.judgeName" class="type-body text-content-secondary text-xs truncate">{{ t.judgeName }}</span>
+          <span class="type-label text-content-muted text-xs shrink-0 ml-auto">{{ formatExpiry(t.expiresAt) }}</span>
+          <button
+            @click="copyTokenLink(t.url)"
+            class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-accent transition-colors shrink-0"
+            title="Copy link"
+          ><i class="pi pi-copy text-xs"></i></button>
+          <button
+            @click="handleRevokeToken(t.tokenId)"
+            class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-red-400 transition-colors shrink-0"
+            title="Revoke"
+          ><i class="pi pi-trash text-xs"></i></button>
+        </div>
+      </div>
+    </div>
   </div>
 
   </template>

--- a/BES-frontend/src/views/EventSelector.vue
+++ b/BES-frontend/src/views/EventSelector.vue
@@ -1,27 +1,20 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { fetchAllEvents, verifyEventAccessCode } from '@/utils/api'
-import { whoami } from '@/utils/api'
-import { isEventVerified, markEventVerified, setActiveEvent } from '@/utils/auth'
+import { fetchAllEvents } from '@/utils/api'
+import { markEventVerified, setActiveEvent } from '@/utils/auth'
 
 const router = useRouter()
 const route = useRoute()
 
 const events = ref([])
 const selectedEventId = ref(null)
-const accessCode = ref('')
 const isLoading = ref(false)
 const error = ref('')
-const userRole = ref('')
 
 const selectedEvent = computed(() => events.value.find(e => e.id === selectedEventId.value) ?? null)
-const alreadyVerified = computed(() => selectedEventId.value !== null && isEventVerified(selectedEventId.value))
-const isAdmin = computed(() => userRole.value === 'ROLE_ADMIN')
 
 onMounted(async () => {
-  const user = await whoami()
-  userRole.value = user?.role?.[0]?.authority ?? ''
   events.value = await fetchAllEvents() ?? []
 })
 
@@ -33,28 +26,10 @@ const handleSubmit = async () => {
   error.value = ''
   isLoading.value = true
   try {
-    if (isAdmin.value || alreadyVerified.value) {
-      setActiveEvent(selectedEventId.value, selectedEvent.value.name)
-      markEventVerified(selectedEventId.value)
-      const redirect = String(route.query.redirect || '/')
-      // If coming from an EventDetails page, go to new event's details instead
-      router.push(redirect.startsWith('/events/') ? `/events/${selectedEvent.value.name}` : redirect)
-      return
-    }
-    if (!accessCode.value || accessCode.value.length !== 4) {
-      error.value = 'Please enter the 4-digit access code.'
-      return
-    }
-    const res = await verifyEventAccessCode(selectedEventId.value, accessCode.value)
-    if (res?.valid) {
-      setActiveEvent(selectedEventId.value, selectedEvent.value.name)
-      markEventVerified(selectedEventId.value)
-      const redirect = String(route.query.redirect || '/')
-      router.push(redirect.startsWith('/events/') ? `/events/${selectedEvent.value.name}` : redirect)
-    } else {
-      error.value = 'Incorrect access code. Please try again.'
-      accessCode.value = ''
-    }
+    setActiveEvent(selectedEventId.value, selectedEvent.value.name)
+    markEventVerified(selectedEventId.value)
+    const redirect = String(route.query.redirect || '/')
+    router.push(redirect.startsWith('/events/') ? `/events/${selectedEvent.value.name}` : redirect)
   } finally {
     isLoading.value = false
   }
@@ -86,7 +61,7 @@ const handleSubmit = async () => {
                 v-for="event in events"
                 :key="event.id"
                 type="button"
-                @click="selectedEventId = event.id; accessCode = ''; error = ''"
+                @click="selectedEventId = event.id; error = ''"
                 :class="[
                   'card-hover p-4 sm:p-5 text-left relative group w-full',
                   selectedEventId === event.id ? 'border-[color:var(--accent-muted)]' : ''
@@ -94,38 +69,9 @@ const handleSubmit = async () => {
               >
                 <div class="corner-bar-tl"></div>
                 <div class="type-body mb-1 event-card-name">{{ event.name }}</div>
-                <div
-                  v-if="isAdmin && event.accessCode"
-                  class="type-label text-content-muted"
-                >
-                  {{ event.accessCode }}
-                </div>
               </button>
             </div>
             <p v-if="events.length === 0" class="type-label text-content-muted mt-2">No events found.</p>
-          </div>
-
-          <!-- Already verified chip -->
-          <div
-            v-if="alreadyVerified && !isAdmin"
-            class="semantic-chip-success flex items-center gap-2 px-3 py-2"
-          >
-            <div class="w-2 h-2 rounded-full bg-emerald-400 flex-shrink-0" style="box-shadow: 0 0 6px rgba(52,211,153,0.8)"></div>
-            <span class="type-label text-emerald-400">Already verified — you can proceed directly</span>
-          </div>
-
-          <!-- Access code input (non-admin, not yet verified) -->
-          <div v-if="selectedEventId !== null && !isAdmin && !alreadyVerified">
-            <label class="type-label text-content-muted block mb-2">Access Code</label>
-            <input
-              v-model="accessCode"
-              type="text"
-              inputmode="numeric"
-              maxlength="4"
-              placeholder="0000"
-              class="input-base text-2xl tracking-widest text-center"
-              autocomplete="off"
-            />
           </div>
 
           <!-- Error -->
@@ -139,11 +85,9 @@ const handleSubmit = async () => {
             style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
           >
             <span v-if="isLoading">
-              <i class="pi pi-spin pi-spinner mr-2"></i>Verifying…
+              <i class="pi pi-spin pi-spinner mr-2"></i>Loading…
             </span>
-            <span v-else>
-              {{ alreadyVerified || isAdmin ? 'Enter Event' : 'Verify & Enter' }}
-            </span>
+            <span v-else>Enter Event</span>
           </button>
 
         </form>

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -19,11 +19,12 @@ const closeExpanded = () => { expandedId.value = null }
 onMounted(()  => document.addEventListener('click', closeExpanded))
 onUnmounted(() => document.removeEventListener('click', closeExpanded))
 
-const filtered = computed(() =>
-  events.value.filter(e =>
-    e.folderName.toLowerCase().includes(search.value.toLowerCase())
-  )
-)
+const filtered = computed(() => {
+  const base = isAdmin.value
+    ? events.value
+    : events.value.filter(e => dbEvents.value.some(db => db.name === e.folderName))
+  return base.filter(e => e.folderName.toLowerCase().includes(search.value.toLowerCase()))
+})
 
 function getAccessCode(folderName) {
   if (!isAdmin.value) return null

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -79,7 +79,7 @@ onMounted(async () => {
         <p class="type-label text-content-muted">Select an event to manage participants and scores</p>
       </div>
       <span class="badge-neutral type-label self-start sm:self-auto px-3 py-1">
-        {{ events.length }} event{{ events.length !== 1 ? 's' : '' }}
+        {{ filtered.length }} event{{ filtered.length !== 1 ? 's' : '' }}
       </span>
     </div>
 

--- a/BES-frontend/src/views/HelperSessionView.vue
+++ b/BES-frontend/src/views/HelperSessionView.vue
@@ -1,0 +1,277 @@
+<script setup>
+import { onMounted, ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/utils/auth'
+import { whoami } from '@/utils/api'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const eventName = computed(() => authStore.activeEvent?.name || '')
+const sessionReady = ref(false)
+const loading = ref(true)
+const linkCopied = ref(false)
+
+onMounted(async () => {
+  if (!authStore.user) {
+    try {
+      const user = await whoami()
+      if (user?.authenticated) authStore.login(user)
+    } catch { /* not authenticated */ }
+  }
+  loading.value = false
+  sessionReady.value = !!authStore.user && !!authStore.activeEvent
+})
+
+function copyToClipboard(text) {
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.style.position = 'fixed'
+  ta.style.left = '-9999px'
+  ta.style.top = '-9999px'
+  ta.setAttribute('readonly', '')
+  document.body.appendChild(ta)
+  ta.select()
+  ta.setSelectionRange(0, text.length)
+  document.execCommand('copy')
+  document.body.removeChild(ta)
+}
+
+function copyAuditionScreenLink() {
+  copyToClipboard(window.location.origin + '/event/audition-number')
+  linkCopied.value = true
+  setTimeout(() => { linkCopied.value = false }, 2000)
+}
+
+function goToEventDetails() {
+  if (authStore.activeEvent) {
+    router.push({
+      name: 'Event Details',
+      params: { eventName: authStore.activeEvent.name },
+      query: authStore.activeEvent.folderID ? { folderID: authStore.activeEvent.folderID } : {}
+    })
+  }
+}
+</script>
+
+<template>
+  <div class="session-root">
+    <div class="color-bleed"></div>
+
+    <!-- Not authenticated / session lost -->
+    <div v-if="!loading && !sessionReady" class="session-card">
+      <h1 class="session-title">SESSION NOT FOUND</h1>
+      <p class="empty-text">Your session could not be restored. Please use your invitation link again, or contact the event organiser for a new link.</p>
+    </div>
+
+    <!-- Main hub -->
+    <div v-else class="session-card">
+
+      <!-- Title -->
+      <h1 class="session-title">HELPER SESSION</h1>
+
+      <!-- Identity block -->
+      <div class="info-grid">
+        <div class="info-block">
+          <span class="info-label">EVENT</span>
+          <span class="info-value">{{ eventName }}</span>
+        </div>
+        <div class="info-block">
+          <span class="info-label">ROLE</span>
+          <span class="info-value">Helper</span>
+        </div>
+      </div>
+
+      <!-- Section header -->
+      <div class="section-header">
+        <span class="section-label">NAVIGATION</span>
+        <span class="section-rule"></span>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="loading-text">LOADING…</div>
+
+      <!-- Navigation buttons -->
+      <div v-else class="nav-list">
+        <button
+          @click="goToEventDetails"
+          class="nav-btn"
+        >
+          <i class="pi pi-calendar nav-btn-icon"></i>
+          <span class="nav-btn-label">Event Details</span>
+        </button>
+
+        <button
+          @click="copyAuditionScreenLink"
+          class="nav-btn"
+          :class="linkCopied ? 'nav-btn--copied' : ''"
+        >
+          <i class="pi nav-btn-icon" :class="linkCopied ? 'pi-check' : 'pi-hashtag'"></i>
+          <span class="nav-btn-label">{{ linkCopied ? 'Link Copied!' : 'Audition Screen' }}</span>
+        </button>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.session-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111111;
+  font-family: 'Anton SC', sans-serif;
+  text-transform: uppercase;
+  padding: 16px;
+}
+
+.color-bleed {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 60% 35% at 0% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 35% at 100% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%);
+}
+
+.session-card {
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  background: #1a1a1a;
+  border: 1px solid rgba(255,255,255,0.07);
+  padding: 48px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 380px;
+  max-width: 520px;
+  width: 90%;
+  position: relative;
+  z-index: 1;
+}
+
+.session-title {
+  font-size: 28px;
+  letter-spacing: 0.06em;
+  color: rgba(255,255,255,0.9);
+  text-shadow: 1px 1px 0 var(--accent-muted, rgba(255,255,255,0.08));
+  text-align: center;
+  margin: 0;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.info-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.info-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.4);
+}
+
+.info-value {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: rgba(255,255,255,0.85);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.section-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.4);
+  white-space: nowrap;
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: rgba(255,255,255,0.07);
+}
+
+.loading-text,
+.empty-text {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: rgba(255,255,255,0.35);
+  text-align: center;
+}
+
+.nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-btn {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 20px 24px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.6);
+  font-family: 'Anton SC', sans-serif;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  min-height: 56px;
+  -webkit-tap-highlight-color: transparent;
+  width: 100%;
+}
+
+.nav-btn:hover,
+.nav-btn:active {
+  color: var(--accent-color, #fff);
+  border-color: var(--accent-muted, rgba(255,255,255,0.25));
+  background: var(--accent-subtle, rgba(255,255,255,0.04));
+}
+
+.nav-btn--copied {
+  color: #4ade80;
+  border-color: rgba(74,222,128,0.3);
+  background: rgba(74,222,128,0.06);
+}
+
+.nav-btn-icon {
+  font-size: 1.2rem;
+  width: 1.5rem;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.nav-btn-label {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  .session-card {
+    padding: 32px 20px;
+    gap: 20px;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .nav-btn {
+    padding: 16px 20px;
+  }
+}
+</style>

--- a/BES-frontend/src/views/JudgeSessionView.vue
+++ b/BES-frontend/src/views/JudgeSessionView.vue
@@ -10,8 +10,6 @@ const authStore = useAuthStore()
 const isJudgeSession = computed(() => !!authStore.judgeName && !!authStore.judgeId)
 const eventName = computed(() => authStore.activeEvent?.name || '')
 const judgeName = computed(() => authStore.judgeName || '')
-const judgeId = computed(() => authStore.judgeId)
-
 const divisions = ref([])
 const loading = ref(true)
 const error = ref(null)
@@ -23,7 +21,7 @@ async function loadDivisions() {
   try {
     const data = await getJudgeDivisions(authStore.activeEvent.name, authStore.judgeId)
     divisions.value = data ?? []
-  } catch (e) {
+  } catch {
     error.value = 'Failed to load divisions.'
   } finally {
     loading.value = false

--- a/BES-frontend/src/views/JudgeSessionView.vue
+++ b/BES-frontend/src/views/JudgeSessionView.vue
@@ -1,0 +1,348 @@
+<script setup>
+import { onMounted, ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/utils/auth'
+import { getJudgeDivisions, whoami } from '@/utils/api'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const isJudgeSession = computed(() => !!authStore.judgeName && !!authStore.judgeId)
+const eventName = computed(() => authStore.activeEvent?.name || '')
+const judgeName = computed(() => authStore.judgeName || '')
+const judgeId = computed(() => authStore.judgeId)
+
+const divisions = ref([])
+const loading = ref(true)
+const error = ref(null)
+const sessionReady = ref(false)
+
+async function loadDivisions() {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await getJudgeDivisions(authStore.activeEvent.name, authStore.judgeId)
+    divisions.value = data ?? []
+  } catch (e) {
+    error.value = 'Failed to load divisions.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(async () => {
+  // Public route — auth store may not be populated. Restore via whoami.
+  if (!isJudgeSession.value) {
+    try {
+      const user = await whoami()
+      if (user?.authenticated && user.judgeName) {
+        authStore.login(user)
+      }
+    } catch { /* not authenticated */ }
+  }
+  if (!authStore.judgeName || !authStore.activeEvent) {
+    loading.value = false
+    sessionReady.value = false
+    return
+  }
+  sessionReady.value = true
+  await loadDivisions()
+})
+
+function navigateToAudition(divisionName) {
+  localStorage.setItem('selectedGenre', divisionName)
+  if (authStore.judgeName) {
+    localStorage.setItem('currentJudge', authStore.judgeName)
+    localStorage.setItem('selectedRole', 'Judge')
+  }
+  router.push({ name: 'Audition List' })
+}
+
+function navigateToBattle() {
+  router.push({ name: 'Battle Judge' })
+}
+</script>
+
+<template>
+  <div class="session-root">
+    <div class="color-bleed"></div>
+
+    <!-- Not authenticated / session lost -->
+    <div v-if="!loading && !sessionReady" class="session-card">
+      <h1 class="session-title">SESSION NOT FOUND</h1>
+      <p class="empty-text">Your session could not be restored. Please use your invitation link again, or contact the event organiser for a new link.</p>
+    </div>
+
+    <!-- Main hub -->
+    <div v-else class="session-card session-card--wide">
+
+      <!-- Title -->
+      <h1 class="session-title">JUDGE SESSION</h1>
+
+      <!-- Identity block (locked display) -->
+      <div class="info-grid">
+        <div class="info-block">
+          <span class="info-label">EVENT</span>
+          <span class="info-value">{{ eventName }}</span>
+        </div>
+        <div class="info-block">
+          <span class="info-label">JUDGE</span>
+          <span class="info-value">{{ judgeName }}</span>
+        </div>
+      </div>
+
+      <!-- Section header -->
+      <div class="section-header">
+        <span class="section-label">ASSIGNED DIVISIONS</span>
+        <span class="section-rule"></span>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="loading-text">LOADING…</div>
+
+      <!-- Error -->
+      <div v-else-if="error" class="flex flex-col items-center gap-3">
+        <p class="empty-text">{{ error }}</p>
+        <button
+          @click="loadDivisions"
+          class="para-chip-sm px-4 py-2 type-label text-content-muted hover:text-content-primary transition-colors"
+        >RETRY</button>
+      </div>
+
+      <!-- Empty -->
+      <div v-else-if="divisions.length === 0" class="empty-text">
+        No divisions assigned. Contact an organiser to be added to this event's judging panel.
+      </div>
+
+      <!-- Division rows with action buttons -->
+      <div v-else class="division-list">
+        <div v-for="(d, i) in divisions" :key="i" class="division-row">
+          <div class="division-info">
+            <span class="division-name">{{ d.divisionName }}</span>
+            <span v-if="d.format" class="division-format">{{ d.format }}</span>
+          </div>
+          <div class="division-actions">
+            <button
+              @click="navigateToAudition(d.divisionName)"
+              class="action-btn action-btn--audition"
+            >AUDITION</button>
+            <button
+              @click="navigateToBattle()"
+              class="action-btn action-btn--battle"
+            >BATTLE</button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.session-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111111;
+  font-family: 'Anton SC', sans-serif;
+  text-transform: uppercase;
+  padding: 16px;
+}
+
+.color-bleed {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 60% 35% at 0% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 35% at 100% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%);
+}
+
+.session-card {
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  background: #1a1a1a;
+  border: 1px solid rgba(255,255,255,0.07);
+  padding: 48px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 380px;
+  max-width: 520px;
+  width: 90%;
+  position: relative;
+  z-index: 1;
+}
+
+.session-card--wide {
+  max-width: 640px;
+}
+
+.session-title {
+  font-size: 28px;
+  letter-spacing: 0.06em;
+  color: rgba(255,255,255,0.9);
+  text-shadow: 1px 1px 0 var(--accent-muted, rgba(255,255,255,0.08));
+  text-align: center;
+  margin: 0;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.info-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.info-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.4);
+}
+
+.info-value {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: rgba(255,255,255,0.85);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.section-label {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.4);
+  white-space: nowrap;
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: rgba(255,255,255,0.07);
+}
+
+.loading-text,
+.empty-text {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: rgba(255,255,255,0.35);
+  text-align: center;
+}
+
+.division-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: rgba(255,255,255,0.04);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+}
+
+.division-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  background: #1a1a1a;
+  flex-wrap: wrap;
+}
+
+.division-row + .division-row {
+  border-top: 1px solid rgba(255,255,255,0.05);
+}
+
+.division-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.division-name {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: rgba(255,255,255,0.85);
+}
+
+.division-format {
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: rgba(255,255,255,0.35);
+  border: 1px solid rgba(255,255,255,0.07);
+  padding: 3px 8px;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+}
+
+.division-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.action-btn {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.5);
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+  min-width: 44px;
+  min-height: 44px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.action-btn--audition:hover,
+.action-btn--audition:active {
+  color: var(--accent-color, #fff);
+  border-color: var(--accent-muted, rgba(255,255,255,0.25));
+  background: var(--accent-subtle, rgba(255,255,255,0.04));
+}
+
+.action-btn--battle:hover,
+.action-btn--battle:active {
+  color: rgba(255,255,255,0.85);
+  border-color: rgba(255,255,255,0.2);
+  background: rgba(255,255,255,0.04);
+}
+
+/* Mobile: stack division row vertically */
+@media (max-width: 480px) {
+  .session-card {
+    padding: 32px 20px;
+    gap: 20px;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .session-card--wide {
+    max-width: 100%;
+  }
+
+  .division-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    padding: 12px 14px;
+  }
+
+  .division-actions {
+    align-self: flex-end;
+  }
+}
+</style>

--- a/BES-frontend/src/views/MainMenu.vue
+++ b/BES-frontend/src/views/MainMenu.vue
@@ -11,7 +11,7 @@ const role = computed(() =>
 const activeEvent = computed(() => authStore.activeEvent)
 
 const roleDisplay = computed(() => {
-  const labels = { ROLE_ADMIN: 'Admin', ROLE_ORGANISER: 'Organiser', ROLE_JUDGE: 'Judge', ROLE_EMCEE: 'Emcee' }
+  const labels = { ROLE_ADMIN: 'Admin', ROLE_ORGANISER: 'Organiser', ROLE_JUDGE: 'Judge', ROLE_EMCEE: 'Emcee', ROLE_HELPER: 'Helper' }
   const label = labels[role.value]
   return label ? { label } : null
 })

--- a/BES-frontend/src/views/MainMenu.vue
+++ b/BES-frontend/src/views/MainMenu.vue
@@ -49,9 +49,21 @@ const roleDisplay = computed(() => {
           <p class="type-label text-content-muted">Manage and browse events</p>
         </router-link>
 
+        <!-- Event Day (Helper) -->
+        <router-link
+          v-if="activeEvent && role === 'ROLE_HELPER'"
+          :to="{ name: 'Event Details', params: { eventName: activeEvent.name } }"
+          class="card-hover p-6 relative cursor-pointer group"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-calendar-clock text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Event Day</div>
+          <p class="type-label text-content-muted">Walk-ins, check-in, audition screen</p>
+        </router-link>
+
         <!-- Audition List -->
         <router-link
-          v-if="activeEvent"
+          v-if="activeEvent && role !== 'ROLE_HELPER'"
           :to="{ name: 'Audition List' }"
           class="card-hover p-6 relative cursor-pointer group"
         >
@@ -112,7 +124,7 @@ const roleDisplay = computed(() => {
       </div>
 
       <!-- No event selected hint -->
-      <div v-if="!activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE')"
+      <div v-if="!activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_JUDGE' || role === 'ROLE_HELPER')"
         class="mt-8 p-4 semantic-chip-warning flex items-start gap-3">
         <div class="w-2 h-2 rounded-full bg-amber-400 box-shadow-[0_0_6px_rgba(245,158,11,0.8)] mt-0.5 flex-shrink-0"></div>
         <div>

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -1,0 +1,124 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { redeemToken } from '@/utils/api'
+import { useAuthStore } from '@/utils/auth'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+
+const loading = ref(true)
+const error = ref(null)
+
+onMounted(async () => {
+  const token = route.query.t
+  if (!token) {
+    error.value = 'No token provided.'
+    loading.value = false
+    return
+  }
+  const data = await redeemToken(token)
+  if (!data || !data.authenticated) {
+    error.value = data?.error || 'Invalid or expired link.'
+    loading.value = false
+    return
+  }
+  authStore.login(data)
+  const authority = data.role?.[0]?.authority
+  if (authority === 'ROLE_JUDGE') {
+    router.replace('/battle/judge')
+  } else if (authority === 'ROLE_EMCEE') {
+    router.replace('/event/audition-list')
+  } else if (authority === 'ROLE_HELPER') {
+    router.replace('/event/update-event-details')
+  } else {
+    router.replace('/')
+  }
+})
+</script>
+
+<template>
+  <div class="token-root">
+    <div class="color-bleed"></div>
+    <div class="token-card">
+      <template v-if="loading">
+        <div class="spinner"></div>
+        <p class="token-text">SIGNING IN&#8230;</p>
+      </template>
+      <template v-else-if="error">
+        <p class="token-title">LINK INVALID</p>
+        <p class="token-sub">{{ error }}</p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.token-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111111;
+  font-family: 'Anton SC', sans-serif;
+}
+
+.color-bleed {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 60% 35% at 0% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 35% at 100% 100%, var(--accent-subtle, rgba(255,255,255,0.04)) 0%, transparent 70%);
+}
+
+.token-card {
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  background: #1a1a1a;
+  border: 1px solid rgba(255,255,255,0.07);
+  padding: 48px 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  min-width: 260px;
+}
+
+.token-title {
+  font-size: 28px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.9);
+  text-shadow: 1px 1px 0 var(--accent-muted, rgba(255,255,255,0.08));
+}
+
+.token-text {
+  font-size: 18px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.6);
+}
+
+.token-sub {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.45);
+  text-align: center;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 2px solid rgba(255,255,255,0.1);
+  border-top-color: rgba(255,255,255,0.7);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -2,7 +2,7 @@
 import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { redeemToken } from '@/utils/api'
-import { useAuthStore } from '@/utils/auth'
+import { useAuthStore, setActiveEvent } from '@/utils/auth'
 
 const route = useRoute()
 const router = useRouter()
@@ -25,6 +25,9 @@ onMounted(async () => {
     return
   }
   authStore.login(data)
+  if (data.eventId && data.eventName) {
+    setActiveEvent(data.eventId, data.eventName)
+  }
   const authority = data.role?.[0]?.authority
   if (authority === 'ROLE_JUDGE') {
     router.replace('/battle/judge')

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -34,7 +34,7 @@ onMounted(async () => {
   } else if (authority === 'ROLE_EMCEE') {
     router.replace('/event/audition-list')
   } else if (authority === 'ROLE_HELPER') {
-    router.replace('/event/update-event-details')
+    router.replace(`/events/${encodeURIComponent(data.eventName)}`)
   } else {
     router.replace('/')
   }

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -19,7 +19,7 @@ onMounted(async () => {
     return
   }
   const data = await redeemToken(token)
-  if (!data || !data.authenticated) {
+  if (!data?.authenticated) {
     error.value = data?.error || 'Invalid or expired link.'
     loading.value = false
     return

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -32,9 +32,9 @@ onMounted(async () => {
   if (authority === 'ROLE_JUDGE') {
     router.replace('/judge/session')
   } else if (authority === 'ROLE_EMCEE') {
-    router.replace('/event/audition-list')
+    router.replace('/emcee/session')
   } else if (authority === 'ROLE_HELPER') {
-    router.replace(`/events/${encodeURIComponent(data.eventName)}`)
+    router.replace('/helper/session')
   } else {
     router.replace('/')
   }

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -30,7 +30,7 @@ onMounted(async () => {
   }
   const authority = data.role?.[0]?.authority
   if (authority === 'ROLE_JUDGE') {
-    router.replace('/battle/judge')
+    router.replace('/judge/session')
   } else if (authority === 'ROLE_EMCEE') {
     router.replace('/event/audition-list')
   } else if (authority === 'ROLE_HELPER') {

--- a/BES/src/main/java/com/example/BES/config/SecurityConfig.java
+++ b/BES/src/main/java/com/example/BES/config/SecurityConfig.java
@@ -1,42 +1,33 @@
 package com.example.BES.config;
 
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
+
+import com.example.BES.services.AccountUserDetailsService;
 
 @Configuration
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    @Value("${BES_ADMIN_PASSWORD}")
-    private String adminPassword;
-
-    @Value("${BES_EMCEE_PASSWORD}")
-    private String emceePassword;
-
-    @Value("${BES_JUDGE_PASSWORD}")
-    private String judgePassword;
-
-    @Value("${BES_ORGANISER_PASSWORD}")
-    private String organiserPassword;
+    @Autowired
+    private AccountUserDetailsService accountUserDetailsService;
 
     @Value("${BES_COOKIE_DOMAIN:localhost}")
     private String cookieDomain;
@@ -44,7 +35,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
         return http
-        // to enable again if needed
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
@@ -63,28 +53,11 @@ public class SecurityConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService(){
-        UserDetails admin = User.builder()
-            .username("admin")
-            .password(pwdEncoder().encode(adminPassword))
-            .roles("ADMIN")
-            .build();
-        UserDetails emcee = User.builder()
-            .username("emcee")
-            .password(pwdEncoder().encode(emceePassword))
-            .roles("EMCEE")
-            .build();
-        UserDetails judge = User.builder()
-            .username("judge")
-            .password(pwdEncoder().encode(judgePassword))
-            .roles("JUDGE")
-            .build();
-        UserDetails organiser = User.builder()
-            .username("organiser")
-            .password(pwdEncoder().encode(organiserPassword))
-            .roles("ORGANISER")
-            .build();
-        return new InMemoryUserDetailsManager(admin, emcee, judge, organiser);
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(accountUserDetailsService);
+        provider.setPasswordEncoder(pwdEncoder());
+        return provider;
     }
 
     @Bean

--- a/BES/src/main/java/com/example/BES/controllers/AdminController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AdminController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,7 @@ import com.example.BES.dtos.GetJudgeDto;
 import com.example.BES.dtos.admin.AddFeedbackGroupDto;
 import com.example.BES.dtos.admin.AddFeedbackTagDto;
 import com.example.BES.dtos.admin.AssignOrganiserDto;
+import com.example.BES.dtos.admin.CreateOrganiserDto;
 import com.example.BES.dtos.admin.DeleteFeedbackGroupDto;
 import com.example.BES.dtos.admin.DeleteFeedbackTagDto;
 import com.example.BES.dtos.admin.GetFeedbackGroupDto;
@@ -177,6 +179,18 @@ public class AdminController {
     public ResponseEntity<?> assignOrganiser(@Valid @RequestBody AssignOrganiserDto dto) {
         accountService.assignEvent(dto.getAccountId(), dto.getEventId());
         return ResponseEntity.ok(Map.of("message", "assigned"));
+    }
+
+    @PostMapping("/organisers")
+    public ResponseEntity<?> createOrganiser(@Valid @RequestBody CreateOrganiserDto dto) {
+        accountService.createOrganiser(dto.getUsername(), dto.getPassword());
+        return ResponseEntity.ok(Map.of("message", "created"));
+    }
+
+    @DeleteMapping("/organisers/{accountId}")
+    public ResponseEntity<?> deleteOrganiser(@PathVariable Long accountId) {
+        accountService.deleteOrganiser(accountId);
+        return ResponseEntity.ok(Map.of("message", "deleted"));
     }
 
     @DeleteMapping("/organisers/assign")

--- a/BES/src/main/java/com/example/BES/controllers/AdminController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AdminController.java
@@ -20,6 +20,7 @@ import com.example.BES.dtos.GetGenreDto;
 import com.example.BES.dtos.GetJudgeDto;
 import com.example.BES.dtos.admin.AddFeedbackGroupDto;
 import com.example.BES.dtos.admin.AddFeedbackTagDto;
+import com.example.BES.dtos.admin.AssignOrganiserDto;
 import com.example.BES.dtos.admin.DeleteFeedbackGroupDto;
 import com.example.BES.dtos.admin.DeleteFeedbackTagDto;
 import com.example.BES.dtos.admin.GetFeedbackGroupDto;
@@ -27,10 +28,12 @@ import com.example.BES.dtos.admin.AddGenreDto;
 import com.example.BES.dtos.admin.DeleteGenreDto;
 import com.example.BES.dtos.admin.DeleteJudgeDto;
 import com.example.BES.dtos.admin.DeleteScoreByEventDto;
+import com.example.BES.dtos.admin.GetOrganiserDto;
 import com.example.BES.dtos.admin.UpdateGenreDto;
 import com.example.BES.dtos.admin.UpdateJudgeDto;
 import com.example.BES.models.Genre;
 import com.example.BES.models.Judge;
+import com.example.BES.services.AccountService;
 import com.example.BES.services.AuditionFeedbackService;
 import com.example.BES.services.GenreService;
 import com.example.BES.services.JudgeService;
@@ -53,6 +56,9 @@ public class AdminController {
 
     @Autowired
     AuditionFeedbackService feedbackService;
+
+    @Autowired
+    AccountService accountService;
 
     // ── Feedback Tag Groups ──────────────────────────────────────────────────
 
@@ -158,6 +164,25 @@ public class AdminController {
             "message", "deleted",
             "judge", deletedJudge
         ));
+    }
+
+    // ── Organisers ────────────────────────────────────────────────────────────
+
+    @GetMapping("/organisers")
+    public ResponseEntity<List<GetOrganiserDto>> getOrganisers() {
+        return ResponseEntity.ok(accountService.getAllOrganisers());
+    }
+
+    @PostMapping("/organisers/assign")
+    public ResponseEntity<?> assignOrganiser(@Valid @RequestBody AssignOrganiserDto dto) {
+        accountService.assignEvent(dto.getAccountId(), dto.getEventId());
+        return ResponseEntity.ok(Map.of("message", "assigned"));
+    }
+
+    @DeleteMapping("/organisers/assign")
+    public ResponseEntity<?> removeOrganiser(@Valid @RequestBody AssignOrganiserDto dto) {
+        accountService.removeEvent(dto.getAccountId(), dto.getEventId());
+        return ResponseEntity.ok(Map.of("message", "removed"));
     }
 
     // Delete Score by Event

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -2,7 +2,9 @@ package com.example.BES.controllers;
 import jakarta.validation.Valid;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +18,9 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.BES.config.SecurityConfig;
+import com.example.BES.dtos.GetSessionTokenDto;
 import com.example.BES.dtos.LoginDto;
 import com.example.BES.dtos.RedeemTokenDto;
 import com.example.BES.models.SessionToken;
@@ -176,5 +181,30 @@ public class AuthController {
         return ResponseEntity.ok(Map.of(
             "tokenId", tokenId,
             "url", "/auth/token?t=" + tokenId));
+    }
+
+    @Operation(summary = "List Tokens", description = "Returns all non-revoked, non-expired session tokens for an event")
+    @GetMapping("/tokens")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<List<GetSessionTokenDto>> listTokens(@RequestParam Long eventId) {
+        List<SessionToken> tokens = sessionTokenService.getActiveTokens(eventId);
+        List<GetSessionTokenDto> dtos = tokens.stream().map(t -> {
+            GetSessionTokenDto dto = new GetSessionTokenDto();
+            dto.tokenId = t.getTokenId();
+            dto.role = t.getRole();
+            dto.judgeName = t.getJudge() != null ? t.getJudge().getName() : null;
+            dto.expiresAt = t.getExpiresAt().toString();
+            dto.url = "/auth/token?t=" + t.getTokenId();
+            return dto;
+        }).collect(Collectors.toList());
+        return ResponseEntity.ok(dtos);
+    }
+
+    @Operation(summary = "Revoke Token", description = "Revokes a session token")
+    @DeleteMapping("/tokens/{tokenId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> revokeToken(@PathVariable String tokenId) {
+        sessionTokenService.revoke(tokenId);
+        return ResponseEntity.ok(Map.of("message", "Token revoked"));
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -1,14 +1,17 @@
 package com.example.BES.controllers;
 import jakarta.validation.Valid;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
@@ -17,10 +20,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.BES.config.SecurityConfig;
 import com.example.BES.dtos.LoginDto;
+import com.example.BES.dtos.RedeemTokenDto;
+import com.example.BES.models.SessionToken;
+import com.example.BES.services.SessionTokenService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,6 +45,9 @@ public class AuthController {
     @Autowired
     SecurityConfig config;
 
+    @Autowired
+    private SessionTokenService sessionTokenService;
+
     @Operation(summary = "Debug Session", description = "Returns current session ID and authentication context for debugging")
     @GetMapping("/debug-session")
     public Map<String, Object> debugSession(HttpSession session) {
@@ -48,16 +58,28 @@ public class AuthController {
 
     @Operation(summary = "Get Current User Info", description = "Returns details of the currently authenticated user")
     @GetMapping("/me")
-    public ResponseEntity<?> me() {
+    public ResponseEntity<?> me(HttpServletRequest request) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         boolean isAuthenticated = auth != null
                 && auth.isAuthenticated()
                 && !(auth instanceof AnonymousAuthenticationToken);
 
-        return ResponseEntity.ok(Map.of(
-                "authenticated", isAuthenticated,
-                "username", auth.getName(),
-                "role", auth.getAuthorities()));
+        Map<String, Object> response = new HashMap<>();
+        response.put("authenticated", isAuthenticated);
+        response.put("username", auth.getName());
+        response.put("role", auth.getAuthorities());
+
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            Long eventId = (Long) session.getAttribute("eventId");
+            Long judgeId = (Long) session.getAttribute("judgeId");
+            String judgeName = (String) session.getAttribute("judgeName");
+            if (eventId != null) response.put("eventId", eventId);
+            if (judgeId != null) response.put("judgeId", judgeId);
+            if (judgeName != null) response.put("judgeName", judgeName);
+        }
+
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "Login", description = "Authenticates a user and establishes a session")
@@ -94,5 +116,63 @@ public class AuthController {
             session.invalidate();
         SecurityContextHolder.clearContext();
         return ResponseEntity.ok(Map.of("message", "Logged Out "));
+    }
+
+    @Operation(summary = "Redeem Token", description = "Redeems a session token for authentication without password")
+    @PostMapping("/token")
+    public ResponseEntity<?> redeemToken(@Valid @RequestBody RedeemTokenDto dto, HttpServletRequest request) {
+        try {
+            SessionToken token = sessionTokenService.validate(dto.getTokenId());
+
+            String username = "token:" + dto.getTokenId();
+            String role = token.getRole();
+            String roleAuthority = "ROLE_" + role;
+
+            UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(username, null,
+                    java.util.List.of(new SimpleGrantedAuthority(roleAuthority)));
+
+            SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+            securityContext.setAuthentication(authToken);
+            SecurityContextHolder.setContext(securityContext);
+
+            HttpSession session = request.getSession(true);
+            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+
+            Long eventId = token.getEvent().getEventId();
+            session.setAttribute("eventId", eventId);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("authenticated", true);
+            response.put("role", authToken.getAuthorities());
+            response.put("eventId", eventId);
+
+            if (token.getJudge() != null) {
+                Long judgeId = token.getJudge().getJudgeId();
+                String judgeName = token.getJudge().getName();
+                session.setAttribute("judgeId", judgeId);
+                session.setAttribute("judgeName", judgeName);
+                response.put("judgeId", judgeId);
+                response.put("judgeName", judgeName);
+            }
+
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "Generate Token", description = "Generates a session token for a given role, event, and optional judge")
+    @PostMapping("/generate-token")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> generateToken(
+            @RequestParam String role,
+            @RequestParam Long eventId,
+            @RequestParam(required = false) Long judgeId,
+            @RequestParam(required = false, defaultValue = "7") int expiresInDays) {
+        String tokenId = sessionTokenService.generateToken(role, eventId, judgeId, expiresInDays);
+        return ResponseEntity.ok(Map.of(
+            "tokenId", tokenId,
+            "url", "/auth/token?t=" + tokenId));
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -71,8 +71,13 @@ public class AuthController {
 
         Map<String, Object> response = new HashMap<>();
         response.put("authenticated", isAuthenticated);
-        response.put("username", auth.getName());
-        response.put("role", auth.getAuthorities());
+        if (auth != null) {
+            response.put("username", auth.getName());
+            response.put("role", auth.getAuthorities());
+        } else {
+            response.put("username", null);
+            response.put("role", java.util.List.of());
+        }
 
         HttpSession session = request.getSession(false);
         if (session != null) {
@@ -169,6 +174,9 @@ public class AuthController {
         }
     }
 
+    private static final java.util.Set<String> ALLOWED_SESSION_ROLES =
+        java.util.Set.of("JUDGE", "EMCEE", "HELPER");
+
     @Operation(summary = "Generate Token", description = "Generates a session token for a given role, event, and optional judge")
     @PostMapping("/generate-token")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
@@ -177,7 +185,11 @@ public class AuthController {
             @RequestParam Long eventId,
             @RequestParam(required = false) Long judgeId,
             @RequestParam(required = false, defaultValue = "7") int expiresInDays) {
-        String tokenId = sessionTokenService.generateToken(role, eventId, judgeId, expiresInDays);
+        if (!ALLOWED_SESSION_ROLES.contains(role.toUpperCase())) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid role: " + role
+                + ". Allowed session roles: JUDGE, EMCEE, HELPER."));
+        }
+        String tokenId = sessionTokenService.generateToken(role.toUpperCase(), eventId, judgeId, expiresInDays);
         return ResponseEntity.ok(Map.of(
             "tokenId", tokenId,
             "url", "/auth/token?t=" + tokenId));

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -140,12 +140,14 @@ public class AuthController {
             session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
 
             Long eventId = token.getEvent().getEventId();
+            String eventName = token.getEvent().getEventName();
             session.setAttribute("eventId", eventId);
 
             Map<String, Object> response = new HashMap<>();
             response.put("authenticated", true);
             response.put("role", authToken.getAuthorities());
             response.put("eventId", eventId);
+            response.put("eventName", eventName);
 
             if (token.getJudge() != null) {
                 Long judgeId = token.getJudge().getJudgeId();

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -47,6 +47,7 @@ import com.example.BES.dtos.GetEventGenreParticipantDto;
 import com.example.BES.dtos.GetEventDivisionDto;
 import com.example.BES.dtos.GetGenreDto;
 import com.example.BES.dtos.GetJudgeDto;
+import com.example.BES.dtos.JudgeDivisionDto;
 import com.example.BES.dtos.GetParticipantByEventDto;
 import com.example.BES.dtos.GetParticipatnScoreDto;
 import com.example.BES.dtos.GetUnverifiedParticipantDto;
@@ -297,11 +298,18 @@ public class EventController {
         return ResponseEntity.ok(judgeService.getJudgesByEvent(eventName));
     }
 
+    @Operation(summary = "Get Divisions by Judge", description = "Returns divisions a judge belongs to within an event")
+    @GetMapping("/{eventName}/judge/{judgeId}/divisions")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'JUDGE', 'EMCEE', 'HELPER')")
+    public ResponseEntity<List<JudgeDivisionDto>> getDivisionsByJudge(@PathVariable String eventName, @PathVariable Long judgeId) {
+        return ResponseEntity.ok(judgeService.getDivisionsByJudge(eventName, judgeId));
+    }
+
     // ── Per-division judge endpoints ─────────────────────────────────────
 
     @Operation(summary = "Get Judges by Division", description = "Returns judges assigned to a specific division")
     @GetMapping("/{eventName}/divisions/{divisionId}/judges")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'JUDGE', 'EMCEE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'JUDGE', 'EMCEE', 'HELPER')")
     public ResponseEntity<List<GetJudgeDto>> getJudgesByDivision(@PathVariable String eventName, @PathVariable Long divisionId) {
         return ResponseEntity.ok(judgeService.getJudgesByDivision(divisionId));
     }
@@ -313,6 +321,13 @@ public class EventController {
         return ResponseEntity.ok(judgeService.addJudgeToDivision(divisionId, dto.judgeName));
     }
 
+    @Operation(summary = "Assign Judge to Division", description = "Assigns an existing event-level judge to a specific division")
+    @PostMapping("/{eventName}/divisions/{divisionId}/assign-judge/{judgeId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<List<GetJudgeDto>> assignJudgeToDivision(@PathVariable String eventName, @PathVariable Long divisionId, @PathVariable Long judgeId) {
+        return ResponseEntity.ok(judgeService.assignJudgeToDivision(divisionId, judgeId));
+    }
+
     @Operation(summary = "Remove Judge from Division", description = "Removes a judge from a division")
     @DeleteMapping("/{eventName}/divisions/{divisionId}/judge/{judgeId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
@@ -322,7 +337,7 @@ public class EventController {
 
     @Operation(summary = "Add Walk-in Participant", description = "Registers a new walk-in participant into an event")
     @PostMapping("/walkins/")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'HELPER')")
     public ResponseEntity<String> addWalkInToSystem(@Valid @RequestBody AddWalkInDto dto) {
         try {
             Participant p = participantService.addWalkInService(dto);
@@ -369,7 +384,7 @@ public class EventController {
 
     @Operation(summary = "Get Check-in List", description = "Returns all participants for the event with their genre audition status")
     @GetMapping("/{eventName}/checkin-list")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'HELPER')")
     public ResponseEntity<List<GetCheckinListDto>> getCheckinList(@PathVariable String eventName) {
         try {
             return new ResponseEntity<>(registerService.getCheckinList(eventName), HttpStatus.OK);
@@ -405,7 +420,7 @@ public class EventController {
 
     @Operation(summary = "Get Participants by Event Genre", description = "Retrieves a list of participants for a specific event based on their genre")
     @GetMapping("/participants/{eventName}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'JUDGE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'JUDGE', 'HELPER')")
     public ResponseEntity<List<GetEventGenreParticipantDto>> getParticipantsFromEventGenre(
             @PathVariable String eventName) throws IOException, MessagingException, WriterException {
         try {
@@ -433,14 +448,14 @@ public class EventController {
 
     @Operation(summary = "Get Active Check-In Previews", description = "Returns the set of participant IDs currently being previewed (check-in dialog open) for an event")
     @GetMapping("/{eventName}/checkin-preview")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'HELPER')")
     public ResponseEntity<Set<Long>> getCheckinPreviews(@PathVariable String eventName) {
         return ResponseEntity.ok(checkinPreviewService.getActivePreviews(eventName));
     }
 
     @Operation(summary = "Send Check-In Preview", description = "Broadcasts participant details to AuditionNumber display before generating numbers")
     @PostMapping("/{eventName}/checkin-preview")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'HELPER')")
     public ResponseEntity<String> sendCheckinPreview(
             @PathVariable String eventName,
             @RequestBody CheckinPreviewDto dto) {
@@ -643,6 +658,12 @@ public class EventController {
             @RequestParam String judgeName,
             @RequestParam Integer auditionNumber) {
         return ResponseEntity.ok(feedbackService.getFeedback(eventName, genreName, judgeName, auditionNumber));
+    }
+
+    @Operation(summary = "Get Feedback Tag Groups", description = "Returns all feedback tag groups with their tags (used by judges/emcees for audition feedback)")
+    @GetMapping("/feedback-groups")
+    public ResponseEntity<List<com.example.BES.dtos.admin.GetFeedbackGroupDto>> getFeedbackGroups() {
+        return ResponseEntity.ok(feedbackService.getAllFeedbackGroups());
     }
 
     @Operation(summary = "Get All Judge Feedback for Participant", description = "Returns feedback from all judges for a given participant in a specific event genre")

--- a/BES/src/main/java/com/example/BES/dtos/GetSessionTokenDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetSessionTokenDto.java
@@ -1,0 +1,9 @@
+package com.example.BES.dtos;
+
+public class GetSessionTokenDto {
+    public String tokenId;
+    public String role;
+    public String judgeName;
+    public String expiresAt;
+    public String url;
+}

--- a/BES/src/main/java/com/example/BES/dtos/JudgeDivisionDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/JudgeDivisionDto.java
@@ -1,0 +1,13 @@
+package com.example.BES.dtos;
+
+public class JudgeDivisionDto {
+    public String divisionName;
+    public String format;
+
+    public JudgeDivisionDto() {}
+
+    public JudgeDivisionDto(String divisionName, String format) {
+        this.divisionName = divisionName;
+        this.format = format;
+    }
+}

--- a/BES/src/main/java/com/example/BES/dtos/RedeemTokenDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/RedeemTokenDto.java
@@ -1,0 +1,10 @@
+package com.example.BES.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RedeemTokenDto {
+    @NotBlank
+    private String tokenId;
+}

--- a/BES/src/main/java/com/example/BES/dtos/admin/AssignOrganiserDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/admin/AssignOrganiserDto.java
@@ -1,0 +1,27 @@
+package com.example.BES.dtos.admin;
+
+import jakarta.validation.constraints.NotNull;
+
+public class AssignOrganiserDto {
+    @NotNull
+    private Long accountId;
+
+    @NotNull
+    private Long eventId;
+
+    public Long getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(Long accountId) {
+        this.accountId = accountId;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+}

--- a/BES/src/main/java/com/example/BES/dtos/admin/CreateOrganiserDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/admin/CreateOrganiserDto.java
@@ -1,0 +1,19 @@
+package com.example.BES.dtos.admin;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CreateOrganiserDto {
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/BES/src/main/java/com/example/BES/dtos/admin/CreateOrganiserDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/admin/CreateOrganiserDto.java
@@ -1,12 +1,14 @@
 package com.example.BES.dtos.admin;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class CreateOrganiserDto {
     @NotBlank
     private String username;
 
     @NotBlank
+    @Size(min = 6, message = "Password must be at least 6 characters")
     private String password;
 
     public String getUsername() {

--- a/BES/src/main/java/com/example/BES/dtos/admin/GetOrganiserDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/admin/GetOrganiserDto.java
@@ -1,0 +1,41 @@
+package com.example.BES.dtos.admin;
+
+import java.util.List;
+
+public class GetOrganiserDto {
+    private Long id;
+    private String username;
+    private List<Long> assignedEventIds;
+
+    public GetOrganiserDto() {}
+
+    public GetOrganiserDto(Long id, String username, List<Long> assignedEventIds) {
+        this.id = id;
+        this.username = username;
+        this.assignedEventIds = assignedEventIds;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public List<Long> getAssignedEventIds() {
+        return assignedEventIds;
+    }
+
+    public void setAssignedEventIds(List<Long> assignedEventIds) {
+        this.assignedEventIds = assignedEventIds;
+    }
+}

--- a/BES/src/main/java/com/example/BES/models/Account.java
+++ b/BES/src/main/java/com/example/BES/models/Account.java
@@ -1,0 +1,60 @@
+package com.example.BES.models;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "account")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long accountId;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String username;
+
+    @Column(nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(nullable = false, length = 20)
+    private String role;
+
+    @Column(nullable = false)
+    private int eventCredits = 0;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String referralCode;
+
+    @ManyToOne
+    @JoinColumn(name = "referred_by")
+    private Account referredBy;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @ManyToMany
+    @JoinTable(
+        name = "organiser_event",
+        joinColumns = @JoinColumn(name = "account_id"),
+        inverseJoinColumns = @JoinColumn(name = "event_id")
+    )
+    private List<Event> assignedEvents;
+}

--- a/BES/src/main/java/com/example/BES/models/SessionToken.java
+++ b/BES/src/main/java/com/example/BES/models/SessionToken.java
@@ -1,0 +1,45 @@
+package com.example.BES.models;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "session_token")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SessionToken {
+
+    @Id
+    @Column(length = 64)
+    private String tokenId;
+
+    @Column(nullable = false, length = 20)
+    private String role;
+
+    @ManyToOne
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne
+    @JoinColumn(name = "judge_id")
+    private Judge judge;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean revoked = false;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/BES/src/main/java/com/example/BES/respositories/AccountRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/AccountRepository.java
@@ -1,5 +1,6 @@
 package com.example.BES.respositories;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,5 @@ import com.example.BES.models.Account;
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByUsername(String username);
     Optional<Account> findByReferralCode(String referralCode);
+    List<Account> findByRole(String role);
 }

--- a/BES/src/main/java/com/example/BES/respositories/AccountRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/AccountRepository.java
@@ -1,0 +1,14 @@
+package com.example.BES.respositories;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.BES.models.Account;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+    Optional<Account> findByUsername(String username);
+    Optional<Account> findByReferralCode(String referralCode);
+}

--- a/BES/src/main/java/com/example/BES/respositories/EventGenreParticpantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventGenreParticpantRepo.java
@@ -16,6 +16,9 @@ import com.example.BES.models.EventGenreParticipantId;
 public interface EventGenreParticpantRepo extends JpaRepository<EventGenreParticipant, EventGenreParticipantId> {
     List<EventGenreParticipant> findByEvent(Event event);
 
+    @Query("SELECT DISTINCT e FROM EventGenreParticipant e LEFT JOIN FETCH e.judge WHERE e.event = :event")
+    List<EventGenreParticipant> findByEventWithJudge(@Param("event") Event event);
+
     @Query(value = """
        SELECT e
        FROM EventGenreParticipant e

--- a/BES/src/main/java/com/example/BES/respositories/JudgeRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/JudgeRepo.java
@@ -1,12 +1,36 @@
 package com.example.BES.respositories;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.BES.models.Judge;
 
 @Repository
 public interface JudgeRepo extends JpaRepository<Judge,Long>{
-    Optional<Judge> findFirstByName(String name);
-} 
+
+    @Query("SELECT j FROM Judge j WHERE LOWER(TRIM(j.name)) = LOWER(TRIM(:name))")
+    Optional<Judge> findFirstByName(@Param("name") String name);
+
+    boolean existsByNameIgnoreCase(String name);
+
+    // ── event_judge pool table ────────────────────────────────────────────
+
+    @Modifying
+    @Transactional
+    @Query(value = "INSERT INTO event_judge (event_id, judge_id) VALUES (:eventId, :judgeId) ON CONFLICT DO NOTHING", nativeQuery = true)
+    void insertEventJudge(@Param("eventId") Long eventId, @Param("judgeId") Long judgeId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM event_judge WHERE event_id = :eventId AND judge_id = :judgeId", nativeQuery = true)
+    void deleteEventJudge(@Param("eventId") Long eventId, @Param("judgeId") Long judgeId);
+
+    @Query(value = "SELECT j.* FROM judge j INNER JOIN event_judge ej ON j.judge_id = ej.judge_id WHERE ej.event_id = :eventId", nativeQuery = true)
+    List<Judge> findJudgesByEventId(@Param("eventId") Long eventId);
+}

--- a/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
@@ -12,4 +12,6 @@ import com.example.BES.models.SessionToken;
 public interface SessionTokenRepository extends JpaRepository<SessionToken, String> {
     List<SessionToken> findByEvent_EventIdAndRoleAndRevokedFalseAndExpiresAtAfter(
         Long eventId, String role, LocalDateTime now);
+
+    List<SessionToken> findByEvent_EventIdAndRevokedFalse(Long eventId);
 }

--- a/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
@@ -1,0 +1,15 @@
+package com.example.BES.respositories;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.BES.models.SessionToken;
+
+@Repository
+public interface SessionTokenRepository extends JpaRepository<SessionToken, String> {
+    List<SessionToken> findByEvent_EventIdAndRoleAndRevokedFalseAndExpiresAtAfter(
+        Long eventId, String role, LocalDateTime now);
+}

--- a/BES/src/main/java/com/example/BES/services/AccountService.java
+++ b/BES/src/main/java/com/example/BES/services/AccountService.java
@@ -1,11 +1,16 @@
 package com.example.BES.services;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.example.BES.dtos.admin.GetOrganiserDto;
 import com.example.BES.models.Account;
@@ -21,6 +26,9 @@ public class AccountService {
 
     @Autowired
     private EventRepo eventRepo;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     public List<GetOrganiserDto> getAllOrganisers() {
         return accountRepository.findByRole("ORGANISER")
@@ -59,5 +67,29 @@ public class AccountService {
             account.getAssignedEvents().remove(event);
             accountRepository.save(account);
         }
+    }
+
+    public Account createOrganiser(String username, String password) {
+        if (accountRepository.findByUsername(username).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username already exists");
+        }
+        Account account = new Account();
+        account.setUsername(username);
+        account.setPasswordHash(passwordEncoder.encode(password));
+        account.setRole("ORGANISER");
+        account.setReferralCode(generateReferralCode());
+        account.setCreatedAt(LocalDateTime.now());
+        return accountRepository.save(account);
+    }
+
+    @Transactional
+    public void deleteOrganiser(Long accountId) {
+        Account account = accountRepository.findById(accountId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Organiser not found"));
+        accountRepository.delete(account);
+    }
+
+    private String generateReferralCode() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
     }
 }

--- a/BES/src/main/java/com/example/BES/services/AccountService.java
+++ b/BES/src/main/java/com/example/BES/services/AccountService.java
@@ -1,0 +1,63 @@
+package com.example.BES.services;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.BES.dtos.admin.GetOrganiserDto;
+import com.example.BES.models.Account;
+import com.example.BES.models.Event;
+import com.example.BES.respositories.AccountRepository;
+import com.example.BES.respositories.EventRepo;
+
+@Service
+public class AccountService {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    public List<GetOrganiserDto> getAllOrganisers() {
+        return accountRepository.findByRole("ORGANISER")
+            .stream()
+            .map(a -> new GetOrganiserDto(
+                a.getAccountId(),
+                a.getUsername(),
+                a.getAssignedEvents() != null
+                    ? a.getAssignedEvents().stream().map(Event::getEventId).collect(Collectors.toList())
+                    : List.of()
+            ))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void assignEvent(Long accountId, Long eventId) {
+        Account account = accountRepository.findById(accountId)
+            .orElseThrow(() -> new RuntimeException("Account not found: " + accountId));
+        Event event = eventRepo.findById(eventId)
+            .orElseThrow(() -> new RuntimeException("Event not found: " + eventId));
+
+        if (account.getAssignedEvents() == null || !account.getAssignedEvents().contains(event)) {
+            account.getAssignedEvents().add(event);
+            accountRepository.save(account);
+        }
+    }
+
+    @Transactional
+    public void removeEvent(Long accountId, Long eventId) {
+        Account account = accountRepository.findById(accountId)
+            .orElseThrow(() -> new RuntimeException("Account not found: " + accountId));
+        Event event = eventRepo.findById(eventId)
+            .orElseThrow(() -> new RuntimeException("Event not found: " + eventId));
+
+        if (account.getAssignedEvents() != null) {
+            account.getAssignedEvents().remove(event);
+            accountRepository.save(account);
+        }
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/AccountService.java
+++ b/BES/src/main/java/com/example/BES/services/AccountService.java
@@ -30,6 +30,7 @@ public class AccountService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Transactional(readOnly = true)
     public List<GetOrganiserDto> getAllOrganisers() {
         return accountRepository.findByRole("ORGANISER")
             .stream()

--- a/BES/src/main/java/com/example/BES/services/AccountUserDetailsService.java
+++ b/BES/src/main/java/com/example/BES/services/AccountUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.example.BES.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.example.BES.models.Account;
+import com.example.BES.respositories.AccountRepository;
+
+@Service
+public class AccountUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Account account = accountRepository.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("Account not found: " + username));
+
+        return User.builder()
+            .username(account.getUsername())
+            .password(account.getPasswordHash())
+            .roles(account.getRole())
+            .build();
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -224,11 +224,12 @@ public class EventGenreParticpantService {
         }
     }
 
+    @Transactional(readOnly = true)
     public List<GetEventGenreParticipantDto> getAllEventGenreParticipantByEventService(String eventName){
         Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
         if (event == null) return new ArrayList<>();
         LinkedHashMap<com.example.BES.models.EventGenreParticipantId, EventGenreParticipant> seen = new LinkedHashMap<>();
-        for (EventGenreParticipant egp : repo.findByEvent(event)) {
+        for (EventGenreParticipant egp : repo.findByEventWithJudge(event)) {
             seen.putIfAbsent(egp.getId(), egp);
         }
         List<EventGenreParticipant> results = new ArrayList<>(seen.values());

--- a/BES/src/main/java/com/example/BES/services/EventService.java
+++ b/BES/src/main/java/com/example/BES/services/EventService.java
@@ -10,6 +10,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.example.BES.models.Account;
@@ -64,6 +65,7 @@ public class EventService {
         return null;
     }
 
+    @Transactional(readOnly = true)
     public List<GetEventDto> getAllEvents(boolean includeAccessCode){
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         List<Event> events;

--- a/BES/src/main/java/com/example/BES/services/EventService.java
+++ b/BES/src/main/java/com/example/BES/services/EventService.java
@@ -7,13 +7,17 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.example.BES.models.Account;
 import com.example.BES.models.Event;
 import com.example.BES.dtos.AddEventDto;
 import com.example.BES.dtos.GetEventDto;
 import com.example.BES.dtos.GetJudgingModeDto;
+import com.example.BES.respositories.AccountRepository;
 import com.example.BES.respositories.EventRepo;
 
 @Service
@@ -26,6 +30,9 @@ public class EventService {
 
     @Autowired
     SimpMessagingTemplate messagingTemplate;
+
+    @Autowired
+    AccountRepository accountRepository;
 
     public void createEventService(AddEventDto dto){
         if (repo.findByEventName(dto.eventName).isPresent()) return;
@@ -58,7 +65,22 @@ public class EventService {
     }
 
     public List<GetEventDto> getAllEvents(boolean includeAccessCode){
-        List<Event> events = repo.findAll();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        List<Event> events;
+
+        if (auth != null && auth.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
+            events = repo.findAll();
+        } else if (auth != null && auth.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ORGANISER"))) {
+            Account account = accountRepository.findByUsername(auth.getName()).orElse(null);
+            events = account != null && account.getAssignedEvents() != null
+                ? account.getAssignedEvents()
+                : List.of();
+        } else {
+            events = repo.findAll();
+        }
+
         List<GetEventDto> dtos = new ArrayList<>();
         for(Event event: events){
             GetEventDto dto = new GetEventDto();

--- a/BES/src/main/java/com/example/BES/services/InitialAccountSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/InitialAccountSeeder.java
@@ -1,0 +1,57 @@
+package com.example.BES.services;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.example.BES.models.Account;
+import com.example.BES.respositories.AccountRepository;
+
+@Component
+public class InitialAccountSeeder {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Value("${BES_ADMIN_PASSWORD}")
+    private String adminPassword;
+
+    @Value("${BES_ORGANISER_PASSWORD}")
+    private String organiserPassword;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void seed() {
+        if (accountRepository.findByUsername("admin").isEmpty()) {
+            Account admin = new Account();
+            admin.setUsername("admin");
+            admin.setPasswordHash(passwordEncoder.encode(adminPassword));
+            admin.setRole("ADMIN");
+            admin.setReferralCode(generateReferralCode());
+            admin.setCreatedAt(LocalDateTime.now());
+            accountRepository.save(admin);
+        }
+
+        if (accountRepository.findByUsername("organiser").isEmpty()) {
+            Account organiser = new Account();
+            organiser.setUsername("organiser");
+            organiser.setPasswordHash(passwordEncoder.encode(organiserPassword));
+            organiser.setRole("ORGANISER");
+            organiser.setReferralCode(generateReferralCode());
+            organiser.setCreatedAt(LocalDateTime.now());
+            accountRepository.save(organiser);
+        }
+    }
+
+    private String generateReferralCode() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/JudgeService.java
+++ b/BES/src/main/java/com/example/BES/services/JudgeService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.BES.dtos.AddJudgeDto;
 import com.example.BES.dtos.GetJudgeDto;
+import com.example.BES.dtos.JudgeDivisionDto;
 import com.example.BES.dtos.admin.DeleteJudgeDto;
 import com.example.BES.dtos.admin.UpdateJudgeDto;
 import com.example.BES.models.Event;
@@ -77,20 +78,13 @@ public class JudgeService {
     public List<GetJudgeDto> getJudgesByEvent(String eventName) {
         Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
         if (event == null) return new ArrayList<>();
-        List<EventGenre> genres = eventGenreRepo.findByEvent(event);
+        List<Judge> judges = judgeRepo.findJudgesByEventId(event.getEventId());
         List<GetJudgeDto> dtos = new ArrayList<>();
-        Set<Long> seen = new HashSet<>();
-        for (EventGenre eg : genres) {
-            if (eg.getJudges() != null) {
-                for (Judge j : eg.getJudges()) {
-                    if (seen.add(j.getJudgeId())) {
-                        GetJudgeDto dto = new GetJudgeDto();
-                        dto.judgeName = j.getName();
-                        dto.judgeId = j.getJudgeId();
-                        dtos.add(dto);
-                    }
-                }
-            }
+        for (Judge j : judges) {
+            GetJudgeDto dto = new GetJudgeDto();
+            dto.judgeName = j.getName();
+            dto.judgeId = j.getJudgeId();
+            dtos.add(dto);
         }
         return dtos;
     }
@@ -99,17 +93,15 @@ public class JudgeService {
     public Judge addJudgeToEvent(String eventName, String judgeName) {
         Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
         if (event == null) return null;
-        List<EventGenre> genres = eventGenreRepo.findByEvent(event);
-        if (genres.isEmpty()) return null;
-        Judge j = judgeRepo.findFirstByName(judgeName).orElseGet(() -> {
+        String trimmed = judgeName != null ? judgeName.trim() : "";
+        if (trimmed.isEmpty()) return null;
+        Judge j = judgeRepo.findFirstByName(trimmed).orElseGet(() -> {
             Judge newJ = new Judge();
-            newJ.setName(judgeName);
+            newJ.setName(trimmed);
             return judgeRepo.save(newJ);
         });
-        EventGenre eg = genres.get(0);
-        if (eg.getJudges() == null) eg.setJudges(new ArrayList<>());
-        eg.getJudges().add(j);
-        eventGenreRepo.save(eg);
+        // Add to event-level pool only — no division assignment
+        judgeRepo.insertEventJudge(event.getEventId(), j.getJudgeId());
         return j;
     }
 
@@ -117,6 +109,7 @@ public class JudgeService {
     public void removeJudgeFromEvent(String eventName, Long judgeId) {
         Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
         if (event == null) return;
+        // Remove from all divisions
         List<EventGenre> genres = eventGenreRepo.findByEvent(event);
         for (EventGenre eg : genres) {
             if (eg.getJudges() != null) {
@@ -124,6 +117,8 @@ public class JudgeService {
             }
         }
         eventGenreRepo.saveAll(genres);
+        // Remove from event pool
+        judgeRepo.deleteEventJudge(event.getEventId(), judgeId);
     }
 
     @Transactional
@@ -141,14 +136,47 @@ public class JudgeService {
     @Transactional
     public List<GetJudgeDto> addJudgeToDivision(Long divisionId, String judgeName) {
         EventGenre eg = eventGenreRepo.findById(divisionId).orElseThrow();
-        Judge j = judgeRepo.findFirstByName(judgeName).orElseGet(() -> {
+        String trimmed = judgeName != null ? judgeName.trim() : "";
+        if (trimmed.isEmpty()) return getJudgesByDivision(divisionId);
+
+        Judge j = judgeRepo.findFirstByName(trimmed).orElseGet(() -> {
             Judge newJ = new Judge();
-            newJ.setName(judgeName);
+            newJ.setName(trimmed);
             return judgeRepo.save(newJ);
         });
+
+        // Also ensure in event-level pool
+        judgeRepo.insertEventJudge(eg.getEvent().getEventId(), j.getJudgeId());
+
         if (eg.getJudges() == null) eg.setJudges(new ArrayList<>());
-        eg.getJudges().add(j);
-        eventGenreRepo.save(eg);
+
+        // Prevent duplicate in same division
+        boolean alreadyInDivision = eg.getJudges().stream()
+            .anyMatch(existing -> existing.getJudgeId().equals(j.getJudgeId()));
+        if (!alreadyInDivision) {
+            eg.getJudges().add(j);
+            eventGenreRepo.save(eg);
+        }
+
+        return getJudgesByDivision(divisionId);
+    }
+
+    @Transactional
+    public List<GetJudgeDto> assignJudgeToDivision(Long divisionId, Long judgeId) {
+        EventGenre eg = eventGenreRepo.findById(divisionId).orElseThrow();
+        Judge j = judgeRepo.findById(judgeId).orElse(null);
+        if (j == null) return getJudgesByDivision(divisionId);
+
+        // Also ensure in event-level pool
+        judgeRepo.insertEventJudge(eg.getEvent().getEventId(), judgeId);
+
+        if (eg.getJudges() == null) eg.setJudges(new ArrayList<>());
+        boolean alreadyInDivision = eg.getJudges().stream()
+            .anyMatch(existing -> existing.getJudgeId().equals(judgeId));
+        if (!alreadyInDivision) {
+            eg.getJudges().add(j);
+            eventGenreRepo.save(eg);
+        }
         return getJudgesByDivision(divisionId);
     }
 
@@ -159,4 +187,23 @@ public class JudgeService {
         eventGenreRepo.save(eg);
         return getJudgesByDivision(divisionId);
     }
+
+    public List<JudgeDivisionDto> getDivisionsByJudge(String eventName, Long judgeId) {
+        Event event = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
+        if (event == null) return new ArrayList<>();
+        List<EventGenre> genres = eventGenreRepo.findByEvent(event);
+        List<JudgeDivisionDto> result = new ArrayList<>();
+        for (EventGenre eg : genres) {
+            if (eg.getJudges() != null) {
+                for (Judge j : eg.getJudges()) {
+                    if (j.getJudgeId().equals(judgeId)) {
+                        result.add(new JudgeDivisionDto(eg.getName(), eg.getFormat()));
+                        break;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
 }

--- a/BES/src/main/java/com/example/BES/services/SessionTokenService.java
+++ b/BES/src/main/java/com/example/BES/services/SessionTokenService.java
@@ -1,0 +1,72 @@
+package com.example.BES.services;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.BES.models.Event;
+import com.example.BES.models.Judge;
+import com.example.BES.models.SessionToken;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.JudgeRepo;
+import com.example.BES.respositories.SessionTokenRepository;
+
+@Service
+public class SessionTokenService {
+
+    @Autowired
+    private SessionTokenRepository sessionTokenRepository;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    @Autowired
+    private JudgeRepo judgeRepo;
+
+    public String generateToken(String role, Long eventId, Long judgeId, int expiresInDays) {
+        Event event = eventRepo.findById(eventId)
+            .orElseThrow(() -> new IllegalArgumentException("Event not found: " + eventId));
+
+        Judge judge = null;
+        if (judgeId != null) {
+            judge = judgeRepo.findById(judgeId)
+                .orElseThrow(() -> new IllegalArgumentException("Judge not found: " + judgeId));
+        }
+
+        SessionToken token = new SessionToken();
+        token.setTokenId(UUID.randomUUID().toString());
+        token.setRole(role);
+        token.setEvent(event);
+        token.setJudge(judge);
+        token.setExpiresAt(LocalDateTime.now().plusDays(expiresInDays));
+        token.setRevoked(false);
+        token.setCreatedAt(LocalDateTime.now());
+
+        sessionTokenRepository.save(token);
+        return token.getTokenId();
+    }
+
+    public SessionToken validate(String tokenId) {
+        SessionToken token = sessionTokenRepository.findById(tokenId)
+            .orElseThrow(() -> new IllegalArgumentException("Token not found: " + tokenId));
+
+        if (token.isRevoked()) {
+            throw new IllegalArgumentException("Token has been revoked");
+        }
+
+        if (token.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Token has expired");
+        }
+
+        return token;
+    }
+
+    public void revoke(String tokenId) {
+        SessionToken token = sessionTokenRepository.findById(tokenId)
+            .orElseThrow(() -> new IllegalArgumentException("Token not found: " + tokenId));
+        token.setRevoked(true);
+        sessionTokenRepository.save(token);
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/SessionTokenService.java
+++ b/BES/src/main/java/com/example/BES/services/SessionTokenService.java
@@ -1,7 +1,9 @@
 package com.example.BES.services;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -68,5 +70,11 @@ public class SessionTokenService {
             .orElseThrow(() -> new IllegalArgumentException("Token not found: " + tokenId));
         token.setRevoked(true);
         sessionTokenRepository.save(token);
+    }
+
+    public List<SessionToken> getActiveTokens(Long eventId) {
+        return sessionTokenRepository.findByEvent_EventIdAndRevokedFalse(eventId).stream()
+            .filter(t -> t.getExpiresAt().isAfter(LocalDateTime.now()))
+            .collect(Collectors.toList());
     }
 }

--- a/BES/src/main/java/com/example/BES/services/SessionTokenService.java
+++ b/BES/src/main/java/com/example/BES/services/SessionTokenService.java
@@ -43,9 +43,12 @@ public class SessionTokenService {
         if (judgeId != null) {
             judge = judgeRepo.findById(judgeId)
                 .orElseThrow(() -> new IllegalArgumentException("Judge not found: " + judgeId));
-            // Validate judge belongs to the event
-            List<Judge> eventJudges = judgeRepo.findJudgesByEventId(eventId);
-            if (eventJudges.stream().noneMatch(j -> j.getJudgeId().equals(judgeId))) {
+            // Validate judge belongs to the event via division assignment (JPA relationship)
+            boolean belongsToEvent = judge.getEventGenres() != null
+                && judge.getEventGenres().stream()
+                    .anyMatch(eg -> eg.getEvent() != null
+                        && eg.getEvent().getEventId().equals(eventId));
+            if (!belongsToEvent) {
                 throw new IllegalArgumentException("Judge " + judgeId
                     + " does not belong to event " + eventId);
             }

--- a/BES/src/main/java/com/example/BES/services/SessionTokenService.java
+++ b/BES/src/main/java/com/example/BES/services/SessionTokenService.java
@@ -2,6 +2,7 @@ package com.example.BES.services;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -27,7 +28,14 @@ public class SessionTokenService {
     @Autowired
     private JudgeRepo judgeRepo;
 
+    private static final Set<String> ALLOWED_ROLES = Set.of("JUDGE", "EMCEE", "HELPER");
+
     public String generateToken(String role, Long eventId, Long judgeId, int expiresInDays) {
+        if (!ALLOWED_ROLES.contains(role)) {
+            throw new IllegalArgumentException("Invalid role: " + role
+                + ". Allowed session roles: JUDGE, EMCEE, HELPER.");
+        }
+
         Event event = eventRepo.findById(eventId)
             .orElseThrow(() -> new IllegalArgumentException("Event not found: " + eventId));
 
@@ -35,6 +43,12 @@ public class SessionTokenService {
         if (judgeId != null) {
             judge = judgeRepo.findById(judgeId)
                 .orElseThrow(() -> new IllegalArgumentException("Judge not found: " + judgeId));
+            // Validate judge belongs to the event
+            List<Judge> eventJudges = judgeRepo.findJudgesByEventId(eventId);
+            if (eventJudges.stream().noneMatch(j -> j.getJudgeId().equals(judgeId))) {
+                throw new IllegalArgumentException("Judge " + judgeId
+                    + " does not belong to event " + eventId);
+            }
         }
 
         SessionToken token = new SessionToken();

--- a/BES/src/main/resources/application-test.properties
+++ b/BES/src/main/resources/application-test.properties
@@ -12,6 +12,10 @@ spring.jpa.hibernate.ddl-auto=create-drop
 # Disable Flyway for tests
 spring.flyway.enabled=false
 
+# Initialize additional tables not managed by JPA entities (event_judge)
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
+
 # Disable mail in tests
 spring.mail.host=localhost
 spring.mail.port=25

--- a/BES/src/main/resources/db/migration/V31__add_account_and_session_token.sql
+++ b/BES/src/main/resources/db/migration/V31__add_account_and_session_token.sql
@@ -1,0 +1,26 @@
+CREATE TABLE account (
+    account_id    BIGSERIAL    PRIMARY KEY,
+    username      VARCHAR(100) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    role          VARCHAR(20)  NOT NULL,
+    event_credits INT          NOT NULL DEFAULT 0,
+    referral_code VARCHAR(20)  UNIQUE NOT NULL,
+    referred_by   BIGINT       REFERENCES account(account_id),
+    created_at    TIMESTAMP    NOT NULL DEFAULT now()
+);
+
+CREATE TABLE organiser_event (
+    account_id BIGINT NOT NULL REFERENCES account(account_id) ON DELETE CASCADE,
+    event_id   BIGINT NOT NULL REFERENCES event(event_id)   ON DELETE CASCADE,
+    PRIMARY KEY (account_id, event_id)
+);
+
+CREATE TABLE session_token (
+    token_id   VARCHAR(64)  PRIMARY KEY,
+    role       VARCHAR(20)  NOT NULL,
+    event_id   BIGINT       NOT NULL REFERENCES event(event_id) ON DELETE CASCADE,
+    judge_id   BIGINT       REFERENCES judge(judge_id) ON DELETE SET NULL,
+    expires_at TIMESTAMP    NOT NULL,
+    revoked    BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP    NOT NULL DEFAULT now()
+);

--- a/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
@@ -20,7 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.BES.dtos.LoginDto;
 import com.example.BES.dtos.RedeemTokenDto;
 import com.example.BES.models.Event;
+import com.example.BES.models.EventGenre;
 import com.example.BES.models.Judge;
+import com.example.BES.respositories.EventGenreRepo;
 import com.example.BES.respositories.EventRepo;
 import com.example.BES.respositories.JudgeRepo;
 import com.example.BES.services.SessionTokenService;
@@ -45,6 +47,9 @@ public class AuthControllerIntegrationTest {
     private JudgeRepo judgeRepo;
 
     @Autowired
+    private EventGenreRepo eventGenreRepo;
+
+    @Autowired
     private SessionTokenService sessionTokenService;
 
     private Event testEvent;
@@ -60,6 +65,13 @@ public class AuthControllerIntegrationTest {
         testJudge = new Judge();
         testJudge.setName("Test Judge");
         testJudge = judgeRepo.save(testJudge);
+
+        // Create a division and assign judge so JPA relationship check passes
+        EventGenre eg = new EventGenre();
+        eg.setName("Test Division");
+        eg.setEvent(testEvent);
+        eg.setJudges(new java.util.ArrayList<>(java.util.List.of(testJudge)));
+        eventGenreRepo.save(eg);
     }
 
     @Test

--- a/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,13 +15,21 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.BES.dtos.LoginDto;
+import com.example.BES.dtos.RedeemTokenDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.Judge;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.JudgeRepo;
+import com.example.BES.services.SessionTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Transactional
 public class AuthControllerIntegrationTest {
 
     @Autowired
@@ -28,6 +37,30 @@ public class AuthControllerIntegrationTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    @Autowired
+    private JudgeRepo judgeRepo;
+
+    @Autowired
+    private SessionTokenService sessionTokenService;
+
+    private Event testEvent;
+    private Judge testJudge;
+
+    @BeforeEach
+    void setUp() {
+        testEvent = new Event();
+        testEvent.setEventName("Test Event");
+        testEvent.setAccessCode("1234");
+        testEvent = eventRepo.save(testEvent);
+
+        testJudge = new Judge();
+        testJudge.setName("Test Judge");
+        testJudge = judgeRepo.save(testJudge);
+    }
 
     @Test
     public void testMeEndpointUnauthenticated() throws Exception {
@@ -75,7 +108,6 @@ public class AuthControllerIntegrationTest {
 
     @Test
     public void testLogout() throws Exception {
-        // First login to get a session
         LoginDto loginDto = new LoginDto();
         loginDto.setUsername("admin");
         loginDto.setPassword("test-admin-password");
@@ -89,9 +121,127 @@ public class AuthControllerIntegrationTest {
 
         MockHttpSession session = (MockHttpSession) result.getRequest().getSession();
 
-        // Now logout
         mockMvc.perform(post("/api/v1/auth/logout").session(session))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("Logged Out "));
+    }
+
+    @Test
+    public void testRedeemValidJudgeToken() throws Exception {
+        String tokenId = sessionTokenService.generateToken("JUDGE", testEvent.getEventId(), testJudge.getJudgeId(), 7);
+
+        RedeemTokenDto dto = new RedeemTokenDto();
+        dto.setTokenId(tokenId);
+
+        mockMvc.perform(post("/api/v1/auth/token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.role[0].authority").value("ROLE_JUDGE"))
+                .andExpect(jsonPath("$.judgeId").value(testJudge.getJudgeId()))
+                .andExpect(jsonPath("$.judgeName").value("Test Judge"))
+                .andExpect(jsonPath("$.eventId").value(testEvent.getEventId()));
+    }
+
+    @Test
+    public void testRedeemInvalidToken() throws Exception {
+        RedeemTokenDto dto = new RedeemTokenDto();
+        dto.setTokenId("non-existent-token-id");
+
+        mockMvc.perform(post("/api/v1/auth/token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    public void testRedeemRevokedToken() throws Exception {
+        String tokenId = sessionTokenService.generateToken("JUDGE", testEvent.getEventId(), testJudge.getJudgeId(), 7);
+        sessionTokenService.revoke(tokenId);
+
+        RedeemTokenDto dto = new RedeemTokenDto();
+        dto.setTokenId(tokenId);
+
+        mockMvc.perform(post("/api/v1/auth/token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Token has been revoked"));
+    }
+
+    @Test
+    public void testMeWithSessionAttributes() throws Exception {
+        String tokenId = sessionTokenService.generateToken("JUDGE", testEvent.getEventId(), testJudge.getJudgeId(), 7);
+
+        RedeemTokenDto redeemDto = new RedeemTokenDto();
+        redeemDto.setTokenId(tokenId);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(redeemDto)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) result.getRequest().getSession();
+
+        mockMvc.perform(get("/api/v1/auth/me").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.eventId").value(testEvent.getEventId()))
+                .andExpect(jsonPath("$.judgeId").value(testJudge.getJudgeId()))
+                .andExpect(jsonPath("$.judgeName").value("Test Judge"));
+    }
+
+    @Test
+    public void testGenerateTokenAuthenticatedAdmin() throws Exception {
+        LoginDto loginDto = new LoginDto();
+        loginDto.setUsername("admin");
+        loginDto.setPassword("test-admin-password");
+
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/auth/login")
+                .secure(true)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginDto)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession();
+
+        mockMvc.perform(post("/api/v1/auth/generate-token")
+                .session(session)
+                .param("role", "JUDGE")
+                .param("eventId", String.valueOf(testEvent.getEventId()))
+                .param("judgeId", String.valueOf(testJudge.getJudgeId()))
+                .param("expiresInDays", "7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokenId").exists())
+                .andExpect(jsonPath("$.url").exists());
+    }
+
+    @Test
+    public void testOrganiserSeesOnlyAssignedEvents() throws Exception {
+        Event unassignedEvent = new Event();
+        unassignedEvent.setEventName("Unassigned Event");
+        unassignedEvent.setAccessCode("5678");
+        eventRepo.save(unassignedEvent);
+
+        LoginDto loginDto = new LoginDto();
+        loginDto.setUsername("organiser");
+        loginDto.setPassword("test-organiser-password");
+
+        MvcResult loginResult = mockMvc.perform(post("/api/v1/auth/login")
+                .secure(true)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginDto)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession();
+
+        mockMvc.perform(get("/api/v1/event/events").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
     }
 }

--- a/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
@@ -66,12 +66,16 @@ public class AuthControllerIntegrationTest {
         testJudge.setName("Test Judge");
         testJudge = judgeRepo.save(testJudge);
 
-        // Create a division and assign judge so JPA relationship check passes
+        // Create a division and assign judge to it so the JPA relationship
+        // (judge.eventGenres → EventGenre.event) resolves for SessionTokenService validation
         EventGenre eg = new EventGenre();
         eg.setName("Test Division");
         eg.setEvent(testEvent);
         eg.setJudges(new java.util.ArrayList<>(java.util.List.of(testJudge)));
-        eventGenreRepo.save(eg);
+        eg = eventGenreRepo.save(eg);
+        // Ensure the judge entity has the division in its collection
+        testJudge.setEventGenres(new java.util.ArrayList<>(java.util.List.of(eg)));
+        testJudge = judgeRepo.save(testJudge);
     }
 
     @Test

--- a/BES/src/test/java/com/example/BES/services/JudgeServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/JudgeServiceTest.java
@@ -150,8 +150,11 @@ class JudgeServiceTest {
     @Test
     void addJudgeToDivision_savesAndAddsJudge() {
         Judge j = judge(1L, "Mike");
+        Event e = new Event();
+        e.setEventId(1L);
         EventGenre eg = new EventGenre();
         eg.setId(10L);
+        eg.setEvent(e);
         eg.setJudges(new ArrayList<>());
         when(eventGenreRepo.findById(10L)).thenReturn(Optional.of(eg));
         when(judgeRepo.save(any())).thenReturn(j);

--- a/BES/src/test/resources/schema.sql
+++ b/BES/src/test/resources/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS event_judge (
+    event_id BIGINT NOT NULL,
+    judge_id BIGINT NOT NULL,
+    PRIMARY KEY (event_id, judge_id)
+);


### PR DESCRIPTION
## What this PR does

Implements the two-tier account model from **#63**, built on billing schema decisions from **#40**.

### Two-tier auth model
- **Admin / Organiser** → persistent DB-backed accounts (replaces InMemoryUserDetailsManager)
- **Emcee / Judge / Helper** → no account needed; organiser generates a per-event session link (signed token URL), they open it and they're in

### Backend
- V31 migration: `account`, `organiser_event`, `session_token` tables with billing columns (`event_credits`, `referral_code`, `referred_by`)
- `AccountUserDetailsService` replaces InMemoryUserDetailsManager
- `InitialAccountSeeder` seeds admin/organiser from env vars on startup
- Session token service: generate (UUID, role + eventId + optional judgeId, expiry), validate, revoke
- `POST /api/v1/auth/token` — redeem session link, creates Spring Security session
- `POST /api/v1/auth/generate-token` — generate token (Admin/Organiser only)
- `GET/DELETE /api/v1/auth/tokens` — list and revoke tokens
- Organiser ↔ Event assignment endpoints (admin assigns events to organiser accounts)
- Organiser event scoping — organisers only see their assigned events
- 3 new roles: ROLE_HELPER, ROLE_EMCEE, ROLE_JUDGE with endpoint-level @PreAuthorize

### Frontend
- **TokenAuth.vue** — session link landing page (`/auth/token?t=...`), redeems token, redirects by role
- **JudgeSessionView** — judge hub: shows assigned divisions, links to Audition List + Battle Judge
- **EmceeSessionView** — emcee hub: links to Audition List, Score, Battle Control
- **HelperSessionView** — helper hub: links to Event Details, copy audition screen link
- **BattleJudge.vue** — judge identity read from session (no more localStorage picker); shows "NOT ASSIGNED" overlay if judge not in battle
- **AuditionList.vue** — ROLE_JUDGE auto-identifies from session, skips old picker
- **EventDetails.vue** — new "Session Links" collapsible section: generate EMCEE/HELPER/JUDGE tokens, copy link, revoke
- **AdminPage.vue** — new "Organisers" tab: create/delete organiser accounts, assign/remove from events
- Router guards for all new roles, session roles redirected from Main to their hub

### Deferred
- EMCEE restricted BattleControl mode → #61
- HELPER quick-action cards in MainMenu → #61
- Billing logic & UI (credit enforcement, credit management, referral wiring) → **#66** (schema exists, business logic pending)

### Addresses
- Closes #63 (two-tier account model)
- Partial #40 (schema foundation for billing model)

---

## Test Plan

Run through these scenarios in order. Each builds on the previous.

### Phase 1 — Admin & Organiser Accounts

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 1.1 | **Admin login** | Navigate to `/login`, log in as `admin` with env-var password | Redirected to MainMenu. Navbar shows "Admin" badge. Admin tab visible. |
| 1.2 | **Create organiser** | Admin → AdminPage → Organisers tab. Enter username + password (min 6 chars), click create. | Organiser appears in list. Count badge increments. |
| 1.3 | **Short password rejected** | Try creating an organiser with a 3-char password | Backend returns 400 validation error. |
| 1.4 | **Duplicate username rejected** | Try creating an organiser with the same username | Error modal: "Username already exists". |
| 1.5 | **Delete organiser** | Click delete on an organiser, confirm | Organiser removed from list. |
| 1.6 | **Assign organiser to event** | Tick checkbox next to an event name under an organiser | Organiser now sees that event on login. |
| 1.7 | **Remove organiser from event** | Untick the checkbox | Event removed from organiser's scope. |
| 1.8 | **Organiser login** | Log out, log in as the organiser created above | MainMenu loads. Only assigned events visible in event selector. |
| 1.9 | **Organiser event scoping** | As organiser, open the event panel | Only assigned events appear. No access to AdminPage (403 or hidden nav). |

### Phase 2 — Session Link Generation & Redemption

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 2.1 | **Generate EMCEE token** | As admin/organiser → EventDetails → Session Links section. Click +EMCEE. | Token appears in list with role "EMCEE", expiry date, and copy/revoke buttons. |
| 2.2 | **Generate HELPER token** | Same section, click +HELPER. | Token appears with role "HELPER". |
| 2.3 | **Generate JUDGE token without judge** | Click +JUDGE **without** selecting a judge from the dropdown. | Button is disabled / nothing happens (judgeId required). |
| 2.4 | **Generate JUDGE token with judge** | Select a judge from the judge dropdown, then click +JUDGE. | Token appears with judge name shown. |
| 2.5 | **Copy token link** | Click copy icon on a token. | Link copied to clipboard. Paste into address bar → format: `http://localhost/auth/token?t=<uuid>`. |
| 2.6 | **Revoke token** | Click revoke (X) on a token. | Token disappears from list. |
| 2.7 | **Redeem EMCEE token** | Open a new incognito/private window. Paste the EMCEE token link and navigate. | Loading spinner → redirected to EmceeSessionView. Shows event name + "Emcee" role. |
| 2.8 | **Redeem HELPER token** | Same with HELPER token link. | Redirected to HelperSessionView. Shows event name + "Helper" role. |
| 2.9 | **Redeem JUDGE token** | Same with JUDGE token link. | Redirected to JudgeSessionView. Shows event name + judge name + assigned divisions. |
| 2.10 | **Redeem revoked token** | Revoke a token from EventDetails, then try to open its link in incognito. | Error: "Token has been revoked" or "Invalid or expired link." |
| 2.11 | **Redeem invalid/malformed token** | Navigate to `/auth/token?t=garbage` | Error: "Token not found" or "Invalid or expired link." |
| 2.12 | **Redeem without token param** | Navigate to `/auth/token` (no `?t=`) | Error: "No token provided." |
| 2.13 | **Network error handling** | Stop the backend, then try to redeem a token link. | Error: "Unable to reach server. Check your connection and try again." (not "Invalid or expired link") |

### Phase 3 — Session Hub Views

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 3.1 | **Emcee hub navigation** | As emcee session user, on EmceeSessionView | Three buttons: Audition List, Score, Battle Control. All three navigate correctly. |
| 3.2 | **Emcee page refresh** | On EmceeSessionView, refresh the page (F5) | Session restores. Event name and role still shown. Navigation buttons still work. |
| 3.3 | **Emcee session timeout** | Wait for session to expire (or clear cookies), then refresh | "SESSION NOT FOUND" shown with explanation text. |
| 3.4 | **Helper hub navigation** | As helper session user, on HelperSessionView | Event Details button navigates to event details. Audition Screen button copies audition screen link. |
| 3.5 | **Helper page refresh** | Refresh the helper hub page | Session restores correctly. |
| 3.6 | **Judge hub — divisions shown** | As judge session user, on JudgeSessionView | Assigned divisions listed with format badges. AUDITION and BATTLE buttons per division. |
| 3.7 | **Judge hub — no divisions** | Generate a JUDGE token for a judge with no division assignments | "No divisions assigned. Contact an organiser..." empty state shown. |
| 3.8 | **Judge hub — navigate to audition** | Click AUDITION on a division | Navigates to AuditionList. `selectedGenre` is set in localStorage. Judge auto-identified (no "Who are you?" picker). |
| 3.9 | **Judge hub — navigate to battle** | Click BATTLE on a division | Navigates to BattleJudge. Judge identity from session. |
| 3.10 | **Judge hub page refresh** | Refresh the judge hub page | Session restores. Judge name and divisions still shown. |

### Phase 4 — Session Role Restrictions

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 4.1 | **Judge can't access admin** | As judge session user, navigate to `/admin` | Redirected to 403 Forbidden page. |
| 4.2 | **Judge can't access event details** | Navigate to `/events/<eventName>` | Redirected to 403. |
| 4.3 | **Emcee can't access admin** | As emcee session user, navigate to `/admin` | Redirected to 403. |
| 4.4 | **Helper can't access battle control** | As helper session user, navigate to `/battle/control` | Redirected to 403. |
| 4.5 | **Session role redirected from Main** | As judge/emcee/helper, navigate to `/` | Redirected to respective session hub (JudgeSession/EmceeSession/HelperSession). |
| 4.6 | **Navbar locked for session roles** | As any session role, look at the navbar event chip | Event name shown but chip is NOT clickable (no dropdown arrow). No "Change Event" option. |
| 4.7 | **Navbar home link hidden** | As any session role, look at the navbar | No "Home" link in nav. No "Events" link. Only logout + theme toggle. |

### Phase 5 — Battle Judge Session Identity

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 5.1 | **Judge auto-identified** | As judge session user, navigate to BattleJudge (via judge hub BATTLE button) | Judge name shown in chip at top. No localStorage judge picker. |
| 5.2 | **Judge NOT in battle judges list** | As a judge assigned to divisions but NOT added to the battle judges | "NOT ASSIGNED TO THIS BATTLE" overlay shown. Back to hub button available. |
| 5.3 | **Judge can vote** | As a judge who IS in the battle judges list, during VOTING phase | Vote buttons work. Vote registered via `/api/v1/battle/vote` with correct judgeId from session. |
| 5.4 | **Judge vote survives page refresh** | Vote, then refresh the BattleJudge page during VOTING | Vote restored from backend judges list or localStorage fallback. |
| 5.5 | **Judge sees result on REVEALED** | After voting ends and phase changes to REVEALED | Winner displayed. Vote locked (no more voting). |

### Phase 6 — Token Generation Security (Hardening Fixes)

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 6.1 | **Reject ADMIN role via API** | Call `POST /api/v1/auth/generate-token` with `role=ADMIN` (using curl or API tool) | 400 error: "Invalid role: ADMIN. Allowed session roles: JUDGE, EMCEE, HELPER." |
| 6.2 | **Reject ORGANISER role via API** | Same with `role=ORGANISER` | 400 error: "Invalid role: ORGANISER..." |
| 6.3 | **Reject garbage role via API** | Same with `role=FAKE` | 400 error: "Invalid role: FAKE..." |
| 6.4 | **Reject lowercase role via API** | Same with `role=judge` | Should succeed (normalized to uppercase) — token generated with role "JUDGE". |
| 6.5 | **Judge from wrong event rejected** | Call generate-token with `judgeId` from a different event than `eventId` | Error: "Judge X does not belong to event Y". |
| 6.6 | **Non-existent judge rejected** | Call generate-token with `judgeId=99999` | Error: "Judge not found: 99999". |

### Phase 7 — Regression Checks

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 7.1 | **Existing admin still works** | Log in as admin with the same credentials as before this PR | All existing functionality works: event CRUD, genre management, judge management, etc. |
| 7.2 | **Public routes still public** | Without logging in, navigate to `/battle/overlay`, `/battle/bracket`, `/battle/chart`, `/results` | All load without redirect to login. |
| 7.3 | **`/api/v1/auth/me` without auth** | Curl `GET /api/v1/auth/me` without cookies | Returns `{ "authenticated": false, "username": null, "role": [] }` — no 500/NPE. |
| 7.4 | **Old shared judge/emcee accounts gone** | Try logging in with old `judge` / `emcee` shared accounts | Login fails (credentials no longer exist). Expected — replaced by session links. |
| 7.5 | **Event creation still works** | As admin/organiser, create a new event | Event created. Appears in event list. (Note: credits not enforced yet — see #66.) |

### Phase 8 — Frontend Build

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 8.1 | **Frontend builds** | `cd BES-frontend && npm run build` | Build succeeds with no errors. |
| 8.2 | **Frontend tests** | `cd BES-frontend && npm test` | All existing tests pass. No regressions. |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)