### PR TITLE
fix: Prevent starting battle round with zero judges

### DIFF
--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -55,6 +55,8 @@ const setupLocked = computed(() =>
   (isSmoke.value && Array.isArray(rounds.value) && rounds.value.some(r => (r?.score ?? 0) > 0))
 )
 
+const hasJudges = computed(() => (battleJudges.value?.judges ?? []).length > 0)
+
 // Auto-collapse setup panel the first time a battle starts
 watch(setupLocked, (locked) => {
   if (locked) setupExpanded.value = false
@@ -242,6 +244,10 @@ const updateSmokePair = async () => {
 }
 
 const initiateBattlePairAt = async (top, pairList, startIdx) => {
+  if (!hasJudges.value) {
+    alert('Cannot start round: no judges assigned. Add at least one judge first.')
+    return
+  }
   markSaving()
   currentWinner.value = -2
   revealActive.value = false

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -304,6 +304,15 @@ public class BattleService {
 
     public void setBattlePhaseService(String phase) {
         if ("REVEALED".equals(phase)) return;
+        // Prevent starting a round with zero judges
+        if ("LOCKED".equals(phase)) {
+            synchronized (judges) {
+                if (judges.isEmpty()) {
+                    throw new IllegalArgumentException(
+                        "Cannot start round: no judges assigned. Add at least one judge first.");
+                }
+            }
+        }
         battlePhase = phase;
         messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
             "phase", battlePhase,


### PR DESCRIPTION
## Problem (#71)

BattleControl allowed starting a round with zero judges assigned, resulting in an un-scorable match.

## Fix

### Backend
`BattleService.setBattlePhaseService` now rejects `LOCKED` transitions when the judges list is empty, throwing an `IllegalArgumentException` with a clear message.

### Frontend
Added `hasJudges` computed property. `initiateBattlePairAt` checks it before proceeding and shows an alert if no judges are assigned. The backend guard remains authoritative.

## Test
1. Go to BattleControl for an event with no judges added
2. Try to start a round (click a bracket match)
3. Expect: alert "Cannot start round: no judges assigned"
4. Add at least one judge
5. Try again → round starts normally

Closes #71

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)