### PR TITLE
fix: persist session cookie for 24h to prevent mobile auto-logout

### DIFF
--- a/BES/src/main/resources/application.properties
+++ b/BES/src/main/resources/application.properties
@@ -16,6 +16,7 @@ spring.mail.password=${EMAIL_PASSWORD}
 # Schema managed by Flyway — validate only, never auto-modify
 spring.jpa.hibernate.ddl-auto=validate
 server.servlet.session.timeout=1440m
+server.servlet.session.cookie.max-age=1d
 
 # Flyway migration settings
 spring.flyway.baseline-on-migrate=true


### PR DESCRIPTION
## Summary
- Adds `server.servlet.session.cookie.max-age=1d` to `application.properties`
- Without `Max-Age`, the `JSESSIONID` was a session cookie — mobile browsers (and iOS Safari in particular) clear these aggressively when the browser is closed, backgrounded, or killed by the OS
- This made mobile users appear to "auto-logout" far faster than desktop users, who typically benefit from browser session restore
- With `Max-Age=86400`, the cookie is written to disk and survives browser restarts for 24 hours on all platforms

## How it works
The server-side session timeout (`server.servlet.session.timeout=1440m`) was already correct — sessions live 24h on the server. The problem was the browser discarding the cookie (the "key" to the session) on mobile before the server ever expired it.

This fix also applies to session link users (Judge, Emcee, Helper) — once they authenticate via their `?t=xxxx` link, the cookie persists for 24h so they don't need to re-visit the link just because they closed the browser.

## Test plan
- [ ] Log in on mobile, close the browser entirely, reopen — should still be authenticated
- [ ] Verify `Set-Cookie` response header contains `Max-Age=86400` and `Expires` on first request
- [ ] Log in via a session link on mobile, close browser, reopen link destination — should land on the session view without re-authenticating

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)