### PR TITLE
feat: per-event WebSocket routing — multi-event concurrency (#97)

### DIFF
--- a/BES-frontend/src/components/BattleTimer.vue
+++ b/BES-frontend/src/components/BattleTimer.vue
@@ -21,7 +21,8 @@ const props = defineProps({
   phase:         { type: String, default: 'IDLE' },
   stompClient:   { type: Object, default: null },
   presets:       { type: Array,  default: () => [30, 45, 60, 90] },
-  recoveryState: { type: Object, default: null }  // { running, timeLeft, totalDuration }
+  recoveryState: { type: Object, default: null },  // { running, timeLeft, totalDuration }
+  eventName:     { type: String, default: '' }
 })
 
 // ── Reactive state ──
@@ -152,7 +153,10 @@ onMounted(() => {
   if (!props.stompClient) return
   const doSubscribe = () => {
     if (timerSub) return
-    timerSub = props.stompClient.subscribe('/topic/battle/timer', (raw) => {
+    const timerTopic = props.eventName
+      ? `/topic/battle/${props.eventName}/timer`
+      : '/topic/battle/timer'
+    timerSub = props.stompClient.subscribe(timerTopic, (raw) => {
       try {
         const msg = JSON.parse(raw.body)
         if (msg && msg.running) { wsRecoveryAttempted = true; recoverFromState(msg) }
@@ -187,7 +191,10 @@ function publishState() {
   // Use REST API instead of STOMP — more reliable for writes.
   // Backend stores the payload and broadcasts to /topic/battle/timer for overlay + recovery.
   try {
-    fetch('/api/v1/battle/timer', {
+    const url = props.eventName
+      ? `/api/v1/battle/timer?event=${encodeURIComponent(props.eventName)}`
+      : '/api/v1/battle/timer'
+    fetch(url, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },

--- a/BES-frontend/src/components/LiveMatchPanel.vue
+++ b/BES-frontend/src/components/LiveMatchPanel.vue
@@ -460,6 +460,7 @@ const viewedPairList = computed(() => {
           :phase="battlePhase"
           :stomp-client="stompClient"
           :recovery-state="recoveryTimer"
+          :event-name="selectedEvent"
         />
       </div>
 
@@ -469,6 +470,7 @@ const viewedPairList = computed(() => {
           ref="smokeFormatTimerRef"
           :stomp-client="stompClient"
           :recovery-state="recoveryFormatTimer"
+          :event-name="selectedEvent"
         />
       </div>
 

--- a/BES-frontend/src/components/SmokeFormatTimer.vue
+++ b/BES-frontend/src/components/SmokeFormatTimer.vue
@@ -12,7 +12,8 @@ import { ref, computed, onBeforeUnmount, onMounted, watch } from 'vue'
 
 const props = defineProps({
   stompClient:   { type: Object, default: null },
-  recoveryState: { type: Object, default: null }
+  recoveryState: { type: Object, default: null },
+  eventName:     { type: String, default: '' }
 })
 
 const emit = defineEmits(['expired'])
@@ -122,7 +123,10 @@ defineExpose({ isExpired, autoStartIfIdle, resetTimer, selectedMinutes })
 // ── Backend sync ─────────────────────────────────────────────────────
 function publishState() {
   try {
-    fetch('/api/v1/battle/format-timer', {
+    const url = props.eventName
+      ? `/api/v1/battle/format-timer?event=${encodeURIComponent(props.eventName)}`
+      : '/api/v1/battle/format-timer'
+    fetch(url, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
@@ -168,7 +172,10 @@ onMounted(() => {
   if (!props.stompClient) return
   const doSubscribe = () => {
     if (fmtSub) return
-    fmtSub = props.stompClient.subscribe('/topic/battle/format-timer', (raw) => {
+    const fmtTopic = props.eventName
+      ? `/topic/battle/${props.eventName}/format-timer`
+      : '/topic/battle/format-timer'
+    fmtSub = props.stompClient.subscribe(fmtTopic, (raw) => {
       try {
         const msg = JSON.parse(raw.body)
         if (msg) recoverFromState(msg)

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -673,12 +673,6 @@ export const setActiveGenre = async (eventName, genreName) => {
   } catch (e) { console.error(e) }
 }
 
-export const getActiveGenre = async () => {
-  try {
-    const res = await fetch(`${domain}/api/v1/battle/active-genre`, { credentials: 'include' })
-    return res.ok ? await res.json() : null
-  } catch (_e) { return null }
-}
 
 export const getBattleState = async (eventName = '') => {
   try {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -420,9 +420,12 @@ export const resetJudgeFeedback = async (eventName, genreName, judgeName) => {
   } catch (e) { console.log(e) }
 }
 
-export const getBattleJudges = async() =>{
+export const getBattleJudges = async(eventName = '') =>{
   try{
-    const res = await fetch(`${domain}/api/v1/battle/judges`,{
+    const url = eventName
+      ? `${domain}/api/v1/battle/judges?event=${encodeURIComponent(eventName)}`
+      : `${domain}/api/v1/battle/judges`
+    const res = await fetch(url,{
       credentials: 'include'
     })
     if(res.ok){
@@ -433,9 +436,12 @@ export const getBattleJudges = async() =>{
   }
 }
 
-export const getCurrentBattlePair = async()=>{
+export const getCurrentBattlePair = async(eventName = '')=>{
   try{
-    const res = await fetch(`${domain}/api/v1/battle/battle-pair`,{
+    const url = eventName
+      ? `${domain}/api/v1/battle/battle-pair?event=${encodeURIComponent(eventName)}`
+      : `${domain}/api/v1/battle/battle-pair`
+    const res = await fetch(url,{
       credentials: 'include'
     })
     return res.ok ? await res.json() : null
@@ -444,7 +450,7 @@ export const getCurrentBattlePair = async()=>{
   }
 }
 
-export const battleJudgeVote = async(id, vote) =>{
+export const battleJudgeVote = async(id, vote, eventName = '') =>{
   try{
     return await fetch(`${domain}/api/v1/battle/vote`,{
       method: 'POST',
@@ -455,7 +461,8 @@ export const battleJudgeVote = async(id, vote) =>{
       },
       body: JSON.stringify({
         id: Number(id),
-        vote: Number(vote)
+        vote: Number(vote),
+        ...(eventName ? { eventName } : {})
       })
     })
   }catch(e){
@@ -464,7 +471,7 @@ export const battleJudgeVote = async(id, vote) =>{
   }
 }
 
-export const addBattleJudge = async(id, weightage = 1) =>{
+export const addBattleJudge = async(id, weightage = 1, eventName = '') =>{
   try{
     return await fetch(`${domain}/api/v1/battle/judge`,{
       method: 'POST',
@@ -476,6 +483,7 @@ export const addBattleJudge = async(id, weightage = 1) =>{
       body: JSON.stringify({
         id: Number(id),
         weightage: Math.max(1, Number(weightage) || 1),
+        ...(eventName ? { eventName } : {})
       })
     })
   }catch(e){
@@ -484,7 +492,7 @@ export const addBattleJudge = async(id, weightage = 1) =>{
   }
 }
 
-export const updateJudgeWeightage = async(id, weightage) =>{
+export const updateJudgeWeightage = async(id, weightage, eventName = '') =>{
   try{
     return await fetch(`${domain}/api/v1/battle/judge/weightage`,{
       method: 'POST',
@@ -496,6 +504,7 @@ export const updateJudgeWeightage = async(id, weightage) =>{
       body: JSON.stringify({
         id: Number(id),
         weightage: Math.max(1, Number(weightage) || 1),
+        ...(eventName ? { eventName } : {})
       })
     })
   }catch(e){
@@ -504,7 +513,7 @@ export const updateJudgeWeightage = async(id, weightage) =>{
   }
 }
 
-export const removeBattleJudge = async(id) =>{
+export const removeBattleJudge = async(id, eventName = '') =>{
   try{
     return await fetch(`${domain}/api/v1/battle/judge`,{
       method: 'DELETE',
@@ -515,6 +524,7 @@ export const removeBattleJudge = async(id) =>{
       },
       body: JSON.stringify({
         id: Number(id),
+        ...(eventName ? { eventName } : {})
       })
     })
   }catch(e){
@@ -522,7 +532,7 @@ export const removeBattleJudge = async(id) =>{
     return null
   }
 }
-export const setBattlePair = async(leftBattler, rightBattler, isFinal = false, leftMembers = [], rightMembers = []) =>{
+export const setBattlePair = async(leftBattler, rightBattler, isFinal = false, leftMembers = [], rightMembers = [], eventName = '') =>{
   try{
     return await fetch(`${domain}/api/v1/battle/battle-pair`,{
       method: 'POST',
@@ -536,7 +546,8 @@ export const setBattlePair = async(leftBattler, rightBattler, isFinal = false, l
         rightBattler: rightBattler,
         isFinal: isFinal,
         leftMembers: leftMembers,
-        rightMembers: rightMembers
+        rightMembers: rightMembers,
+        ...(eventName ? { eventName } : {})
       })
     })
   }catch(e){
@@ -545,9 +556,12 @@ export const setBattlePair = async(leftBattler, rightBattler, isFinal = false, l
   }
 }
 
-export const clearBattlePair = async () => {
+export const clearBattlePair = async (eventName = '') => {
   try {
-    return await fetch(`${domain}/api/v1/battle/battle-pair`, {
+    const url = eventName
+      ? `${domain}/api/v1/battle/battle-pair?event=${encodeURIComponent(eventName)}`
+      : `${domain}/api/v1/battle/battle-pair`
+    return await fetch(url, {
       method: 'DELETE',
       credentials: 'include',
       headers: { 'Accept': 'application/json' }
@@ -558,13 +572,13 @@ export const clearBattlePair = async () => {
   }
 }
 
-export const setBattleScore = async (isFinal = false) => {
+export const setBattleScore = async (isFinal = false, eventName = '') => {
   try {
     return await fetch(`${domain}/api/v1/battle/score`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ isFinal })
+      body: JSON.stringify({ isFinal, ...(eventName ? { eventName } : {}) })
     })
   } catch (e) {
     console.log(e)
@@ -572,12 +586,13 @@ export const setBattleScore = async (isFinal = false) => {
   }
 }
 
-export const resetBattleVotes = async () => {
+export const resetBattleVotes = async (eventName = '') => {
   try {
     return await fetch(`${domain}/api/v1/battle/revote`, {
       method: 'POST',
       credentials: 'include',
-      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' }
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: eventName ? JSON.stringify({ eventName }) : undefined
     })
   } catch (e) {
     console.log(e)
@@ -585,13 +600,13 @@ export const resetBattleVotes = async () => {
   }
 }
 
-export const revealChampion = async (genreName, championName) => {
+export const revealChampion = async (genreName, championName, eventName = '') => {
   try {
     return await fetch(`${domain}/api/v1/battle/champion-reveal`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ genreName, championName, dismiss: false })
+      body: JSON.stringify({ genreName, championName, dismiss: false, ...(eventName ? { eventName } : {}) })
     })
   } catch (e) {
     console.log(e)
@@ -612,13 +627,13 @@ export const getBattleChampions = async (eventName) => {
   }
 }
 
-export const dismissChampionReveal = async () => {
+export const dismissChampionReveal = async (eventName = '') => {
   try {
     return await fetch(`${domain}/api/v1/battle/champion-reveal`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ dismiss: true })
+      body: JSON.stringify({ dismiss: true, ...(eventName ? { eventName } : {}) })
     })
   } catch (e) {
     console.log(e)
@@ -626,20 +641,23 @@ export const dismissChampionReveal = async () => {
   }
 }
 
-export const setBracketState = async (rounds, topSize, currentRoundIndex = 0) => {
+export const setBracketState = async (rounds, topSize, currentRoundIndex = 0, eventName = '') => {
   try {
     return await fetch(`${domain}/api/v1/battle/bracket`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rounds, topSize: String(topSize), currentRoundIndex })
+      body: JSON.stringify({ rounds, topSize: String(topSize), currentRoundIndex, ...(eventName ? { eventName } : {}) })
     })
   } catch (e) { console.error(e) }
 }
 
-export const getBracketState = async () => {
+export const getBracketState = async (eventName = '') => {
   try {
-    const res = await fetch(`${domain}/api/v1/battle/bracket`, { credentials: 'include' })
+    const url = eventName
+      ? `${domain}/api/v1/battle/bracket?event=${encodeURIComponent(eventName)}`
+      : `${domain}/api/v1/battle/bracket`
+    const res = await fetch(url, { credentials: 'include' })
     return res.ok ? await res.json() : null
   } catch (_e) { return null }
 }
@@ -662,9 +680,12 @@ export const getActiveGenre = async () => {
   } catch (_e) { return null }
 }
 
-export const getBattleState = async () => {
+export const getBattleState = async (eventName = '') => {
   try {
-    const res = await fetch(`${domain}/api/v1/battle/state`, { credentials: 'include' })
+    const url = eventName
+      ? `${domain}/api/v1/battle/state?event=${encodeURIComponent(eventName)}`
+      : `${domain}/api/v1/battle/state`
+    const res = await fetch(url, { credentials: 'include' })
     return res.ok ? await res.json() : null
   } catch (_e) { return null }
 }
@@ -708,20 +729,23 @@ export const getImage = async (filename) => {
   }
 };
 
-export const getBattlePhase = async () => {
+export const getBattlePhase = async (eventName = '') => {
   try {
-    const res = await fetch(`${domain}/api/v1/battle/phase`, { credentials: 'include' })
+    const url = eventName
+      ? `${domain}/api/v1/battle/phase?event=${encodeURIComponent(eventName)}`
+      : `${domain}/api/v1/battle/phase`
+    const res = await fetch(url, { credentials: 'include' })
     return res.ok ? await res.json() : { phase: 'IDLE' }
   } catch (_e) { return { phase: 'IDLE' } }
 }
 
-export const setBattlePhase = async (phase, champion) => {
+export const setBattlePhase = async (phase, champion, eventName = '') => {
   try {
     return await fetch(`${domain}/api/v1/battle/phase`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ phase, ...(champion ? { champion } : {}) })
+      body: JSON.stringify({ phase, ...(champion ? { champion } : {}), ...(eventName ? { eventName } : {}) })
     })
   } catch (e) { console.log(e) }
 }
@@ -871,7 +895,7 @@ export const addGenreToParticipant = async (participantId, eventId, genreName, e
   }
 }
 
-export const updateSmokeList  = async(battlers)=>{
+export const updateSmokeList  = async(battlers, eventName = '')=>{
   try{
     return await fetch(`${domain}/api/v1/battle/smoke`,{
       method: 'POST',
@@ -881,7 +905,8 @@ export const updateSmokeList  = async(battlers)=>{
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        battlers: battlers
+        battlers: battlers,
+        ...(eventName ? { eventName } : {})
       })
     })
   }catch(e){
@@ -1183,9 +1208,12 @@ export const updateEventGenreFormat = async (eventName, eventGenreId, format) =>
   }
 }
 
-export const getOverlayConfig = async () => {
+export const getOverlayConfig = async (eventName = '') => {
   try {
-    const res = await fetch(`${domain}/api/v1/battle/overlay-config`, {
+    const url = eventName
+      ? `${domain}/api/v1/battle/overlay-config?event=${encodeURIComponent(eventName)}`
+      : `${domain}/api/v1/battle/overlay-config`
+    const res = await fetch(url, {
       credentials: 'include',
     })
     return res.ok ? await res.json() : { showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' }
@@ -1195,7 +1223,7 @@ export const getOverlayConfig = async () => {
   }
 }
 
-export const setOverlayConfig = async (config) => {
+export const setOverlayConfig = async (config, eventName = '') => {
   try {
     return await fetch(`${domain}/api/v1/battle/overlay-config`, {
       method: 'POST',
@@ -1204,7 +1232,7 @@ export const setOverlayConfig = async (config) => {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ ...config, ...(eventName ? { eventName } : {}) }),
     })
   } catch (err) {
     console.log(err)

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -45,6 +45,9 @@ const recoveredFormatTimer = ref(null)   // { running, timeLeft, totalDuration, 
 const lmpRef               = ref(null)   // ref to LiveMatchPanel — for triggerFormatTimerStart
 const lastSetWinnerTime = ref(0)   // timestamp of last local setWinner call (prevents stale WS overwrites)
 let setWinnerCooldown = null       // timeout handle for clearing the cooldown
+const bcTopic = (path) => selectedEvent.value
+  ? `/topic/battle/${selectedEvent.value}/${path}`
+  : `/topic/battle/${path}`
 
 // Single entry point for full-state hydration from /topic/battle/state or REST API.
 // Diffs against lastAppliedState to skip no-op updates and prevent animation disruption.
@@ -300,7 +303,7 @@ const pushOverlayConfig = async () => {
     return
   }
   overlayConfigError.value = ''
-  await setOverlayConfig(overlayConfig.value)
+  await setOverlayConfig(overlayConfig.value, selectedEvent.value)
 }
 
 
@@ -380,7 +383,7 @@ const onFileChange = async (e) => {
 const resetJudgeVote = async () => {
   // Reset locally first so the panel shows WAITING immediately, before WS echo arrives
   ;(battleJudges.value?.judges ?? []).forEach(j => { j.vote = -3 })
-  await Promise.all(battleJudges.value.judges.map(j => battleJudgeVote(j.id, -3)))
+  await Promise.all(battleJudges.value.judges.map(j => battleJudgeVote(j.id, -3, selectedEvent.value)))
 }
 
 const currentBattlePair = computed(() => {
@@ -418,8 +421,8 @@ const initiateBattlePairAt = async (top, pairList, startIdx) => {
   currentBattle.value = [startIdx, pairList]
   const left = pairList[startIdx][0]
   const right = pairList[startIdx][1]
-  await setBattlePair(left, right, top === 'Top2', getMembersFor(left), getMembersFor(right))
-  await setBattlePhase('LOCKED')
+  await setBattlePair(left, right, top === 'Top2', getMembersFor(left), getMembersFor(right), selectedEvent.value)
+  await setBattlePhase('LOCKED', undefined, selectedEvent.value)
   battlePhase.value = 'LOCKED'
   currentRound.value = startIdx
   currentTop.value = top
@@ -438,9 +441,9 @@ const initiateBattlePair = async (top, pairList) => {
   revealActive.value = false
   await resetJudgeVote()
   if (isSmoke.value) {
-    await setBattlePair(rounds.value[0].name, rounds.value[1].name, false, getMembersFor(rounds.value[0].name), getMembersFor(rounds.value[1].name))
+    await setBattlePair(rounds.value[0].name, rounds.value[1].name, false, getMembersFor(rounds.value[0].name), getMembersFor(rounds.value[1].name), selectedEvent.value)
     await updateSmokePair()  // must await so smoke list is posted before overlay reloads
-    await setBattlePhase('LOCKED')
+    await setBattlePhase('LOCKED', undefined, selectedEvent.value)
     battlePhase.value = 'LOCKED'
     return
   }
@@ -453,8 +456,8 @@ const initiateBattlePair = async (top, pairList) => {
   currentBattle.value = [0, pairList]
   const left = currentBattle?.value[1][currentBattle?.value[0]][0]
   const right = currentBattle?.value[1][currentBattle?.value[0]][1]
-  await setBattlePair(left, right, top === 'Top2', getMembersFor(left), getMembersFor(right))
-  await setBattlePhase('LOCKED')
+  await setBattlePair(left, right, top === 'Top2', getMembersFor(left), getMembersFor(right), selectedEvent.value)
+  await setBattlePhase('LOCKED', undefined, selectedEvent.value)
   battlePhase.value = 'LOCKED'
   currentRound.value = 0
   currentTop.value = top
@@ -469,8 +472,8 @@ const nextPair = async () => {
   await resetJudgeVote()
   if (isSmoke.value) {
     await update7toSmokeMatch(currentWinner.value)
-    await setBattlePair(rounds.value[0].name, rounds.value[1].name, false, getMembersFor(rounds.value[0].name), getMembersFor(rounds.value[1].name))
-    await setBattlePhase('LOCKED')
+    await setBattlePair(rounds.value[0].name, rounds.value[1].name, false, getMembersFor(rounds.value[0].name), getMembersFor(rounds.value[1].name), selectedEvent.value)
+    await setBattlePhase('LOCKED', undefined, selectedEvent.value)
     battlePhase.value = 'LOCKED'
     currentWinner.value = -2
   } else {
@@ -478,15 +481,15 @@ const nextPair = async () => {
       currentBattle.value = [currentBattle.value[0] + 1, currentBattle.value[1]]
       const left = currentBattle?.value[1][currentBattle?.value[0]][0]
       const right = currentBattle?.value[1][currentBattle?.value[0]][1]
-      await setBattlePair(left, right, currentTop.value === 'Top2', getMembersFor(left), getMembersFor(right))
-      await setBattlePhase('LOCKED')
+      await setBattlePair(left, right, currentTop.value === 'Top2', getMembersFor(left), getMembersFor(right), selectedEvent.value)
+      await setBattlePhase('LOCKED', undefined, selectedEvent.value)
       battlePhase.value = 'LOCKED'
       currentWinner.value = -2
       currentRound.value += 1
     
     } else {
-      await clearBattlePair()
-      await setBattlePhase('IDLE')
+      await clearBattlePair(selectedEvent.value)
+      await setBattlePhase('IDLE', undefined, selectedEvent.value)
       battlePhase.value = 'IDLE'
       currentWinner.value = -2
       currentBattle.value = []
@@ -820,9 +823,9 @@ const broadcastBracket = async () => {
   // fire before a genre switch, causing smokeBattlers to be stale).
   if (isSmoke.value) {
     const named = rounds.value.filter(r => r?.name)
-    await updateSmokeList(named)
+    await updateSmokeList(named, selectedEvent.value)
   }
-  return setBracketState(toRaw(rounds.value), topSize.value, currentRound.value)
+  return setBracketState(toRaw(rounds.value), topSize.value, currentRound.value, selectedEvent.value)
 }
 
 // Re-broadcast the current battle pair to the overlay if a bracket drag/drop changed
@@ -833,7 +836,7 @@ const reBroadcastCurrentPairIfActive = () => {
   const pair = currentBattlePair.value
   if (pair?.[0] && pair?.[1]) {
     setBattlePair(pair[0], pair[1], currentTop.value === 'Top2',
-      getMembersFor(pair[0]), getMembersFor(pair[1]))
+      getMembersFor(pair[0]), getMembersFor(pair[1]), selectedEvent.value)
   }
 }
 
@@ -1259,17 +1262,19 @@ const jumpToRecoveredPair = async () => {
       await setBattlePair(
         currentPair.left, currentPair.right, currentPair.isFinal,
         currentPair.leftMembers?.length ? currentPair.leftMembers : getMembersFor(currentPair.left),
-        currentPair.rightMembers?.length ? currentPair.rightMembers : getMembersFor(currentPair.right)
+        currentPair.rightMembers?.length ? currentPair.rightMembers : getMembersFor(currentPair.right),
+        selectedEvent.value
       )
     } else {
       await setBattlePair(currentPair.left, currentPair.right, false,
-        getMembersFor(currentPair.left), getMembersFor(currentPair.right))
+        getMembersFor(currentPair.left), getMembersFor(currentPair.right),
+        selectedEvent.value)
     }
   }
   // For VOTING recovery, skip setBattlePair — the backend already has the correct
   // pair from loadGenreStateIntoMemory(). Calling setBattlePair would force LOCKED
   // and broadcast it, clearing all judge votes unnecessarily. Just re-broadcast phase.
-  await setBattlePhase(phase)
+  await setBattlePhase(phase, undefined, selectedEvent.value)
   battlePhase.value = phase
   markSaved()
 }
@@ -1292,7 +1297,7 @@ const syncJudgesForGenre = async (_newGenre, _prevGenre) => {
 
 const submitAddBattleJudge = async (name) => {
   const j = allJudges.value.find(j => j.judgeName === name)
-  const res = await addBattleJudge(j?.judgeId)
+  const res = await addBattleJudge(j?.judgeId, 1, selectedEvent.value)
   if (res.status === 404) { console.log("No judge in database"); return }
   battleJudges.value = await getBattleJudges()
 
@@ -1300,14 +1305,14 @@ const submitAddBattleJudge = async (name) => {
 
 const submitUpdateJudgeWeightage = async (id, value) => {
   const weightage = Math.max(1, parseInt(value) || 1)
-  await updateJudgeWeightage(id, weightage)
+  await updateJudgeWeightage(id, weightage, selectedEvent.value)
   battleJudges.value = await getBattleJudges()
 
 }
 
 const submitRemoveBattleJudge = async (name) => {
   const j = allJudges.value.find(j => j.judgeName === name)
-  await removeBattleJudge(j?.judgeId)
+  await removeBattleJudge(j?.judgeId, selectedEvent.value)
   battleJudges.value = await getBattleJudges()
 
 }
@@ -1396,10 +1401,10 @@ const submitGetScore = async () => {
   const hasMinusThree = battleJudges?.value.judges.some(j => j.vote === -3)
   if (hasMinusThree) { currentWinner.value = -3; return }
   if (isSmoke.value) {
-    const res = await setBattleScore()
+    const res = await setBattleScore(false, selectedEvent.value)
     const data = await res.json()
     currentWinner.value = Number(data.winner)
-    await setBattlePhase('REVEALED')
+    await setBattlePhase('REVEALED', undefined, selectedEvent.value)
     battlePhase.value = 'REVEALED'
     // If format timer expired, fetch fresh battler scores (guaranteed up-to-date)
     // and resolve the session winner. Avoids race with WS-delivered rounds update.
@@ -1420,19 +1425,19 @@ const submitGetScore = async () => {
     await resetJudgeVote()
     // Re-broadcast same pair so the overlay hides the judge panel and resets battler animations
     const [rLeft, rRight] = currentBattlePair.value ?? []
-    if (rLeft && rRight) await setBattlePair(rLeft, rRight, isFinalInProgress.value, getMembersFor(rLeft), getMembersFor(rRight))
+    if (rLeft && rRight) await setBattlePair(rLeft, rRight, isFinalInProgress.value, getMembersFor(rLeft), getMembersFor(rRight), selectedEvent.value)
     return
   }
   const left = currentBattle?.value[1][currentBattle?.value[0]][0]
   const right = currentBattle?.value[1][currentBattle?.value[0]][1]
   if (left === "" || right === "") return
   const isFinalMatch = !isSmoke.value && currentTop.value === 'Top2'
-  const res = await setBattleScore(isFinalMatch)
+  const res = await setBattleScore(isFinalMatch, selectedEvent.value)
   if (res?.status === 409) {
     finalTieBlocked.value = true
     // Re-broadcast same pair → overlay/bracket transitions to LOCKED (rematch state)
     const [rLeft, rRight] = currentBattlePair.value ?? []
-    if (rLeft && rRight) await setBattlePair(rLeft, rRight, isFinalInProgress.value, getMembersFor(rLeft), getMembersFor(rRight))
+    if (rLeft && rRight) await setBattlePair(rLeft, rRight, isFinalInProgress.value, getMembersFor(rLeft), getMembersFor(rRight), selectedEvent.value)
     return
   }
   const data = await res.json()
@@ -1442,7 +1447,7 @@ const submitGetScore = async () => {
 }
 
 const startRevote = async () => {
-  await resetBattleVotes()
+  await resetBattleVotes(selectedEvent.value)
   await resetJudgeVote()   // reset to -3 so allJudgesVoted tracks the fresh round
   finalTieBlocked.value = false
   currentWinner.value = -2
@@ -1454,23 +1459,23 @@ const lockChampion = async () => {
     : currentBattlePair.value?.[1]
   if (!winner) return
   genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: winner }
-  await setBattlePhase('DECIDED', winner)
+  await setBattlePhase('DECIDED', winner, selectedEvent.value)
   battlePhase.value = 'DECIDED'
 }
 
 const handleForceSmokeWinner = async (battler) => {
   if (!battler?.name) return
   genreChampions.value = { ...genreChampions.value, [selectedGenre.value]: battler.name }
-  await setBattlePhase('DECIDED', battler.name)
+  await setBattlePhase('DECIDED', battler.name, selectedEvent.value)
   battlePhase.value = 'DECIDED'
-  await revealChampion(selectedGenre.value, battler.name)
+  await revealChampion(selectedGenre.value, battler.name, selectedEvent.value)
   revealActive.value = true
 }
 
 const unlockChampion = async () => {
   const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
   genreChampions.value = rest
-  await setBattlePhase('VOTING')
+  await setBattlePhase('VOTING', undefined, selectedEvent.value)
   battlePhase.value = 'VOTING'
 
 }
@@ -1488,9 +1493,9 @@ const revealChampionForGenre = async () => {
     if (side === -1) return
     setWinner(currentTop.value, currentRound.value, side)
     currentWinner.value = side
-    await revealChampion(selectedGenre.value, championName)
+    await revealChampion(selectedGenre.value, championName, selectedEvent.value)
     // Stay in DECIDED so the genre remains re-revealable forever
-    await setBattlePhase('DECIDED')
+    await setBattlePhase('DECIDED', undefined, selectedEvent.value)
     battlePhase.value = 'DECIDED'
   
     revealActive.value = true
@@ -1505,18 +1510,18 @@ const revealChampionForGenre = async () => {
     const side = champion === currentBattlePair.value[0] ? 0 : (champion === currentBattlePair.value[1] ? 1 : -1)
     if (side !== -1) currentWinner.value = side
   }
-  await revealChampion(selectedGenre.value, champion)
+  await revealChampion(selectedGenre.value, champion, selectedEvent.value)
   revealActive.value = true
 }
 
 const dismissReveal = async () => {
-  await dismissChampionReveal()
+  await dismissChampionReveal(selectedEvent.value)
   revealActive.value = false
 }
 
 const openVoting = async () => {
   markSaving()
-  await setBattlePhase('VOTING')
+  await setBattlePhase('VOTING', undefined, selectedEvent.value)
   battlePhase.value = 'VOTING'
 
   markSaved()
@@ -1532,12 +1537,12 @@ const confirmResetBracket = async () => {
   // setBracketStateService) see fresh scores instead of stale battlers.
   if (isSmoke.value) {
     const named = rounds.value.filter(r => r?.name)
-    await updateSmokeList(named)
+    await updateSmokeList(named, selectedEvent.value)
   }
 
   broadcastBracket()
-  await clearBattlePair()
-  await setBattlePhase('IDLE')
+  await clearBattlePair(selectedEvent.value)
+  await setBattlePhase('IDLE', undefined, selectedEvent.value)
   battlePhase.value = 'IDLE'
   currentWinner.value = -2
   currentBattle.value = []
@@ -1547,7 +1552,7 @@ const confirmResetBracket = async () => {
   finalTieBlocked.value = false
 
   // Clear champion tracking — both backend (DB) and local ref
-  await dismissChampionReveal()
+  await dismissChampionReveal(selectedEvent.value)
   revealActive.value = false
   const { [selectedGenre.value]: _removed, ...rest } = genreChampions.value
   genreChampions.value = rest
@@ -1652,7 +1657,7 @@ watch([allJudgesVoted, tentativeWinner], ([voted, winner]) => {
 
 watch(selectedGenre, async (newVal, oldVal) => {
   // Dismiss before resetting revealActive — the check must happen while it's still true
-  if (oldVal && revealActive.value) await dismissChampionReveal()
+  if (oldVal && revealActive.value) await dismissChampionReveal(selectedEvent.value)
   revealActive.value = false
   if (newVal) {
     // Restore per-genre topSize — smoke auto-detection takes priority, otherwise
@@ -1721,7 +1726,7 @@ watch(selectedGenre, async (newVal, oldVal) => {
       // Defensive: if this genre has a champion locked, force DECIDED regardless
       // of what the backend returned (WS messages can corrupt the phase mid-switch).
       if (genreChampions.value[newVal] && battlePhase.value !== 'DECIDED') {
-        await setBattlePhase('DECIDED')
+        await setBattlePhase('DECIDED', undefined, selectedEvent.value)
         battlePhase.value = 'DECIDED'
       }
     }
@@ -1745,8 +1750,8 @@ watch(topSize, async (newVal, oldVal) => {
   }
   currentWinner.value = -2
   if (oldVal && !programmatic) {
-    await clearBattlePair()
-    await setBattlePhase('IDLE')
+    await clearBattlePair(selectedEvent.value)
+    await setBattlePhase('IDLE', undefined, selectedEvent.value)
     battlePhase.value = 'IDLE'
     currentBattle.value = []
     currentTop.value = ''
@@ -1871,7 +1876,7 @@ onMounted(async () => {
   wsClient.value.onConnect = () => {
     // Subscribe to full state snapshots — used for initial hydration, genre switch, and reconnect recovery.
     // Diff logic prevents re-rendering already-current state.
-    subscribeToChannel(wsClient.value, '/topic/battle/state', (msg) => {
+    subscribeToChannel(wsClient.value, bcTopic('state'), (msg) => {
       // Guard: ignore state broadcasts for a different genre, or when genre is
       // unset (empty/null). Prevents phase/champion leaking between formats.
       if (!msg.genreName || msg.genreName !== selectedGenre.value) return
@@ -1880,7 +1885,7 @@ onMounted(async () => {
     })
 
     // Phase subscription — keep for real-time phase transitions
-    wsClient.value.subscribe('/topic/battle/phase', (raw) => {
+    wsClient.value.subscribe(bcTopic('phase'), (raw) => {
       const msg = JSON.parse(raw.body)
       // Guard: ignore phase broadcasts with missing/mismatched genre.
       // Prevents DECIDED phase from a finished smoke genre leaking into
@@ -1896,7 +1901,7 @@ onMounted(async () => {
     // single atomic getBattleJudges() call (no more remove+add loop causing
     // intermediate states). judgeSyncing guard prevents WS from racing with
     // the explicit fetch during genre switch.
-    wsClient.value.subscribe('/topic/battle/judges', (raw) => {
+    wsClient.value.subscribe(bcTopic('judges'), (raw) => {
       if (judgeSyncing) return
       const msg = JSON.parse(raw.body)
       if (msg?.judges) {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1935,7 +1935,7 @@ onUnmounted(() => {
     <!-- Quick access links -->
     <div v-if="isAdminOrOrganiser" class="flex flex-wrap gap-2">
       <a
-        href="/battle/overlay"
+        :href="selectedEvent ? `/battle/overlay?event=${encodeURIComponent(selectedEvent)}` : '/battle/overlay'"
         target="_blank"
         rel="noopener noreferrer"
         class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
@@ -1945,7 +1945,7 @@ onUnmounted(() => {
         <i class="pi pi-external-link text-xs text-content-muted"></i>
       </a>
       <a
-        href="/battle/overlay?isSmoke=true"
+        :href="selectedEvent ? `/battle/overlay?event=${encodeURIComponent(selectedEvent)}&isSmoke=true` : '/battle/overlay?isSmoke=true'"
         target="_blank"
         rel="noopener noreferrer"
         class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
@@ -1955,7 +1955,7 @@ onUnmounted(() => {
         <i class="pi pi-external-link text-xs text-content-muted"></i>
       </a>
       <a
-        href="/battle/judge"
+        :href="selectedEvent ? `/battle/judge?event=${encodeURIComponent(selectedEvent)}` : '/battle/judge'"
         target="_blank"
         rel="noopener noreferrer"
         class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
@@ -1965,7 +1965,7 @@ onUnmounted(() => {
         <i class="pi pi-external-link text-xs text-content-muted"></i>
       </a>
       <a
-        href="/battle/bracket"
+        :href="selectedEvent ? `/battle/bracket?event=${encodeURIComponent(selectedEvent)}` : '/battle/bracket'"
         target="_blank"
         rel="noopener noreferrer"
         class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -7,10 +7,10 @@ import { useRoute, useRouter } from 'vue-router'
 
 const router = useRouter()
 const route = useRoute()
-// eventName must be provided via ?event= param — passed automatically by the
-// BattleControl "Judge View" link. Without it, subscriptions use a dead flat
-// topic and receive nothing (same behaviour as Overlay/Bracket).
-const eventName = ref(route.query.event || '')
+// eventName derived from the judge's auth session (already tied to one event).
+// ?event= URL param takes priority for edge cases; session event is the default.
+const authStore = useAuthStore()
+const eventName = ref(route.query.event || authStore.activeEvent?.name || '')
 const topic = (path) => eventName.value
   ? `/topic/battle/${eventName.value}/${path}`
   : `/topic/battle/${path}`

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -3,9 +3,14 @@ import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCu
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { useAuthStore } from '@/utils/auth'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 const router = useRouter()
+const route = useRoute()
+const eventName = computed(() => route.query.event || '')
+const topic = (path) => eventName.value
+  ? `/topic/battle/${eventName.value}/${path}`
+  : `/topic/battle/${path}`
 
 // ── Overlay config ──────────────────────────────────────────────────────────
 const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
@@ -164,22 +169,22 @@ function setupVoteSubscription() {
 // ── Mount ───────────────────────────────────────────────────────────────────
 onMounted(async () => {
   // 1. Overlay colors
-  const config = await getOverlayConfig()
+  const config = await getOverlayConfig(eventName.value)
   if (config?.leftColor) overlayConfig.value = config
 
   // 2. Phase
-  const phaseData = await getBattlePhase()
+  const phaseData = await getBattlePhase(eventName.value)
   battlePhase.value = phaseData?.phase ?? 'IDLE'
 
   // 3. Current pair (must come before vote restore so key is correct)
-  const pairData = await getCurrentBattlePair()
+  const pairData = await getCurrentBattlePair(eventName.value)
   if (pairData) {
     leftName.value  = pairData.left  ?? ''
     rightName.value = pairData.right ?? ''
   }
 
   // 4. Judges + identity
-  battleJudges.value = await getBattleJudges()
+  battleJudges.value = await getBattleJudges(eventName.value)
   loadJudgeIdentity(battleJudges.value?.judges ?? [])
 
   // 5. Restore vote from backend judges list if available, fall back to localStorage
@@ -200,11 +205,11 @@ onMounted(async () => {
   const cScore   = createClient(); wsClients.push(cScore)
   const cJudges  = createClient(); wsClients.push(cJudges)
 
-  subscribeToChannel(cOverlay, '/topic/battle/overlay-config', (msg) => {
+  subscribeToChannel(cOverlay, topic('overlay-config'), (msg) => {
     if (msg?.leftColor) overlayConfig.value = msg
   })
 
-  subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
+  subscribeToChannel(cPhase, topic('phase'), (msg) => {
     if (!msg?.phase) return
     const prev = battlePhase.value
     battlePhase.value = msg.phase
@@ -214,7 +219,7 @@ onMounted(async () => {
     }
   })
 
-  subscribeToChannel(cPair, '/topic/battle/battle-pair', (msg) => {
+  subscribeToChannel(cPair, topic('battle-pair'), (msg) => {
     const newLeft  = msg.left  ?? ''
     const newRight = msg.right ?? ''
     if (newLeft !== leftName.value || newRight !== rightName.value) {
@@ -224,11 +229,11 @@ onMounted(async () => {
     }
   })
 
-  subscribeToChannel(cScore, '/topic/battle/score', (msg) => {
+  subscribeToChannel(cScore, topic('score'), (msg) => {
     revealedWinner.value = msg.message
   })
 
-  subscribeToChannel(cJudges, '/topic/battle/judges', (msg) => {
+  subscribeToChannel(cJudges, topic('judges'), (msg) => {
     battleJudges.value = msg
     const authStore = useAuthStore()
     const judges = msg?.judges ?? []
@@ -269,12 +274,12 @@ onMounted(async () => {
 
   // Full-state snapshot for initial hydration and reconnect recovery
   const cState = createClient(); wsClients.push(cState)
-  subscribeToChannel(cState, '/topic/battle/state', (msg) => {
+  subscribeToChannel(cState, topic('state'), (msg) => {
     hydrateJudgeFromState(msg)
   })
 
   // Initial hydration + reconnect recovery
-  const initialState = await getBattleState()
+  const initialState = await getBattleState(eventName.value)
   if (initialState) hydrateJudgeFromState(initialState)
 })
 

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
+import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCurrentBattlePair, getOverlayConfig, getActiveGenre } from '@/utils/api'
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useAuthStore } from '@/utils/auth'
@@ -7,10 +7,10 @@ import { useRoute, useRouter } from 'vue-router'
 
 const router = useRouter()
 const route = useRoute()
-const eventName = computed(() => route.query.event || '')
-const topic = (path) => eventName.value
-  ? `/topic/battle/${eventName.value}/${path}`
-  : `/topic/battle/${path}`
+// Judges access via QR/link and shouldn't need to know the event name — resolve from
+// ?event= param first, then fall back to the server's currently active battle event.
+const eventName = ref(route.query.event || '')
+const topic = (path) => `/topic/battle/${eventName.value}/${path}`
 
 // ── Overlay config ──────────────────────────────────────────────────────────
 const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
@@ -168,6 +168,13 @@ function setupVoteSubscription() {
 
 // ── Mount ───────────────────────────────────────────────────────────────────
 onMounted(async () => {
+  // Resolve event: ?event= param wins; fall back to server's active battle event.
+  // Judges receive links/QR codes and shouldn't need the event name baked in.
+  if (!eventName.value) {
+    const active = await getActiveGenre()
+    if (active?.eventName) eventName.value = active.eventName
+  }
+
   // 1. Overlay colors
   const config = await getOverlayConfig(eventName.value)
   if (config?.leftColor) overlayConfig.value = config

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { useAuthStore } from '@/utils/auth'
 import { useRoute, useRouter } from 'vue-router'
 

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCurrentBattlePair, getOverlayConfig, getActiveGenre } from '@/utils/api'
+import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useAuthStore } from '@/utils/auth'
@@ -7,10 +7,13 @@ import { useRoute, useRouter } from 'vue-router'
 
 const router = useRouter()
 const route = useRoute()
-// Judges access via QR/link and shouldn't need to know the event name — resolve from
-// ?event= param first, then fall back to the server's currently active battle event.
+// eventName must be provided via ?event= param — passed automatically by the
+// BattleControl "Judge View" link. Without it, subscriptions use a dead flat
+// topic and receive nothing (same behaviour as Overlay/Bracket).
 const eventName = ref(route.query.event || '')
-const topic = (path) => `/topic/battle/${eventName.value}/${path}`
+const topic = (path) => eventName.value
+  ? `/topic/battle/${eventName.value}/${path}`
+  : `/topic/battle/${path}`
 
 // ── Overlay config ──────────────────────────────────────────────────────────
 const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
@@ -168,13 +171,6 @@ function setupVoteSubscription() {
 
 // ── Mount ───────────────────────────────────────────────────────────────────
 onMounted(async () => {
-  // Resolve event: ?event= param wins; fall back to server's active battle event.
-  // Judges receive links/QR codes and shouldn't need the event name baked in.
-  if (!eventName.value) {
-    const active = await getActiveGenre()
-    if (active?.eventName) eventName.value = active.eventName
-  }
-
   // 1. Overlay colors
   const config = await getOverlayConfig(eventName.value)
   if (config?.leftColor) overlayConfig.value = config

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { battleJudgeVote, getBattleJudges, getBattlePhase, getBattleState, getCurrentBattlePair, getOverlayConfig } from '@/utils/api'
 import { subscribeToChannel, createClient, deactivateClient } from '@/utils/websocket'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useAuthStore } from '@/utils/auth'
 import { useRoute, useRouter } from 'vue-router'
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -7,6 +7,10 @@ import { useRoute } from 'vue-router'
 import Chart from './Chart.vue';
 
 const route = useRoute()
+const eventName = computed(() => route.query.event || '')
+const topic = (path) => eventName.value
+  ? `/topic/battle/${eventName.value}/${path}`
+  : `/topic/battle/${path}`
 
 // ── Overlay config (live from BattleControl + API) ─────────────────────────
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
@@ -420,20 +424,20 @@ onMounted(async () => {
   document.body.classList.add('transparent-page')
 
   // Fetch initial overlay config (survives OBS refresh)
-  const config = await getOverlayConfig()
+  const config = await getOverlayConfig(eventName.value)
   if (config?.showImages !== undefined) overlayConfig.value = config
 
   // Live overlay config updates from BattleControl
   const cOverlay = createClient()
   clients.push(cOverlay)
-  subscribeToChannel(cOverlay, '/topic/battle/overlay-config', (msg) => {
+  subscribeToChannel(cOverlay, topic('overlay-config'), (msg) => {
     if (msg?.showImages !== undefined) overlayConfig.value = msg
   })
 
   // Phase subscription: track phase for stale-event guard; VOTING shows indicator
   const cPhase = createClient()
   clients.push(cPhase)
-  subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
+  subscribeToChannel(cPhase, topic('phase'), (msg) => {
     if (!msg?.phase) return
     // Ignore phase messages from a different (inactive) genre — stale WS from a
     // genre switch can arrive late and corrupt the current genre's phase display.
@@ -464,7 +468,7 @@ onMounted(async () => {
 
   // Restore state from backend on mount — handles OBS refresh and genre switches.
   // Runs for both standard and smoke mode so genre-switch detection always works.
-  const state = await getBattleState()
+  const state = await getBattleState(eventName.value)
   if (state?.genreName !== undefined) {
     isSmoke.value = genreNameIsSmoke(state.genreName)
     activeGenreName.value = state.genreName
@@ -474,9 +478,9 @@ onMounted(async () => {
     if (state?.judges?.length) {
       battleJudges.value = { judges: state.judges }
     } else {
-      battleJudges.value = await getBattleJudges()
+      battleJudges.value = await getBattleJudges(eventName.value)
     }
-    const pair = state?.currentPair?.left ? state.currentPair : await getCurrentBattlePair()
+    const pair = state?.currentPair?.left ? state.currentPair : await getCurrentBattlePair(eventName.value)
     if (pair) await updateBattlePair(pair)
     // Restore winner visual state for REVEALED and DECIDED without replaying the score animation
     if ((state?.battlePhase === 'REVEALED' || state?.battlePhase === 'DECIDED') && state?.bracket?.rounds) {
@@ -489,20 +493,20 @@ onMounted(async () => {
   const cPair2   = createClient(); clients.push(cPair2)
   const cScore2  = createClient(); clients.push(cScore2)
   const cJudges2 = createClient(); clients.push(cJudges2)
-  subscribeToChannel(cPair2,   '/topic/battle/battle-pair', (msg) => {
+  subscribeToChannel(cPair2,   topic('battle-pair'), (msg) => {
     if (!isSmoke.value && (msg.left !== leftName.value || msg.right !== rightName.value)) {
       updateBattlePair(msg)
     }
   })
-  subscribeToChannel(cScore2,  '/topic/battle/score',       (msg) => { if (!isSmoke.value) updateScore(msg) })
-  subscribeToChannel(cJudges2, '/topic/battle/judges',      (msg) => { if (!isSmoke.value) updateBattleJudge(msg) })
+  subscribeToChannel(cScore2,  topic('score'),       (msg) => { if (!isSmoke.value) updateScore(msg) })
+  subscribeToChannel(cJudges2, topic('judges'),      (msg) => { if (!isSmoke.value) updateBattleJudge(msg) })
 
   // /topic/battle/bracket — fires when operator changes bracket format or size in BattleControl.
   // Use topSize to determine smoke mode (7 = smoke, anything else = standard).
   // Format change: overlay will receive phase → IDLE from BattleControl, triggering the
   // blank announcement. No manual wipe needed here.
   const cBracket = createClient(); clients.push(cBracket)
-  subscribeToChannel(cBracket, '/topic/battle/bracket', async (msg) => {
+  subscribeToChannel(cBracket, topic('bracket'), async (msg) => {
     if (!msg) return
     const wasSmoke = isSmoke.value
     const newTopSize = msg.topSize !== undefined ? Number(msg.topSize) : null
@@ -513,7 +517,7 @@ onMounted(async () => {
     // On format switch standard → smoke: Chart handles its own subscriptions.
     // On format switch smoke → standard: fetch current pair from backend to show something.
     if (wasSmoke && !isSmoke.value) {
-      const state = await getBattleState()
+      const state = await getBattleState(eventName.value)
       if (state?.currentPair?.left) await updateBattlePair(state.currentPair)
     }
   })
@@ -521,7 +525,7 @@ onMounted(async () => {
   // Champion reveal — re-plays the winner animation when organiser clicks Reveal Champion
   // after a refresh or genre switch (score already submitted, but overlay needs to animate).
   const cChampion = createClient(); clients.push(cChampion)
-  subscribeToChannel(cChampion, '/topic/battle/champion-reveal', async (msg) => {
+  subscribeToChannel(cChampion, topic('champion-reveal'), async (msg) => {
     if (!msg || msg.dismiss || isSmoke.value) return
     const champion = msg.championName
     if (!champion) return
@@ -531,7 +535,7 @@ onMounted(async () => {
     // animation below.
     let side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
     if (side === -1) {
-      const freshState = await getBattleState()
+      const freshState = await getBattleState(eventName.value)
       if (freshState?.currentPair?.left) {
         // Silent pair update: set refs directly, no entrance animation
         leftName.value    = freshState.currentPair.left
@@ -583,13 +587,13 @@ onMounted(async () => {
 
   // Full-state snapshot — hydrates on mount, genre switch, and reconnect recovery
   const cState = createClient(); clients.push(cState)
-  subscribeToChannel(cState, '/topic/battle/state', (msg) => {
+  subscribeToChannel(cState, topic('state'), (msg) => {
     hydrateOverlayFromState(msg)
   })
 
   // Broadcast timer (from BattleTimer.vue countdown)
   const cTimer = createClient(); clients.push(cTimer)
-  subscribeToChannel(cTimer, '/topic/battle/timer', (msg) => {
+  subscribeToChannel(cTimer, topic('timer'), (msg) => {
     const data = msg
     timerState.value = data
     if (data.running && !showTimer.value) {
@@ -607,7 +611,7 @@ onMounted(async () => {
 
   // Format timer (session-level 7-to-Smoke countdown)
   const cFormatTimer = createClient(); clients.push(cFormatTimer)
-  subscribeToChannel(cFormatTimer, '/topic/battle/format-timer', (msg) => {
+  subscribeToChannel(cFormatTimer, topic('format-timer'), (msg) => {
     formatTimerState.value = msg
     showFormatTimer.value = msg.running || msg.expired
   })

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { getBattleJudges, getBattleState, getCurrentBattlePair, getImage, getOverlayConfig, getActiveGenre } from '@/utils/api';
+import { getBattleJudges, getBattleState, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket';
 import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useDelay } from '@/utils/utils';
@@ -421,13 +421,6 @@ const restoreRevealedState = (rounds) => {
 onMounted(async () => {
   document.documentElement.classList.add('transparent-page')
   document.body.classList.add('transparent-page')
-
-  // Resolve event: ?event= URL param takes priority; fall back to the server's active event.
-  // This means the overlay works both with an explicit event URL and without one.
-  if (!eventName.value) {
-    const active = await getActiveGenre()
-    if (active?.eventName) eventName.value = active.eventName
-  }
 
   // Fetch initial overlay config (survives OBS refresh)
   const config = await getOverlayConfig(eventName.value)

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { getBattleJudges, getBattleState, getCurrentBattlePair, getImage, getOverlayConfig } from '@/utils/api';
+import { getBattleJudges, getBattleState, getCurrentBattlePair, getImage, getOverlayConfig, getActiveGenre } from '@/utils/api';
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket';
 import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useDelay } from '@/utils/utils';
@@ -7,10 +7,9 @@ import { useRoute } from 'vue-router'
 import Chart from './Chart.vue';
 
 const route = useRoute()
-const eventName = computed(() => route.query.event || '')
-const topic = (path) => eventName.value
-  ? `/topic/battle/${eventName.value}/${path}`
-  : `/topic/battle/${path}`
+// eventName is resolved on mount: prefer ?event= URL param, fall back to active event from REST
+const eventName = ref(route.query.event || '')
+const topic = (path) => `/topic/battle/${eventName.value}/${path}`
 
 // ── Overlay config (live from BattleControl + API) ─────────────────────────
 const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
@@ -422,6 +421,13 @@ const restoreRevealedState = (rounds) => {
 onMounted(async () => {
   document.documentElement.classList.add('transparent-page')
   document.body.classList.add('transparent-page')
+
+  // Resolve event: ?event= URL param takes priority; fall back to the server's active event.
+  // This means the overlay works both with an explicit event URL and without one.
+  if (!eventName.value) {
+    const active = await getActiveGenre()
+    if (active?.eventName) eventName.value = active.eventName
+  }
 
   // Fetch initial overlay config (survives OBS refresh)
   const config = await getOverlayConfig(eventName.value)

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
-import { getBattleState, getBracketState, getOverlayConfig } from '@/utils/api'
+import { getBattleState, getBracketState, getOverlayConfig, getActiveGenre } from '@/utils/api'
 import { createClient } from '@/utils/websocket'
 import { useRoute } from 'vue-router'
 
@@ -12,10 +12,8 @@ const activePair     = ref(null)
 const currentGenre   = ref(null)
 let   wsClient       = null
 const route = useRoute()
-const eventName = computed(() => route.query.event || '')
-const topic = (path) => eventName.value
-  ? `/topic/battle/${eventName.value}/${path}`
-  : `/topic/battle/${path}`
+const eventName = ref(route.query.event || '')
+const topic = (path) => `/topic/battle/${eventName.value}/${path}`
 
 // ── animation state ──────────────────────────────────────
 const pendingBracket  = ref(null)
@@ -295,6 +293,12 @@ function getActiveMatchInfo() {
 
 // ── lifecycle ─────────────────────────────────────────────
 onMounted(async () => {
+  // Resolve event: ?event= URL param takes priority; fall back to the server's active event.
+  if (!eventName.value) {
+    const active = await getActiveGenre()
+    if (active?.eventName) eventName.value = active.eventName
+  }
+
   // Restore state from backend — authoritative source for bracket/pair/genre
   const battleState = await getBattleState(eventName.value)
   if (battleState?.bracket && (battleState.bracket.topSize || battleState.bracket.rounds)) {

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -426,7 +426,7 @@ onMounted(async () => {
     })
 
     // Re-hydrate on reconnect — REST covers gap while WS was disconnected
-    getBattleState().then(state => {
+    getBattleState(eventName.value).then(state => {
       if (state && (state.bracket?.topSize || state.bracket?.rounds)) {
         if (state.bracket && !animRunning) {
           const incoming = JSON.stringify(state.bracket)

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
-import { getBattleState, getBracketState, getOverlayConfig, getActiveGenre } from '@/utils/api'
+import { getBattleState, getBracketState, getOverlayConfig } from '@/utils/api'
 import { createClient } from '@/utils/websocket'
 import { useRoute } from 'vue-router'
 
@@ -293,12 +293,6 @@ function getActiveMatchInfo() {
 
 // ── lifecycle ─────────────────────────────────────────────
 onMounted(async () => {
-  // Resolve event: ?event= URL param takes priority; fall back to the server's active event.
-  if (!eventName.value) {
-    const active = await getActiveGenre()
-    if (active?.eventName) eventName.value = active.eventName
-  }
-
   // Restore state from backend — authoritative source for bracket/pair/genre
   const battleState = await getBattleState(eventName.value)
   if (battleState?.bracket && (battleState.bracket.topSize || battleState.bracket.rounds)) {

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { getBattleState, getBracketState, getOverlayConfig } from '@/utils/api'
 import { createClient } from '@/utils/websocket'
+import { useRoute } from 'vue-router'
 
 const bracketState   = ref(null)
 const lastBracketSnapshot = ref('')  // JSON diff guard
@@ -10,6 +11,11 @@ const championReveal = ref(null)   // null = hidden; { genreName, championName }
 const activePair     = ref(null)
 const currentGenre   = ref(null)
 let   wsClient       = null
+const route = useRoute()
+const eventName = computed(() => route.query.event || '')
+const topic = (path) => eventName.value
+  ? `/topic/battle/${eventName.value}/${path}`
+  : `/topic/battle/${path}`
 
 // ── animation state ──────────────────────────────────────
 const pendingBracket  = ref(null)
@@ -290,7 +296,7 @@ function getActiveMatchInfo() {
 // ── lifecycle ─────────────────────────────────────────────
 onMounted(async () => {
   // Restore state from backend — authoritative source for bracket/pair/genre
-  const battleState = await getBattleState()
+  const battleState = await getBattleState(eventName.value)
   if (battleState?.bracket && (battleState.bracket.topSize || battleState.bracket.rounds)) {
     bracketState.value = battleState.bracket
   }
@@ -302,17 +308,17 @@ onMounted(async () => {
   }
 
   if (!bracketState.value) {
-    const state = await getBracketState()
+    const state = await getBracketState(eventName.value)
     if (state && (state.topSize || state.rounds)) bracketState.value = state
   }
 
-  const cfg = await getOverlayConfig()
+  const cfg = await getOverlayConfig(eventName.value)
   if (cfg) overlayConfig.value = cfg
 
   wsClient = createClient()
   wsClient.onConnect = () => {
 
-    wsClient.subscribe('/topic/battle/state', (msg) => {
+    wsClient.subscribe(topic('state'), (msg) => {
       // Diff guard: compare raw body string to skip no-op updates.
       // Avoids unnecessary JSON.parse + JSON.stringify round-trip on every message.
       if (msg.body === lastBracketSnapshot.value) return
@@ -336,7 +342,7 @@ onMounted(async () => {
       }
     })
 
-    wsClient.subscribe('/topic/battle/bracket', (msg) => {
+    wsClient.subscribe(topic('bracket'), (msg) => {
       if (msg.body === lastBracketBody) return
       lastBracketBody = msg.body
       const newState = JSON.parse(msg.body)
@@ -351,12 +357,12 @@ onMounted(async () => {
       }
     })
 
-    wsClient.subscribe('/topic/battle/battle-pair', (msg) => {
+    wsClient.subscribe(topic('battle-pair'), (msg) => {
       const data = JSON.parse(msg.body)
       activePair.value = { left: data.left, right: data.right }
     })
 
-    wsClient.subscribe('/topic/battle/phase', () => {
+    wsClient.subscribe(topic('phase'), () => {
       // Phase subscription for future phase-aware bracket display
     })
 
@@ -365,12 +371,12 @@ onMounted(async () => {
       currentGenre.value = data.genre ?? data.message ?? null
     })
 
-    wsClient.subscribe('/topic/battle/overlay-config', (msg) => {
+    wsClient.subscribe(topic('overlay-config'), (msg) => {
       const cfg = JSON.parse(msg.body)
       overlayConfig.value = cfg
     })
 
-    wsClient.subscribe('/topic/battle/champion-reveal', (msg) => {
+    wsClient.subscribe(topic('champion-reveal'), (msg) => {
       const data = JSON.parse(msg.body)
       if (data.dismiss) {
         championReveal.value = null
@@ -379,7 +385,7 @@ onMounted(async () => {
       }
     })
 
-    wsClient.subscribe('/topic/battle/score', (msg) => {
+    wsClient.subscribe(topic('score'), (msg) => {
       const data = JSON.parse(msg.body)
       if (data.message !== 0 && data.message !== 1) return
       if (animRunning) return

--- a/BES-frontend/src/views/Chart.vue
+++ b/BES-frontend/src/views/Chart.vue
@@ -4,7 +4,14 @@ import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { getSmokeList, getOverlayConfig, getBattleJudges, getBattleState } from '@/utils/api'
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket'
 import { useDelay } from '@/utils/utils'
+import { useRoute } from 'vue-router'
 import { barHeightPct, findScoreGainers } from '@/utils/smokeChartHelpers'
+
+const route = useRoute()
+const eventName = computed(() => route.query.event || '')
+const topic = (path) => eventName.value
+  ? `/topic/battle/${eventName.value}/${path}`
+  : `/topic/battle/${path}`
 
 const props = defineProps({
   bottomPad: { type: Number, default: 0 }
@@ -234,30 +241,30 @@ onMounted(async () => {
   document.documentElement.classList.add('transparent-page')
   document.body.classList.add('transparent-page')
 
-  const config = await getOverlayConfig()
+  const config = await getOverlayConfig(eventName.value)
   if (config?.leftColor !== undefined) overlayConfig.value = config
 
   const smoke = await getSmokeList()
   if (smoke?.list) smokeParticipants.value = smoke.list
 
-  battleJudges.value = await getBattleJudges()
+  battleJudges.value = await getBattleJudges(eventName.value)
 
   const cConfig = createClient(); clients.push(cConfig)
-  subscribeToChannel(cConfig, '/topic/battle/overlay-config', (msg) => {
+  subscribeToChannel(cConfig, topic('overlay-config'), (msg) => {
     if (msg?.leftColor !== undefined) overlayConfig.value = msg
   })
 
   const cSmoke = createClient(); clients.push(cSmoke)
-  subscribeToChannel(cSmoke, '/topic/battle/smoke', updateList)
+  subscribeToChannel(cSmoke, topic('smoke'), updateList)
 
   const cJudges = createClient(); clients.push(cJudges)
-  subscribeToChannel(cJudges, '/topic/battle/judges', updateBattleJudge)
+  subscribeToChannel(cJudges, topic('judges'), updateBattleJudge)
 
   const cScore = createClient(); clients.push(cScore)
-  subscribeToChannel(cScore, '/topic/battle/score', updateScore)
+  subscribeToChannel(cScore, topic('score'), updateScore)
 
   const cPhase = createClient(); clients.push(cPhase)
-  subscribeToChannel(cPhase, '/topic/battle/phase', (msg) => {
+  subscribeToChannel(cPhase, topic('phase'), (msg) => {
     if (!msg?.phase) return
     battlePhase.value = msg.phase
     if (msg.phase === 'LOCKED') showResult.value = false
@@ -266,19 +273,19 @@ onMounted(async () => {
   })
 
   const cReveal = createClient(); clients.push(cReveal)
-  subscribeToChannel(cReveal, '/topic/battle/champion-reveal', (msg) => {
+  subscribeToChannel(cReveal, topic('champion-reveal'), (msg) => {
     if (!msg) return
     if (msg.dismiss) { showChampion.value = false; return }
     if (msg.championName) showChampionFor(msg.championName)
   })
 
   const cState = createClient(); clients.push(cState)
-  subscribeToChannel(cState, '/topic/battle/state', (msg) => {
+  subscribeToChannel(cState, topic('state'), (msg) => {
     hydrateChartFromState(msg)
   })
 
   // Initial hydration + reconnect recovery
-  const initialState = await getBattleState()
+  const initialState = await getBattleState(eventName.value)
   if (initialState) hydrateChartFromState(initialState)
 })
 

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -57,6 +57,12 @@ public class BattleController {
     @Autowired
     BattleService battleService;
 
+    private String resolveEvent(String dtoEventName) {
+        return (dtoEventName != null && !dtoEventName.isBlank())
+            ? dtoEventName
+            : battleService.getActiveEventName() != null ? battleService.getActiveEventName() : "";
+    }
+
     @GetMapping("/modes")
     public ResponseEntity<?> getAllModes(){
         return ResponseEntity.ok(
@@ -111,7 +117,7 @@ public class BattleController {
     @PostMapping("/battle-pair")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
     public ResponseEntity<?> setBattlerPair(@Valid @RequestBody SetBattlerPairDto dto){
-        battleService.setBattlerPairService(dto);
+        battleService.setBattlerPairService(resolveEvent(dto.getEventName()), dto);
         return ResponseEntity.ok(Map.of(
             "message", "successfully set the battle pair",
             "left", battleService.getCurrentPair().getLeftBattler().getName(),
@@ -121,31 +127,36 @@ public class BattleController {
 
     @DeleteMapping("/battle-pair")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
-    public ResponseEntity<?> clearBattlePair(){
-        battleService.clearBattlePairService();
+    public ResponseEntity<?> clearBattlePair(@RequestParam(required = false) String event){
+        battleService.clearBattlePairService(resolveEvent(event));
         return ResponseEntity.ok(Map.of(
             "message", "battle pair cleared"
         ));
     }
 
     @PostMapping("/timer")
-    public ResponseEntity<?> updateTimer(@RequestBody Map<String, Object> payload) {
-        battleService.handleTimerPayload(payload);
+    public ResponseEntity<?> updateTimer(
+            @RequestParam(required = false) String event,
+            @RequestBody Map<String, Object> payload) {
+        battleService.handleTimerPayload(resolveEvent(event), payload);
         return ResponseEntity.ok(Map.of("message", "Timer updated"));
     }
 
     @PostMapping("/format-timer")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
-    public ResponseEntity<?> updateFormatTimer(@RequestBody Map<String, Object> payload) {
-        battleService.handleFormatTimerPayload(payload);
+    public ResponseEntity<?> updateFormatTimer(
+            @RequestParam(required = false) String event,
+            @RequestBody Map<String, Object> payload) {
+        battleService.handleFormatTimerPayload(resolveEvent(event), payload);
         return ResponseEntity.ok(Map.of("message", "Format timer updated"));
     }
 
     @PostMapping("/score")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
     public ResponseEntity<?> setBattleScore(@RequestBody(required = false) SetBattleScoreDto dto){
+        String eName = resolveEvent(dto != null ? dto.getEventName() : null);
         boolean isFinal = dto != null && dto.isFinal();
-        Integer code = battleService.setScoreService(isFinal);
+        Integer code = battleService.setScoreService(eName, isFinal);
         if(code == -2){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
                 Map.of("message", "No judge found")
@@ -160,28 +171,28 @@ public class BattleController {
             return ResponseEntity.ok(Map.of(
                 "message", "Left side get one point",
                 "winner", 0,
-                "current score", battleService.getCurrentPair().getLeftBattler().getScore()
+                "current score", battleService.getCurrentPair(eName).getLeftBattler().getScore()
             ));
         }else {
             return ResponseEntity.ok(Map.of(
                 "message", "Right side get one point",
                 "winner", 1,
-                "current score", battleService.getCurrentPair().getRightBattler().getScore()
+                "current score", battleService.getCurrentPair(eName).getRightBattler().getScore()
             ));
         }
     }
 
     @PostMapping("/revote")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
-    public ResponseEntity<?> revote(){
-        battleService.resetJudgeVotesService();
+    public ResponseEntity<?> revote(@RequestParam(required = false) String event){
+        battleService.resetJudgeVotesService(resolveEvent(event));
         return ResponseEntity.ok(Map.of("message", "Judge votes reset"));
     }
 
     @PostMapping("/champion-reveal")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
     public ResponseEntity<?> championReveal(@RequestBody ChampionRevealDto dto){
-        battleService.broadcastChampionReveal(dto);
+        battleService.broadcastChampionReveal(resolveEvent(dto.getEventName()), dto);
         return ResponseEntity.ok(Map.of("message", "Champion reveal broadcast"));
     }
 
@@ -191,9 +202,9 @@ public class BattleController {
     }
 
     @GetMapping("/judges")
-    public ResponseEntity<?> getAllBattleJudges(){
+    public ResponseEntity<?> getAllBattleJudges(@RequestParam(required = false) String event){
         return ResponseEntity.ok(Map.of(
-            "judges",battleService.getJudges()
+            "judges", battleService.getJudges(resolveEvent(event))
         ));
     }
     
@@ -201,14 +212,14 @@ public class BattleController {
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
     public ResponseEntity<?> removeBattleJudge(@Valid @RequestBody SetJudgeDto dto){
         return ResponseEntity.ok(Map.of(
-            "judge removed",battleService.removeBattleJudgeService(dto)
+            "judge removed", battleService.removeBattleJudgeService(resolveEvent(dto.getEventName()), dto)
         ));
     }
 
     @PostMapping("/judge")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
     public ResponseEntity<?> setJudge(@Valid @RequestBody SetJudgeDto dto){
-        Integer status = battleService.setBattleJudgeService(dto);
+        Integer status = battleService.setBattleJudgeService(resolveEvent(dto.getEventName()), dto);
         if(status == -1) return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
             Map.of(
                 "message", "Judge not found"
@@ -227,13 +238,13 @@ public class BattleController {
     @PostMapping("/judge/weightage")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
     public ResponseEntity<?> updateJudgeWeightage(@Valid @RequestBody UpdateJudgeWeightageDto dto) {
-        battleService.updateJudgeWeightageService(dto);
+        battleService.updateJudgeWeightageService(resolveEvent(dto.getEventName()), dto);
         return ResponseEntity.ok(Map.of("message", "Weightage updated"));
     }
 
     @PostMapping("/vote")
     public ResponseEntity<?> submitVote(@Valid @RequestBody SetVoteDto dto){
-        Integer vote = battleService.setVoteService(dto);
+        Integer vote = battleService.setVoteService(resolveEvent(dto.getEventName()), dto);
         if(vote == -2){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
                 Map.of("message", "Judge not found")
@@ -326,7 +337,7 @@ public class BattleController {
     @PostMapping("/smoke")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
     public ResponseEntity<?> setSmokeList(@Valid @RequestBody SetSmokeBattlersDto dto){
-        battleService.setSmokeBattlersService(dto);
+        battleService.setSmokeBattlersService(resolveEvent(dto.getEventName()), dto);
         return ResponseEntity.ok(Map.of(
             "message", "List updated"
         ));
@@ -340,7 +351,7 @@ public class BattleController {
     @PostMapping("/phase")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
     public ResponseEntity<?> setBattlePhase(@Valid @RequestBody SetBattlePhaseDto dto){
-        battleService.setBattlePhaseService(dto.getPhase(), dto.getChampion());
+        battleService.setBattlePhaseService(resolveEvent(dto.getEventName()), dto.getPhase(), dto.getChampion());
         return ResponseEntity.ok(Map.of("phase", battleService.getBattlePhase()));
     }
 
@@ -354,20 +365,20 @@ public class BattleController {
     @PostMapping("/bracket")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE')")
     public ResponseEntity<?> setBracketState(@Valid @RequestBody SetBracketStateDto dto){
-        battleService.setBracketStateService(dto);
+        battleService.setBracketStateService(resolveEvent(dto.getEventName()), dto);
         return ResponseEntity.ok(Map.of("message", "Bracket state updated"));
     }
 
     @GetMapping("/overlay-config")
-    public ResponseEntity<?> getOverlayConfig() {
-        return ResponseEntity.ok(battleService.getOverlayConfig());
+    public ResponseEntity<?> getOverlayConfig(@RequestParam(required = false) String event) {
+        return ResponseEntity.ok(battleService.getOverlayConfig(resolveEvent(event)));
     }
 
     @PostMapping("/overlay-config")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
     public ResponseEntity<?> setOverlayConfig(@Valid @RequestBody SetOverlayConfigDto dto) {
-        battleService.setOverlayConfigService(dto);
-        return ResponseEntity.ok(battleService.getOverlayConfig());
+        battleService.setOverlayConfigService(resolveEvent(dto.getEventName()), dto);
+        return ResponseEntity.ok(battleService.getOverlayConfig(resolveEvent(dto.getEventName())));
     }
 
     @PostMapping("/active-genre")
@@ -386,12 +397,11 @@ public class BattleController {
     }
 
     @GetMapping("/state")
-    public ResponseEntity<?> getBattleState() {
-        Map<String, Object> state = battleService.getBattleStateService();
-        // Also push timer to WS topic so BattleTimer recovers on page refresh.
-        // GET is a poll — no broadcast would otherwise reach the fresh subscription.
+    public ResponseEntity<?> getBattleState(@RequestParam(required = false) String event) {
+        String eName = resolveEvent(event);
+        Map<String, Object> state = battleService.getBattleStateService(eName);
         if (state.containsKey("timer")) {
-            battleService.rebroadcastTimer(state.get("timer"));
+            battleService.rebroadcastTimer(eName, state.get("timer"));
         }
         return ResponseEntity.ok(state);
     }

--- a/BES/src/main/java/com/example/BES/controllers/BattleTimerController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleTimerController.java
@@ -16,6 +16,11 @@ public class BattleTimerController {
 
     @MessageMapping("/battle/timer")
     public void handleTimerState(Map<String, Object> payload) {
-        battleService.handleTimerPayload(payload);
+        String eventName = payload != null ? (String) payload.get("eventName") : null;
+        if (eventName == null || eventName.isBlank()) {
+            eventName = battleService.getActiveEventName();
+        }
+        if (eventName == null) eventName = "";
+        battleService.handleTimerPayload(eventName, payload);
     }
 }

--- a/BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/ChampionRevealDto.java
@@ -4,6 +4,9 @@ public class ChampionRevealDto {
     private String genreName;
     private String championName;
     private boolean dismiss;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public String getGenreName()    { return genreName; }
     public String getChampionName() { return championName; }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBattlePhaseDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBattlePhaseDto.java
@@ -8,6 +8,9 @@ public class SetBattlePhaseDto {
     private String phase;
 
     private String champion;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public String getPhase() {
         return phase;

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBattleScoreDto.java
@@ -5,5 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class SetBattleScoreDto {
     @JsonProperty("isFinal")
     private boolean isFinal;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
+
     public boolean isFinal() { return isFinal; }
 }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBattlerPairDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBattlerPairDto.java
@@ -14,6 +14,9 @@ public class SetBattlerPairDto {
     private boolean isFinal;
     private List<String> leftMembers;
     private List<String> rightMembers;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public String getLeftBattler() { return leftBattler; }
     public String getRightBattler() { return rightBattler; }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetBracketStateDto.java
@@ -4,6 +4,9 @@ public class SetBracketStateDto {
     private String topSize;
     private Object rounds;
     private Integer currentRoundIndex;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public String getTopSize() {
         return topSize;

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetJudgeDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetJudgeDto.java
@@ -9,6 +9,9 @@ public class SetJudgeDto {
 
     @Min(1)
     private int weightage = 1;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public Long getId() { return id; }
     public int getWeightage() { return weightage; }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java
@@ -15,6 +15,9 @@ public class SetOverlayConfigDto {
     @NotNull
     @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "rightColor must be a valid 6-digit hex color")
     private String rightColor;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public Boolean isShowImages() { return showImages; }
     public String getLeftColor()  { return leftColor; }

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetSmokeBattlersDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetSmokeBattlersDto.java
@@ -6,6 +6,9 @@ import com.example.BES.services.BattleService;
 
 public class SetSmokeBattlersDto {
     private List<BattleService.Battler> battlers;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public List<BattleService.Battler> getBattlers() {
         return battlers;

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetVoteDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetVoteDto.java
@@ -9,7 +9,10 @@ public class SetVoteDto {
     private Long id;
     @NotNull @Min(-3) @Max(1)
     private Integer vote;
-    
+    private String eventName;
+
+    public String getEventName() { return eventName; }
+
     public Long getId() {
         return id;
     }

--- a/BES/src/main/java/com/example/BES/dtos/battle/UpdateJudgeWeightageDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/UpdateJudgeWeightageDto.java
@@ -9,6 +9,9 @@ public class UpdateJudgeWeightageDto {
 
     @Min(1)
     private int weightage;
+    private String eventName;
+
+    public String getEventName() { return eventName; }
 
     public Long getId() { return id; }
     public int getWeightage() { return weightage; }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -65,32 +66,19 @@ public class BattleService {
     private List<String> modes = Arrays.asList("Top32", "Top16", "7-to-Smoke");
     private String selectedMode;
 
-    private Object bracketState = null;
-    private Integer currentRoundIndex = 0;
-    private List<Battler> battlers = new ArrayList<>();
-    private String battlePhase = "IDLE";
-    private boolean currentIsFinal = false;
-    private Map<String, Object> overlayConfig = new HashMap<>(Map.of(
-        "showImages", true,
-        "leftColor",  "#dc2626",
-        "rightColor", "#2563eb"
-    ));
-    private BattlePair currentPair;
-    private final List<BattleJudge> judges = Collections.synchronizedList(new ArrayList<>());
-    private String status;
+    private final ConcurrentHashMap<String, EventBattleState> eventStates = new ConcurrentHashMap<>();
 
     private String activeEventName;
-    private String activeGenreName;
-    private String genreFormat;
-    private String champion = null;
+    private String status;
 
-    BattleService() {
-        selectedMode = "";
-        currentPair = new BattlePair();
-        Battler left = new Battler();
-        Battler right = new Battler();
-        currentPair.leftBattler = left;
-        currentPair.rightBattler = right;
+    private EventBattleState stateFor(String eventName) {
+        return eventStates.computeIfAbsent(
+            eventName != null ? eventName : "", k -> new EventBattleState());
+    }
+
+    private String resolveEvent(String explicit) {
+        if (explicit != null && !explicit.isBlank()) return explicit;
+        return activeEventName != null ? activeEventName : "";
     }
 
     @PostConstruct
@@ -99,8 +87,7 @@ public class BattleService {
             battleActiveGenreRepository.findById(1).ifPresent(active -> {
                 if (active.getEventName() != null && active.getGenreName() != null) {
                     activeEventName = active.getEventName();
-                    activeGenreName = active.getGenreName();
-                    loadGenreStateIntoMemory(activeEventName, activeGenreName);
+                    loadGenreStateIntoMemory(activeEventName, active.getGenreName());
                 }
             });
         } catch (Exception e) {
@@ -110,61 +97,66 @@ public class BattleService {
 
     public List<String> getModes() { return modes; }
 
-    public List<Battler> getSmokeBattlersService() { return battlers; }
+    public List<Battler> getSmokeBattlersService() {
+        return stateFor(resolveEvent(null)).battlers;
+    }
 
-    public void setSmokeBattlersService(SetSmokeBattlersDto dto) {
-        battlers = new ArrayList<>();
-        for (Battler battler : dto.getBattlers()) battlers.add(battler);
-        messagingTemplate.convertAndSend("/topic/battle/smoke", Map.of("battlers", battlers));
-        for (Battler battler : battlers) {
+    public void setSmokeBattlersService(String eventName, SetSmokeBattlersDto dto) {
+        EventBattleState s = stateFor(eventName);
+        s.battlers = new ArrayList<>(dto.getBattlers());
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/smoke",
+            Map.of("battlers", s.battlers));
+        for (Battler battler : s.battlers) {
             if (battler.getScore() != null && battler.getScore() >= 7) {
-                battlePhase = "DECIDED";
-                champion = battler.getName();
-                messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
-                    "phase", battlePhase,
-                    "genre", activeGenreName != null ? activeGenreName : "",
-                    "champion", champion
+                s.battlePhase = "DECIDED";
+                s.champion = battler.getName();
+                messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/phase", Map.of(
+                    "phase",    s.battlePhase,
+                    "genre",    s.activeGenreName != null ? s.activeGenreName : "",
+                    "champion", s.champion
                 ));
                 break;
             }
         }
-        persistActiveState();
+        persistActiveState(eventName);
     }
 
-    public void setBattlerPairService(SetBattlerPairDto dto) {
-        getCurrentPair().leftBattler.setName(dto.getLeftBattler());
-        getCurrentPair().leftBattler.setScore(0);
-        getCurrentPair().leftBattler.setMembers(dto.getLeftMembers());
-        getCurrentPair().rightBattler.setName(dto.getRightBattler());
-        getCurrentPair().rightBattler.setScore(0);
-        getCurrentPair().rightBattler.setMembers(dto.getRightMembers());
-        currentIsFinal = dto.isFinal();
-        messagingTemplate.convertAndSend("/topic/battle/battle-pair", Map.of(
-            "left",         currentPair.getLeftBattler().getName(),
-            "leftScore",    currentPair.getLeftBattler().getScore(),
-            "leftMembers",  currentPair.getLeftBattler().getMembers(),
-            "right",        currentPair.getRightBattler().getName(),
-            "rightScore",   currentPair.getRightBattler().getScore(),
-            "rightMembers", currentPair.getRightBattler().getMembers(),
-            "isFinal",      currentIsFinal
+    public void setBattlerPairService(String eventName, SetBattlerPairDto dto) {
+        EventBattleState s = stateFor(eventName);
+        s.currentPair.getLeftBattler().setName(dto.getLeftBattler());
+        s.currentPair.getLeftBattler().setScore(0);
+        s.currentPair.getLeftBattler().setMembers(dto.getLeftMembers());
+        s.currentPair.getRightBattler().setName(dto.getRightBattler());
+        s.currentPair.getRightBattler().setScore(0);
+        s.currentPair.getRightBattler().setMembers(dto.getRightMembers());
+        s.currentIsFinal = dto.isFinal();
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/battle-pair", Map.of(
+            "left",         s.currentPair.getLeftBattler().getName(),
+            "leftScore",    s.currentPair.getLeftBattler().getScore(),
+            "leftMembers",  s.currentPair.getLeftBattler().getMembers(),
+            "right",        s.currentPair.getRightBattler().getName(),
+            "rightScore",   s.currentPair.getRightBattler().getScore(),
+            "rightMembers", s.currentPair.getRightBattler().getMembers(),
+            "isFinal",      s.currentIsFinal
         ));
-        battlePhase = "LOCKED";
-        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
-            "phase", battlePhase,
-            "genre", activeGenreName != null ? activeGenreName : ""
+        s.battlePhase = "LOCKED";
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/phase", Map.of(
+            "phase", s.battlePhase,
+            "genre", s.activeGenreName != null ? s.activeGenreName : ""
         ));
-        persistActiveState();
+        persistActiveState(eventName);
     }
 
-    public void clearBattlePairService() {
-        getCurrentPair().leftBattler.setName("");
-        getCurrentPair().leftBattler.setScore(0);
-        getCurrentPair().leftBattler.setMembers(new ArrayList<>());
-        getCurrentPair().rightBattler.setName("");
-        getCurrentPair().rightBattler.setScore(0);
-        getCurrentPair().rightBattler.setMembers(new ArrayList<>());
-        currentIsFinal = false;
-        messagingTemplate.convertAndSend("/topic/battle/battle-pair", Map.of(
+    public void clearBattlePairService(String eventName) {
+        EventBattleState s = stateFor(eventName);
+        s.currentPair.getLeftBattler().setName("");
+        s.currentPair.getLeftBattler().setScore(0);
+        s.currentPair.getLeftBattler().setMembers(new ArrayList<>());
+        s.currentPair.getRightBattler().setName("");
+        s.currentPair.getRightBattler().setScore(0);
+        s.currentPair.getRightBattler().setMembers(new ArrayList<>());
+        s.currentIsFinal = false;
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/battle-pair", Map.of(
             "left",         "",
             "leftScore",    0,
             "leftMembers",  new ArrayList<>(),
@@ -173,127 +165,126 @@ public class BattleService {
             "rightMembers", new ArrayList<>(),
             "isFinal",      false
         ));
-        // Does NOT change phase — caller sets phase afterward
     }
 
-    public Integer setScoreService(boolean isFinal) {
+    public Integer setScoreService(String eventName, boolean isFinal) {
+        EventBattleState s = stateFor(eventName);
         int leftWeight, rightWeight;
-        synchronized (judges) {
-            leftWeight  = judges.stream().filter(j -> j.getVote() == 0).mapToInt(BattleJudge::getWeightage).sum();
-            rightWeight = judges.stream().filter(j -> j.getVote() == 1).mapToInt(BattleJudge::getWeightage).sum();
+        synchronized (s.judges) {
+            leftWeight  = s.judges.stream().filter(j -> j.getVote() == 0).mapToInt(BattleJudge::getWeightage).sum();
+            rightWeight = s.judges.stream().filter(j -> j.getVote() == 1).mapToInt(BattleJudge::getWeightage).sum();
         }
         Integer res;
         if (leftWeight == rightWeight) {
             if (isFinal) return -3;
             res = -1;
         } else if (leftWeight > rightWeight) {
-            currentPair.getLeftBattler().setScore(currentPair.leftBattler.getScore() + 1);
+            s.currentPair.getLeftBattler().setScore(s.currentPair.getLeftBattler().getScore() + 1);
             res = 0;
         } else {
-            currentPair.getRightBattler().setScore(currentPair.rightBattler.getScore() + 1);
+            s.currentPair.getRightBattler().setScore(s.currentPair.getRightBattler().getScore() + 1);
             res = 1;
         }
-        messagingTemplate.convertAndSend("/topic/battle/score", Map.of(
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/score", Map.of(
             "message", res,
-            "left",    currentPair.getLeftBattler().getScore(),
-            "right",   currentPair.getRightBattler().getScore()
+            "left",    s.currentPair.getLeftBattler().getScore(),
+            "right",   s.currentPair.getRightBattler().getScore()
         ));
         if (res == 0 || res == 1) {
-            // For smoke mode: persist the winner's score immediately so page-refresh
-            // shows the correct score before the Emcee clicks "Next".
-            if (res == 0 && battlers.size() > 0) {
-                battlers.get(0).setScore(battlers.get(0).getScore() + 1);
-            } else if (res == 1 && battlers.size() > 1) {
-                battlers.get(1).setScore(battlers.get(1).getScore() + 1);
+            if (res == 0 && !s.battlers.isEmpty()) {
+                s.battlers.get(0).setScore(s.battlers.get(0).getScore() + 1);
+            } else if (res == 1 && s.battlers.size() > 1) {
+                s.battlers.get(1).setScore(s.battlers.get(1).getScore() + 1);
             }
-            battlePhase = "REVEALED";
-            messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
-                "phase", battlePhase,
-                "genre", activeGenreName != null ? activeGenreName : ""
+            s.battlePhase = "REVEALED";
+            messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/phase", Map.of(
+                "phase", s.battlePhase,
+                "genre", s.activeGenreName != null ? s.activeGenreName : ""
             ));
-            persistActiveState();
+            persistActiveState(eventName);
         }
         return res;
     }
 
-    public Integer removeBattleJudgeService(SetJudgeDto dto) {
-        judges.removeIf(judge -> Objects.equals(judge.getId(), dto.getId()));
-        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
-        persistActiveState();
+    public Integer removeBattleJudgeService(String eventName, SetJudgeDto dto) {
+        EventBattleState s = stateFor(eventName);
+        s.judges.removeIf(judge -> Objects.equals(judge.getId(), dto.getId()));
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/judges",
+            Map.of("judges", s.judges));
+        persistActiveState(eventName);
         return dto.getId().intValue();
     }
 
-    public void updateJudgeWeightageService(UpdateJudgeWeightageDto dto) {
-        synchronized (judges) {
-            judges.stream()
+    public void updateJudgeWeightageService(String eventName, UpdateJudgeWeightageDto dto) {
+        EventBattleState s = stateFor(eventName);
+        synchronized (s.judges) {
+            s.judges.stream()
                 .filter(j -> j.getId().equals(dto.getId()))
                 .findFirst()
                 .ifPresent(j -> j.setWeightage(Math.max(1, dto.getWeightage())));
         }
-        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
-        persistActiveState();
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/judges",
+            Map.of("judges", s.judges));
+        persistActiveState(eventName);
     }
 
-    public Integer setBattleJudgeService(SetJudgeDto dto) {
+    public Integer setBattleJudgeService(String eventName, SetJudgeDto dto) {
+        EventBattleState s = stateFor(eventName);
         Judge judge = judgeService.getJudgeById(dto.getId());
-        Integer code = -50;
-        if (judge != null) {
-            Boolean exists = judges.stream().anyMatch(j -> j.getName().equals(judge.getName()));
+        if (judge == null) return -1;
+        synchronized (s.judges) {
+            boolean exists = s.judges.stream().anyMatch(j -> j.getName().equals(judge.getName()));
             if (exists) return 0;
             BattleJudge battleJudge = new BattleJudge();
             battleJudge.setName(judge.getName());
             battleJudge.setVote(-3);
             battleJudge.setId(dto.getId());
             battleJudge.setWeightage(Math.max(1, dto.getWeightage()));
-            judges.add(battleJudge);
-            code = dto.getId().intValue();
-        } else {
-            return -1;
+            s.judges.add(battleJudge);
         }
-        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
-        persistActiveState();
-        return code;
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/judges",
+            Map.of("judges", s.judges));
+        persistActiveState(eventName);
+        return dto.getId().intValue();
     }
 
-    public Integer setVoteService(SetVoteDto dto) {
-        Integer code = -50;
-        Optional<BattleJudge> battleJude = judges.stream()
+    public Integer setVoteService(String eventName, SetVoteDto dto) {
+        EventBattleState s = stateFor(eventName);
+        Optional<BattleJudge> battleJudge = s.judges.stream()
             .filter(j -> j.getId().equals(dto.getId())).findFirst();
-        if (battleJude.isPresent()) {
-            battleJude.get().setVote(dto.getVote());
-        } else {
-            return -2;
-        }
-        code = dto.getVote();
+        if (battleJudge.isEmpty()) return -2;
+        battleJudge.get().setVote(dto.getVote());
+        Integer code = dto.getVote();
         messagingTemplate.convertAndSend(
             String.format("/topic/battle/vote/%d", dto.getId()),
             Map.of("vote", code, "judge", dto.getId())
         );
-        persistActiveState();
+        persistActiveState(eventName);
         return code;
     }
 
-    public void resetJudgeVotesService() {
-        synchronized (judges) {
-            for (BattleJudge judge : judges) judge.setVote(-3);
+    public void resetJudgeVotesService(String eventName) {
+        EventBattleState s = stateFor(eventName);
+        synchronized (s.judges) {
+            for (BattleJudge judge : s.judges) judge.setVote(-3);
         }
-        messagingTemplate.convertAndSend("/topic/battle/judges", Map.of("judges", judges));
-        persistActiveState();
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/judges",
+            Map.of("judges", s.judges));
+        persistActiveState(eventName);
     }
 
-    public Object getBracketState() { return bracketState; }
+    public Object getBracketState() { return stateFor(resolveEvent(null)).bracketState; }
 
-    public void setBracketStateService(SetBracketStateDto dto) {
+    public void setBracketStateService(String eventName, SetBracketStateDto dto) {
+        EventBattleState s = stateFor(eventName);
         Map<String, Object> state = new HashMap<>();
         state.put("topSize", dto.getTopSize());
         state.put("rounds", dto.getRounds());
-        this.bracketState = state;
-        if (dto.getCurrentRoundIndex() != null) {
-            this.currentRoundIndex = dto.getCurrentRoundIndex();
-        }
-        messagingTemplate.convertAndSend("/topic/battle/bracket", state);
-        persistActiveState();
-        broadcastStateSnapshot();
+        s.bracketState = state;
+        if (dto.getCurrentRoundIndex() != null) s.currentRoundIndex = dto.getCurrentRoundIndex();
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/bracket", state);
+        persistActiveState(eventName);
+        broadcastStateSnapshot(eventName);
     }
 
     public String getSelectedMode() { return selectedMode; }
@@ -302,74 +293,108 @@ public class BattleService {
         this.selectedMode = dto.getMode();
     }
 
-    public BattlePair getCurrentPair() { return currentPair; }
+    public BattlePair getCurrentPair(String eventName) {
+        return stateFor(eventName).currentPair;
+    }
 
-    public void setCurrentPair(BattlePair currentPair) { this.currentPair = currentPair; }
+    public BattlePair getCurrentPair() {
+        return stateFor(resolveEvent(null)).currentPair;
+    }
 
-    public List<BattleJudge> getJudges() { return judges; }
+    public void setCurrentPair(String eventName, BattlePair pair) {
+        stateFor(eventName).currentPair = pair;
+    }
+
+    public List<BattleJudge> getJudges() {
+        return stateFor(resolveEvent(null)).judges;
+    }
+
+    public List<BattleJudge> getJudges(String eventName) {
+        return stateFor(eventName).judges;
+    }
 
     public void setJudges(List<BattleJudge> judges) {
-        synchronized (this.judges) { this.judges.clear(); this.judges.addAll(judges); }
+        EventBattleState s = stateFor(resolveEvent(null));
+        synchronized (s.judges) { s.judges.clear(); s.judges.addAll(judges); }
     }
 
     public String getStatus() { return status; }
 
     public void setStatus(String status) { this.status = status; }
 
-    public String getBattlePhase() { return battlePhase; }
-
-    public boolean isCurrentFinal() { return currentIsFinal; }
-
-    public void setBattlePhaseService(String phase) {
-        setBattlePhaseService(phase, null);
+    public String getBattlePhase() {
+        return stateFor(resolveEvent(null)).battlePhase;
     }
 
-    public void setBattlePhaseService(String phase, String championName) {
+    public String getBattlePhase(String eventName) {
+        return stateFor(eventName).battlePhase;
+    }
+
+    public boolean isCurrentFinal() {
+        return stateFor(resolveEvent(null)).currentIsFinal;
+    }
+
+    public boolean isCurrentFinal(String eventName) {
+        return stateFor(eventName).currentIsFinal;
+    }
+
+    public void setBattlePhaseService(String eventName, String phase) {
+        setBattlePhaseService(eventName, phase, null);
+    }
+
+    public void setBattlePhaseService(String eventName, String phase, String championName) {
         if ("REVEALED".equals(phase)) return;
-        // Prevent starting a round with zero judges
+        EventBattleState s = stateFor(eventName);
         if ("LOCKED".equals(phase)) {
-            synchronized (judges) {
-                if (judges.isEmpty()) {
+            synchronized (s.judges) {
+                if (s.judges.isEmpty()) {
                     throw new IllegalArgumentException(
                         "Cannot start round: no judges assigned. Add at least one judge first.");
                 }
             }
         }
-        battlePhase = phase;
-        if (championName != null) {
-            champion = championName;
-        }
-        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
-            "phase", battlePhase,
-            "genre", activeGenreName != null ? activeGenreName : "",
-            "champion", champion != null ? champion : ""
+        s.battlePhase = phase;
+        if (championName != null) s.champion = championName;
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/phase", Map.of(
+            "phase",    s.battlePhase,
+            "genre",    s.activeGenreName != null ? s.activeGenreName : "",
+            "champion", s.champion != null ? s.champion : ""
         ));
-        persistActiveState();
+        persistActiveState(eventName);
     }
 
-    public Map<String, Object> getOverlayConfig() { return overlayConfig; }
+    public Map<String, Object> getOverlayConfig() {
+        return stateFor(resolveEvent(null)).overlayConfig;
+    }
 
-    public void setOverlayConfigService(SetOverlayConfigDto dto) {
+    public Map<String, Object> getOverlayConfig(String eventName) {
+        return stateFor(eventName).overlayConfig;
+    }
+
+    public void setOverlayConfigService(String eventName, SetOverlayConfigDto dto) {
+        EventBattleState s = stateFor(eventName);
         Map<String, Object> newConfig = new HashMap<>();
         newConfig.put("showImages", dto.isShowImages());
         newConfig.put("leftColor",  dto.getLeftColor());
         newConfig.put("rightColor", dto.getRightColor());
-        overlayConfig = newConfig;
-        messagingTemplate.convertAndSend("/topic/battle/overlay-config", newConfig);
+        s.overlayConfig = newConfig;
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/overlay-config", newConfig);
     }
 
-    public void broadcastChampionReveal(ChampionRevealDto dto) {
+    public void broadcastChampionReveal(String eventName, ChampionRevealDto dto) {
+        EventBattleState s = stateFor(eventName);
         if (dto.isDismiss()) {
-            champion = null;
-            persistActiveState();
-            messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of("dismiss", true));
+            s.champion = null;
+            persistActiveState(eventName);
+            messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/champion-reveal",
+                Map.of("dismiss", true));
         } else {
-            champion = dto.getChampionName() != null ? dto.getChampionName() : "";
-            persistActiveState();
-            messagingTemplate.convertAndSend("/topic/battle/champion-reveal", Map.of(
-                "dismiss",       false,
-                "genreName",     dto.getGenreName()    != null ? dto.getGenreName()    : "",
-                "championName",  champion
+            s.champion = dto.getChampionName() != null ? dto.getChampionName() : "";
+            persistActiveState(eventName);
+            messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/champion-reveal", Map.of(
+                "dismiss",      false,
+                "genreName",    dto.getGenreName()    != null ? dto.getGenreName()    : "",
+                "championName", s.champion
             ));
         }
     }
@@ -387,20 +412,18 @@ public class BattleService {
     @Transactional
     public void setResolvedParticipants(String eventName, String genreName, List<String> participants) {
         try {
-            BattleGenreState s = battleGenreStateRepository
+            BattleGenreState st = battleGenreStateRepository
                 .findByEventNameAndGenreName(eventName, genreName)
                 .orElse(new BattleGenreState());
-            s.setEventName(eventName);
-            s.setGenreName(genreName);
-            s.setResolvedParticipantsJson(
+            st.setEventName(eventName);
+            st.setGenreName(genreName);
+            st.setResolvedParticipantsJson(
                 participants != null ? objectMapper.writeValueAsString(participants) : null);
-            s.setUpdatedAt(LocalDateTime.now());
-            battleGenreStateRepository.save(s);
-            // Broadcast updated full state so BattleControl in other tabs sees the change.
-            // Only broadcast if the update was for the currently active genre.
-            if (eventName != null && eventName.equals(activeEventName)
-                && genreName != null && genreName.equals(activeGenreName)) {
-                broadcastStateSnapshot();
+            st.setUpdatedAt(LocalDateTime.now());
+            battleGenreStateRepository.save(st);
+            EventBattleState s = stateFor(eventName);
+            if (genreName != null && genreName.equals(s.activeGenreName)) {
+                broadcastStateSnapshot(eventName);
             }
         } catch (Exception e) {
             System.err.println("Failed to save resolved participants: " + e.getMessage());
@@ -409,86 +432,74 @@ public class BattleService {
 
     @Transactional
     public void switchActiveGenreService(SetActiveGenreDto dto) {
-        persistActiveState();
+        if (activeEventName != null) persistActiveState(activeEventName);
+
         BattleActiveGenre active = battleActiveGenreRepository.findById(1)
             .orElse(new BattleActiveGenre(1, null, null));
         active.setEventName(dto.getEventName());
         active.setGenreName(dto.getGenreName());
         battleActiveGenreRepository.save(active);
         activeEventName = dto.getEventName();
-        activeGenreName = dto.getGenreName();
-        loadGenreStateIntoMemory(activeEventName, activeGenreName);
-        broadcastStateSnapshot();
-        // Broadcast judges so BattleJudge clients can re-check assignment immediately
-        synchronized (judges) {
-            messagingTemplate.convertAndSend("/topic/battle/judges",
-                Map.of("judges", new ArrayList<>(judges)));
+        loadGenreStateIntoMemory(activeEventName, dto.getGenreName());
+        broadcastStateSnapshot(activeEventName);
+
+        EventBattleState s = stateFor(activeEventName);
+        synchronized (s.judges) {
+            messagingTemplate.convertAndSend("/topic/battle/" + activeEventName + "/judges",
+                Map.of("judges", new ArrayList<>(s.judges)));
         }
-        messagingTemplate.convertAndSend("/topic/battle/phase", Map.of(
-            "phase", battlePhase,
-            "genre", activeGenreName != null ? activeGenreName : ""
+        messagingTemplate.convertAndSend("/topic/battle/" + activeEventName + "/phase", Map.of(
+            "phase", s.battlePhase,
+            "genre", s.activeGenreName != null ? s.activeGenreName : ""
         ));
     }
 
-    public Map<String, Object> getBattleStateService() {
-        if (activeEventName == null || activeGenreName == null) return new HashMap<>();
+    public Map<String, Object> getBattleStateService(String eventName) {
+        EventBattleState s = stateFor(eventName);
+        if (s.activeGenreName == null) return new HashMap<>();
         Map<String, Object> state = new HashMap<>();
-        state.put("eventName", activeEventName);
-        state.put("genreName", activeGenreName);
-        state.put("genreFormat", genreFormat);
-        state.put("bracket", bracketState);
-        state.put("currentRoundIndex", currentRoundIndex);
+        state.put("eventName",      eventName);
+        state.put("genreName",      s.activeGenreName);
+        state.put("genreFormat",    s.genreFormat);
+        state.put("bracket",        s.bracketState);
+        state.put("currentRoundIndex", s.currentRoundIndex);
         Map<String, Object> pair = new HashMap<>();
-        pair.put("left",         currentPair.getLeftBattler().getName());
-        pair.put("leftMembers",  currentPair.getLeftBattler().getMembers());
-        pair.put("right",        currentPair.getRightBattler().getName());
-        pair.put("rightMembers", currentPair.getRightBattler().getMembers());
-        pair.put("isFinal",      currentIsFinal);
+        pair.put("left",         s.currentPair.getLeftBattler().getName());
+        pair.put("leftMembers",  s.currentPair.getLeftBattler().getMembers());
+        pair.put("right",        s.currentPair.getRightBattler().getName());
+        pair.put("rightMembers", s.currentPair.getRightBattler().getMembers());
+        pair.put("isFinal",      s.currentIsFinal);
         state.put("currentPair", pair);
-        state.put("battlePhase", battlePhase);
-        state.put("champion", champion);
-        // Restore tie-breaker resolved list from DB if present
+        state.put("battlePhase", s.battlePhase);
+        state.put("champion",    s.champion);
         String resolvedJson = null;
-        if (activeEventName != null && activeGenreName != null) {
+        if (s.activeGenreName != null) {
             var st = battleGenreStateRepository
-                .findByEventNameAndGenreName(activeEventName, activeGenreName).orElse(null);
+                .findByEventNameAndGenreName(eventName, s.activeGenreName).orElse(null);
             if (st != null) resolvedJson = st.getResolvedParticipantsJson();
         }
         state.put("resolvedParticipants", resolvedJson != null ? resolvedJson : "");
-        synchronized (judges) {
-            state.put("judges", new ArrayList<>(judges));
+        synchronized (s.judges) {
+            state.put("judges", new ArrayList<>(s.judges));
         }
-        if (!battlers.isEmpty()) {
-            state.put("smokeBattlers", new ArrayList<>(battlers));
-        }
-        // Recoverable per-round timer state — recalculate timeLeft from elapsed wall-clock
-        if (lastTimerPayload != null) {
-            Map<String, Object> timer = new HashMap<>(lastTimerPayload);
+        if (!s.battlers.isEmpty()) state.put("smokeBattlers", new ArrayList<>(s.battlers));
+        if (s.lastTimerPayload != null) {
+            Map<String, Object> timer = new HashMap<>(s.lastTimerPayload);
             if (Boolean.TRUE.equals(timer.get("running"))) {
-                long elapsedSec = (System.currentTimeMillis() - timerLastUpdated) / 1000;
-                int currentLeft = ((Number) timer.getOrDefault("timeLeft", 0)).intValue();
-                int adjusted = Math.max(0, currentLeft - (int) elapsedSec);
+                long elapsedSec = (System.currentTimeMillis() - s.timerLastUpdated) / 1000;
+                int adjusted = Math.max(0, ((Number) timer.getOrDefault("timeLeft", 0)).intValue() - (int) elapsedSec);
                 timer.put("timeLeft", adjusted);
-                if (adjusted <= 0) {
-                    timer.put("running", false);
-                    timer.put("timeLeft", 0);
-                }
+                if (adjusted <= 0) { timer.put("running", false); timer.put("timeLeft", 0); }
             }
             state.put("timer", timer);
         }
-        // Recoverable format timer state — recalculate timeLeft from elapsed wall-clock
-        if (lastFormatTimerPayload != null) {
-            Map<String, Object> ft = new HashMap<>(lastFormatTimerPayload);
+        if (s.lastFormatTimerPayload != null) {
+            Map<String, Object> ft = new HashMap<>(s.lastFormatTimerPayload);
             if (Boolean.TRUE.equals(ft.get("running"))) {
-                long elapsedSec = (System.currentTimeMillis() - formatTimerLastUpdated) / 1000;
-                int currentLeft = ((Number) ft.getOrDefault("timeLeft", 0)).intValue();
-                int adjusted = Math.max(0, currentLeft - (int) elapsedSec);
+                long elapsedSec = (System.currentTimeMillis() - s.formatTimerLastUpdated) / 1000;
+                int adjusted = Math.max(0, ((Number) ft.getOrDefault("timeLeft", 0)).intValue() - (int) elapsedSec);
                 ft.put("timeLeft", adjusted);
-                if (adjusted <= 0) {
-                    ft.put("running", false);
-                    ft.put("timeLeft", 0);
-                    ft.put("expired", true);
-                }
+                if (adjusted <= 0) { ft.put("running", false); ft.put("timeLeft", 0); ft.put("expired", true); }
             }
             state.put("formatTimer", ft);
         }
@@ -496,173 +507,200 @@ public class BattleService {
     }
 
     public String getActiveEventName() { return activeEventName; }
-    public String getActiveGenreName() { return activeGenreName; }
-
-    // ── Per-round timer state recovery ──────────────────────────────
-    private Map<String, Object> lastTimerPayload = null;
-    private long timerLastUpdated = 0;
-
-    public void handleTimerPayload(Map<String, Object> payload) {
-        this.lastTimerPayload = new HashMap<>(payload);
-        this.timerLastUpdated = System.currentTimeMillis();
-        messagingTemplate.convertAndSend("/topic/battle/timer", payload);
+    public String getActiveGenreName() {
+        return stateFor(resolveEvent(null)).activeGenreName;
     }
 
-    /** Rebroadcast timer state to WS topic (used by REST state endpoint for page-refresh recovery). */
-    public void rebroadcastTimer(Object timerState) {
+    public void handleTimerPayload(String eventName, Map<String, Object> payload) {
+        EventBattleState s = stateFor(eventName);
+        s.lastTimerPayload = new HashMap<>(payload);
+        s.timerLastUpdated = System.currentTimeMillis();
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/timer", payload);
+    }
+
+    public void rebroadcastTimer(String eventName, Object timerState) {
         if (timerState != null) {
-            messagingTemplate.convertAndSend("/topic/battle/timer", timerState);
+            messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/timer", timerState);
         }
     }
 
-    // ── Format timer state (7-to-Smoke session-level countdown) ─────
-    private Map<String, Object> lastFormatTimerPayload = null;
-    private long formatTimerLastUpdated = 0;
-
-    public void handleFormatTimerPayload(Map<String, Object> payload) {
-        this.lastFormatTimerPayload = new HashMap<>(payload);
-        this.formatTimerLastUpdated = System.currentTimeMillis();
-        messagingTemplate.convertAndSend("/topic/battle/format-timer", payload);
-        persistFormatTimer();
+    public void handleFormatTimerPayload(String eventName, Map<String, Object> payload) {
+        EventBattleState s = stateFor(eventName);
+        s.lastFormatTimerPayload = new HashMap<>(payload);
+        s.formatTimerLastUpdated = System.currentTimeMillis();
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/format-timer", payload);
+        persistFormatTimer(eventName);
     }
 
-    private void persistFormatTimer() {
-        if (activeEventName == null || activeGenreName == null || lastFormatTimerPayload == null) return;
+    private void persistFormatTimer(String eventName) {
+        EventBattleState s = stateFor(eventName);
+        if (activeEventName == null || s.activeGenreName == null || s.lastFormatTimerPayload == null) return;
         try {
-            BattleGenreState s = battleGenreStateRepository
-                .findByEventNameAndGenreName(activeEventName, activeGenreName)
-                .orElse(null);
-            if (s == null) return;
-            s.setFormatTimerJson(objectMapper.writeValueAsString(lastFormatTimerPayload));
-            s.setUpdatedAt(LocalDateTime.now());
-            battleGenreStateRepository.save(s);
+            BattleGenreState st = battleGenreStateRepository
+                .findByEventNameAndGenreName(eventName, s.activeGenreName).orElse(null);
+            if (st == null) return;
+            st.setFormatTimerJson(objectMapper.writeValueAsString(s.lastFormatTimerPayload));
+            st.setUpdatedAt(LocalDateTime.now());
+            battleGenreStateRepository.save(st);
         } catch (Exception e) {
             System.err.println("Failed to persist format timer: " + e.getMessage());
         }
     }
 
-    private void persistActiveState() {
-        if (activeEventName == null || activeGenreName == null) return;
+    private void persistActiveState(String eventName) {
+        EventBattleState s = stateFor(eventName);
+        if (s.activeGenreName == null) return;
         try {
-            BattleGenreState s = battleGenreStateRepository
-                .findByEventNameAndGenreName(activeEventName, activeGenreName)
+            BattleGenreState st = battleGenreStateRepository
+                .findByEventNameAndGenreName(eventName, s.activeGenreName)
                 .orElse(new BattleGenreState());
-            s.setEventName(activeEventName);
-            s.setGenreName(activeGenreName);
-            s.setBracketJson(bracketState != null ? objectMapper.writeValueAsString(bracketState) : null);
-            if (bracketState instanceof Map) {
-                Object ts = ((Map<?, ?>) bracketState).get("topSize");
+            st.setEventName(eventName);
+            st.setGenreName(s.activeGenreName);
+            st.setBracketJson(s.bracketState != null ? objectMapper.writeValueAsString(s.bracketState) : null);
+            if (s.bracketState instanceof Map) {
+                Object ts = ((Map<?, ?>) s.bracketState).get("topSize");
                 if (ts != null) {
-                    try { s.setTopSize(Integer.parseInt(ts.toString())); }
+                    try { st.setTopSize(Integer.parseInt(ts.toString())); }
                     catch (NumberFormatException ignored) {}
                 }
             }
-            s.setCurrentRoundIndex(currentRoundIndex);
-            s.setCurrentPairLeft(currentPair.getLeftBattler().getName());
-            s.setCurrentPairLeftMembers(
-                objectMapper.writeValueAsString(currentPair.getLeftBattler().getMembers()));
-            s.setCurrentPairRight(currentPair.getRightBattler().getName());
-            s.setCurrentPairRightMembers(
-                objectMapper.writeValueAsString(currentPair.getRightBattler().getMembers()));
-            s.setIsFinal(currentIsFinal);
-            s.setBattlePhase(battlePhase);
-            s.setChampion(champion);
-            s.setSmokeListJson(objectMapper.writeValueAsString(new ArrayList<>(battlers)));
-            synchronized (judges) {
-                s.setJudgesJson(objectMapper.writeValueAsString(new ArrayList<>(judges)));
+            st.setCurrentRoundIndex(s.currentRoundIndex);
+            st.setCurrentPairLeft(s.currentPair.getLeftBattler().getName());
+            st.setCurrentPairLeftMembers(
+                objectMapper.writeValueAsString(s.currentPair.getLeftBattler().getMembers()));
+            st.setCurrentPairRight(s.currentPair.getRightBattler().getName());
+            st.setCurrentPairRightMembers(
+                objectMapper.writeValueAsString(s.currentPair.getRightBattler().getMembers()));
+            st.setIsFinal(s.currentIsFinal);
+            st.setBattlePhase(s.battlePhase);
+            st.setChampion(s.champion);
+            st.setSmokeListJson(objectMapper.writeValueAsString(new ArrayList<>(s.battlers)));
+            synchronized (s.judges) {
+                st.setJudgesJson(objectMapper.writeValueAsString(new ArrayList<>(s.judges)));
             }
-            if (lastFormatTimerPayload != null) {
-                s.setFormatTimerJson(objectMapper.writeValueAsString(lastFormatTimerPayload));
+            if (s.lastFormatTimerPayload != null) {
+                st.setFormatTimerJson(objectMapper.writeValueAsString(s.lastFormatTimerPayload));
             }
-            s.setUpdatedAt(LocalDateTime.now());
-            battleGenreStateRepository.save(s);
+            st.setUpdatedAt(LocalDateTime.now());
+            battleGenreStateRepository.save(st);
         } catch (Exception e) {
             System.err.println("Failed to persist battle state: " + e.getMessage());
         }
     }
 
     private void loadGenreStateIntoMemory(String eventName, String genreName) {
-        // Resolve the genre format from the EventGenre table so the frontend
-        // can detect smoke mode without fragile name-based heuristics.
-        genreFormat = null;
+        EventBattleState s = stateFor(eventName);
+        s.activeGenreName = genreName;
+        s.genreFormat = null;
         if (eventName != null && genreName != null) {
             Event ev = eventRepo.findByEventNameIgnoreCase(eventName).orElse(null);
             if (ev != null) {
                 eventGenreRepo.findByEventAndName(ev, genreName)
-                    .ifPresent(eg -> genreFormat = eg.getFormat());
+                    .ifPresent(eg -> s.genreFormat = eg.getFormat());
             }
         }
         Optional<BattleGenreState> stateOpt =
             battleGenreStateRepository.findByEventNameAndGenreName(eventName, genreName);
-        if (stateOpt.isEmpty()) { resetToDefaults(); return; }
-        BattleGenreState s = stateOpt.get();
+        if (stateOpt.isEmpty()) { resetToDefaults(eventName); return; }
+        BattleGenreState dbState = stateOpt.get();
         try {
-            bracketState = s.getBracketJson() != null
-                ? objectMapper.readValue(s.getBracketJson(), Map.class) : null;
-            currentRoundIndex = s.getCurrentRoundIndex() != null ? s.getCurrentRoundIndex() : 0;
-            currentPair.getLeftBattler().setName(s.getCurrentPairLeft() != null ? s.getCurrentPairLeft() : "");
-            currentPair.getLeftBattler().setScore(0);
-            currentPair.getLeftBattler().setMembers(s.getCurrentPairLeftMembers() != null
-                ? objectMapper.readValue(s.getCurrentPairLeftMembers(), new TypeReference<List<String>>(){})
+            s.bracketState = dbState.getBracketJson() != null
+                ? objectMapper.readValue(dbState.getBracketJson(), Map.class) : null;
+            s.currentRoundIndex = dbState.getCurrentRoundIndex() != null ? dbState.getCurrentRoundIndex() : 0;
+            s.currentPair.getLeftBattler().setName(
+                dbState.getCurrentPairLeft() != null ? dbState.getCurrentPairLeft() : "");
+            s.currentPair.getLeftBattler().setScore(0);
+            s.currentPair.getLeftBattler().setMembers(dbState.getCurrentPairLeftMembers() != null
+                ? objectMapper.readValue(dbState.getCurrentPairLeftMembers(), new TypeReference<List<String>>(){})
                 : new ArrayList<>());
-            currentPair.getRightBattler().setName(s.getCurrentPairRight() != null ? s.getCurrentPairRight() : "");
-            currentPair.getRightBattler().setScore(0);
-            currentPair.getRightBattler().setMembers(s.getCurrentPairRightMembers() != null
-                ? objectMapper.readValue(s.getCurrentPairRightMembers(), new TypeReference<List<String>>(){})
+            s.currentPair.getRightBattler().setName(
+                dbState.getCurrentPairRight() != null ? dbState.getCurrentPairRight() : "");
+            s.currentPair.getRightBattler().setScore(0);
+            s.currentPair.getRightBattler().setMembers(dbState.getCurrentPairRightMembers() != null
+                ? objectMapper.readValue(dbState.getCurrentPairRightMembers(), new TypeReference<List<String>>(){})
                 : new ArrayList<>());
-            currentIsFinal = Boolean.TRUE.equals(s.getIsFinal());
-            battlePhase = s.getBattlePhase() != null ? s.getBattlePhase() : "IDLE";
-            champion = s.getChampion();
-            battlers = s.getSmokeListJson() != null
-                ? objectMapper.readValue(s.getSmokeListJson(), new TypeReference<List<Battler>>(){})
+            s.currentIsFinal = Boolean.TRUE.equals(dbState.getIsFinal());
+            s.battlePhase = dbState.getBattlePhase() != null ? dbState.getBattlePhase() : "IDLE";
+            s.champion = dbState.getChampion();
+            s.battlers = dbState.getSmokeListJson() != null
+                ? objectMapper.readValue(dbState.getSmokeListJson(), new TypeReference<List<Battler>>(){})
                 : new ArrayList<>();
-            synchronized (judges) {
-                judges.clear();
-                if (s.getJudgesJson() != null) {
+            synchronized (s.judges) {
+                s.judges.clear();
+                if (dbState.getJudgesJson() != null) {
                     List<BattleJudge> restored =
-                        objectMapper.readValue(s.getJudgesJson(), new TypeReference<List<BattleJudge>>(){});
-                    judges.addAll(restored);
+                        objectMapper.readValue(dbState.getJudgesJson(), new TypeReference<List<BattleJudge>>(){});
+                    s.judges.addAll(restored);
                 }
             }
-            if (s.getFormatTimerJson() != null) {
-                lastFormatTimerPayload = objectMapper.readValue(
-                    s.getFormatTimerJson(), new TypeReference<Map<String, Object>>(){});
-                formatTimerLastUpdated = System.currentTimeMillis();
+            if (dbState.getFormatTimerJson() != null) {
+                s.lastFormatTimerPayload = objectMapper.readValue(
+                    dbState.getFormatTimerJson(), new TypeReference<Map<String, Object>>(){});
+                s.formatTimerLastUpdated = System.currentTimeMillis();
             } else {
-                lastFormatTimerPayload = null;
+                s.lastFormatTimerPayload = null;
             }
         } catch (Exception e) {
             System.err.println("Failed to load genre state from DB: " + e.getMessage());
-            resetToDefaults();
+            resetToDefaults(eventName);
         }
     }
 
-    private void resetToDefaults() {
-        bracketState = null;
-        currentRoundIndex = 0;
-        currentPair.getLeftBattler().setName("");
-        currentPair.getLeftBattler().setScore(0);
-        currentPair.getLeftBattler().setMembers(new ArrayList<>());
-        currentPair.getRightBattler().setName("");
-        currentPair.getRightBattler().setScore(0);
-        currentPair.getRightBattler().setMembers(new ArrayList<>());
-        currentIsFinal = false;
-        battlePhase = "IDLE";
-        champion = null;
-        battlers = new ArrayList<>();
-        synchronized (judges) { judges.clear(); }
-        lastFormatTimerPayload = null;
-        formatTimerLastUpdated = 0;
+    private void resetToDefaults(String eventName) {
+        EventBattleState s = stateFor(eventName);
+        s.bracketState = null;
+        s.currentRoundIndex = 0;
+        s.currentPair.getLeftBattler().setName("");
+        s.currentPair.getLeftBattler().setScore(0);
+        s.currentPair.getLeftBattler().setMembers(new ArrayList<>());
+        s.currentPair.getRightBattler().setName("");
+        s.currentPair.getRightBattler().setScore(0);
+        s.currentPair.getRightBattler().setMembers(new ArrayList<>());
+        s.currentIsFinal = false;
+        s.battlePhase = "IDLE";
+        s.champion = null;
+        s.battlers = new ArrayList<>();
+        synchronized (s.judges) { s.judges.clear(); }
+        s.lastFormatTimerPayload = null;
+        s.formatTimerLastUpdated = 0;
     }
 
-    private void broadcastStateSnapshot() {
-        Map<String, Object> state = getBattleStateService();
-        messagingTemplate.convertAndSend("/topic/battle/state", state);
+    private void broadcastStateSnapshot(String eventName) {
+        Map<String, Object> state = getBattleStateService(eventName);
+        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/state", state);
         if (state.containsKey("timer")) {
-            messagingTemplate.convertAndSend("/topic/battle/timer", state.get("timer"));
+            messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/timer", state.get("timer"));
         }
         if (state.containsKey("formatTimer")) {
-            messagingTemplate.convertAndSend("/topic/battle/format-timer", state.get("formatTimer"));
+            messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/format-timer", state.get("formatTimer"));
+        }
+    }
+
+    public static class EventBattleState {
+        Object bracketState = null;
+        Integer currentRoundIndex = 0;
+        List<Battler> battlers = new ArrayList<>();
+        String battlePhase = "IDLE";
+        boolean currentIsFinal = false;
+        BattlePair currentPair;
+        final List<BattleJudge> judges = Collections.synchronizedList(new ArrayList<>());
+        String activeGenreName;
+        String genreFormat;
+        String champion = null;
+        Map<String, Object> lastTimerPayload = null;
+        long timerLastUpdated = 0;
+        Map<String, Object> lastFormatTimerPayload = null;
+        long formatTimerLastUpdated = 0;
+        Map<String, Object> overlayConfig = new HashMap<>(Map.of(
+            "showImages", true,
+            "leftColor",  "#dc2626",
+            "rightColor", "#2563eb"
+        ));
+
+        EventBattleState() {
+            currentPair = new BattlePair();
+            currentPair.setLeftBattler(new Battler());
+            currentPair.setRightBattler(new Battler());
         }
     }
 
@@ -696,7 +734,7 @@ public class BattleService {
         }
     }
 
-    public class BattlePair {
+    public static class BattlePair {
         private Battler leftBattler;
         private Battler rightBattler;
         public Battler getLeftBattler() { return leftBattler; }

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class BattleServiceTest {
 
+    private static final String E = "TestEvent";
+
     @Mock
     JudgeService judgeService;
 
@@ -36,7 +38,7 @@ class BattleServiceTest {
 
     @Test
     void initialPhaseIsIDLE() {
-        assertThat(service.getBattlePhase()).isEqualTo("IDLE");
+        assertThat(service.getBattlePhase(E)).isEqualTo("IDLE");
     }
 
     @Test
@@ -45,44 +47,42 @@ class BattleServiceTest {
         when(dto.getLeftBattler()).thenReturn("Alice");
         when(dto.getRightBattler()).thenReturn("Bob");
 
-        service.setBattlerPairService(dto);
+        service.setBattlerPairService(E, dto);
 
-        assertThat(service.getCurrentPair().getLeftBattler().getName()).isEqualTo("Alice");
-        assertThat(service.getCurrentPair().getRightBattler().getName()).isEqualTo("Bob");
-        assertThat(service.getBattlePhase()).isEqualTo("LOCKED");
+        assertThat(service.getCurrentPair(E).getLeftBattler().getName()).isEqualTo("Alice");
+        assertThat(service.getCurrentPair(E).getRightBattler().getName()).isEqualTo("Bob");
+        assertThat(service.getBattlePhase(E)).isEqualTo("LOCKED");
     }
 
     @Test
     void setBattlePhase_cannotManuallySetREVEALED() {
-        service.setBattlePhaseService("REVEALED");
+        service.setBattlePhaseService(E, "REVEALED");
 
-        assertThat(service.getBattlePhase()).isEqualTo("IDLE");
+        assertThat(service.getBattlePhase(E)).isEqualTo("IDLE");
     }
 
     @Test
     void setBattlePhase_setsVOTING() {
-        service.setBattlePhaseService("VOTING");
+        service.setBattlePhaseService(E, "VOTING");
 
-        assertThat(service.getBattlePhase()).isEqualTo("VOTING");
+        assertThat(service.getBattlePhase(E)).isEqualTo("VOTING");
     }
 
     @Test
     void setScore_returnsMinusOneWhenNoJudges() {
-        // Empty judges list: score list is empty, frequency(0)==frequency(1) → tie → returns -1
-        assertThat(service.setScoreService(false)).isEqualTo(-1);
+        assertThat(service.setScoreService(E, false)).isEqualTo(-1);
     }
 
     @Test
     void setScore_finalTie_returnsMinusThreeToSignalBlock() {
-        // empty judges → tie, isFinal=true → returns -3 (blocked)
-        assertThat(service.setScoreService(true)).isEqualTo(-3);
-        verify(messagingTemplate, never()).convertAndSend(eq("/topic/battle/score"), any(Map.class));
+        assertThat(service.setScoreService(E, true)).isEqualTo(-3);
+        verify(messagingTemplate, never()).convertAndSend(
+            eq("/topic/battle/" + E + "/score"), any(Map.class));
     }
 
     @Test
     void setScore_nonFinalTie_returnsMinusOne() {
-        // empty judges → tie, isFinal=false → normal tie return -1
-        assertThat(service.setScoreService(false)).isEqualTo(-1);
+        assertThat(service.setScoreService(E, false)).isEqualTo(-1);
     }
 
     @Test
@@ -94,15 +94,15 @@ class BattleServiceTest {
 
         SetJudgeDto jDto = mock(SetJudgeDto.class);
         when(jDto.getId()).thenReturn(10L);
-        service.setBattleJudgeService(jDto);
+        service.setBattleJudgeService(E, jDto);
 
         SetVoteDto vDto = mock(SetVoteDto.class);
         when(vDto.getId()).thenReturn(10L);
         when(vDto.getVote()).thenReturn(0);
-        service.setVoteService(vDto);
+        service.setVoteService(E, vDto);
 
-        assertThat(service.setScoreService(true)).isEqualTo(0);
-        assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
+        assertThat(service.setScoreService(E, true)).isEqualTo(0);
+        assertThat(service.getBattlePhase(E)).isEqualTo("REVEALED");
     }
 
     @Test
@@ -114,17 +114,17 @@ class BattleServiceTest {
 
         SetJudgeDto jDto = mock(SetJudgeDto.class);
         when(jDto.getId()).thenReturn(1L);
-        service.setBattleJudgeService(jDto);
+        service.setBattleJudgeService(E, jDto);
 
         SetVoteDto vDto = mock(SetVoteDto.class);
         when(vDto.getId()).thenReturn(1L);
-        when(vDto.getVote()).thenReturn(0); // vote for left
-        service.setVoteService(vDto);
+        when(vDto.getVote()).thenReturn(0);
+        service.setVoteService(E, vDto);
 
-        Integer result = service.setScoreService(false);
+        Integer result = service.setScoreService(E, false);
 
         assertThat(result).isEqualTo(0);
-        assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
+        assertThat(service.getBattlePhase(E)).isEqualTo("REVEALED");
     }
 
     @Test
@@ -136,15 +136,15 @@ class BattleServiceTest {
 
         SetJudgeDto jDto = mock(SetJudgeDto.class);
         when(jDto.getId()).thenReturn(2L);
-        service.setBattleJudgeService(jDto);
+        service.setBattleJudgeService(E, jDto);
 
         SetVoteDto vDto = mock(SetVoteDto.class);
         when(vDto.getId()).thenReturn(2L);
-        when(vDto.getVote()).thenReturn(1); // vote for right
-        service.setVoteService(vDto);
+        when(vDto.getVote()).thenReturn(1);
+        service.setVoteService(E, vDto);
 
-        assertThat(service.setScoreService(false)).isEqualTo(1);
-        assertThat(service.getBattlePhase()).isEqualTo("REVEALED");
+        assertThat(service.setScoreService(E, false)).isEqualTo(1);
+        assertThat(service.getBattlePhase(E)).isEqualTo("REVEALED");
     }
 
     @Test
@@ -156,11 +156,11 @@ class BattleServiceTest {
 
         SetJudgeDto dto = mock(SetJudgeDto.class);
         when(dto.getId()).thenReturn(1L);
-        service.setBattleJudgeService(dto);
+        service.setBattleJudgeService(E, dto);
 
-        Integer result = service.setBattleJudgeService(dto);
+        Integer result = service.setBattleJudgeService(E, dto);
 
-        assertThat(result).isEqualTo(0); // already exists
+        assertThat(result).isEqualTo(0);
     }
 
     @Test
@@ -170,7 +170,7 @@ class BattleServiceTest {
         SetJudgeDto dto = mock(SetJudgeDto.class);
         when(dto.getId()).thenReturn(99L);
 
-        assertThat(service.setBattleJudgeService(dto)).isEqualTo(-1);
+        assertThat(service.setBattleJudgeService(E, dto)).isEqualTo(-1);
     }
 
     @Test
@@ -182,28 +182,27 @@ class BattleServiceTest {
 
         SetJudgeDto addDto = mock(SetJudgeDto.class);
         when(addDto.getId()).thenReturn(1L);
-        service.setBattleJudgeService(addDto);
-        assertThat(service.getJudges()).hasSize(1);
+        service.setBattleJudgeService(E, addDto);
+        assertThat(service.getJudges(E)).hasSize(1);
 
         SetJudgeDto removeDto = mock(SetJudgeDto.class);
         when(removeDto.getId()).thenReturn(1L);
-        service.removeBattleJudgeService(removeDto);
+        service.removeBattleJudgeService(E, removeDto);
 
-        assertThat(service.getJudges()).isEmpty();
+        assertThat(service.getJudges(E)).isEmpty();
     }
 
     @Test
     void setVote_returnsMinusTwoWhenJudgeNotInList() {
-        // judges list is empty, stream filter never calls dto.getId() — use lenient to avoid UnnecessaryStubbingException
         SetVoteDto dto = mock(SetVoteDto.class);
         lenient().when(dto.getId()).thenReturn(99L);
 
-        assertThat(service.setVoteService(dto)).isEqualTo(-2);
+        assertThat(service.setVoteService(E, dto)).isEqualTo(-2);
     }
 
     @Test
     void getOverlayConfig_returnsDefaults() {
-        Map<String, Object> config = service.getOverlayConfig();
+        Map<String, Object> config = service.getOverlayConfig(E);
         assertThat(config.get("showImages")).isEqualTo(true);
         assertThat(config.get("leftColor")).isEqualTo("#dc2626");
         assertThat(config.get("rightColor")).isEqualTo("#2563eb");
@@ -216,9 +215,9 @@ class BattleServiceTest {
         when(dto.getLeftColor()).thenReturn("#ff0000");
         when(dto.getRightColor()).thenReturn("#0000ff");
 
-        service.setOverlayConfigService(dto);
+        service.setOverlayConfigService(E, dto);
 
-        Map<String, Object> config = service.getOverlayConfig();
+        Map<String, Object> config = service.getOverlayConfig(E);
         assertThat(config.get("showImages")).isEqualTo(false);
         assertThat(config.get("leftColor")).isEqualTo("#ff0000");
         assertThat(config.get("rightColor")).isEqualTo("#0000ff");
@@ -231,10 +230,10 @@ class BattleServiceTest {
         when(dto.getLeftColor()).thenReturn("#aabbcc");
         when(dto.getRightColor()).thenReturn("#112233");
 
-        service.setOverlayConfigService(dto);
+        service.setOverlayConfigService(E, dto);
 
         verify(messagingTemplate).convertAndSend(
-            eq("/topic/battle/overlay-config"),
+            eq("/topic/battle/" + E + "/overlay-config"),
             any(Map.class)
         );
     }
@@ -248,18 +247,18 @@ class BattleServiceTest {
 
         SetJudgeDto addDto = mock(SetJudgeDto.class);
         when(addDto.getId()).thenReturn(5L);
-        service.setBattleJudgeService(addDto);
+        service.setBattleJudgeService(E, addDto);
 
         SetVoteDto voteDto = mock(SetVoteDto.class);
         when(voteDto.getId()).thenReturn(5L);
         when(voteDto.getVote()).thenReturn(0);
-        service.setVoteService(voteDto);
+        service.setVoteService(E, voteDto);
 
-        service.resetJudgeVotesService();
+        service.resetJudgeVotesService(E);
 
-        assertThat(service.getJudges().get(0).getVote()).isEqualTo(-3);
+        assertThat(service.getJudges(E).get(0).getVote()).isEqualTo(-3);
         verify(messagingTemplate, atLeastOnce()).convertAndSend(
-            eq("/topic/battle/judges"), any(Map.class));
+            eq("/topic/battle/" + E + "/judges"), any(Map.class));
     }
 
     @Test
@@ -269,9 +268,9 @@ class BattleServiceTest {
         when(dto.getRightBattler()).thenReturn("W10");
         when(dto.isFinal()).thenReturn(true);
 
-        service.setBattlerPairService(dto);
+        service.setBattlerPairService(E, dto);
 
-        assertThat(service.isCurrentFinal()).isTrue();
+        assertThat(service.isCurrentFinal(E)).isTrue();
     }
 
     @Test
@@ -281,9 +280,9 @@ class BattleServiceTest {
         when(dto.getRightBattler()).thenReturn("Bob");
         when(dto.isFinal()).thenReturn(false);
 
-        service.setBattlerPairService(dto);
+        service.setBattlerPairService(E, dto);
 
-        assertThat(service.isCurrentFinal()).isFalse();
+        assertThat(service.isCurrentFinal(E)).isFalse();
     }
 
     @Test
@@ -293,10 +292,10 @@ class BattleServiceTest {
         when(dto.getRightBattler()).thenReturn("W10");
         when(dto.isFinal()).thenReturn(true);
 
-        service.setBattlerPairService(dto);
+        service.setBattlerPairService(E, dto);
 
         verify(messagingTemplate).convertAndSend(
-            eq("/topic/battle/battle-pair"),
+            eq("/topic/battle/" + E + "/battle-pair"),
             argThat((Map<String, Object> m) -> Boolean.TRUE.equals(m.get("isFinal")))
         );
     }
@@ -308,10 +307,10 @@ class BattleServiceTest {
         when(dto.getChampionName()).thenReturn("PULSE");
         when(dto.isDismiss()).thenReturn(false);
 
-        service.broadcastChampionReveal(dto);
+        service.broadcastChampionReveal(E, dto);
 
         verify(messagingTemplate).convertAndSend(
-            eq("/topic/battle/champion-reveal"),
+            eq("/topic/battle/" + E + "/champion-reveal"),
             any(Map.class)
         );
     }
@@ -326,19 +325,19 @@ class BattleServiceTest {
         SetJudgeDto dtoA = mock(SetJudgeDto.class);
         when(dtoA.getId()).thenReturn(10L);
         when(dtoA.getWeightage()).thenReturn(2);
-        service.setBattleJudgeService(dtoA);
+        service.setBattleJudgeService(E, dtoA);
 
         SetJudgeDto dtoB = mock(SetJudgeDto.class);
         when(dtoB.getId()).thenReturn(11L);
         when(dtoB.getWeightage()).thenReturn(1);
-        service.setBattleJudgeService(dtoB);
+        service.setBattleJudgeService(E, dtoB);
 
         SetVoteDto vA = mock(SetVoteDto.class); when(vA.getId()).thenReturn(10L); when(vA.getVote()).thenReturn(0);
         SetVoteDto vB = mock(SetVoteDto.class); when(vB.getId()).thenReturn(11L); when(vB.getVote()).thenReturn(1);
-        service.setVoteService(vA);
-        service.setVoteService(vB);
+        service.setVoteService(E, vA);
+        service.setVoteService(E, vB);
 
-        assertThat(service.setScoreService(false)).isEqualTo(0);
+        assertThat(service.setScoreService(E, false)).isEqualTo(0);
     }
 
     @Test
@@ -351,19 +350,19 @@ class BattleServiceTest {
         SetJudgeDto dtoA = mock(SetJudgeDto.class);
         when(dtoA.getId()).thenReturn(12L);
         when(dtoA.getWeightage()).thenReturn(2);
-        service.setBattleJudgeService(dtoA);
+        service.setBattleJudgeService(E, dtoA);
 
         SetJudgeDto dtoB = mock(SetJudgeDto.class);
         when(dtoB.getId()).thenReturn(13L);
         when(dtoB.getWeightage()).thenReturn(2);
-        service.setBattleJudgeService(dtoB);
+        service.setBattleJudgeService(E, dtoB);
 
         SetVoteDto vA = mock(SetVoteDto.class); when(vA.getId()).thenReturn(12L); when(vA.getVote()).thenReturn(0);
         SetVoteDto vB = mock(SetVoteDto.class); when(vB.getId()).thenReturn(13L); when(vB.getVote()).thenReturn(1);
-        service.setVoteService(vA);
-        service.setVoteService(vB);
+        service.setVoteService(E, vA);
+        service.setVoteService(E, vB);
 
-        assertThat(service.setScoreService(false)).isEqualTo(-1);
+        assertThat(service.setScoreService(E, false)).isEqualTo(-1);
     }
 
     @Test
@@ -373,15 +372,38 @@ class BattleServiceTest {
 
         SetJudgeDto addDto = mock(SetJudgeDto.class);
         when(addDto.getId()).thenReturn(14L);
-        service.setBattleJudgeService(addDto);
+        service.setBattleJudgeService(E, addDto);
 
         UpdateJudgeWeightageDto updateDto = mock(UpdateJudgeWeightageDto.class);
         when(updateDto.getId()).thenReturn(14L);
         when(updateDto.getWeightage()).thenReturn(3);
-        service.updateJudgeWeightageService(updateDto);
+        service.updateJudgeWeightageService(E, updateDto);
 
-        assertThat(service.getJudges().get(0).getWeightage()).isEqualTo(3);
+        assertThat(service.getJudges(E).get(0).getWeightage()).isEqualTo(3);
         verify(messagingTemplate, atLeastOnce()).convertAndSend(
-            eq("/topic/battle/judges"), any(Map.class));
+            eq("/topic/battle/" + E + "/judges"), any(Map.class));
+    }
+
+    @Test
+    void twoEvents_statesAreIsolated() {
+        SetBattlerPairDto dtoA = mock(SetBattlerPairDto.class);
+        when(dtoA.getLeftBattler()).thenReturn("Alice");
+        when(dtoA.getRightBattler()).thenReturn("Bob");
+        lenient().when(dtoA.getLeftMembers()).thenReturn(new java.util.ArrayList<>());
+        lenient().when(dtoA.getRightMembers()).thenReturn(new java.util.ArrayList<>());
+
+        SetBattlerPairDto dtoB = mock(SetBattlerPairDto.class);
+        when(dtoB.getLeftBattler()).thenReturn("Charlie");
+        when(dtoB.getRightBattler()).thenReturn("Dave");
+        lenient().when(dtoB.getLeftMembers()).thenReturn(new java.util.ArrayList<>());
+        lenient().when(dtoB.getRightMembers()).thenReturn(new java.util.ArrayList<>());
+
+        service.setBattlerPairService("EventAlpha", dtoA);
+        service.setBattlerPairService("EventBeta", dtoB);
+
+        assertThat(service.getCurrentPair("EventAlpha").getLeftBattler().getName()).isEqualTo("Alice");
+        assertThat(service.getCurrentPair("EventBeta").getLeftBattler().getName()).isEqualTo("Charlie");
+        assertThat(service.getBattlePhase("EventAlpha")).isEqualTo("LOCKED");
+        assertThat(service.getBattlePhase("EventBeta")).isEqualTo("LOCKED");
     }
 }


### PR DESCRIPTION
## Summary

Closes #97, #98, #99, #100, #101, #102

Two events can now run simultaneously without state corruption or cross-contamination between their overlays, brackets, and judge screens.

**Backend**
- `BattleService`: all mutable state extracted into `EventBattleState` inner class, held in a `ConcurrentHashMap<String, EventBattleState>` keyed by event name — each event gets its own isolated phase, bracket, pair, judges, timers, and battlers
- All 25 WS broadcasts namespaced: `/topic/battle/{eventName}/...` (vote topics remain judge-scoped at `/topic/battle/vote/{judgeId}`)
- 10 mutation DTOs gain an optional `eventName` field; `BattleController` resolves it via `resolveEvent()` with fallback to `activeEventName`
- `GET /battle/state`, `/battle/overlay-config`, `/battle/judges` accept `?event=` query param
- 26 backend tests updated + new `twoEvents_statesAreIsolated` isolation test

**Frontend**
- `BattleOverlay`, `BracketVisualization`, `Chart`: read `?event=` URL param, subscribe to namespaced topics — silent without the param (intentional; forces explicit configuration)
- `BattleJudge`: derives event from `authStore.activeEvent.name` (session-bound, no URL param needed)
- `BattleControl` quick-links (`Stream Overlay`, `Smoke Overlay`, `Judge View`, `Live Bracket`) automatically inject `?event=EventName` into each URL
- All mutation API calls in `api.js` pass `eventName` in request body
- `BattleControl` + timer components subscribe to event-namespaced topics using `selectedEvent.value`

## Test plan
- [x] Open BattleControl for an event → click "Stream Overlay" → confirm URL includes `?event=EventName`
- [x] In Brave DevTools → Network → WS → Messages: set a battle pair, confirm incoming frames show `/topic/battle/{EventName}/battle-pair` (namespaced, not flat)
- [x] Open overlay without `?event=` → confirm it receives no messages (silent)
- [x] Open `/battle/judge` as a logged-in judge → confirm phase changes from BattleControl update the judge screen in real time
- [x] `mvn test -Dtest=BattleServiceTest` — 26 tests pass

## Out of scope (tracked separately)
- `AuditionNumber.vue` + `EventDetails.vue /checkin-preview/` WS event scoping → #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)