### PR TITLE
feat: 7-to-Smoke session format timer with winner resolution

### DIFF
--- a/BES-frontend/src/components/LiveMatchPanel.vue
+++ b/BES-frontend/src/components/LiveMatchPanel.vue
@@ -8,10 +8,12 @@
  * Props are passed by the BattleControl orchestrator parent.
  * Every write action is emitted up for the parent to handle.
  */
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import BattleTimer from '@/components/BattleTimer.vue'
+import SmokeFormatTimer from '@/components/SmokeFormatTimer.vue'
 
-const battleTimerRef = ref(null)
+const battleTimerRef      = ref(null)
+const smokeFormatTimerRef = ref(null)
 
 const props = defineProps({
   selectedEvent:             { type: String,  required: true },
@@ -39,6 +41,7 @@ const props = defineProps({
   revealActive:              { type: Boolean, default: false },
   activeRoundIdx:            { type: Number,  default: 0 },
   recoveryTimer:             { type: Object,  default: null },
+  recoveryFormatTimer:       { type: Object,  default: null },
   guestsForCurrentGenre:     { type: Array,   default: () => [] },
 })
 
@@ -57,14 +60,62 @@ const emit = defineEmits([
   'set-winner',
   'request-start-at',
   'request-start-all',
+  'force-smoke-winner',
 ])
+
+// ── Format timer winner picker ───────────────────────────────────
+const showSmokeWinnerPicker  = ref(false)
+const smokeWinnerCandidates  = ref([])   // [{ name, score }]
+const autoSmokeWinner        = ref(null) // set when single clear top scorer
 
 function handleGetScore() {
   battleTimerRef.value?.resetTimer()
-  // Brief pause — let the timer clear before the judge result arrives,
-  // so the two events don't rush over each other.
   setTimeout(() => emit('get-score'), 400)
 }
+
+/**
+ * Called by BattleControl after scoring completes with a fresh battler list from
+ * the server. Only acts when the format timer is actually expired.
+ */
+function checkFormatWinnerIfExpired(battlers) {
+  if (!smokeFormatTimerRef.value?.isExpired) return
+  const filtered = (battlers ?? []).filter(b => b?.name)
+  if (!filtered.length) return
+  const maxScore = Math.max(...filtered.map(b => b.score ?? 0))
+  const topBattlers = filtered.filter(b => (b.score ?? 0) === maxScore)
+  if (topBattlers.length === 1) {
+    emit('force-smoke-winner', topBattlers[0])
+  } else {
+    smokeWinnerCandidates.value = filtered
+    autoSmokeWinner.value = null
+    showSmokeWinnerPicker.value = true
+  }
+}
+
+function isFormatTimerExpired() {
+  return !!smokeFormatTimerRef.value?.isExpired
+}
+
+function confirmSmokeWinner(battler) {
+  showSmokeWinnerPicker.value = false
+  emit('force-smoke-winner', battler)
+}
+
+/** Called by BattleControl after the existing Start Round confirmation is accepted. */
+function triggerFormatTimerStart() {
+  smokeFormatTimerRef.value?.autoStartIfIdle()
+}
+
+// Stop the format timer when the smoke battle is decided (natural 7-smoke or format expiry)
+watch(() => props.battlePhase, (phase) => {
+  if (phase === 'DECIDED' && props.isSmoke) {
+    smokeFormatTimerRef.value?.resetTimer()
+  }
+})
+
+const formatTimerSelectedMinutes = computed(() => smokeFormatTimerRef.value?.selectedMinutes ?? 30)
+
+defineExpose({ triggerFormatTimerStart, formatTimerSelectedMinutes, isFormatTimerExpired, checkFormatWinnerIfExpired })
 
 // ── Genre status dot ─────────────────────────────────────────────
 // Returns 'champion' | 'active' | 'idle'
@@ -409,6 +460,15 @@ const viewedPairList = computed(() => {
           :phase="battlePhase"
           :stomp-client="stompClient"
           :recovery-state="recoveryTimer"
+        />
+      </div>
+
+      <!-- 7-to-Smoke format timer (session-level countdown) -->
+      <div v-if="isSmoke" class="mb-4">
+        <SmokeFormatTimer
+          ref="smokeFormatTimerRef"
+          :stomp-client="stompClient"
+          :recovery-state="recoveryFormatTimer"
         />
       </div>
 
@@ -918,6 +978,50 @@ const viewedPairList = computed(() => {
       </div>
     </div>
   </div>
+
+  <!-- ── Smoke Format Winner Picker Modal ──────────────────────── -->
+  <Teleport to="body">
+    <Transition name="modal-fade">
+      <div v-if="showSmokeWinnerPicker" class="smoke-picker-overlay" @click.self="showSmokeWinnerPicker = false">
+        <div class="smoke-picker-modal">
+          <div class="section-rule mb-4">
+            <span class="section-rule-label">BATTLE HAS ENDED</span>
+            <span class="section-rule-line"></span>
+          </div>
+
+          <p class="type-label text-content-muted mb-4" style="font-size:11px;letter-spacing:0.12em">
+            {{ autoSmokeWinner ? 'CLEAR WINNER BY SCORE — CONFIRM TO DECLARE CHAMPION' : 'SCORES ARE TIED — SELECT THE FORMAT WINNER' }}
+          </p>
+
+          <div class="flex flex-col gap-2 mb-5">
+            <button
+              v-for="b in smokeWinnerCandidates"
+              :key="b.name"
+              class="smoke-picker-row"
+              :class="{
+                'smoke-picker-row-top': autoSmokeWinner?.name === b.name,
+                'smoke-picker-row-tied': !autoSmokeWinner && smokeWinnerCandidates.filter(x => x.score === Math.max(...smokeWinnerCandidates.map(x => x.score ?? 0))).some(x => x.name === b.name)
+              }"
+              @click="confirmSmokeWinner(b)"
+            >
+              <span class="type-body flex-1 truncate">{{ b.name }}</span>
+              <span class="smoke-score-badge">{{ b.score ?? 0 }} <span style="font-size:9px;opacity:0.6">SMK</span></span>
+              <span v-if="autoSmokeWinner?.name === b.name" class="type-label text-accent ml-2" style="font-size:9px">HIGHEST</span>
+              <i class="pi pi-chevron-right text-content-muted text-xs ml-1"></i>
+            </button>
+          </div>
+
+          <button
+            class="para-chip-sm px-4 py-2 type-label text-content-muted hover:text-content-primary w-full text-center"
+            @click="showSmokeWinnerPicker = false"
+          >
+            CANCEL — CONTINUE BATTLE
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+
 </template>
 
 <style scoped>
@@ -1112,5 +1216,72 @@ button.border-accent:hover:not(:disabled) {
 /* Pi icon default */
 i.pi {
   font-style: normal;
+}
+
+/* ── Smoke Format Winner Picker ─────────────────────────────── */
+.smoke-picker-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 16px;
+}
+
+.smoke-picker-modal {
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  padding: 24px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.smoke-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  cursor: pointer;
+  transition: background 0.15s;
+  width: 100%;
+  text-align: left;
+  min-height: 52px;
+}
+
+.smoke-picker-row:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.smoke-picker-row-top {
+  border-color: color-mix(in srgb, var(--accent-color) 40%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 6%, transparent);
+}
+
+.smoke-picker-row-tied {
+  border-color: rgba(251, 191, 36, 0.4);
+  background: rgba(251, 191, 36, 0.06);
+}
+
+.smoke-score-badge {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+  color: var(--accent-color, #fff);
+  flex-shrink: 0;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.2s;
+}
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/BES-frontend/src/components/SmokeFormatTimer.vue
+++ b/BES-frontend/src/components/SmokeFormatTimer.vue
@@ -132,8 +132,8 @@ function publishState() {
         totalDuration: totalDuration.value,
         expired: isExpired.value
       })
-    }).catch(() => {})
-  } catch (_) {}
+    }).catch(() => { /* fire-and-forget */ })
+  } catch (_) { /* ignore publish errors */ }
 }
 
 function recoverFromState(state) {
@@ -172,7 +172,7 @@ onMounted(() => {
       try {
         const msg = JSON.parse(raw.body)
         if (msg) recoverFromState(msg)
-      } catch (_) {}
+      } catch (_) { /* ignore malformed WS messages */ }
     })
   }
   if (props.stompClient.connected) {

--- a/BES-frontend/src/components/SmokeFormatTimer.vue
+++ b/BES-frontend/src/components/SmokeFormatTimer.vue
@@ -1,0 +1,363 @@
+<script setup>
+/**
+ * SmokeFormatTimer.vue
+ *
+ * Session-level countdown for 7-to-Smoke format.
+ *   - Operator selects a duration (30m / 45m preset, or custom)
+ *   - Timer auto-starts when the first round begins (autoStartIfIdle() called from LiveMatchPanel)
+ *   - Stays EXPIRED — operator must manually reset
+ *   - Expiry flags state so Get Score shows the winner picker instead of normal flow
+ */
+import { ref, computed, onBeforeUnmount, onMounted, watch } from 'vue'
+
+const props = defineProps({
+  stompClient:   { type: Object, default: null },
+  recoveryState: { type: Object, default: null }
+})
+
+const emit = defineEmits(['expired'])
+
+// ── State ────────────────────────────────────────────────────────────
+const timerState       = ref('IDLE')   // 'IDLE' | 'RUNNING' | 'EXPIRED'
+const selectedMinutes  = ref(30)       // chosen duration — used when autoStartIfIdle fires
+const showCustomInput  = ref(false)    // toggle custom input visibility
+const customMinutes    = ref('')
+const isCustomSelected = ref(false)    // true when a custom duration chip is active
+const totalDuration    = ref(0)
+const timeLeft         = ref(0)
+
+let intervalId = null
+
+// ── Computed ─────────────────────────────────────────────────────────
+const isIdle    = computed(() => timerState.value === 'IDLE')
+const isRunning = computed(() => timerState.value === 'RUNNING')
+const isExpired = computed(() => timerState.value === 'EXPIRED')
+
+const displayTime = computed(() => {
+  const m = Math.floor(timeLeft.value / 60)
+  const s = timeLeft.value % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+})
+
+const progressPct = computed(() => {
+  if (totalDuration.value === 0) return 0
+  return (timeLeft.value / totalDuration.value) * 100
+})
+
+const isWarning = computed(() => isRunning.value && timeLeft.value <= 300) // last 5 min
+
+// ── Timer control ────────────────────────────────────────────────────
+function startWithDuration(seconds) {
+  clearInterval(intervalId)
+  intervalId = null
+  timerState.value = 'RUNNING'
+  totalDuration.value = seconds
+  timeLeft.value = seconds
+  publishState()
+  intervalId = setInterval(() => {
+    timeLeft.value--
+    publishState()
+    if (timeLeft.value <= 0) expireTimer()
+  }, 1000)
+}
+
+function expireTimer() {
+  clearInterval(intervalId)
+  intervalId = null
+  timerState.value = 'EXPIRED'
+  timeLeft.value = 0
+  publishState()
+  emit('expired')
+}
+
+function resetTimer() {
+  clearInterval(intervalId)
+  intervalId = null
+  timerState.value = 'IDLE'
+  totalDuration.value = 0
+  timeLeft.value = 0
+  selectedMinutes.value = 30
+  showCustomInput.value = false
+  customMinutes.value = ''
+  isCustomSelected.value = false
+  publishState()
+}
+
+function selectPreset(minutes) {
+  selectedMinutes.value = minutes
+  showCustomInput.value = false
+  customMinutes.value = ''
+  isCustomSelected.value = false
+}
+
+function toggleCustomInput() {
+  showCustomInput.value = !showCustomInput.value
+  if (!showCustomInput.value) customMinutes.value = ''
+}
+
+function confirmCustom() {
+  const mins = parseInt(customMinutes.value, 10)
+  if (!mins || mins <= 0) return
+  selectedMinutes.value = mins
+  showCustomInput.value = false
+  customMinutes.value = ''
+  isCustomSelected.value = true
+}
+
+function removeCustom() {
+  isCustomSelected.value = false
+  selectedMinutes.value = 30
+  customMinutes.value = ''
+  showCustomInput.value = false
+}
+
+/** Called from LiveMatchPanel when the first smoke round starts. Only fires if IDLE. */
+function autoStartIfIdle() {
+  if (!isIdle.value) return
+  startWithDuration(selectedMinutes.value * 60)
+}
+
+defineExpose({ isExpired, autoStartIfIdle, resetTimer, selectedMinutes })
+
+// ── Backend sync ─────────────────────────────────────────────────────
+function publishState() {
+  try {
+    fetch('/api/v1/battle/format-timer', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        running: isRunning.value,
+        timeLeft: timeLeft.value,
+        totalDuration: totalDuration.value,
+        expired: isExpired.value
+      })
+    }).catch(() => {})
+  } catch (_) {}
+}
+
+function recoverFromState(state) {
+  if (!state) return
+  if (timerState.value !== 'IDLE') return
+
+  if (state.expired) {
+    timerState.value = 'EXPIRED'
+    timeLeft.value = 0
+    totalDuration.value = state.totalDuration || 0
+    return
+  }
+  if (!state.running || (state.timeLeft ?? 0) <= 0) return
+
+  timerState.value = 'RUNNING'
+  totalDuration.value = state.totalDuration || state.timeLeft
+  timeLeft.value = state.timeLeft
+  selectedMinutes.value = Math.round((state.totalDuration || state.timeLeft) / 60)
+
+  clearInterval(intervalId)
+  intervalId = setInterval(() => {
+    timeLeft.value--
+    publishState()
+    if (timeLeft.value <= 0) expireTimer()
+  }, 1000)
+}
+
+watch(() => props.recoveryState, (state) => { if (state) recoverFromState(state) }, { immediate: true })
+
+let fmtSub = null
+onMounted(() => {
+  if (!props.stompClient) return
+  const doSubscribe = () => {
+    if (fmtSub) return
+    fmtSub = props.stompClient.subscribe('/topic/battle/format-timer', (raw) => {
+      try {
+        const msg = JSON.parse(raw.body)
+        if (msg) recoverFromState(msg)
+      } catch (_) {}
+    })
+  }
+  if (props.stompClient.connected) {
+    doSubscribe()
+  } else {
+    const prev = props.stompClient.onConnect
+    // eslint-disable-next-line vue/no-mutating-props
+    props.stompClient.onConnect = () => { if (prev) prev(); doSubscribe() }
+  }
+})
+
+onBeforeUnmount(() => {
+  if (fmtSub) { fmtSub.unsubscribe(); fmtSub = null }
+  clearInterval(intervalId)
+  intervalId = null
+})
+
+if (props.recoveryState) recoverFromState(props.recoveryState)
+</script>
+
+<template>
+  <div class="select-none">
+    <div class="section-rule w-full mb-3">
+      <span class="section-rule-label">FORMAT TIMER</span>
+      <span class="section-rule-line"></span>
+    </div>
+
+    <!-- IDLE / EXPIRED: duration selector — shown in both states so no manual reset needed -->
+    <div v-if="isIdle || isExpired" class="flex flex-col gap-2">
+      <!-- Expired hint -->
+      <div v-if="isExpired" class="flex items-center gap-2 mb-1">
+        <span class="expired-dot"></span>
+        <span class="type-label text-content-muted" style="font-size:10px;letter-spacing:0.14em">BATTLE HAS ENDED · SELECT DURATION FOR NEXT SESSION</span>
+      </div>
+
+      <div class="flex items-center gap-2 flex-wrap">
+        <!-- Preset chips -->
+        <button
+          v-for="m in [30, 45]"
+          :key="m"
+          class="para-chip-sm px-3 py-2 type-body transition-all duration-150 active:scale-95"
+          :class="selectedMinutes === m && !showCustomInput && !isCustomSelected
+            ? 'preset-selected text-accent'
+            : 'text-content-muted hover:text-content-primary hover:border-white/20'"
+          @click="selectPreset(m)"
+        >
+          {{ m }}m
+        </button>
+
+        <!-- Custom chip: shows selected duration with × remove when confirmed, otherwise shows CUSTOM toggle -->
+        <div
+          v-if="isCustomSelected"
+          class="para-chip-sm px-3 py-2 type-body preset-selected text-accent flex items-center gap-2"
+        >
+          <span>{{ selectedMinutes }}m</span>
+          <button
+            class="leading-none text-accent/60 hover:text-accent transition-colors active:scale-95"
+            style="font-size:15px;line-height:1"
+            @click="removeCustom"
+            title="Remove custom duration"
+          >×</button>
+        </div>
+        <button
+          v-else
+          class="para-chip-sm px-3 py-2 type-body transition-all duration-150 active:scale-95"
+          :class="showCustomInput
+            ? 'preset-selected text-accent'
+            : 'text-content-muted hover:text-content-primary hover:border-white/20'"
+          @click="toggleCustomInput"
+        >
+          CUSTOM
+        </button>
+      </div>
+
+      <!-- Custom input — shown when CUSTOM chip is toggled -->
+      <div v-if="showCustomInput" class="flex items-center gap-2 mt-1">
+        <input
+          v-model="customMinutes"
+          type="number"
+          min="1"
+          max="180"
+          placeholder="min"
+          class="custom-input"
+          @keydown.enter="confirmCustom"
+          autofocus
+        />
+        <button
+          class="para-chip-sm px-3 py-2 type-body transition-all duration-150 active:scale-95"
+          :class="customMinutes ? 'preset-selected text-accent' : 'text-content-muted opacity-40 pointer-events-none'"
+          @click="confirmCustom"
+        >
+          SET
+        </button>
+      </div>
+
+      <!-- Hint -->
+      <span class="type-label text-content-muted" style="font-size:10px;letter-spacing:0.14em">
+        {{ selectedMinutes }}M SELECTED · STARTS WITH FIRST ROUND
+      </span>
+    </div>
+
+    <!-- RUNNING: countdown + progress + reset -->
+    <div v-else-if="isRunning" class="flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <span
+          class="format-countdown transition-colors duration-300"
+          :class="isWarning ? 'text-amber-400' : 'text-content-primary'"
+        >
+          {{ displayTime }}
+        </span>
+        <button
+          class="para-chip-sm px-3 py-1 type-label text-content-muted hover:text-content-primary"
+          @click="resetTimer"
+        >
+          RESET
+        </button>
+      </div>
+      <div class="progress-track w-full" :class="isWarning ? 'progress-track-warning' : ''">
+        <div
+          class="progress-fill h-full transition-all duration-1000 ease-linear"
+          :class="isWarning ? 'bg-amber-400' : 'bg-[color:var(--accent-color)]'"
+          :style="{ width: progressPct + '%' }"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.expired-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ef4444;
+  box-shadow: 0 0 6px #ef4444;
+  flex-shrink: 0;
+}
+
+.preset-selected {
+  border-color: color-mix(in srgb, var(--accent-color) 55%, transparent);
+}
+
+.format-countdown {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 22px;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.progress-track {
+  height: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.progress-track-warning {
+  background: rgba(251, 191, 36, 0.12);
+}
+
+.progress-fill {
+  border-radius: 0;
+}
+
+.custom-input {
+  width: 64px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--content-primary, #fff);
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  padding: 6px 8px;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+  outline: none;
+  text-align: center;
+}
+
+.custom-input:focus {
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.custom-input::-webkit-outer-spin-button,
+.custom-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+</style>

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -40,7 +40,9 @@ const showRecoveryBanner = ref(false)
 const recoveryState      = ref(null)
 const genreChampions     = ref({})
 const lastAppliedState = ref('')  // JSON string of last applied /topic/battle/state snapshot
-const recoveredTimer = ref(null)   // { running, timeLeft, totalDuration } from backend state
+const recoveredTimer       = ref(null)   // { running, timeLeft, totalDuration } from backend state
+const recoveredFormatTimer = ref(null)   // { running, timeLeft, totalDuration, expired } from backend state
+const lmpRef               = ref(null)   // ref to LiveMatchPanel — for triggerFormatTimerStart
 const lastSetWinnerTime = ref(0)   // timestamp of last local setWinner call (prevents stale WS overwrites)
 let setWinnerCooldown = null       // timeout handle for clearing the cooldown
 
@@ -162,7 +164,10 @@ const hydrateFromState = (state) => {
     } catch (_) { resolvedParticipants.value = null }
   }
   if (state.timer) {
-    recoveredTimer.value = state.timer  // { running, timeLeft, totalDuration }
+    recoveredTimer.value = state.timer
+  }
+  if (state.formatTimer) {
+    recoveredFormatTimer.value = state.formatTimer
   }
 }
 
@@ -236,6 +241,7 @@ const confirmStartAt = async () => {
   if (!pendingStartAt.value) return
   if (pendingStartAt.value.smoke) {
     pendingStartAt.value = null
+    lmpRef.value?.triggerFormatTimerStart()
     await initiateBattlePair()
     return
   }
@@ -1395,6 +1401,14 @@ const submitGetScore = async () => {
     currentWinner.value = Number(data.winner)
     await setBattlePhase('REVEALED')
     battlePhase.value = 'REVEALED'
+    // If format timer expired, fetch fresh battler scores (guaranteed up-to-date)
+    // and resolve the session winner. Avoids race with WS-delivered rounds update.
+    if (lmpRef.value?.isFormatTimerExpired?.()) {
+      const freshState = await getBattleState()
+      if (freshState?.smokeBattlers?.length) {
+        lmpRef.value.checkFormatWinnerIfExpired(freshState.smokeBattlers)
+      }
+    }
     return
   }
   if (currentBattle.value.length === 0) return
@@ -1442,7 +1456,15 @@ const lockChampion = async () => {
   genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
   await setBattlePhase('DECIDED', winner)
   battlePhase.value = 'DECIDED'
+}
 
+const handleForceSmokeWinner = async (battler) => {
+  if (!battler?.name) return
+  genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: battler.name }
+  await setBattlePhase('DECIDED', battler.name)
+  battlePhase.value = 'DECIDED'
+  await revealChampion(selectedGenre.value, battler.name)
+  revealActive.value = true
 }
 
 const unlockChampion = async () => {
@@ -2592,6 +2614,7 @@ onUnmounted(() => {
 
     <!-- Live Match panel — rendered for all roles, acts as orchestrator -->
     <LiveMatchPanel
+      ref="lmpRef"
       :selectedEvent="selectedEvent"
       :selectedGenre="selectedGenre"
       :uniqueGenres="uniqueGenres"
@@ -2617,6 +2640,7 @@ onUnmounted(() => {
       :revealActive="revealActive"
       :activeRoundIdx="viewedRoundIdx"
       :recoveryTimer="recoveredTimer"
+      :recoveryFormatTimer="recoveredFormatTimer"
       :guestsForCurrentGenre="guestsForCurrentGenre"
       @request-genre-change="requestGenreChange"
       @open-voting="openVoting"
@@ -2629,6 +2653,7 @@ onUnmounted(() => {
       @unlock-champion="unlockChampion"
       @set-round="(idx) => { viewedRoundIdx = idx }"
       @start-round="handleEmceeStartRound"
+      @force-smoke-winner="handleForceSmokeWinner"
       @set-winner="(roundKey, matchIdx, slotIdx) => requestWin(roundKey, matchIdx, slotIdx)"
       @request-start-at="(top, pairList, matchIdx) => requestStartAt(top, pairList, matchIdx)"
       @request-start-all="(top, pairList) => requestStartAll(top, pairList)"
@@ -2670,7 +2695,7 @@ onUnmounted(() => {
     <!-- Start-from-here confirmation modal -->
     <Transition name="fade">
       <div v-if="pendingStartAt" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-        <div class="card-hover p-6 max-w-md w-full mx-4 relative max-h-[90vh] overflow-y-auto">
+        <div class="confirm-modal card-hover p-6 max-w-md w-full mx-4 relative max-h-[90vh] overflow-y-auto">
           <div class="corner-bar-tl"></div>
           <div class="type-page-title text-lg mb-4">Confirm Battle Round</div>
 
@@ -2703,6 +2728,17 @@ onUnmounted(() => {
               <span class="text-content-primary">{{ pendingStartAt.player1 }}</span>
               <span class="text-content-muted mx-2">vs</span>
               <span class="text-content-primary">{{ pendingStartAt.player2 }}</span>
+            </p>
+
+            <div class="section-rule mb-3">
+              <span class="section-rule-label">Format Timer</span>
+              <div class="section-rule-line"></div>
+            </div>
+            <p class="type-body text-content-primary mb-1">
+              {{ lmpRef?.formatTimerSelectedMinutes ?? 30 }} min
+            </p>
+            <p class="type-label text-content-muted mb-3" style="font-size:10px;letter-spacing:0.12em">
+              Timer auto-starts on first round. Change duration in the Format Timer panel before confirming.
             </p>
           </template>
 
@@ -2737,7 +2773,7 @@ onUnmounted(() => {
             <p v-else class="type-body text-content-primary mb-4">All matches in this round will be started from the beginning.</p>
           </template>
 
-          <div class="flex gap-3 justify-end">
+          <div class="confirm-modal-actions flex gap-3 justify-end">
             <button @click="cancelStartAt" class="para-chip-sm px-4 py-2 type-label transition-all">Cancel</button>
             <button @click="confirmStartAt" class="para-chip-sm px-4 py-2 type-label bg-accent transition-all" :disabled="!(battleJudges?.judges ?? []).length">
               <i class="pi pi-play text-xs mr-1.5"></i>Start Round
@@ -2916,4 +2952,27 @@ onUnmounted(() => {
 .recovery-fade-leave-active { transition: opacity 0.3s ease; }
 .recovery-fade-enter-from,
 .recovery-fade-leave-to { opacity: 0; }
+
+/* ── Confirm modal — mobile responsiveness ───────────────────── */
+@media (max-width: 640px) {
+  .confirm-modal {
+    padding: 20px 16px;
+    margin-left: 8px;
+    margin-right: 8px;
+  }
+
+  .confirm-modal-actions {
+    flex-direction: column-reverse;
+    gap: 10px;
+  }
+
+  .confirm-modal-actions button {
+    width: 100%;
+    justify-content: center;
+    padding-top: 14px;
+    padding-bottom: 14px;
+    font-size: 13px;
+    letter-spacing: 0.12em;
+  }
+}
 </style>

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -126,10 +126,14 @@ let animToken = 0
 // animation fires after LOCKED confirms and panels mount (isBlank flips false).
 let pendingEntrance = false
 
-// ── Broadcast timer (BattleTimer countdown) ──────────────────────
+// ── Broadcast timer (per-round BattleTimer countdown) ────────────
 const timerState    = ref({ running: false, timeLeft: 0, totalDuration: 0 })
 const showTimer     = ref(false)
 const timerFinished = ref(false)
+
+// ── Format timer (7-to-Smoke session-level countdown) ────────────
+const formatTimerState   = ref({ running: false, timeLeft: 0, totalDuration: 0, expired: false })
+const showFormatTimer    = ref(false)
 
 // Start from URL param; updated in real-time when backend state reports a different genre
 const isSmoke = ref(route.query.isSmoke === 'true')
@@ -600,6 +604,13 @@ onMounted(async () => {
       }, 600)
     }
   })
+
+  // Format timer (session-level 7-to-Smoke countdown)
+  const cFormatTimer = createClient(); clients.push(cFormatTimer)
+  subscribeToChannel(cFormatTimer, '/topic/battle/format-timer', (msg) => {
+    formatTimerState.value = msg
+    showFormatTimer.value = msg.running || msg.expired
+  })
 })
 
 onBeforeUnmount(() => {
@@ -635,6 +646,35 @@ onUnmounted(() => {
           <div class="timer-countdown" :class="{ 'timer-text-warning': timerState.timeLeft <= 10 }">
             {{ Math.floor(timerState.timeLeft / 60) }}:{{ String(timerState.timeLeft % 60).padStart(2, '0') }}
           </div>
+        </div>
+      </div>
+    </Transition>
+
+    <!-- Format timer — full-width bar at bottom, smoke mode only.
+         Per-round match timer stays at top-center; this lives at the bottom
+         so both can coexist. Chart content gets padding-bottom to clear it. -->
+    <Transition name="fmt-bar-enter">
+      <div v-if="isSmoke && showFormatTimer" class="fmt-bar" :class="{ 'fmt-bar-expired': formatTimerState.expired }">
+        <!-- Progress fill behind everything -->
+        <div
+          v-if="!formatTimerState.expired"
+          class="fmt-bar-fill"
+          :class="{ 'fmt-bar-fill-warning': formatTimerState.timeLeft <= 300 }"
+          :style="{ width: (formatTimerState.totalDuration > 0 ? (formatTimerState.timeLeft / formatTimerState.totalDuration) * 100 : 0) + '%' }"
+        ></div>
+        <!-- Text overlay -->
+        <div class="fmt-bar-inner">
+          <span
+            class="fmt-bar-time"
+            :class="{
+              'fmt-bar-time-warning': !formatTimerState.expired && formatTimerState.timeLeft <= 300,
+              'fmt-bar-time-expired': formatTimerState.expired
+            }"
+          >
+            {{ formatTimerState.expired
+              ? 'BATTLE HAS ENDED'
+              : (Math.floor(formatTimerState.timeLeft / 60) + ':' + String(formatTimerState.timeLeft % 60).padStart(2, '0')) }}
+          </span>
         </div>
       </div>
     </Transition>
@@ -854,7 +894,7 @@ onUnmounted(() => {
          SMOKE MODE  (isSmoke = true)
     ═══════════════════════════════════════════════════ -->
     <template v-else>
-      <Chart />
+      <Chart :bottom-pad="showFormatTimer ? 52 : 0" />
     </template>
 
   </div>
@@ -1587,6 +1627,74 @@ body.transparent-page #app {
 .timer-enter-leave-active { animation: timer-slide-out 200ms ease-in; }
 @keyframes timer-slide-in { from { opacity: 0; transform: translateX(-50%) translateY(-100%); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }
 @keyframes timer-slide-out { from { opacity: 1; transform: translateX(-50%) translateY(0); } to { opacity: 0; transform: translateX(-50%) translateY(-100%); } }
+
+/* ── Format timer — full-width bottom bar (smoke mode only) ─────── */
+/* Per-round match timer lives at top-center (narrow centered bar). */
+/* This bar spans the full width at the bottom and is taller, so   */
+/* the two are clearly different in size, position, and purpose.   */
+.fmt-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 52px;
+  z-index: 100;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.82);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+.fmt-bar-expired {
+  border-top-color: rgba(239, 68, 68, 0.4);
+  background: rgba(20, 0, 0, 0.88);
+}
+/* Progress fill sweeps from left — sits behind text layer */
+.fmt-bar-fill {
+  position: absolute;
+  inset: 0;
+  background: var(--accent-color, #fff);
+  opacity: 0.07;
+  transition: width 1s linear;
+  transform-origin: left;
+}
+.fmt-bar-fill-warning {
+  background: #fbbf24;
+  opacity: 0.10;
+}
+/* Text layer — label + time centred vertically */
+.fmt-bar-inner {
+  position: relative;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+.fmt-bar-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.30em;
+  color: rgba(255, 255, 255, 0.30);
+  line-height: 1;
+}
+.fmt-bar-time {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 28px;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.80);
+  font-variant-numeric: tabular-nums;
+}
+.fmt-bar-time-warning { color: #fbbf24; }
+.fmt-bar-time-expired {
+  color: #ef4444;
+  text-shadow: 0 0 12px rgba(239, 68, 68, 0.5);
+  animation: fmt-pulse 1.2s ease-in-out infinite alternate;
+}
+@keyframes fmt-pulse { from { opacity: 1; } to { opacity: 0.5; } }
+.fmt-bar-enter-enter-active { transition: transform 300ms cubic-bezier(0.22, 0.61, 0.36, 1), opacity 300ms; }
+.fmt-bar-enter-leave-active { transition: transform 200ms ease-in, opacity 200ms; }
+.fmt-bar-enter-enter-from, .fmt-bar-enter-leave-to { transform: translateY(100%); opacity: 0; }
 @keyframes timer-pulse-bar { from { opacity: 0.6; } to { opacity: 1; } }
 @keyframes timer-pulse-text { from { opacity: 0.7; transform: scale(1); } to { opacity: 1; transform: scale(1.03); } }
 

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -6,6 +6,10 @@ import { createClient, subscribeToChannel, deactivateClient } from '@/utils/webs
 import { useDelay } from '@/utils/utils'
 import { barHeightPct, findScoreGainers } from '@/utils/smokeChartHelpers'
 
+const props = defineProps({
+  bottomPad: { type: Number, default: 0 }
+})
+
 // ── Overlay config ──────────────────────────────────────────────────────────
 const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
 
@@ -172,6 +176,29 @@ const updateScore = async (msg) => {
   }
 }
 
+// ── Champion helper (used by both WS paths) ──────────────────────────────────
+const showChampionFor = async (name) => {
+  if (!name || showChampion.value) return
+  champName.value = name
+  const idx = smokeParticipants.value.findIndex(p => p.name === name)
+  champColor.value = idx === 0
+    ? overlayConfig.value.leftColor
+    : idx === 1
+      ? overlayConfig.value.rightColor
+      : overlayConfig.value.leftColor
+  // If result overlay is still showing, wait for updateScore to clear it first,
+  // then add the same 400ms pause as the natural 7-smoke champion path.
+  if (showResult.value) {
+    while (showResult.value && !unmounted) {
+      await useDelay().wait(50)
+    }
+    if (unmounted) return
+    await useDelay().wait(400)
+    if (unmounted) return
+  }
+  showChampion.value = true
+}
+
 // ── State hydration (used on WS connect + reconnect) ────────────────────────
 const hydrateChartFromState = (state) => {
   if (!state) return
@@ -194,6 +221,11 @@ const hydrateChartFromState = (state) => {
   // Smoke participants — restore from state on page-refresh recovery
   if (state.smokeBattlers?.length) {
     smokeParticipants.value = state.smokeBattlers
+  }
+
+  // Champion — restore on page refresh when phase is DECIDED
+  if (state.battlePhase === 'DECIDED' && state.champion) {
+    showChampionFor(state.champion)
   }
 }
 
@@ -228,8 +260,16 @@ onMounted(async () => {
   subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
     if (!msg?.phase) return
     battlePhase.value = msg.phase
-    // When phase resets to LOCKED (Next was clicked), dismiss any visible result overlay
     if (msg.phase === 'LOCKED') showResult.value = false
+    // DECIDED broadcast includes champion name — show the overlay immediately
+    if (msg.phase === 'DECIDED' && msg.champion) showChampionFor(msg.champion)
+  })
+
+  const cReveal = createClient(); clients.push(cReveal)
+  subscribeToChannel(cReveal, '/topic/battle/champion-reveal', (msg) => {
+    if (!msg) return
+    if (msg.dismiss) { showChampion.value = false; return }
+    if (msg.championName) showChampionFor(msg.championName)
   })
 
   const cState = createClient(); clients.push(cState)
@@ -253,7 +293,7 @@ onBeforeUnmount(() => {
 <template>
   <div
     class="smoke-root"
-    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
+    :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor, paddingBottom: props.bottomPad ? props.bottomPad + 'px' : undefined }"
   >
     <!-- Atmospheric background bleeds -->
     <div class="atmo-bleed" aria-hidden="true"></div>
@@ -558,24 +598,28 @@ body.transparent-page #app {
 .bg-names {
   position: absolute; z-index: 1;
   top: 4%; left: 0; right: 0;
-  display: flex; align-items: center; justify-content: space-between;
+  display: flex; align-items: center;
   padding: 0 14px;
   pointer-events: none;
 }
 .bg-name {
+  flex: 1;
   font-family: 'Anton SC', sans-serif;
   font-size: clamp(32px, 8vw, 110px);
-  letter-spacing: 0.06em; line-height: 1;
+  letter-spacing: 0.06em; line-height: 1.05;
   opacity: 0.1;
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
-.bg-name-left  { color: var(--left-color);  text-shadow: 0 0 40px var(--left-color); }
-.bg-name-right { color: var(--right-color); text-shadow: 0 0 40px var(--right-color); }
+.bg-name-left  { color: var(--left-color);  text-shadow: 0 0 40px var(--left-color); text-align: left; }
+.bg-name-right { color: var(--right-color); text-shadow: 0 0 40px var(--right-color); text-align: right; }
 .bg-vs {
   font-family: 'Anton SC', sans-serif;
   font-size: clamp(10px, 2vw, 24px); letter-spacing: 0.2em;
   color: rgba(255,255,255,0.08);
-  flex-shrink: 0; padding: 0 8px;
+  flex-shrink: 0; padding: 0 12px;
+  text-align: center;
 }
 
 /* ── FLIP column slide (TransitionGroup move) ─────────── */

--- a/BES-frontend/src/views/EmceeSessionView.vue
+++ b/BES-frontend/src/views/EmceeSessionView.vue
@@ -235,10 +235,16 @@ function navigate(routeName) {
   line-height: 1.3;
 }
 
-/* Mobile: stack to single column */
+/* Mobile */
 @media (max-width: 480px) {
+  .session-root {
+    padding: 12px;
+    align-items: flex-start;
+    padding-top: 32px;
+  }
+
   .session-card {
-    padding: 32px 20px;
+    padding: 28px 20px;
     gap: 20px;
     min-width: 0;
     width: 100%;
@@ -248,16 +254,35 @@ function navigate(routeName) {
     max-width: 100%;
   }
 
+  .session-title {
+    font-size: 24px;
+  }
+
+  .info-value {
+    font-size: 15px;
+  }
+
+  /* 2-column grid on mobile — 3 buttons fit better as 2+1 than a long single column */
   .nav-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
   }
 
   .nav-btn {
-    flex-direction: row;
-    gap: 14px;
-    padding: 16px 20px;
-    min-height: 56px;
-    justify-content: flex-start;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 22px 12px;
+    min-height: 96px;
+  }
+
+  .nav-btn-icon {
+    font-size: 1.7rem;
+  }
+
+  .nav-btn-label {
+    font-size: 12px;
+    letter-spacing: 0.1em;
   }
 }
 </style>

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -134,6 +134,13 @@ public class BattleController {
         return ResponseEntity.ok(Map.of("message", "Timer updated"));
     }
 
+    @PostMapping("/format-timer")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
+    public ResponseEntity<?> updateFormatTimer(@RequestBody Map<String, Object> payload) {
+        battleService.handleFormatTimerPayload(payload);
+        return ResponseEntity.ok(Map.of("message", "Format timer updated"));
+    }
+
     @PostMapping("/score")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
     public ResponseEntity<?> setBattleScore(@RequestBody(required = false) SetBattleScoreDto dto){

--- a/BES/src/main/java/com/example/BES/models/BattleGenreState.java
+++ b/BES/src/main/java/com/example/BES/models/BattleGenreState.java
@@ -64,6 +64,9 @@ public class BattleGenreState {
     @Column(name = "resolved_participants_json", columnDefinition = "TEXT")
     private String resolvedParticipantsJson;
 
+    @Column(name = "format_timer_json", columnDefinition = "TEXT")
+    private String formatTimerJson;
+
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -461,7 +461,7 @@ public class BattleService {
         if (!battlers.isEmpty()) {
             state.put("smokeBattlers", new ArrayList<>(battlers));
         }
-        // Recoverable timer state — recalculate timeLeft from elapsed wall-clock
+        // Recoverable per-round timer state — recalculate timeLeft from elapsed wall-clock
         if (lastTimerPayload != null) {
             Map<String, Object> timer = new HashMap<>(lastTimerPayload);
             if (Boolean.TRUE.equals(timer.get("running"))) {
@@ -476,15 +476,31 @@ public class BattleService {
             }
             state.put("timer", timer);
         }
+        // Recoverable format timer state — recalculate timeLeft from elapsed wall-clock
+        if (lastFormatTimerPayload != null) {
+            Map<String, Object> ft = new HashMap<>(lastFormatTimerPayload);
+            if (Boolean.TRUE.equals(ft.get("running"))) {
+                long elapsedSec = (System.currentTimeMillis() - formatTimerLastUpdated) / 1000;
+                int currentLeft = ((Number) ft.getOrDefault("timeLeft", 0)).intValue();
+                int adjusted = Math.max(0, currentLeft - (int) elapsedSec);
+                ft.put("timeLeft", adjusted);
+                if (adjusted <= 0) {
+                    ft.put("running", false);
+                    ft.put("timeLeft", 0);
+                    ft.put("expired", true);
+                }
+            }
+            state.put("formatTimer", ft);
+        }
         return state;
     }
 
     public String getActiveEventName() { return activeEventName; }
     public String getActiveGenreName() { return activeGenreName; }
 
-    // ── Timer state recovery ─────────────────────────────────────────
+    // ── Per-round timer state recovery ──────────────────────────────
     private Map<String, Object> lastTimerPayload = null;
-    private long timerLastUpdated = 0; // System.currentTimeMillis() when last payload arrived
+    private long timerLastUpdated = 0;
 
     public void handleTimerPayload(Map<String, Object> payload) {
         this.lastTimerPayload = new HashMap<>(payload);
@@ -496,6 +512,32 @@ public class BattleService {
     public void rebroadcastTimer(Object timerState) {
         if (timerState != null) {
             messagingTemplate.convertAndSend("/topic/battle/timer", timerState);
+        }
+    }
+
+    // ── Format timer state (7-to-Smoke session-level countdown) ─────
+    private Map<String, Object> lastFormatTimerPayload = null;
+    private long formatTimerLastUpdated = 0;
+
+    public void handleFormatTimerPayload(Map<String, Object> payload) {
+        this.lastFormatTimerPayload = new HashMap<>(payload);
+        this.formatTimerLastUpdated = System.currentTimeMillis();
+        messagingTemplate.convertAndSend("/topic/battle/format-timer", payload);
+        persistFormatTimer();
+    }
+
+    private void persistFormatTimer() {
+        if (activeEventName == null || activeGenreName == null || lastFormatTimerPayload == null) return;
+        try {
+            BattleGenreState s = battleGenreStateRepository
+                .findByEventNameAndGenreName(activeEventName, activeGenreName)
+                .orElse(null);
+            if (s == null) return;
+            s.setFormatTimerJson(objectMapper.writeValueAsString(lastFormatTimerPayload));
+            s.setUpdatedAt(LocalDateTime.now());
+            battleGenreStateRepository.save(s);
+        } catch (Exception e) {
+            System.err.println("Failed to persist format timer: " + e.getMessage());
         }
     }
 
@@ -528,6 +570,9 @@ public class BattleService {
             s.setSmokeListJson(objectMapper.writeValueAsString(new ArrayList<>(battlers)));
             synchronized (judges) {
                 s.setJudgesJson(objectMapper.writeValueAsString(new ArrayList<>(judges)));
+            }
+            if (lastFormatTimerPayload != null) {
+                s.setFormatTimerJson(objectMapper.writeValueAsString(lastFormatTimerPayload));
             }
             s.setUpdatedAt(LocalDateTime.now());
             battleGenreStateRepository.save(s);
@@ -579,6 +624,13 @@ public class BattleService {
                     judges.addAll(restored);
                 }
             }
+            if (s.getFormatTimerJson() != null) {
+                lastFormatTimerPayload = objectMapper.readValue(
+                    s.getFormatTimerJson(), new TypeReference<Map<String, Object>>(){});
+                formatTimerLastUpdated = System.currentTimeMillis();
+            } else {
+                lastFormatTimerPayload = null;
+            }
         } catch (Exception e) {
             System.err.println("Failed to load genre state from DB: " + e.getMessage());
             resetToDefaults();
@@ -599,14 +651,18 @@ public class BattleService {
         champion = null;
         battlers = new ArrayList<>();
         synchronized (judges) { judges.clear(); }
+        lastFormatTimerPayload = null;
+        formatTimerLastUpdated = 0;
     }
 
     private void broadcastStateSnapshot() {
         Map<String, Object> state = getBattleStateService();
         messagingTemplate.convertAndSend("/topic/battle/state", state);
-        // Also rebroadcast timer so BattleTimer can recover on page refresh
         if (state.containsKey("timer")) {
             messagingTemplate.convertAndSend("/topic/battle/timer", state.get("timer"));
+        }
+        if (state.containsKey("formatTimer")) {
+            messagingTemplate.convertAndSend("/topic/battle/format-timer", state.get("formatTimer"));
         }
     }
 

--- a/BES/src/main/resources/db/migration/V33__add_format_timer.sql
+++ b/BES/src/main/resources/db/migration/V33__add_format_timer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE battle_genre_state ADD COLUMN format_timer_json TEXT;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ When switching to a new branch (option B): check for open PRs on the current bra
 
 - File naming: `V{version}__{description}.sql` (double underscore, snake_case description)
 - Always add new migrations as new files — never edit existing ones
-- Latest migration: `V16__add_pickup_crew.sql` → next is `V17__...`
+- Latest migration: `V33__add_format_timer.sql` → next is `V34__...`
 
 ### Layer Modification Order
 


### PR DESCRIPTION
## Summary

- **SmokeFormatTimer component**: Session-level countdown for 7-to-Smoke format (IDLE/RUNNING/EXPIRED states). Duration presets (30m/45m) + custom chip that shows `60m ×` with one-tap remove. Timer auto-starts when first round begins; stops automatically when champion is declared.
- **Winner resolution on expiry**: When format timer has expired and Get Score is clicked — points are added first, then the battler with the highest total score is auto-announced as champion (overlay animation fires). If tied, a modal prompts the operator to pick; after confirming, champion is announced.
- **Chart.vue champion overlay**: Now subscribes to `/topic/battle/champion-reveal` and the DECIDED phase message so the champion overlay fires for format-timer winners (not just natural 7-smoke). Waits for judge result overlay to clear before transitioning (same 400ms delay as natural path).
- **Overlay bar**: Full-width 52px bar at bottom of smoke overlay shows countdown, amber warning at ≤5 min, "BATTLE HAS ENDED" when expired. Chart content pushed up via `bottomPad` prop.
- **Backend**: `V33__add_format_timer.sql` adds `format_timer_json` column; `BattleService` persists and broadcasts timer state; new `POST /battle/format-timer` endpoint (Admin/Organiser/Emcee).
- **Responsive**: BattleControl confirm modal stacks buttons full-width on mobile; smoke winner picker rows have larger tap targets; EmceeSessionView uses 2-column nav grid on mobile with bigger icons/labels.

## Test plan

- [ ] Start a 7-to-Smoke genre, verify format timer auto-starts with first round
- [ ] Timer shows amber at ≤5 min remaining
- [ ] Timer expires → control panel shows options again (no manual RESET needed), overlay bar shows "BATTLE HAS ENDED"
- [ ] Click Get Score after expiry (single top scorer) → points added, chart updates, champion overlay fires automatically
- [ ] Click Get Score after expiry (tied scorers) → picker modal appears, selecting a battler announces champion on overlay
- [ ] Natural 7-smoke win → timer stops, champion overlay fires normally
- [ ] Page refresh with timer running → timer recovers correctly
- [ ] Custom duration: type value, press SET → chip shows `Xm ×`; click × to remove
- [ ] BattleControl confirm modal is usable on 360px phone screen
- [ ] EmceeSessionView nav grid shows 2 columns on mobile

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)