### PR TITLE
fix: Reset card stack to first participant when switching genres

### DIFF
--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -847,6 +847,7 @@ onMounted(async () => {
     <div class="flex-1 min-h-0" style="overflow: hidden;">
     <template v-if="selectedRole === 'Emcee' && filteredParticipantsForEmceeView.length > 0">
       <EmceeRoundView
+        :key="selectedGenre"
         :participants="filteredParticipantsForEmceeView"
         :mode="judgingMode"
       />
@@ -912,6 +913,7 @@ onMounted(async () => {
       />
       <SwipeableCardsV2
         v-else
+        :key="selectedGenre"
         :cards="filteredParticipantsForJudge"
         :feedbackData="feedbackGiven"
         :criteria="criteria"


### PR DESCRIPTION
## Problem (#69)

When an emcee or judge switched genres in AuditionList, the card stack retained the previous genre's position — landing mid-stack instead of starting from the first participant.

## Fix

Added `:key="selectedGenre"` to both card components in AuditionList:
- `SwipeableCardsV2` (judge score entry)
- `EmceeRoundView` (emcee round timer/status)

Vue's keyed component recreation destroys and remounts the component when the genre changes, resetting all internal state including the current card index. Each genre switch now starts at participant #1.

## Test
1. As judge or emcee, go to AuditionList
2. Navigate several cards deep into a genre
3. Switch to a different genre via the genre selector
4. Expect: card stack starts from the first participant in the new genre
5. Switch back to the original genre
6. Expect: card stack starts from the first participant again

Closes #69

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)