### PR TITLE
fix: Broadcast judges on event/genre switch so BattleJudge clients stay in sync

### DIFF
--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -37,6 +37,7 @@ function clearJudge() {
   clearVote()
   judgeId.value   = null
   judgeName.value = ''
+  notAssigned.value = true
   if (voteClient) {
     deactivateClient(voteClient)
     const idx = wsClients.indexOf(voteClient)
@@ -182,6 +183,7 @@ onMounted(async () => {
       const still = (msg?.judges ?? []).find(j => j.id === judgeId.value)
       if (still) {
         clearTimeout(clearJudgeTimer)
+        notAssigned.value = false
       } else {
         // Judge absent — may be a temporary genre-sync remove+re-add. Debounce before clearing
         // so the re-add has time to arrive. If still gone after 2.5s, clear for real.

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -370,6 +370,11 @@ public class BattleService {
         activeGenreName = dto.getGenreName();
         loadGenreStateIntoMemory(activeEventName, activeGenreName);
         broadcastStateSnapshot();
+        // Broadcast judges so BattleJudge clients can re-check assignment immediately
+        synchronized (judges) {
+            messagingTemplate.convertAndSend("/topic/battle/judges",
+                Map.of("judges", new ArrayList<>(judges)));
+        }
         messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
             "phase", battlePhase,
             "genre", activeGenreName != null ? activeGenreName : ""


### PR DESCRIPTION
## Problem (#73)

When the organiser switched events or genres in BattleControl, the change was not broadcast to connected BattleJudge clients. A judge not assigned to the new genre would still see the old battle state and could interact until they manually refreshed the page.

## Fix

### Backend
`switchActiveGenreService` now broadcasts the new genre's judge list to `/topic/battle/judges` after loading state. Since this channel is already subscribed by BattleJudge clients, they immediately receive the updated judge list for the new event/genre.

### Frontend
Two changes in `BattleJudge.vue`:
1. `clearJudge()` now sets `notAssigned = true` so the "NOT ASSIGNED TO THIS BATTLE" overlay shows immediately when the judge is removed from the list, without requiring a page refresh.
2. The judges WS handler clears `notAssigned` when the judge IS found in the updated list, fixing a stuck-overlay edge case on re-assignment.

## Test
1. Open BattleControl as organiser, add Judge A to the battle
2. Open BattleJudge as Judge A in a separate browser/incognito — verify judge is identified and can vote
3. In BattleControl, switch to a different genre where Judge A is NOT assigned
4. Judge A's BattleJudge page should show "NOT ASSIGNED TO THIS BATTLE" overlay within ~3 seconds
5. Switch back to the original genre — overlay should clear and judge should be identified again

Closes #73

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)