### PR TITLE
fix: Show validation error for short organiser password instead of 'user exists'

### DIFF
--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -70,7 +70,13 @@ const submitCreateOrganiser = async () => {
     openModal("Account Created", `Organiser "${username}" created successfully.`, "info")
   } else {
     const body = await res?.json().catch(() => null)
-    openModal("Error", body?.message || "Failed to create organiser. Username may already exist.", "warning")
+    // Spring validation errors: { errors: [{ defaultMessage }] }
+    // Custom errors from backend: { message: "..." }
+    const msg = body?.errors?.[0]?.defaultMessage
+      || body?.message
+      || body?.detail
+      || "Failed to create organiser. Username may already exist."
+    openModal("Error", msg, "warning")
   }
 }
 


### PR DESCRIPTION
## Problem (#68)

When creating an organiser with a password shorter than 6 characters, the UI showed "Failed to create organiser. Username may already exist." — misleading the user into thinking the username was taken.

## Root Cause

Spring's @Size validation returns a 400 with errors in Spring's structured format:
```json
{ "errors": [{ "field": "password", "defaultMessage": "Password must be at least 6 characters" }] }
```

The frontend was reading `body?.message` which is undefined for validation errors, falling back to the misleading fallback message.

## Fix

In `AdminPage.vue:submitCreateOrganiser`, parse Spring validation errors from `body.errors[0].defaultMessage` first, then fall back to `body.message` (custom errors like duplicate username), then `body.detail`, then the generic fallback.

## Test
1. Go to AdminPage → Organisers tab
2. Enter a username and a password shorter than 6 characters
3. Click "Create Account"
4. Expect: "Password must be at least 6 characters"
5. Enter a valid password but a duplicate username
6. Expect: "Username already exists"

Closes #68

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)