### PR TITLE
Show organiser username in navbar role badge (fixes #74)

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -54,7 +54,9 @@ const roleDisplay = computed(() => {
   }
   const label = labels[role.value]
   if (!label) return null
-  const name = (role.value === 'ROLE_JUDGE' && authStore.judgeName) ? authStore.judgeName : null
+  const name = (role.value === 'ROLE_JUDGE' && authStore.judgeName) ? authStore.judgeName
+    : (role.value === 'ROLE_ORGANISER' && authStore.user?.username) ? authStore.user.username
+    : null
   return { label, name }
 })
 


### PR DESCRIPTION
## What

Extends the navbar role badge to show the organiser's username alongside their role label, matching the existing pattern for judges.

Before: Organisers saw only "Organiser" in the navbar badge.
After: Organisers see "Organiser - username" (e.g., "Organiser - janesmith").

## Change

- `App.vue` — Extended `roleDisplay.name` computed to also pull `authStore.user.username` for `ROLE_ORGANISER` (judges continue to use `judgeName` from session)

No backend changes needed — `/api/v1/auth/me` already returns `username`.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)