### PR TITLE
fix: Password validation, real-time genre switch, Start Round dialog, score race condition

### DIFF
--- a/BES-frontend/src/utils/adminApi.js
+++ b/BES-frontend/src/utils/adminApi.js
@@ -206,11 +206,23 @@ export const createOrganiser = async (username, password) => {
         const res = await fetch(`${domain}/api/v1/admin/organisers`, {
             method: 'POST',
             credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
             body: JSON.stringify({ username, password })
         })
-        return res
-    } catch (_err) { /* network error */ }
+        if (res.ok) return { ok: true }
+        // Extract error from response body — try multiple Spring Boot formats
+        const body = await res.json().catch(() => ({}))
+        const msg = body?.properties
+            ? Object.values(body.properties)[0]           // ProblemDetail (Spring Boot 3.x)
+            : body?.errors?.[0]?.defaultMessage           // BindingResult (Spring Boot 2.x)
+            || body?.message                               // custom { message: "..." }
+            || body?.detail                                // ProblemDetail fallback
+            || body?.error                                 // BasicErrorController
+            || 'Failed to create organiser.'
+        return { ok: false, error: typeof msg === 'string' ? msg : 'Failed to create organiser.' }
+    } catch (_err) {
+        return { ok: false, error: 'Unable to reach server. Check your connection.' }
+    }
 }
 
 export const deleteOrganiser = async (accountId) => {

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -61,6 +61,10 @@ const submitCreateOrganiser = async () => {
     openModal("Validation Error", "Username and password cannot be empty.", "error")
     return
   }
+  if (newOrganiserPassword.value.length < 6) {
+    openModal("Validation Error", "Password must be at least 6 characters.", "error")
+    return
+  }
   const username = newOrganiserUsername.value
   const res = await createOrganiser(username, newOrganiserPassword.value)
   if (res?.ok) {

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -69,18 +69,7 @@ const submitCreateOrganiser = async () => {
     newOrganiserPassword.value = ''
     openModal("Account Created", `Organiser "${username}" created successfully.`, "info")
   } else {
-    const body = await res?.json().catch(() => null)
-    // Spring Boot 3.x ProblemDetail format: { properties: { password: "..." } }
-    // Spring Boot 2.x format: { errors: [{ defaultMessage: "..." }] }
-    // Custom backend errors: { message: "..." }
-    const props = body?.properties
-    const firstProp = props ? Object.values(props)[0] : null
-    const msg = firstProp
-      || body?.errors?.[0]?.defaultMessage
-      || body?.message
-      || body?.detail
-      || "Failed to create organiser. Username may already exist."
-    openModal("Error", msg, "warning")
+    openModal("Error", res?.error || "Failed to create organiser.", "warning")
   }
 }
 

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -70,9 +70,13 @@ const submitCreateOrganiser = async () => {
     openModal("Account Created", `Organiser "${username}" created successfully.`, "info")
   } else {
     const body = await res?.json().catch(() => null)
-    // Spring validation errors: { errors: [{ defaultMessage }] }
-    // Custom errors from backend: { message: "..." }
-    const msg = body?.errors?.[0]?.defaultMessage
+    // Spring Boot 3.x ProblemDetail format: { properties: { password: "..." } }
+    // Spring Boot 2.x format: { errors: [{ defaultMessage: "..." }] }
+    // Custom backend errors: { message: "..." }
+    const props = body?.properties
+    const firstProp = props ? Object.values(props)[0] : null
+    const msg = firstProp
+      || body?.errors?.[0]?.defaultMessage
       || body?.message
       || body?.detail
       || "Failed to create organiser. Username may already exist."

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -188,6 +188,12 @@ const filteredParticipantsForJudge = computed({
 // aspect == "" → single score mode; aspect != "" → criteria mode (one row per criterion).
 const loadScoresFromDb = async (event, genre, judge) => {
   if (!event || !genre || !judge) return
+  // Guard: don't apply scores if participants for this genre haven't loaded yet.
+  // The selectedGenre watcher (immediate) can fire before the selectedEvent watcher
+  // finishes fetching participants. Without this check, scores are applied to an
+  // empty array via .map(), then participants load with score:0 overwriting everything.
+  // The selectedEvent watcher will call loadScoresFromDb again after participants arrive.
+  if (!participants.value.some(p => p.genreName === genre)) return
   const allScores = await getParticipantScore(event)
   if (!allScores || !Array.isArray(allScores)) return
 

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -84,7 +84,7 @@ const confirmWin = () => {
 const cancelWin = () => { pendingWin.value = null }
 
 // ── Start-from-here confirmation ──────────────────────────────
-// { top, pairList, matchIdx } — null when no pending confirm
+// { top, pairList, matchIdx, startAll } — null when no pending confirm
 const pendingStartAt = ref(null)
 
 const roundLabel = (top) => {
@@ -93,14 +93,22 @@ const roundLabel = (top) => {
 }
 
 const requestStartAt = (top, pairList, matchIdx) => {
-  pendingStartAt.value = { top, pairList, matchIdx }
+  pendingStartAt.value = { top, pairList, matchIdx, startAll: false }
+}
+
+const requestStartAll = (top, pairList) => {
+  pendingStartAt.value = { top, pairList, matchIdx: 0, startAll: true }
 }
 
 const confirmStartAt = async () => {
   if (!pendingStartAt.value) return
-  const { top, pairList, matchIdx } = pendingStartAt.value
+  const { top, pairList, matchIdx, startAll } = pendingStartAt.value
   pendingStartAt.value = null
-  await initiateBattlePairAt(top, pairList, matchIdx)
+  if (startAll) {
+    await initiateBattlePair(top, pairList)
+  } else {
+    await initiateBattlePairAt(top, pairList, matchIdx)
+  }
 }
 
 const cancelStartAt = () => { pendingStartAt.value = null }
@@ -277,6 +285,10 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
 }
 
 const initiateBattlePair = async (top, pairList) => {
+  if (!hasJudges.value) {
+    alert('Cannot start round: no judges assigned. Add at least one judge first.')
+    return
+  }
   markSaving()
   currentWinner.value = -2
   revealActive.value = false
@@ -2473,7 +2485,7 @@ onUnmounted(() => {
             <button
               v-if="effectivePhase === 'IDLE' && !setupLocked"
               :disabled="!isActiveRoundFilled"
-              @click="initiateBattlePair(`Top${size}`, rounds[`Top${size}`])"
+              @click="requestStartAll(`Top${size}`, rounds[`Top${size}`])"
               class="w-full py-4 sm:py-2 para-chip type-label transition-all duration-200"
               :class="isActiveRoundFilled ? 'bg-accent' : 'bg-surface-700 text-content-muted cursor-not-allowed'"
               :title="isActiveRoundFilled ? '' : 'All slots must be filled and the previous round must be completed'"
@@ -3110,19 +3122,22 @@ onUnmounted(() => {
           <p v-else class="type-label text-red-400 mb-3">⚠ No judges assigned — add judges before starting</p>
 
           <!-- Starting match -->
-          <div class="section-rule mb-3">
+          <div v-if="!pendingStartAt?.startAll" class="section-rule mb-3">
             <span class="section-rule-label">Starting Match</span>
             <div class="section-rule-line"></div>
           </div>
-          <p class="type-body mb-1">
-            <span class="text-content-primary">{{ pendingStartAt?.pairList?.[pendingStartAt.matchIdx]?.[0] }}</span>
-            <span class="text-content-muted mx-2">vs</span>
-            <span class="text-content-primary">{{ pendingStartAt?.pairList?.[pendingStartAt.matchIdx]?.[1] }}</span>
-          </p>
-          <p v-if="pendingStartAt?.matchIdx > 0" class="type-label text-amber-400/80 mb-4" style="font-size:10px;letter-spacing:0.12em">
-            {{ pendingStartAt.matchIdx }} match{{ pendingStartAt.matchIdx !== 1 ? 'es' : '' }} before this one will be skipped.
-          </p>
-          <p v-else class="mb-4"></p>
+          <template v-if="!pendingStartAt?.startAll">
+            <p class="type-body mb-1">
+              <span class="text-content-primary">{{ pendingStartAt?.pairList?.[pendingStartAt.matchIdx]?.[0] }}</span>
+              <span class="text-content-muted mx-2">vs</span>
+              <span class="text-content-primary">{{ pendingStartAt?.pairList?.[pendingStartAt.matchIdx]?.[1] }}</span>
+            </p>
+            <p v-if="pendingStartAt?.matchIdx > 0" class="type-label text-amber-400/80 mb-4" style="font-size:10px;letter-spacing:0.12em">
+              {{ pendingStartAt.matchIdx }} match{{ pendingStartAt.matchIdx !== 1 ? 'es' : '' }} before this one will be skipped.
+            </p>
+            <p v-else class="mb-4"></p>
+          </template>
+          <p v-else class="type-body text-content-primary mb-4">All matches in this round will be started from the beginning.</p>
 
           <div class="flex gap-3 justify-end">
             <button @click="cancelStartAt" class="para-chip-sm px-4 py-2 type-label transition-all">Cancel</button>

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -183,23 +183,20 @@ onMounted(async () => {
       const still = (msg?.judges ?? []).find(j => j.id === judgeId.value)
       if (still) {
         clearTimeout(clearJudgeTimer)
+        clearJudgeTimer = null
         notAssigned.value = false
       } else {
-        // Judge absent — may be a temporary genre-sync remove+re-add. Debounce before clearing
-        // so the re-add has time to arrive. If still gone after 2.5s, clear for real.
-        if (clearJudgeTimer == null) {
-          clearJudgeTimer = setTimeout(() => {
-            clearJudgeTimer = null
-            const authStore = useAuthStore()
-            const byName = authStore.judgeName
-              ? (battleJudges.value?.judges ?? []).find(j => j.name === authStore.judgeName)
-              : null
-            if (byName) {
-              judgeId.value = byName.id
-            } else if (!(battleJudges.value?.judges ?? []).find(j => j.id === judgeId.value)) {
-              clearJudge()
-            }
-          }, 2500)
+        // Judge not in list — check by name (organiser may have re-created the judge
+        // with a new ID during genre sync). If not found by name either, clear immediately.
+        const authStore = useAuthStore()
+        const byName = authStore.judgeName
+          ? (battleJudges.value?.judges ?? []).find(j => j.name === authStore.judgeName)
+          : null
+        if (byName) {
+          judgeId.value = byName.id
+          notAssigned.value = false
+        } else {
+          clearJudge()
         }
       }
     }

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -179,18 +179,32 @@ onMounted(async () => {
 
   subscribeToChannel(cJudges, '/topic/battle/judges', (msg) => {
     battleJudges.value = msg
+    const authStore = useAuthStore()
+    const judges = msg?.judges ?? []
+
+    // If currently blocked (notAssigned), check if judge re-appeared
+    if (notAssigned.value && authStore.judgeName) {
+      const match = judges.find(j => j.name === authStore.judgeName)
+      if (match) {
+        judgeId.value = match.id
+        judgeName.value = match.name
+        notAssigned.value = false
+        setupVoteSubscription()
+        return
+      }
+    }
+
     if (judgeId.value != null) {
-      const still = (msg?.judges ?? []).find(j => j.id === judgeId.value)
+      const still = judges.find(j => j.id === judgeId.value)
       if (still) {
         clearTimeout(clearJudgeTimer)
         clearJudgeTimer = null
         notAssigned.value = false
       } else {
-        // Judge not in list — check by name (organiser may have re-created the judge
-        // with a new ID during genre sync). If not found by name either, clear immediately.
-        const authStore = useAuthStore()
+        // Judge not in list — check by name first (organiser may have re-created
+        // the judge with a new ID during genre sync). If not found, clear immediately.
         const byName = authStore.judgeName
-          ? (battleJudges.value?.judges ?? []).find(j => j.name === authStore.judgeName)
+          ? judges.find(j => j.name === authStore.judgeName)
           : null
         if (byName) {
           judgeId.value = byName.id


### PR DESCRIPTION
## Problems fixed

### 1. Start Round button bypassed dialog and judge guard
The main "Start Round" button called `initiateBattlePair` directly, skipping both the confirmation dialog (#81) and the zero-judge check (#71). Only the per-match start button (desktop-only, hidden on mobile via `hidden sm:flex`) went through the confirmation flow.

**Fix:** 
- `initiateBattlePair` now checks `hasJudges` before proceeding
- "Start Round" button now calls `requestStartAll` → shows the confirmation dialog with division, round, judges, and match count
- Added `startAll` flag to `pendingStartAt` so the dialog shows "All matches in this round" instead of a specific starting match

### 2. Multi-genre score race condition (#82)
On page load, the `selectedGenre` watcher (immediate) called `loadScoresFromDb` before participants finished loading, applying scores to an empty array. Then the `selectedEvent` watcher overwrote with `score:0` data.

**Fix:** `loadScoresFromDb` now checks if participants for the target genre exist before applying scores. Returns early if not — the `selectedEvent` watcher calls it again after participants load.

## Test
1. Go to BattleControl, fill a bracket
2. Click "Start Round" → confirmation dialog appears showing division, round, judges
3. Remove all judges, click "Start Round" → alert warns about no judges
4. As a multi-genre judge, score participants in two genres, refresh, switch between genres → scores persist correctly

Closes #82, fixes #71 and #81 integration

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)