### PR TITLE
Refactor: Replace BattleControl localStorage state cache with DB-backed WebSocket sync

### DIFF
--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -715,13 +715,13 @@ export const getBattlePhase = async () => {
   } catch (_e) { return { phase: 'IDLE' } }
 }
 
-export const setBattlePhase = async (phase) => {
+export const setBattlePhase = async (phase, champion) => {
   try {
     return await fetch(`${domain}/api/v1/battle/phase`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ phase })
+      body: JSON.stringify({ phase, ...(champion ? { champion } : {}) })
     })
   } catch (e) { console.log(e) }
 }

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1452,3 +1452,14 @@ export const revokeSessionToken = async (tokenId) => {
     })
   } catch (err) { console.error(err) }
 }
+
+export const setResolvedParticipants = async (eventName, genreName, participants) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/resolved-participants`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventName, genreName, participants })
+    })
+  } catch (e) { console.error(e) }
+}

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1100,8 +1100,12 @@ const voteWeightDisplay = computed(() => {
 
 
 const restoreAndBroadcastGenreBattle = async (genre) => {
-  // Reset local state, then wait for /topic/battle/state WS to deliver the
-  // real state from the backend. switchActiveGenreService already broadcast it.
+  // Reset local state, then fetch the real state from the backend.
+  // switchActiveGenreService already broadcast /topic/battle/state — if the WS
+  // message arrived before we reset refs, the diff guard would block re-hydration.
+  // Clear lastAppliedState so hydrateFromState always applies on genre switch.
+  lastAppliedState.value = ''
+
   currentBattle.value = []
   currentTop.value = ''
   currentRound.value = 0

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -2339,7 +2339,7 @@ onUnmounted(() => {
             </div>
 
             <button
-              v-if="effectivePhase === 'IDLE' && !setupLocked"
+              v-if="effectivePhase === 'IDLE'"
               :disabled="!isActiveRoundFilled"
               @click="requestStartAll(`Top${size}`, rounds[`Top${size}`])"
               class="w-full py-4 sm:py-2 para-chip type-label transition-all duration-200"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1157,6 +1157,10 @@ const jumpToRecoveredPair = async () => {
     const resolvedIdx = nameIdx >= 0 ? nameIdx : (currentRoundIndex ?? 0)
     currentRound.value = resolvedIdx
     currentBattle.value = [resolvedIdx, pairList]
+    // Restore the round tab to match the recovered currentTop
+    const recoveredSize = parseInt(topKey.replace('Top', ''))
+    const recoveredIdx = roundSizes.value.indexOf(recoveredSize)
+    if (recoveredIdx >= 0) activeRoundIdx.value = recoveredIdx
   }
 
   // REVEALED: backend already has the correct state loaded from DB on startup.
@@ -1462,10 +1466,13 @@ const effectivePhase = computed(() =>
   isActiveBattleInThisRound.value ? battlePhase.value : 'IDLE'
 )
 
-// Guard: prompt before switching round tab when battle is in progress
+// Guard: only prompt when switching AWAY from a round with an active battle.
+// Completed rounds and future rounds switch freely without prompting.
 const requestRoundChange = (idx) => {
   if (roundTabStatus(idx) === 'locked') return
-  if (battlePhase.value !== 'IDLE' && idx !== activeRoundIdx.value) {
+  if (idx === activeRoundIdx.value) return
+  // Only prompt if the CURRENT round has an active battle in progress
+  if (roundTabStatus(activeRoundIdx.value) === 'active' && battlePhase.value !== 'IDLE') {
     pendingRoundIdx.value = idx
     showRoundChangeConfirm.value = true
   } else {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { addBattleJudge, addBattleGuest, battleJudgeVote, clearBattlePair, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, getSmokeList, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateJudgeWeightage, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, addBattleGuest, battleJudgeVote, clearBattlePair, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateJudgeWeightage, updateSmokeList, uploadImage } from '@/utils/api'
 import { deleteImage } from '@/utils/adminApi'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
@@ -1584,14 +1584,13 @@ watch(selectedGenre, async (newVal, oldVal) => {
     pickupCrews.value = await getPickupCrews(selectedEvent.value, newVal)
     placeGuestsInBracket()
     if (oldVal) {
+      // Switch backend to new genre FIRST — persistActiveState() saves outgoing genre's state,
+      // loadGenreStateIntoMemory() loads incoming genre's state, broadcastStateSnapshot() pushes
+      // the full snapshot to all clients.
       await setActiveGenre(selectedEvent.value, newVal)
-    }
-    // Broadcast local rounds on a genre SWITCH (oldVal truthy).
-    // On initial load (oldVal falsy), setActiveGenre in onMounted hasn't completed yet so the
-    // backend still points at the previous event — broadcasting here would corrupt that event's
-    // DB row. onMounted handles state restoration after setActiveGenre confirms the correct event.
-    if (oldVal) broadcastBracket()
-    if (oldVal) {
+      // Restore local BattleControl UI from the backend state just loaded.
+      // Do NOT call broadcastBracket() here — the DB already has the correct bracket data
+      // from the last mutation, and pushing initRounds() would overwrite it.
       await restoreAndBroadcastGenreBattle(newVal)
     }
     // Sync per-genre judges on genre switch.
@@ -1760,11 +1759,10 @@ onMounted(async () => {
     syncJudgeVoteSubscriptions()
   }
   wsClient.value.activate()
-  // After WS activation, hydrate from REST to cover the gap before subscription went live.
-  // The WS /topic/battle/state subscription above was registered in onConnect BEFORE activate().
-  // This REST call ensures we have state even before the first WS message arrives.
+  // After WS activation, hydrate from the same battleState already fetched above.
+  // The WS /topic/battle/state subscription was registered in onConnect BEFORE activate().
+  // This reuses the existing REST response to cover the gap before the first WS message arrives.
   if (selectedEvent.value && selectedGenre.value) {
-    const battleState = await getBattleState()
     if (battleState) hydrateFromState(battleState)
   }
 })

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -5,7 +5,7 @@ import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
 import { useEventUtils } from '@/utils/eventUtils'
 import { useBattleLogic } from '@/utils/battleLogic'
-import { createClient, deactivateClient } from '@/utils/websocket'
+import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket'
 import { parseDropKey } from '@/utils/pointerDnd'
 
 const { selectedEvent, selectedGenre, initialiseDropdown } = useDropdowns()
@@ -32,6 +32,74 @@ const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: 
 const showRecoveryBanner = ref(false)
 const recoveryState      = ref(null)
 const genreChampions     = ref({})
+const lastAppliedState = ref('')  // JSON string of last applied /topic/battle/state snapshot
+
+// Single entry point for full-state hydration from /topic/battle/state or REST API.
+// Diffs against lastAppliedState to skip no-op updates and prevent animation disruption.
+const hydrateFromState = (state) => {
+  if (!state) return
+  const snapshot = JSON.stringify(state)
+  if (snapshot === lastAppliedState.value) return
+  lastAppliedState.value = snapshot
+
+  if (state.bracket) {
+    if (state.bracket.topSize !== undefined) {
+      const size = Number(state.bracket.topSize)
+      if (!isNaN(size) && size !== Number(topSize.value)) {
+        skipSizeChangeClear = true
+        topSize.value = size
+      }
+    }
+    if (state.bracket.rounds) {
+      rounds.value = state.bracket.rounds
+    }
+  }
+  if (state.currentRoundIndex !== undefined) {
+    currentRound.value = state.currentRoundIndex
+  }
+  if (state.currentPair) {
+    const pair = state.currentPair
+    if (pair.left || pair.right) {
+      const bracketRounds = state.bracket?.rounds ?? rounds.value
+      let topKey = pair.isFinal ? 'Top2' : null
+      if (!topKey && bracketRounds) {
+        for (const key of Object.keys(bracketRounds)) {
+          const matchList = bracketRounds[key]
+          if (!Array.isArray(matchList)) continue
+          if (matchList.some(m => Array.isArray(m) && m[0] === pair.left && m[1] === pair.right)) {
+            topKey = key; break
+          }
+        }
+      }
+      if (topKey) {
+        currentTop.value = topKey
+        const pairList = bracketRounds[topKey] ?? []
+        const pairIdx = pairList.findIndex(
+          m => Array.isArray(m) && m[0] === pair.left && m[1] === pair.right
+        )
+        if (pairIdx >= 0) currentRound.value = pairIdx
+        currentBattle.value = [pairIdx >= 0 ? pairIdx : 0, pairList]
+      }
+    } else {
+      currentBattle.value = []
+      currentTop.value = ''
+    }
+  }
+  if (state.battlePhase) {
+    battlePhase.value = state.battlePhase
+  }
+  if (state.champion) {
+    genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: state.champion }
+  }
+  if (state.judges?.length) {
+    battleJudges.value = { judges: state.judges }
+  }
+  if (state.resolvedParticipants && state.resolvedParticipants !== '') {
+    try {
+      resolvedParticipants.value = JSON.parse(state.resolvedParticipants)
+    } catch (_) { resolvedParticipants.value = null }
+  }
+}
 
 const saveStatus = ref('idle') // 'idle' | 'saving' | 'saved' | 'error'
 let saveTimer = null
@@ -1893,19 +1961,26 @@ onMounted(async () => {
     showRecoveryBanner.value = true  // then notify the operator
   }
   wsClient.value = createClient()
-  // Single onConnect handler — multiple subscribeToChannel calls before connection
-  // overwrite each other's onConnect, so we wire everything here directly.
   wsClient.value.onConnect = () => {
+    // Subscribe to full state snapshots — used for initial hydration, genre switch, and reconnect recovery.
+    // Diff logic prevents re-rendering already-current state.
+    subscribeToChannel(wsClient.value, '/topic/battle/state', (msg) => {
+      // Guard: ignore state broadcasts for a different genre (stale WS from genre switch)
+      if (msg.genreName && msg.genreName !== selectedGenre.value) return
+      hydrateFromState(msg)
+      syncJudgeVoteSubscriptions()
+    })
+
+    // Phase subscription — keep for real-time phase transitions
     wsClient.value.subscribe('/topic/battle/phase', (raw) => {
       const msg = JSON.parse(raw.body)
-      // Ignore phase messages intended for a different genre — stale WS from a genre
-      // switch can arrive after we've already switched back and set the correct phase.
       if (msg.genre && msg.genre !== selectedGenre.value) return
       battlePhase.value = msg.phase
       if (msg.phase === 'DECIDED' && msg.champion) {
         genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: msg.champion }
       }
     })
+
     // NOTE: /topic/battle/judges is intentionally NOT subscribed here.
     // syncJudgesForGenre does multiple remove+add operations in sequence; each
     // triggers a WS broadcast with an intermediate state. These late-arriving
@@ -1915,6 +1990,13 @@ onMounted(async () => {
     syncJudgeVoteSubscriptions()
   }
   wsClient.value.activate()
+  // After WS activation, hydrate from REST to cover the gap before subscription went live.
+  // The WS /topic/battle/state subscription above was registered in onConnect BEFORE activate().
+  // This REST call ensures we have state even before the first WS message arrives.
+  if (selectedEvent.value && selectedGenre.value) {
+    const battleState = await getBattleState()
+    if (battleState) hydrateFromState(battleState)
+  }
 })
 
 onUnmounted(() => {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1099,7 +1099,7 @@ const voteWeightDisplay = computed(() => {
 
 
 
-const restoreAndBroadcastGenreBattle = async (genre) => {
+const restoreAndBroadcastGenreBattle = async (_genre) => {
   // Reset local state, then fetch the real state from the backend.
   // switchActiveGenreService already broadcast /topic/battle/state — if the WS
   // message arrived before we reset refs, the diff guard would block re-hydration.
@@ -1203,7 +1203,7 @@ let judgeSyncing = false  // prevents concurrent syncJudgesForGenre calls
 // Called when genre switches: loads the new genre's judges from backend.
 // Judges are persisted per-genre in the DB via battle_genre_state; setActiveGenre
 // already loaded the correct set on the backend. No localStorage needed.
-const syncJudgesForGenre = async (newGenre, prevGenre) => {
+const syncJudgesForGenre = async (_newGenre, _prevGenre) => {
   if (judgeSyncing) return
   judgeSyncing = true
   try {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1750,12 +1750,18 @@ onMounted(async () => {
       }
     })
 
-    // NOTE: /topic/battle/judges is intentionally NOT subscribed here.
-    // syncJudgesForGenre does multiple remove+add operations in sequence; each
-    // triggers a WS broadcast with an intermediate state. These late-arriving
-    // messages would race against the explicit getBattleJudges() call at the end
-    // of syncJudgesForGenre and corrupt battleJudges.value.
-    // We update battleJudges.value only via explicit getBattleJudges() calls.
+    // Sync judge list from WS broadcasts — safe now that syncJudgesForGenre is a
+    // single atomic getBattleJudges() call (no more remove+add loop causing
+    // intermediate states). judgeSyncing guard prevents WS from racing with
+    // the explicit fetch during genre switch.
+    wsClient.value.subscribe('/topic/battle/judges', (raw) => {
+      if (judgeSyncing) return
+      const msg = JSON.parse(raw.body)
+      if (msg?.judges) {
+        battleJudges.value = { judges: msg.judges }
+        syncJudgeVoteSubscriptions()
+      }
+    })
     syncJudgeVoteSubscriptions()
   }
   wsClient.value.activate()

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -187,9 +187,8 @@ const _genreStatusDotMap = computed(() => {
   const map = {}
   for (const genre of uniqueGenres.value) {
     if (genreChampions.value[genre]) { map[genre] = 'champion'; continue }
-    const phase = genre === selectedGenre.value
-      ? battlePhase.value
-      : (JSON.parse(localStorage.getItem(genreBattleStateKey(genre)) ?? '{}').phase ?? 'IDLE')
+    // Only the active genre has a known phase; other genres show as idle
+    const phase = genre === selectedGenre.value ? battlePhase.value : 'IDLE'
     map[genre] = ['LOCKED', 'VOTING', 'REVEALED'].includes(phase) ? 'active' : 'idle'
   }
   return map
@@ -346,7 +345,7 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
   currentRound.value = startIdx
   currentTop.value = top
   broadcastBracket()  // syncs currentRoundIndex to backend so recovery finds the right pair
-  saveGenreBattleState(selectedGenre.value)
+
   markSaved()
 }
 
@@ -380,7 +379,7 @@ const initiateBattlePair = async (top, pairList) => {
   battlePhase.value = 'LOCKED'
   currentRound.value = 0
   currentTop.value = top
-  saveGenreBattleState(selectedGenre.value)
+
   markSaved()
 }
 
@@ -405,7 +404,7 @@ const nextPair = async () => {
       battlePhase.value = 'LOCKED'
       currentWinner.value = -2
       currentRound.value += 1
-      saveGenreBattleState(selectedGenre.value)
+    
     } else {
       await clearBattlePair()
       await setBattlePhase('IDLE')
@@ -413,7 +412,7 @@ const nextPair = async () => {
       currentWinner.value = -2
       currentBattle.value = []
       currentTop.value = ''
-      saveGenreBattleState(selectedGenre.value)
+    
     }
   }
   markSaved()
@@ -530,14 +529,8 @@ const poolParticipants = computed(() => {
 // Bracket seeding
 const bracketSize = computed(() => Number(topSize.value) === 7 ? 8 : Number(topSize.value))
 
-// Load resolved tie-breaker list from Score.vue if one exists for this event+genre+bracketSize
+// Resolved tie-breaker participants loaded from backend via getBattleState() / hydrateFromState.
 const resolvedParticipants = ref(null)
-const loadResolvedParticipants = () => {
-  const key = `tbResolved_${selectedEvent.value}_${selectedGenre.value}_${bracketSize.value}`
-  const saved = localStorage.getItem(key)
-  resolvedParticipants.value = saved ? JSON.parse(saved) : null
-}
-watch([selectedEvent, selectedGenre, bracketSize], loadResolvedParticipants, { immediate: true })
 
 const topNParticipants = computed(() => {
   if (resolvedParticipants.value) return resolvedParticipants.value.slice(0, bracketSize.value)
@@ -1105,91 +1098,23 @@ const voteWeightDisplay = computed(() => {
 })
 
 
-// Per-genre battle state persistence — saves which round/match was in progress so
-// switching genres and back re-broadcasts the correct pair to the overlay automatically.
-const genreBattleStateKey = (genre) => `battleState_${selectedEvent.value}_${genre}`
-
-const saveGenreBattleState = (genre) => {
-  if (!genre) return
-  if (currentBattle.value.length === 0) {
-    localStorage.removeItem(genreBattleStateKey(genre))
-    return
-  }
-  localStorage.setItem(genreBattleStateKey(genre), JSON.stringify({
-    battle: toRaw(currentBattle.value),
-    top: currentTop.value,
-    round: currentRound.value,
-    phase: battlePhase.value,
-  }))
-}
 
 const restoreAndBroadcastGenreBattle = async (genre) => {
-  // Always reset bracket grid for the current event before restoring state — prevents
-  // stale rounds from a previous event persisting when the genre name is the same across events.
-  const storedRounds = localStorage.getItem(`Top${topSize.value}${selectedEvent.value}${genre}Rounds`)
-  rounds.value = storedRounds ? JSON.parse(storedRounds) : initRounds()
-
-  // At this point, switchActiveGenreService has already loaded this genre's state from DB
-  // and broadcast it to all connected clients (overlay, bracket, judge). We only need
-  // to restore local BattleControl UI state — no backend calls needed here.
-  const saved = localStorage.getItem(genreBattleStateKey(genre))
-  if (saved) {
-    const { battle, top, round, phase } = JSON.parse(saved)
-    currentBattle.value = battle ?? []
-    currentTop.value = top ?? ''
-    currentRound.value = round ?? 0
-    currentWinner.value = -2
-    battlePhase.value = phase ?? 'IDLE'
-    return
-  }
-  // No localStorage: reconstruct local state from backend (already loaded by switchActiveGenreService).
-  // Do NOT clear or re-push to backend — it already has the correct state.
-  const state = await getBattleState()
-  if (!state?.currentPair?.left || state.battlePhase === 'IDLE') {
-    currentBattle.value = []
-    currentTop.value = ''
-    currentRound.value = 0
-    currentWinner.value = -2
-    return
-  }
-  battlePhase.value = state.battlePhase ?? 'IDLE'
+  // Reset local state, then wait for /topic/battle/state WS to deliver the
+  // real state from the backend. switchActiveGenreService already broadcast it.
+  currentBattle.value = []
+  currentTop.value = ''
+  currentRound.value = 0
   currentWinner.value = -2
-  if (!isSmoke.value && state.bracket?.rounds) {
-    // Populate rounds.value from DB so the bracket UI is visible, then cache to localStorage
-    // so future genre switches don't need to fall back to DB again.
-    rounds.value = state.bracket.rounds
-    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${genre}Rounds`, JSON.stringify(state.bracket.rounds))
-    const bRounds = state.bracket.rounds
-    let topKey = state.currentPair.isFinal ? 'Top2' : null
-    if (!topKey) {
-      for (const key of Object.keys(bRounds)) {
-        const matchList = bRounds[key]
-        if (!Array.isArray(matchList)) continue
-        if (matchList.some(m => m[0] === state.currentPair.left && m[1] === state.currentPair.right)) {
-          topKey = key; break
-        }
-      }
-    }
-    if (topKey) {
-      currentTop.value = topKey
-      const pairList = bRounds[topKey] ?? []
-      const nameIdx = pairList.findIndex(m => m[0] === state.currentPair.left && m[1] === state.currentPair.right)
-      const resolvedIdx = nameIdx >= 0 ? nameIdx : (state.currentRoundIndex ?? 0)
-      currentRound.value = resolvedIdx
-      currentBattle.value = [resolvedIdx, pairList]
-      saveGenreBattleState(genre)
-    }
-  } else if (isSmoke.value) {
-    const smokeRes = await getSmokeList()
-    if (smokeRes?.list && Array.isArray(smokeRes.list)) {
-      rounds.value = smokeRes.list.map(b => ({ name: b.name, score: b.score }))
-      localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${genre}Rounds`, JSON.stringify(toRaw(rounds.value)))
-    }
-    if (state?.champion) {
-      genreChampions.value = { ...genreChampions.value, [genre]: state.champion }
-    }
-    saveGenreBattleState(genre)
-  }
+  battlePhase.value = 'IDLE'
+
+  // Fetch state from REST as immediate source; WS will keep it in sync thereafter
+  const state = await getBattleState()
+  if (state) hydrateFromState(state)
+
+  // Also re-fetch judges
+  const judges = await getBattleJudges()
+  if (judges) battleJudges.value = judges
 }
 
 const jumpToRecoveredPair = async () => {
@@ -1197,13 +1122,11 @@ const jumpToRecoveredPair = async () => {
   markSaving()
   const { currentPair, currentRoundIndex, battlePhase: restoredPhase, bracket, champion: restoredChampion } = recoveryState.value
 
-  // Restore topSize from DB bracket state — browser localStorage may be stale if
-  // the operator switched sizes on another session or after clearing storage.
+  // Restore topSize from DB bracket state
   if (bracket?.topSize !== undefined) {
     const restored = Number(bracket.topSize)
     if (!isNaN(restored) && restored !== Number(topSize.value)) {
       topSize.value = restored
-      localStorage.setItem('topSize', String(restored))
     }
   }
 
@@ -1228,7 +1151,6 @@ const jumpToRecoveredPair = async () => {
       }
     }
     currentTop.value = topKey
-    localStorage.setItem('currentTop', topKey)
     const pairList = bracket.rounds[topKey] ?? []
     // Find pair by name — currentRoundIndex can be stale if broadcastBracket wasn't called
     const nameIdx = pairList.findIndex(m => m[0] === currentPair.left && m[1] === currentPair.right)
@@ -1245,7 +1167,6 @@ const jumpToRecoveredPair = async () => {
     if (match?.[2]) {
       currentWinner.value = match[2] === currentBattlePair.value?.[0] ? 0 : 1
     }
-    saveGenreBattleState(selectedGenre.value)
     markSaved()
     return
   }
@@ -1266,54 +1187,18 @@ const jumpToRecoveredPair = async () => {
   const phase = restoredPhase && restoredPhase !== 'IDLE' ? restoredPhase : 'LOCKED'
   await setBattlePhase(phase)
   battlePhase.value = phase
-  saveGenreBattleState(selectedGenre.value)
   markSaved()
 }
 
-// Per-genre judge persistence helpers — stores { id, vote } so votes survive genre switches
-const genreJudgeKey = (genre) => `battleJudges_${selectedEvent.value}_${genre}`
 let judgeSyncing = false  // prevents concurrent syncJudgesForGenre calls
 
-const saveGenreJudges = (genre) => {
-  const judges = (battleJudges.value?.judges ?? []).map(j => ({ id: j.id, vote: j.vote, weightage: j.weightage ?? 1 }))
-  localStorage.setItem(genreJudgeKey(genre), JSON.stringify(judges))
-}
-
-// Called when genre switches: removes current backend judges, restores saved judges + votes for new genre
+// Called when genre switches: loads the new genre's judges from backend.
+// Judges are persisted per-genre in the DB via battle_genre_state; setActiveGenre
+// already loaded the correct set on the backend. No localStorage needed.
 const syncJudgesForGenre = async (newGenre, prevGenre) => {
   if (judgeSyncing) return
   judgeSyncing = true
   try {
-    // Save outgoing genre's judges from UI cache BEFORE fetching from backend.
-    // setActiveGenre already switched the backend to newGenre, so getBattleJudges()
-    // would return newGenre's judges — overwriting prevGenre's localStorage with the
-    // wrong list and permanently losing the outgoing genre's judge assignment.
-    if (prevGenre) saveGenreJudges(prevGenre)
-    // Now fetch backend to find out which judges are currently loaded (newGenre's) so
-    // we can remove them before installing prevGenre→newGenre's saved set.
-    battleJudges.value = await getBattleJudges()
-    const toRemove = battleJudges.value?.judges ?? []
-    // Remove sequentially — parallel DELETEs cause ConcurrentModificationException on the
-    // backend's ArrayList, silently leaving judges behind and contaminating the next genre.
-    for (const j of toRemove) {
-      await removeBattleJudge(j.id)
-    }
-    const raw = JSON.parse(localStorage.getItem(genreJudgeKey(newGenre)) ?? '[]')
-    if (raw.length > 0) {
-      // Support both old format (array of ids) and new format (array of { id, vote })
-      const entries = raw.map(s => (typeof s === 'object' ? s : { id: s, vote: -3, weightage: 1 }))
-      // Add sequentially for the same reason as removes above
-      for (const { id, weightage } of entries) {
-        await addBattleJudge(id, weightage ?? 1)
-      }
-      // Restore non-default votes — addBattleJudge sets vote=-3 ("not voted"), so skip those.
-      // -1 is a real tie vote and must be restored; only -3 means "hasn't voted this round".
-      await Promise.all(
-        entries
-          .filter(({ vote }) => vote !== undefined && vote !== -3)
-          .map(({ id, vote }) => battleJudgeVote(id, vote))
-      )
-    }
     battleJudges.value = await getBattleJudges()
     syncJudgeVoteSubscriptions()
   } finally {
@@ -1326,21 +1211,21 @@ const submitAddBattleJudge = async (name) => {
   const res = await addBattleJudge(j?.judgeId)
   if (res.status === 404) console.log("No judge in database")
   battleJudges.value = await getBattleJudges()
-  saveGenreJudges(selectedGenre.value)
+
 }
 
 const submitUpdateJudgeWeightage = async (id, value) => {
   const weightage = Math.max(1, parseInt(value) || 1)
   await updateJudgeWeightage(id, weightage)
   battleJudges.value = await getBattleJudges()
-  saveGenreJudges(selectedGenre.value)
+
 }
 
 const submitRemoveBattleJudge = async (name) => {
   const j = allJudges.value.find(j => j.judgeName === name)
   await removeBattleJudge(j?.judgeId)
   battleJudges.value = await getBattleJudges()
-  saveGenreJudges(selectedGenre.value)
+
 }
 
 const sortedJudgesForToggle = computed(() => {
@@ -1462,7 +1347,7 @@ const lockChampion = async () => {
   genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
   await setBattlePhase('DECIDED')
   battlePhase.value = 'DECIDED'
-  saveGenreBattleState(selectedGenre.value)
+
 }
 
 const unlockChampion = async () => {
@@ -1470,7 +1355,7 @@ const unlockChampion = async () => {
   genreChampions.value = rest
   await setBattlePhase('VOTING')
   battlePhase.value = 'VOTING'
-  saveGenreBattleState(selectedGenre.value)
+
 }
 
 const revealChampionForGenre = async () => {
@@ -1490,7 +1375,7 @@ const revealChampionForGenre = async () => {
     // Stay in DECIDED so the genre remains re-revealable forever
     await setBattlePhase('DECIDED')
     battlePhase.value = 'DECIDED'
-    saveGenreBattleState(selectedGenre.value)
+  
     revealActive.value = true
     return
   }
@@ -1516,7 +1401,7 @@ const openVoting = async () => {
   markSaving()
   await setBattlePhase('VOTING')
   battlePhase.value = 'VOTING'
-  saveGenreBattleState(selectedGenre.value)
+
   markSaved()
 }
 
@@ -1533,8 +1418,8 @@ const confirmResetBracket = async () => {
   currentRound.value = 0
   activeRoundIdx.value = 0
   finalTieBlocked.value = false
-  saveGenreBattleState(selectedGenre.value)
-  // Clear champion tracking — both backend (DB) and local (ref + localStorage)
+
+  // Clear champion tracking — both backend (DB) and local ref
   await dismissChampionReveal()
   revealActive.value = false
   const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
@@ -1634,26 +1519,16 @@ watch(selectedEvent, async (newVal, oldVal) => {
     // across events), watch(selectedGenre) never fires so setActiveGenre is never called.
     // Re-register with the backend here so state is loaded from the correct event's row.
     if (oldVal && selectedGenre.value) {
-      saveGenreBattleState(selectedGenre.value)
+    
       await setActiveGenre(newVal, selectedGenre.value)
       await restoreAndBroadcastGenreBattle(selectedGenre.value)
     }
   }
 }, { immediate: true })
 
-const genreTopSizeKey = (genre) => `battleTopSize_${selectedEvent.value}_${genre}`
-const genreChampionLocalKey = (genre) => `battleChampion_${selectedEvent.value}_${genre}`
-
-// Load pending champions from localStorage for all genres as they become known
 watch(uniqueGenres, (genres) => {
   if (!selectedEvent.value || !genres?.length) return
-  const locals = {}
-  for (const g of genres) {
-    const p = localStorage.getItem(genreChampionLocalKey(g))
-    if (p) locals[g] = p
-  }
-  // Merge: backend confirmed data (already in genreChampions) takes precedence
-  genreChampions.value = { ...locals, ...genreChampions.value }
+  // Champions are loaded from backend via getBattleChampions() in onMounted
 }, { immediate: true })
 
 // When all judges revote to a tie in the final, clear any previously locked
@@ -1663,7 +1538,6 @@ watch(showFinalReveal, (newVal) => {
   if (!newVal && isFinalInProgress.value && allJudgesVoted.value && tentativeWinner.value === -1) {
     const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
     genreChampions.value = rest
-    localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
   }
 })
 
@@ -1675,7 +1549,6 @@ watch([allJudgesVoted, tentativeWinner], ([voted, winner]) => {
   if (voted && winner === -1 && isFinalInProgress.value && genreChampions.value[selectedGenre.value]) {
     const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
     genreChampions.value = rest
-    localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
   }
 })
 
@@ -1684,48 +1557,40 @@ watch(selectedGenre, async (newVal, oldVal) => {
   if (oldVal && revealActive.value) await dismissChampionReveal()
   revealActive.value = false
   if (newVal) {
-    // Persist outgoing genre's topSize before switching
-    if (oldVal) localStorage.setItem(genreTopSizeKey(oldVal), String(topSize.value))
-
     // Restore per-genre topSize — smoke auto-detection takes priority, otherwise
-    // use the saved size for this genre.  When no saved size exists, default to 16
-    // for a genre switch (don't inherit the outgoing genre's size), but keep the
-    // global localStorage value on first/immediate load so a refresh is stable.
+    // fetch from DB-backed state. Default to 16 on genre switch.
     const genreNeedsSmoke = newVal.toLowerCase().includes('7 to smoke') || newVal.toLowerCase().includes('7tosmoke')
     if (genreNeedsSmoke) {
       if (Number(topSize.value) !== 7) {
         topSize.value = 7
-        localStorage.setItem('topSize', '7')
       }
     } else {
-      const savedSize = localStorage.getItem(genreTopSizeKey(newVal))
-      const restoredSize = savedSize ? Number(savedSize) : (oldVal ? 16 : Number(topSize.value))
-      if (restoredSize !== Number(topSize.value)) {
-        skipSizeChangeClear = true
-        topSize.value = restoredSize
-        localStorage.setItem('topSize', String(restoredSize))
+      // Restore per-genre topSize from DB-backed state. Default to 16 on genre switch.
+      if (oldVal) {
+        const state = await getBattleState()
+        if (state?.bracket?.topSize !== undefined) {
+          const dbSize = Number(state.bracket.topSize)
+          if (!isNaN(dbSize) && dbSize !== Number(topSize.value)) {
+            skipSizeChangeClear = true
+            topSize.value = dbSize
+          }
+        } else {
+          topSize.value = 16
+        }
       }
     }
-
-    // Restore pending champion for incoming genre from localStorage
-    if (newVal && !genreChampions.value[newVal]) {
-      const pending = localStorage.getItem(genreChampionLocalKey(newVal))
-      if (pending) genreChampions.value = { ...genreChampions.value, [newVal]: pending }
-    }
     localStorage.setItem("selectedGenre", newVal)
-    const storedRounds = localStorage.getItem(`Top${topSize.value}${selectedEvent.value}${newVal}Rounds`)
-    rounds.value = JSON.parse(storedRounds) || initRounds()
+    rounds.value = initRounds()
     pickupCrews.value = await getPickupCrews(selectedEvent.value, newVal)
     placeGuestsInBracket()
     if (oldVal) {
-      saveGenreBattleState(oldVal)
       await setActiveGenre(selectedEvent.value, newVal)
     }
-    // Only broadcast local rounds on a genre SWITCH (oldVal truthy) when localStorage has data.
+    // Broadcast local rounds on a genre SWITCH (oldVal truthy).
     // On initial load (oldVal falsy), setActiveGenre in onMounted hasn't completed yet so the
     // backend still points at the previous event — broadcasting here would corrupt that event's
     // DB row. onMounted handles state restoration after setActiveGenre confirms the correct event.
-    if (storedRounds && oldVal) broadcastBracket()
+    if (oldVal) broadcastBracket()
     if (oldVal) {
       await restoreAndBroadcastGenreBattle(newVal)
     }
@@ -1745,7 +1610,6 @@ watch(selectedGenre, async (newVal, oldVal) => {
       if (genreChampions.value[newVal] && battlePhase.value !== 'DECIDED') {
         await setBattlePhase('DECIDED')
         battlePhase.value = 'DECIDED'
-        saveGenreBattleState(newVal)
       }
     }
   } else {
@@ -1753,42 +1617,15 @@ watch(selectedGenre, async (newVal, oldVal) => {
   }
 }, { immediate: true })
 
-const sizeStateKey = (size) => `battleSizeState_${selectedEvent.value}_${selectedGenre.value}_${size}`
-const roundIdxKey = () => `battleRoundIdx_${selectedEvent.value}_${selectedGenre.value}_${topSize.value}`
-
-// Persist the active round tab selection so it survives refresh and genre switch.
-// Does NOT auto-broadcast to overlay — the overlay stays on the IDLE announcement
-// until the operator explicitly clicks "Start Round".
-watch(activeRoundIdx, (idx) => {
-  if (selectedEvent.value && selectedGenre.value) {
-    localStorage.setItem(roundIdxKey(), String(idx))
-  }
-})
 
 watch(topSize, async (newVal, oldVal) => {
   if (!newVal) return
   // Restore previously-selected round tab for this size; default to 0 (first round).
   // Only when event+genre are known — during setup they're still null, defer to onMounted.
   if (selectedEvent.value && selectedGenre.value) {
-    const savedIdx = localStorage.getItem(roundIdxKey())
-    activeRoundIdx.value = savedIdx !== null ? Math.min(Number(savedIdx), roundSizes.value.length - 1) : 0
+    activeRoundIdx.value = 0
   }
-  // Save outgoing size's battle state so it can be restored on return (no overlay broadcast)
-  if (oldVal && currentBattle.value.length > 0) {
-    localStorage.setItem(sizeStateKey(oldVal), JSON.stringify({
-      battle: toRaw(currentBattle.value),
-      top: currentTop.value,
-      round: currentRound.value,
-      phase: battlePhase.value,
-    }))
-  }
-  localStorage.setItem("topSize", newVal)
-  // Also save per-genre so it survives refresh (not just genre switch)
-  if (selectedEvent.value && selectedGenre.value) {
-    localStorage.setItem(genreTopSizeKey(selectedGenre.value), String(newVal))
-  }
-  const storedRounds = localStorage.getItem(`Top${newVal}${selectedEvent.value}${selectedGenre.value}Rounds`)
-  rounds.value = JSON.parse(storedRounds) || initRounds()
+  rounds.value = initRounds()
   currentWinner.value = -2
   // Only clear battle on user-initiated size change (not programmatic from
   // genre switch or initial load). The onMounted recovery handles init.
@@ -1804,24 +1641,10 @@ watch(topSize, async (newVal, oldVal) => {
   // would send empty initRounds() to DB, corrupting the stored bracket).
   if (selectedEvent.value && selectedGenre.value) broadcastBracket()
 
-  // Restore the incoming size's battle state (pair + phase). Do NOT push to overlay —
-  // the overlay updates only when the operator clicks a round tab or "Start Round".
-  const savedSizeState = localStorage.getItem(sizeStateKey(newVal))
-  if (savedSizeState) {
-    const { battle, top, round, phase: savedPhase } = JSON.parse(savedSizeState)
-    currentBattle.value = battle ?? []
-    currentTop.value = top ?? ''
-    currentRound.value = round ?? 0
-    // Restore phase locally — but don't broadcast. The overlay stays on whatever
-    // it was last showing. When the operator clicks a round tab, the activeRoundIdx
-    // watcher will find and broadcast the correct pair from the bracket data.
-    battlePhase.value = savedPhase && savedPhase !== 'IDLE' ? savedPhase : 'IDLE'
-    saveGenreBattleState(selectedGenre.value)
-  } else {
-    currentBattle.value = []
-    currentTop.value = ''
-    currentRound.value = 0
-  }
+  // State is restored from /topic/battle/state via hydrateFromState
+  currentBattle.value = []
+  currentTop.value = ''
+  currentRound.value = 0
 }, { immediate: true })
 
 const wsClient = ref(null)
@@ -1882,38 +1705,17 @@ onMounted(async () => {
   if (selectedEvent.value && selectedGenre.value) {
     await setActiveGenre(selectedEvent.value, selectedGenre.value)
   }
-  // Restore per-genre bracket size (survives refresh)
-  if (selectedEvent.value && selectedGenre.value) {
-    const savedSize = localStorage.getItem(genreTopSizeKey(selectedGenre.value))
-    if (savedSize) {
-      topSize.value = Number(savedSize)
-      localStorage.setItem('topSize', savedSize)
-    }
-  }
-  // Now that event+genre are set, restore the saved round tab with correct keys
-  const savedRoundIdx = localStorage.getItem(roundIdxKey())
-  if (savedRoundIdx !== null) {
-    activeRoundIdx.value = Math.min(Number(savedRoundIdx), roundSizes.value.length - 1)
-  }
+  // Round tab starts at 0 on mount
+  activeRoundIdx.value = 0
   await fetchAllJudges(selectedEvent.value)
   await fetchBattleGuests()
   battleJudges.value = await getBattleJudges()
-  // Backend DB is now authoritative for judges (persisted on every change).
-  // On refresh, don't call syncJudgesForGenre — that removes all judges and re-adds
-  // from localStorage, which broadcasts an empty list and makes BattleJudge ask "who are you?".
-  // Just seed localStorage if it's empty so future genre switches have a value to restore.
-  if (selectedGenre.value) {
-    const savedRaw = localStorage.getItem(genreJudgeKey(selectedGenre.value))
-    if (savedRaw === null) {
-      saveGenreJudges(selectedGenre.value)
-    }
-  }
   mountJudgeSyncDone = true
   const savedConfig = await getOverlayConfig()
   if (savedConfig?.showImages !== undefined) overlayConfig.value = savedConfig
   if (selectedEvent.value) {
     const champions = await getBattleChampions(selectedEvent.value)
-    // Merge: localStorage pending (already loaded by watch(uniqueGenres)) +
+    // Merge: backend confirmed data takes precedence over initial ref value
     // backend confirmed. Backend wins on conflict (official record).
     if (champions && typeof champions === 'object') {
       genreChampions.value = { ...genreChampions.value, ...champions }
@@ -1921,12 +1723,6 @@ onMounted(async () => {
   }
   const phaseData = await getBattlePhase()
   battlePhase.value = phaseData?.phase ?? 'IDLE'
-  // Restore currentTop from localStorage only if a battle is genuinely in progress
-  // (avoids stale 'Top2' from a previous session bleeding into non-final rounds)
-  if (battlePhase.value !== 'IDLE') {
-    const storedTop = localStorage.getItem('currentTop')
-    if (storedTop) currentTop.value = storedTop
-  }
   // Auto-restore from backend state on refresh — always check regardless of local state
   const battleState = await getBattleState()
   if (battleState?.battlePhase && battleState.battlePhase !== 'IDLE' && battleState.currentPair?.left) {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -335,7 +335,6 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
   await resetJudgeVote()
   if (top === 'Top2' && Array.isArray(rounds.value['Top2']?.[0])) {
     rounds.value['Top2'][0][2] = null
-    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
   }
   currentBattle.value = [startIdx, pairList]
@@ -346,7 +345,6 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
   battlePhase.value = 'LOCKED'
   currentRound.value = startIdx
   currentTop.value = top
-  localStorage.setItem('currentTop', top)
   broadcastBracket()  // syncs currentRoundIndex to backend so recovery finds the right pair
   saveGenreBattleState(selectedGenre.value)
   markSaved()
@@ -372,7 +370,6 @@ const initiateBattlePair = async (top, pairList) => {
   // preventing a stale "Reveal Champion" button from appearing alongside showFinalReveal.
   if (top === 'Top2' && Array.isArray(rounds.value['Top2']?.[0])) {
     rounds.value['Top2'][0][2] = null
-    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
   }
   currentBattle.value = [0, pairList]
@@ -383,7 +380,6 @@ const initiateBattlePair = async (top, pairList) => {
   battlePhase.value = 'LOCKED'
   currentRound.value = 0
   currentTop.value = top
-  localStorage.setItem('currentTop', top)
   saveGenreBattleState(selectedGenre.value)
   markSaved()
 }
@@ -417,7 +413,6 @@ const nextPair = async () => {
       currentWinner.value = -2
       currentBattle.value = []
       currentTop.value = ''
-      localStorage.removeItem('currentTop')
       saveGenreBattleState(selectedGenre.value)
     }
   }
@@ -661,7 +656,6 @@ const placeGuestsInBracket = () => {
       }
       if (lowestSlot) lowestSlot.name = guest.guestName
     }
-    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     return
   }
@@ -697,7 +691,6 @@ const placeGuestsInBracket = () => {
     }
     if (lowestMatch !== null) lowestMatch[lowestSlot] = guest.guestName
   }
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -710,7 +703,6 @@ const applyToFirstRound = () => {
       if (r?.name && guestNames.has(r.name)) return r // pinned guest
       return { name: filteredSeeds[si++] ?? null, score: r?.score ?? 0 }
     })
-    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     return
   }
@@ -727,7 +719,6 @@ const applyToFirstRound = () => {
   freeSlots.forEach(([mi, si], idx) => {
     rounds.value[key][mi][si] = filteredSeeds[idx] ?? null
   })
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -775,7 +766,6 @@ const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
     if (guestNames.has(rounds.value[tgtRound][tgtMatch][tgtSlot])) return // never overwrite a pinned guest
     rounds.value[tgtRound][tgtMatch][tgtSlot] = name
     rounds.value[tgtRound][tgtMatch][2] = null
-    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     if (tgtIsCurrent) reBroadcastCurrentPairIfActive()
     return
@@ -794,7 +784,6 @@ const onDrop = (tgtRound, tgtMatch, tgtSlot) => {
   rounds.value[srcRound][srcMatch][2] = null
   if (srcRound !== tgtRound || srcMatch !== tgtMatch) rounds.value[tgtRound][tgtMatch][2] = null
 
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
   if (tgtIsCurrent || srcIsCurrent) reBroadcastCurrentPairIfActive()
 }
@@ -809,7 +798,6 @@ const onSmokeDrop = (tgtIdx) => {
     dragOverKey.value = null
     if (guestNames.has(tgtName)) return // never overwrite a pinned guest
     if (rounds.value[tgtIdx]) rounds.value[tgtIdx] = { ...rounds.value[tgtIdx], name }
-    localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
     broadcastBracket()
     return
   }
@@ -823,7 +811,6 @@ const onSmokeDrop = (tgtIdx) => {
   const srcName = rounds.value[srcIdx]?.name
   if (rounds.value[srcIdx]) rounds.value[srcIdx] = { ...rounds.value[srcIdx], name: tgtName ?? null }
   if (rounds.value[tgtIdx]) rounds.value[tgtIdx] = { ...rounds.value[tgtIdx], name: srcName ?? null }
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -957,7 +944,6 @@ const onPointerDragStart = (type, payload, e) => {
 const clearSmokeSlot = (idx) => {
   if (!rounds.value[idx]) return
   rounds.value[idx] = { ...rounds.value[idx], name: null }
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -965,7 +951,6 @@ const clearSlot = (roundKey, matchIdx, slotIdx) => {
   const match = rounds.value[roundKey][matchIdx]
   match[slotIdx] = null
   match[2] = null
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -996,12 +981,11 @@ function setWinner(roundKey, matchIdx, slotIdx) {
   match[2] = winner
   const roundIndex = roundSizes.value.indexOf(parseInt(roundKey.replace("Top", "")))
   const nextRoundSize = roundSizes.value[roundIndex + 1]
-  if (!nextRoundSize) { localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value))); broadcastBracket(); return }
+  if (!nextRoundSize) { broadcastBracket(); return }
   const nextRoundKey = `Top${nextRoundSize}`
   const nextMatchIdx = Math.floor(matchIdx / 2)
   const nextSlotIdx = matchIdx % 2
   rounds.value[nextRoundKey][nextMatchIdx][nextSlotIdx] = winner
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -1015,7 +999,6 @@ function clearWinner(roundKey, matchIdx) {
     rounds.value[`Top${nextRoundSize}`][nextMatchIdx][nextSlotIdx] = null
   }
   match[2] = null
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -1419,7 +1402,6 @@ const submitRemoveBattleGuest = async (guest) => {
       }
     }
   }
-  localStorage.setItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`, JSON.stringify(toRaw(rounds.value)))
   broadcastBracket()
 }
 
@@ -1478,7 +1460,6 @@ const lockChampion = async () => {
     : currentBattlePair.value?.[1]
   if (!winner) return
   genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
-  localStorage.setItem(genreChampionLocalKey(selectedGenre.value), winner)
   await setBattlePhase('DECIDED')
   battlePhase.value = 'DECIDED'
   saveGenreBattleState(selectedGenre.value)
@@ -1487,7 +1468,6 @@ const lockChampion = async () => {
 const unlockChampion = async () => {
   const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
   genreChampions.value = rest
-  localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
   await setBattlePhase('VOTING')
   battlePhase.value = 'VOTING'
   saveGenreBattleState(selectedGenre.value)
@@ -1541,7 +1521,6 @@ const openVoting = async () => {
 }
 
 const confirmResetBracket = async () => {
-  localStorage.removeItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`)
   rounds.value = initRounds()
   placeGuestsInBracket()
   broadcastBracket()
@@ -1554,15 +1533,12 @@ const confirmResetBracket = async () => {
   currentRound.value = 0
   activeRoundIdx.value = 0
   finalTieBlocked.value = false
-  localStorage.removeItem('currentTop')
-  localStorage.removeItem(sizeStateKey(topSize.value))
   saveGenreBattleState(selectedGenre.value)
   // Clear champion tracking — both backend (DB) and local (ref + localStorage)
   await dismissChampionReveal()
   revealActive.value = false
   const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
   genreChampions.value = rest
-  localStorage.removeItem(genreChampionLocalKey(selectedGenre.value))
 }
 
 const requestSizeChange = (newSize) => {
@@ -1577,8 +1553,6 @@ const requestSizeChange = (newSize) => {
 const confirmSizeChange = async () => {
   showSizeChangeConfirm.value = false
   // Reset bracket data for the current genre before switching size
-  localStorage.removeItem(`Top${topSize.value}${selectedEvent.value}${selectedGenre.value}Rounds`)
-  localStorage.removeItem(sizeStateKey(topSize.value))
   topSize.value = pendingSize.value
   pendingSize.value = null
 }

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1353,7 +1353,7 @@ const lockChampion = async () => {
     : currentBattlePair.value?.[1]
   if (!winner) return
   genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
-  await setBattlePhase('DECIDED')
+  await setBattlePhase('DECIDED', winner)
   battlePhase.value = 'DECIDED'
 
 }

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { battleJudgeVote, getBattleJudges, getBattlePhase, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
+import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { useAuthStore } from '@/utils/auth'
@@ -21,6 +21,38 @@ const battleJudges   = ref({ judges: [] })
 const judgeId         = ref(null)   // number | null
 const judgeName       = ref('')
 const notAssigned     = ref(false)
+
+const lastJudgeState = ref('')  // JSON diff guard
+
+const hydrateJudgeFromState = (state) => {
+  if (!state) return
+  const snapshot = JSON.stringify(state)
+  if (snapshot === lastJudgeState.value) return
+  lastJudgeState.value = snapshot
+
+  // Phase — only update if changed
+  if (state.battlePhase && state.battlePhase !== battlePhase.value) {
+    battlePhase.value = state.battlePhase
+    if (state.battlePhase === 'LOCKED') {
+      clearVote()
+      revealedWinner.value = -2
+    }
+  }
+
+  // Pair — only update if changed (prevents unnecessary clearVote)
+  if (state.currentPair?.left) {
+    if (leftName.value !== state.currentPair.left || rightName.value !== state.currentPair.right) {
+      leftName.value = state.currentPair.left || ''
+      rightName.value = state.currentPair.right || ''
+      clearVote()
+    }
+  }
+
+  // Judges — check if current judge was re-added after block
+  if (state.judges?.length) {
+    battleJudges.value = { judges: state.judges }
+  }
+}
 
 function loadJudgeIdentity(judges) {
   const authStore = useAuthStore()
@@ -215,6 +247,16 @@ onMounted(async () => {
       }
     }
   })
+
+  // Full-state snapshot for initial hydration and reconnect recovery
+  const cState = createClient(); wsClients.push(cState)
+  subscribeToChannel(cState, '/topic/battle/state', (msg) => {
+    hydrateJudgeFromState(msg)
+  })
+
+  // Initial hydration + reconnect recovery
+  const initialState = await getBattleState()
+  if (initialState) hydrateJudgeFromState(initialState)
 })
 
 onUnmounted(() => {

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -44,18 +44,22 @@ const hydrateOverlayFromState = async (state) => {
 
   // Standard-mode updates (guarded by !isSmoke to prevent corrupting smoke display)
   if (!isSmoke.value) {
-    // Pair — sync refs directly without triggering entrance animation.
-    // updateBattlePair is reserved for new-pair events via /topic/battle/battle-pair.
-    // State sync (init, reconnect, genre switch) silently updates the display.
+    // Pair — only take action if the pair actually changed
     if (state.currentPair?.left) {
-      leftName.value    = state.currentPair.left
-      rightName.value   = state.currentPair.right
-      leftMembers.value  = state.currentPair.leftMembers  ?? []
-      rightMembers.value = state.currentPair.rightMembers ?? []
-      isFinal.value     = !!state.currentPair.isFinal
-      // Load images if names changed (images are cached by browser)
-      if (state.currentPair.left)  imageLeft.value  = await getImage(`${state.currentPair.left}.png`).catch(() => null)
-      if (state.currentPair.right) imageRight.value = await getImage(`${state.currentPair.right}.png`).catch(() => null)
+      const pairChanged = leftName.value !== state.currentPair.left ||
+                          rightName.value !== state.currentPair.right
+      if (pairChanged) {
+        // New pair (genre switch, recovery) → run entrance animation
+        try {
+          await updateBattlePair(state.currentPair)
+        } catch (_) { /* animation interrupted */ }
+        // If this is a completed battle, restore winner visual after entrance
+        if ((state.battlePhase === 'REVEALED' || state.battlePhase === 'DECIDED') && state.bracket?.rounds) {
+          restoreRevealedState(state.bracket.rounds)
+        }
+      }
+      // Same pair — just update metadata silently (members, scores, etc.)
+      // No animation needed; the pair is already on screen.
     }
 
     // Phase — only update if changed
@@ -73,10 +77,6 @@ const hydrateOverlayFromState = async (state) => {
       }
     }
 
-    // Restore winner visual state for completed battles without replaying animation
-    if ((state.battlePhase === 'REVEALED' || state.battlePhase === 'DECIDED') && state.bracket?.rounds) {
-      restoreRevealedState(state.bracket.rounds)
-    }
   }
 }
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -44,15 +44,18 @@ const hydrateOverlayFromState = async (state) => {
 
   // Standard-mode updates (guarded by !isSmoke to prevent corrupting smoke display)
   if (!isSmoke.value) {
-    // Pair — only update if changed (prevents re-triggering entrance animation)
+    // Pair — sync refs directly without triggering entrance animation.
+    // updateBattlePair is reserved for new-pair events via /topic/battle/battle-pair.
+    // State sync (init, reconnect, genre switch) silently updates the display.
     if (state.currentPair?.left) {
-      const pairChanged = leftName.value !== state.currentPair.left ||
-                          rightName.value !== state.currentPair.right
-      if (pairChanged) {
-        try {
-          await updateBattlePair(state.currentPair)
-        } catch (_) { /* animation interrupted — state is still consistent */ }
-      }
+      leftName.value    = state.currentPair.left
+      rightName.value   = state.currentPair.right
+      leftMembers.value  = state.currentPair.leftMembers  ?? []
+      rightMembers.value = state.currentPair.rightMembers ?? []
+      isFinal.value     = !!state.currentPair.isFinal
+      // Load images if names changed (images are cached by browser)
+      if (state.currentPair.left)  imageLeft.value  = await getImage(`${state.currentPair.left}.png`).catch(() => null)
+      if (state.currentPair.right) imageRight.value = await getImage(`${state.currentPair.right}.png`).catch(() => null)
     }
 
     // Phase — only update if changed

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -475,7 +475,11 @@ onMounted(async () => {
   const cPair2   = createClient(); clients.push(cPair2)
   const cScore2  = createClient(); clients.push(cScore2)
   const cJudges2 = createClient(); clients.push(cJudges2)
-  subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => { if (!isSmoke.value) updateBattlePair(msg) })
+  subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => {
+    if (!isSmoke.value && (msg.left !== leftName.value || msg.right !== rightName.value)) {
+      updateBattlePair(msg)
+    }
+  })
   subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => { if (!isSmoke.value) updateScore(msg) })
   subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => { if (!isSmoke.value) updateBattleJudge(msg) })
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -26,8 +26,45 @@ const leftScore  = ref(0)
 const rightScore = ref(0)
 const currentWinner = ref(-2)
 const battleJudges  = ref([])
+const lastOverlayState = ref('')  // JSON diff guard for /topic/battle/state
 
 const isFinal = ref(false)
+
+const hydrateOverlayFromState = async (state) => {
+  if (!state) return
+  const snapshot = JSON.stringify(state)
+  if (snapshot === lastOverlayState.value) return
+  lastOverlayState.value = snapshot
+
+  // Genre — update if changed
+  if (state.genreName !== undefined && !isSmoke.value) {
+    activeGenreName.value = state.genreName
+  }
+
+  // Pair — only update if changed (prevents re-triggering entrance animation)
+  if (state.currentPair?.left && !isSmoke.value) {
+    const pairChanged = leftName.value !== state.currentPair.left ||
+                        rightName.value !== state.currentPair.right
+    if (pairChanged) {
+      await updateBattlePair(state.currentPair)
+    }
+  }
+
+  // Phase — only update if changed
+  if (state.battlePhase && state.battlePhase !== battlePhase.value) {
+    battlePhase.value = state.battlePhase
+    showVotingIndicator.value = state.battlePhase === 'VOTING'
+  }
+
+  // Judges — only if list actually changed
+  if (state.judges?.length) {
+    const newJudgeIds = state.judges.map(j => j.id).sort().join(',')
+    const oldJudgeIds = (battleJudges.value?.judges ?? []).map(j => j.id).sort().join(',')
+    if (newJudgeIds !== oldJudgeIds) {
+      battleJudges.value = { judges: state.judges }
+    }
+  }
+}
 
 // Tracks the currently active genre name so stale phase WS messages from a
 // recently-deactivated genre can be discarded (same filter applied in BattleControl).
@@ -489,42 +526,10 @@ onMounted(async () => {
     currentWinner.value = side
   })
 
-  // Always subscribe to /topic/battle/state — detects genre switches in real-time
+  // Full-state snapshot — hydrates on mount, genre switch, and reconnect recovery
   const cState = createClient(); clients.push(cState)
-  subscribeToChannel(cState, '/topic/battle/state', async (msg) => {
-    if (!msg) return
-    const wasSmoke = isSmoke.value
-    if (msg.genreName !== undefined) {
-      isSmoke.value = genreNameIsSmoke(msg.genreName)
-      activeGenreName.value = msg.genreName
-    }
-    if (!isSmoke.value) {
-      if (msg.battlePhase !== undefined) battlePhase.value = msg.battlePhase
-      if (msg.judges?.length) updateBattleJudge({ judges: msg.judges })
-      // On format switch from smoke → standard, restore the pair from state
-      if (wasSmoke && !isSmoke.value && msg.currentPair?.left) {
-        await updateBattlePair(msg.currentPair)
-      } else if (!wasSmoke && msg.currentPair?.left) {
-        const pairChanged = msg.currentPair.left !== leftName.value || msg.currentPair.right !== rightName.value
-        const needsWinnerRestore = msg.battlePhase === 'REVEALED' || msg.battlePhase === 'DECIDED'
-        if (pairChanged) {
-          if (needsWinnerRestore && msg.bracket?.rounds) {
-            // Await so winner state is applied after entrance animation completes.
-            // Applies to both REVEALED and DECIDED (genre switch back to a completed genre).
-            await updateBattlePair(msg.currentPair)
-            restoreRevealedState(msg.bracket.rounds)
-          } else {
-            // Only animate if the pair actually changed; prevents re-animation on every bracket drag
-            updateBattlePair(msg.currentPair)
-          }
-        } else if (needsWinnerRestore && !leftWin.value && !rightWin.value) {
-          // Same pair but no winner shown — re-trigger entrance animation so panels reappear
-          // after a WAITING state caused by a genre switch through an IDLE genre.
-          await updateBattlePair(msg.currentPair)
-          if (msg.bracket?.rounds) restoreRevealedState(msg.bracket.rounds)
-        }
-      }
-    }
+  subscribeToChannel(cState, '/topic/battle/state', (msg) => {
+    hydrateOverlayFromState(msg)
   })
 })
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -36,32 +36,43 @@ const hydrateOverlayFromState = async (state) => {
   if (snapshot === lastOverlayState.value) return
   lastOverlayState.value = snapshot
 
-  // Genre — update if changed
-  if (state.genreName !== undefined && !isSmoke.value) {
+  // Derived mode — update isSmoke FIRST so subsequent guards are correct
+  if (state.genreName !== undefined) {
+    isSmoke.value = genreNameIsSmoke(state.genreName)
     activeGenreName.value = state.genreName
   }
 
-  // Pair — only update if changed (prevents re-triggering entrance animation)
-  if (state.currentPair?.left && !isSmoke.value) {
-    const pairChanged = leftName.value !== state.currentPair.left ||
-                        rightName.value !== state.currentPair.right
-    if (pairChanged) {
-      await updateBattlePair(state.currentPair)
+  // Standard-mode updates (guarded by !isSmoke to prevent corrupting smoke display)
+  if (!isSmoke.value) {
+    // Pair — only update if changed (prevents re-triggering entrance animation)
+    if (state.currentPair?.left) {
+      const pairChanged = leftName.value !== state.currentPair.left ||
+                          rightName.value !== state.currentPair.right
+      if (pairChanged) {
+        try {
+          await updateBattlePair(state.currentPair)
+        } catch (_) { /* animation interrupted — state is still consistent */ }
+      }
     }
-  }
 
-  // Phase — only update if changed
-  if (state.battlePhase && state.battlePhase !== battlePhase.value) {
-    battlePhase.value = state.battlePhase
-    showVotingIndicator.value = state.battlePhase === 'VOTING'
-  }
+    // Phase — only update if changed
+    if (state.battlePhase && state.battlePhase !== battlePhase.value) {
+      battlePhase.value = state.battlePhase
+      showVotingIndicator.value = state.battlePhase === 'VOTING'
+    }
 
-  // Judges — only if list actually changed
-  if (state.judges?.length) {
-    const newJudgeIds = state.judges.map(j => j.id).sort().join(',')
-    const oldJudgeIds = (battleJudges.value?.judges ?? []).map(j => j.id).sort().join(',')
-    if (newJudgeIds !== oldJudgeIds) {
-      battleJudges.value = { judges: state.judges }
+    // Judges — only if list actually changed
+    if (state.judges?.length) {
+      const newJudgeIds = state.judges.map(j => j.id).sort().join(',')
+      const oldJudgeIds = (battleJudges.value?.judges ?? []).map(j => j.id).sort().join(',')
+      if (newJudgeIds !== oldJudgeIds) {
+        battleJudges.value = { judges: state.judges }
+      }
+    }
+
+    // Restore winner visual state for completed battles without replaying animation
+    if ((state.battlePhase === 'REVEALED' || state.battlePhase === 'DECIDED') && state.bracket?.rounds) {
+      restoreRevealedState(state.bracket.rounds)
     }
   }
 }

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -36,6 +36,9 @@ const hydrateOverlayFromState = async (state) => {
   if (snapshot === lastOverlayState.value) return
   lastOverlayState.value = snapshot
 
+  // Capture old genre BEFORE updating — needed for pair-changed check below
+  const prevGenre = activeGenreName.value
+
   // Derived mode — update isSmoke FIRST so subsequent guards are correct
   if (state.genreName !== undefined) {
     isSmoke.value = genreNameIsSmoke(state.genreName)
@@ -44,11 +47,13 @@ const hydrateOverlayFromState = async (state) => {
 
   // Standard-mode updates (guarded by !isSmoke to prevent corrupting smoke display)
   if (!isSmoke.value) {
-    // Pair — only take action if the pair actually changed
+    // Pair — only take action if the pair or genre actually changed.
+    // Same names in a different genre is still a different battle.
     if (state.currentPair?.left) {
+      const genreChanged = state.genreName !== undefined && state.genreName !== prevGenre
       const pairChanged = leftName.value !== state.currentPair.left ||
                           rightName.value !== state.currentPair.right
-      if (pairChanged) {
+      if (pairChanged || genreChanged) {
         // New pair (genre switch, recovery) → run entrance animation
         try {
           await updateBattlePair(state.currentPair)

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -512,12 +512,31 @@ onMounted(async () => {
     const champion = msg.championName
     if (!champion) return
     // Check if the champion matches the current overlay pair. If not (e.g. stale pair
-    // from before a genre switch), fetch the authoritative pair from the backend.
+    // from before a genre switch), silently update the pair refs WITHOUT entrance
+    // animation — updateBattlePair would reset all visuals and race with the winner
+    // animation below.
     let side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
     if (side === -1) {
       const freshState = await getBattleState()
       if (freshState?.currentPair?.left) {
-        await updateBattlePair(freshState.currentPair)
+        // Silent pair update: set refs directly, no entrance animation
+        leftName.value    = freshState.currentPair.left
+        rightName.value   = freshState.currentPair.right
+        leftMembers.value  = freshState.currentPair.leftMembers  ?? []
+        rightMembers.value = freshState.currentPair.rightMembers ?? []
+        isFinal.value     = !!freshState.currentPair.isFinal
+        leftScore.value   = 0
+        rightScore.value  = 0
+        currentWinner.value = -2
+        leftWin.value     = false
+        rightWin.value    = false
+        leftReset.value   = false
+        rightReset.value  = false
+        vsAnim.value      = ''
+        winnerTagVisible.value = false
+        hideJudgeDecision.value = true
+        if (freshState.currentPair.left)  imageLeft.value  = await getImage(`${freshState.currentPair.left}.png`).catch(() => null)
+        if (freshState.currentPair.right) imageRight.value = await getImage(`${freshState.currentPair.right}.png`).catch(() => null)
         side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
       }
     }
@@ -525,8 +544,8 @@ onMounted(async () => {
     animToken++
     const myToken = animToken
     const ok = () => !unmounted && animToken === myToken
-    // Brief pause before reveal so entrance animation can complete if pair was just loaded
-    await useDelay().wait(350)
+    // Brief pause so panels are in DOM before winner animation
+    await useDelay().wait(150)
     if (!ok()) return
     hideJudgeDecision.value = true
     judgeAnim.value = ''

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -424,9 +424,13 @@ onMounted(async () => {
     // Ignore phase messages from a different (inactive) genre — stale WS from a
     // genre switch can arrive late and corrupt the current genre's phase display.
     if (msg.genre && activeGenreName.value && msg.genre !== activeGenreName.value) return
+    const prevPhase = battlePhase.value
     battlePhase.value = msg.phase
     showVotingIndicator.value = msg.phase === 'VOTING'
-    if (msg.phase === 'LOCKED') {
+    // Only run LOCKED reset on an actual phase transition — prevents re-broadcasts
+    // (e.g. BattleControl refresh → switchActiveGenreService) from re-triggering
+    // visual resets and entrance animations on the current pair.
+    if (msg.phase === 'LOCKED' && prevPhase !== 'LOCKED') {
       // Next was clicked — abort any in-progress score animation and reset overlay
       animToken++
       hideJudgeDecision.value = true

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -312,11 +312,11 @@ onMounted(async () => {
   wsClient.onConnect = () => {
 
     wsClient.subscribe('/topic/battle/state', (msg) => {
+      // Diff guard: compare raw body string to skip no-op updates.
+      // Avoids unnecessary JSON.parse + JSON.stringify round-trip on every message.
+      if (msg.body === lastBracketSnapshot.value) return
+      lastBracketSnapshot.value = msg.body
       const data = JSON.parse(msg.body)
-      // Diff guard: skip if snapshot hasn't changed
-      const snapshot = JSON.stringify(data)
-      if (snapshot === lastBracketSnapshot.value) return
-      lastBracketSnapshot.value = snapshot
       if (data?.bracket && (data.bracket.topSize || data.bracket.rounds)) {
         if (animRunning) {
           pendingBracket.value = data.bracket

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -4,6 +4,7 @@ import { getBattleState, getBracketState, getOverlayConfig } from '@/utils/api'
 import { createClient } from '@/utils/websocket'
 
 const bracketState   = ref(null)
+const lastBracketSnapshot = ref('')  // JSON diff guard
 const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
 const championReveal = ref(null)   // null = hidden; { genreName, championName } = showing
 const activePair     = ref(null)
@@ -312,6 +313,10 @@ onMounted(async () => {
 
     wsClient.subscribe('/topic/battle/state', (msg) => {
       const data = JSON.parse(msg.body)
+      // Diff guard: skip if snapshot hasn't changed
+      const snapshot = JSON.stringify(data)
+      if (snapshot === lastBracketSnapshot.value) return
+      lastBracketSnapshot.value = snapshot
       if (data?.bracket && (data.bracket.topSize || data.bracket.rounds)) {
         if (animRunning) {
           pendingBracket.value = data.bracket
@@ -412,6 +417,25 @@ onMounted(async () => {
         await runWinnerAnimation(winKey, pending)
       })()
     })
+
+    // Re-hydrate on reconnect — REST covers gap while WS was disconnected
+    getBattleState().then(state => {
+      if (state && (state.bracket?.topSize || state.bracket?.rounds)) {
+        const snapshot = JSON.stringify(state)
+        if (snapshot !== lastBracketSnapshot.value) {
+          lastBracketSnapshot.value = snapshot
+          if (state.bracket && !animRunning) {
+            bracketState.value = state.bracket
+          }
+          if (state.currentPair?.left) {
+            activePair.value = { left: state.currentPair.left, right: state.currentPair.right }
+          }
+          if (state.genreName) {
+            currentGenre.value = state.genreName
+          }
+        }
+      }
+    }).catch(() => {})
   }
   wsClient.activate()
 })

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -1,7 +1,7 @@
 <!-- BES-frontend/src/views/Chart.vue -->
 <script setup>
 import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
-import { getSmokeList, getOverlayConfig, getBattleJudges } from '@/utils/api'
+import { getSmokeList, getOverlayConfig, getBattleJudges, getBattleState } from '@/utils/api'
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket'
 import { useDelay } from '@/utils/utils'
 import { barHeightPct, findScoreGainers } from '@/utils/smokeChartHelpers'
@@ -33,6 +33,7 @@ const scorePopNames = ref(new Set())
 const clients = []
 const subscribedVoteTopics = new Set()
 let unmounted = false
+const lastChartState = ref('')  // JSON diff guard
 
 // ── Computed ────────────────────────────────────────────────────────────────
 const activeLeft  = computed(() => smokeParticipants.value[0] ?? null)
@@ -155,6 +156,26 @@ const updateScore = async (msg) => {
   showResult.value = false
 }
 
+// ── State hydration (used on WS connect + reconnect) ────────────────────────
+const hydrateChartFromState = (state) => {
+  if (!state) return
+  const snapshot = JSON.stringify(state)
+  if (snapshot === lastChartState.value) return
+  lastChartState.value = snapshot
+
+  // Phase — only update if changed
+  if (state.battlePhase && state.battlePhase !== battlePhase.value) {
+    battlePhase.value = state.battlePhase
+    if (state.battlePhase === 'LOCKED') showResult.value = false
+  }
+
+  // Judges — only if list actually changed
+  if (state.judges?.length) {
+    battleJudges.value = { judges: state.judges }
+    updateBattleJudge({ judges: state.judges })
+  }
+}
+
 // ── Mount ───────────────────────────────────────────────────────────────────
 onMounted(async () => {
   document.documentElement.classList.add('transparent-page')
@@ -189,6 +210,15 @@ onMounted(async () => {
     // When phase resets to LOCKED (Next was clicked), dismiss any visible result overlay
     if (msg.phase === 'LOCKED') showResult.value = false
   })
+
+  const cState = createClient(); clients.push(cState)
+  subscribeToChannel(cState, '/topic/battle/state', (msg) => {
+    hydrateChartFromState(msg)
+  })
+
+  // Initial hydration + reconnect recovery
+  const initialState = await getBattleState()
+  if (initialState) hydrateChartFromState(initialState)
 })
 
 onBeforeUnmount(() => {

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
-import { getParticipantScore, getParticipantFeedback, getResultsStatus, releaseResults, getParticipantRefs, getScoringCriteria } from '@/utils/api';
+import { getParticipantScore, getParticipantFeedback, getResultsStatus, releaseResults, getParticipantRefs, getScoringCriteria, setResolvedParticipants } from '@/utils/api';
 import DynamicTable from '@/components/DynamicTable.vue';
 import { useAuthStore } from '@/utils/auth';
 
@@ -43,11 +43,6 @@ const tieBreakerConfirmed = ref(false)
 const tbKey = computed(() =>
   `tb_${selectedEvent.value}_${selectedGenre.value}_${selectedTabulation.value}_${selectedTopN.value}`
 )
-const tbResolvedKey = computed(() => {
-  const n = selectedTopN.value === 'All' ? 0 : parseInt(selectedTopN.value.replace('Top ', ''))
-  return `tbResolved_${selectedEvent.value}_${selectedGenre.value}_${n}`
-})
-
 const saveTieBreaker = () => {
   localStorage.setItem(tbKey.value, JSON.stringify({
     winners: [...tieBreakerWinners.value],
@@ -69,7 +64,6 @@ const resetTieBreaker = () => {
   tieBreakerWinners.value = new Set()
   tieBreakerConfirmed.value = false
   localStorage.removeItem(tbKey.value)
-  localStorage.removeItem(tbResolvedKey.value)
 }
 
 const uniqueGenres = computed(() => {
@@ -193,13 +187,13 @@ const toggleWinner = (name) => {
   saveTieBreaker()
 }
 
-const confirmTieBreaker = () => {
+const confirmTieBreaker = async () => {
   if (tieBreakerWinners.value.size === spotsFromTie.value) {
     tieBreakerConfirmed.value = true
     saveTieBreaker()
-    // Save resolved names for BattleControl to consume
+    // Save resolved names server-side so BattleControl reads them from DB
     const resolved = finalRows.value.map(r => r.participantName)
-    localStorage.setItem(tbResolvedKey.value, JSON.stringify(resolved))
+    await setResolvedParticipants(selectedEvent.value, selectedGenre.value, resolved)
   }
 }
 

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -189,11 +189,15 @@ const toggleWinner = (name) => {
 
 const confirmTieBreaker = async () => {
   if (tieBreakerWinners.value.size === spotsFromTie.value) {
-    tieBreakerConfirmed.value = true
-    saveTieBreaker()
-    // Save resolved names server-side so BattleControl reads them from DB
+    // Save resolved names server-side FIRST so BattleControl can read them from DB.
+    // Only confirm locally after the API succeeds — prevents false-positive UI state
+    // when the server call fails silently.
     const resolved = finalRows.value.map(r => r.participantName)
-    await setResolvedParticipants(selectedEvent.value, selectedGenre.value, resolved)
+    const res = await setResolvedParticipants(selectedEvent.value, selectedGenre.value, resolved)
+    if (res && res.ok) {
+      tieBreakerConfirmed.value = true
+      saveTieBreaker()
+    }
   }
 }
 

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -327,7 +327,7 @@ public class BattleController {
     @PostMapping("/phase")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
     public ResponseEntity<?> setBattlePhase(@Valid @RequestBody SetBattlePhaseDto dto){
-        battleService.setBattlePhaseService(dto.getPhase());
+        battleService.setBattlePhaseService(dto.getPhase(), dto.getChampion());
         return ResponseEntity.ok(Map.of("phase", battleService.getBattlePhase()));
     }
 

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -41,6 +41,7 @@ import com.example.BES.dtos.battle.SetBracketStateDto;
 import com.example.BES.dtos.battle.SetJudgeDto;
 import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetBattleScoreDto;
+import com.example.BES.dtos.battle.SetResolvedParticipantsDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
 import com.example.BES.dtos.battle.SetVoteDto;
 import com.example.BES.dtos.battle.UpdateJudgeWeightageDto;
@@ -374,5 +375,13 @@ public class BattleController {
     @GetMapping("/state")
     public ResponseEntity<?> getBattleState() {
         return ResponseEntity.ok(battleService.getBattleStateService());
+    }
+
+    @PostMapping("/resolved-participants")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> setResolvedParticipants(@Valid @RequestBody SetResolvedParticipantsDto dto) {
+        battleService.setResolvedParticipants(
+            dto.getEventName(), dto.getGenreName(), dto.getParticipants());
+        return ResponseEntity.ok(Map.of("message", "Resolved participants saved"));
     }
 }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBattlePhaseDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBattlePhaseDto.java
@@ -7,7 +7,17 @@ public class SetBattlePhaseDto {
     @NotBlank @Size(max = 50)
     private String phase;
 
+    private String champion;
+
     public String getPhase() {
         return phase;
+    }
+
+    public String getChampion() {
+        return champion;
+    }
+
+    public void setChampion(String champion) {
+        this.champion = champion;
     }
 }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetResolvedParticipantsDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetResolvedParticipantsDto.java
@@ -1,0 +1,22 @@
+package com.example.BES.dtos.battle;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public class SetResolvedParticipantsDto {
+
+    @NotBlank
+    private String eventName;
+
+    @NotBlank
+    private String genreName;
+
+    private List<String> participants;
+
+    public String getEventName() { return eventName; }
+    public void setEventName(String eventName) { this.eventName = eventName; }
+    public String getGenreName() { return genreName; }
+    public void setGenreName(String genreName) { this.genreName = genreName; }
+    public List<String> getParticipants() { return participants; }
+    public void setParticipants(List<String> participants) { this.participants = participants; }
+}

--- a/BES/src/main/java/com/example/BES/models/BattleGenreState.java
+++ b/BES/src/main/java/com/example/BES/models/BattleGenreState.java
@@ -61,6 +61,9 @@ public class BattleGenreState {
     @Column(name = "smoke_list_json", columnDefinition = "TEXT")
     private String smokeListJson;
 
+    @Column(name = "resolved_participants_json", columnDefinition = "TEXT")
+    private String resolvedParticipantsJson;
+
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -359,6 +359,23 @@ public class BattleService {
     }
 
     @Transactional
+    public void setResolvedParticipants(String eventName, String genreName, List<String> participants) {
+        try {
+            BattleGenreState s = battleGenreStateRepository
+                .findByEventNameAndGenreName(eventName, genreName)
+                .orElse(new BattleGenreState());
+            s.setEventName(eventName);
+            s.setGenreName(genreName);
+            s.setResolvedParticipantsJson(
+                participants != null ? objectMapper.writeValueAsString(participants) : null);
+            s.setUpdatedAt(LocalDateTime.now());
+            battleGenreStateRepository.save(s);
+        } catch (Exception e) {
+            System.err.println("Failed to save resolved participants: " + e.getMessage());
+        }
+    }
+
+    @Transactional
     public void switchActiveGenreService(SetActiveGenreDto dto) {
         persistActiveState();
         BattleActiveGenre active = battleActiveGenreRepository.findById(1)
@@ -397,6 +414,14 @@ public class BattleService {
         state.put("currentPair", pair);
         state.put("battlePhase", battlePhase);
         state.put("champion", champion);
+        // Restore tie-breaker resolved list from DB if present
+        String resolvedJson = null;
+        if (activeEventName != null && activeGenreName != null) {
+            var st = battleGenreStateRepository
+                .findByEventNameAndGenreName(activeEventName, activeGenreName).orElse(null);
+            if (st != null) resolvedJson = st.getResolvedParticipantsJson();
+        }
+        state.put("resolvedParticipants", resolvedJson != null ? resolvedJson : "");
         synchronized (judges) {
             state.put("judges", new ArrayList<>(judges));
         }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -303,6 +303,10 @@ public class BattleService {
     public boolean isCurrentFinal() { return currentIsFinal; }
 
     public void setBattlePhaseService(String phase) {
+        setBattlePhaseService(phase, null);
+    }
+
+    public void setBattlePhaseService(String phase, String championName) {
         if ("REVEALED".equals(phase)) return;
         // Prevent starting a round with zero judges
         if ("LOCKED".equals(phase)) {
@@ -314,9 +318,13 @@ public class BattleService {
             }
         }
         battlePhase = phase;
+        if (championName != null) {
+            champion = championName;
+        }
         messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
             "phase", battlePhase,
-            "genre", activeGenreName != null ? activeGenreName : ""
+            "genre", activeGenreName != null ? activeGenreName : "",
+            "champion", champion != null ? champion : ""
         ));
         persistActiveState();
     }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -370,6 +370,12 @@ public class BattleService {
                 participants != null ? objectMapper.writeValueAsString(participants) : null);
             s.setUpdatedAt(LocalDateTime.now());
             battleGenreStateRepository.save(s);
+            // Broadcast updated full state so BattleControl in other tabs sees the change.
+            // Only broadcast if the update was for the currently active genre.
+            if (eventName != null && eventName.equals(activeEventName)
+                && genreName != null && genreName.equals(activeGenreName)) {
+                broadcastStateSnapshot();
+            }
         } catch (Exception e) {
             System.err.println("Failed to save resolved participants: " + e.getMessage());
         }

--- a/BES/src/main/resources/db/migration/V32__add_tiebreaker_to_battle_genre_state.sql
+++ b/BES/src/main/resources/db/migration/V32__add_tiebreaker_to_battle_genre_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE battle_genre_state ADD COLUMN resolved_participants_json TEXT;


### PR DESCRIPTION
## Summary

Closes #75. Replaces all localStorage-based battle state caching with DB-backed WebSocket state synchronization.

### Problem
BattleControl.vue used ~48 localStorage read/write operations to cache battle state (bracket pairings, phase, judges, champion, topSize, round index, tie-breaker lists). This caused:
- **Stale state across tabs** — localStorage not synced
- **Data loss on browser clear**
- **Race conditions** during genre switches
- **Disconnect fragility** — overlay/judge views showed stale data after WS disconnect

### Solution
The backend already persisted every battle mutation to `battle_genre_state` (DB) and broadcast full state snapshots via `/topic/battle/state`. This PR makes ALL battle views consume that WS feed.

### What changed

**Backend (5 files)**
- `V32` migration: new `resolved_participants_json` column
- `BattleGenreState.java`: new field
- `SetResolvedParticipantsDto.java`: new DTO for tie-breaker persistence
- `SetBattlePhaseDto.java`: added optional champion field — champion name now persisted on lock
- `BattleService.java`: resolved participants in state snapshot, save method, champion persistence on phase change, broadcast on save
- `BattleController.java`: `POST /resolved-participants` endpoint, champion passthrough

**Frontend (7 files)**
- **`BattleControl.vue`**: ~48 localStorage calls → 3 (nav state only). New `hydrateFromState` + `/topic/battle/state` WS subscription. Removed all localStorage helper functions and caching.
- **`BattleOverlay.vue`**: `hydrateOverlayFromState` with diff + genre-change detection. Entrance animation only on actual pair/genre change. Champion reveal fix.
- **`BattleJudge.vue`**: `/topic/battle/state` sub with diff, reconnect re-hydrate
- **`Chart.vue`**: `/topic/battle/state` sub with diff, reconnect re-hydrate
- **`BracketVisualization.vue`**: diff guard + reconnect re-hydrate
- **`Score.vue`**: localStorage tie-breaker → API call
- **`api.js`**: `setResolvedParticipants()`, champion support in `setBattlePhase()`

### Fixes included
- VS animation no longer replays on BattleControl refresh
- Real-time judge vote sync regardless of open order (`/topic/battle/judges` sub)
- Start Round button visible for subsequent rounds
- Round tab survives refresh (restored from `currentTop`)
- Champion buttons survive genre switch (diff guard race fix + champion persistence)
- Overlay champion reveal works across genre switches

### Design spec
See `docs/superpowers/specs/2026-06-05-battle-websocket-sync-design.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)