### PR TITLE
fix: scope audition WS subscriptions per event (#103)

### DIFF
--- a/BES-frontend/src/views/AuditionNumber.vue
+++ b/BES-frontend/src/views/AuditionNumber.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRoute } from 'vue-router'
 import ActionDoneModal from './ActionDoneModal.vue'
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket'
 
@@ -19,6 +20,9 @@ const rollingIntervals = {}         // { "${slotId}-${genreName}": intervalId }
 const modalTitle = ref('')
 const modalMessage = ref('')
 const showModal = ref(false)
+
+const route = useRoute()
+const activeEventName = computed(() => route.query.event || '')
 
 const wsClients = []
 
@@ -109,6 +113,7 @@ function processSlotQueue(slotId) {
 
 // ── WS Handlers ─────────────────────────────────────────────────────────────
 const onPreview = (msg) => {
+  if (msg.eventName && msg.eventName !== activeEventName.value) return
   if (msg.cancelled) {
     const id = slotKey(msg.participantId, msg.name)
     const idx = activeSlots.value.findIndex(s => s.slotId === id)
@@ -146,6 +151,7 @@ const onPreview = (msg) => {
 }
 
 const onReceiveAuditionNumber = (msg) => {
+  if (msg.eventName && msg.eventName !== activeEventName.value) return
   const id = slotKey(msg.participantId, msg.name)
   const slot = activeSlots.value.find(s => s.slotId === id)
   if (slot) {
@@ -165,6 +171,7 @@ const onReceiveAuditionNumber = (msg) => {
 }
 
 const onRepeatAudition = (msg) => {
+  if (msg.eventName && msg.eventName !== activeEventName.value) return
   const judgeLabel = msg.judge ? ` · Judge: ${msg.judge}` : ''
   modalTitle.value = `Hey ${msg.name}!`
   modalMessage.value = `Your audition number is ${msg.genre} #${msg.audition}${judgeLabel}`
@@ -192,6 +199,16 @@ onBeforeUnmount(() => {
   <div class="page-container">
     <div class="color-bleed"></div>
 
+    <!-- ── No event linked ───────────────────────────────────────────────── -->
+    <div v-if="!activeEventName" class="flex flex-col items-center justify-center py-24 text-center">
+      <div class="para-chip-sm w-16 h-16 flex items-center justify-center mb-4">
+        <i class="pi pi-link-slash text-content-muted text-2xl"></i>
+      </div>
+      <p class="type-body text-content-secondary">No event linked</p>
+      <p class="type-label text-content-muted mt-1">Open this screen from the Audition Screen button on Event Details</p>
+    </div>
+
+    <template v-else>
     <!-- ── Current Participants ────────────────────────────────────────── -->
     <div class="section-rule mb-4">
       <span class="section-rule-label">Current Participant</span>
@@ -352,6 +369,7 @@ onBeforeUnmount(() => {
         </div>
       </div>
     </template>
+    </template> <!-- end v-else (activeEventName) -->
   </div>
 
   <ActionDoneModal

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -798,7 +798,7 @@ const copyTokenLink = (url) => {
 
 const auditionLinkCopied = ref(false)
 function copyAuditionScreenLink() {
-  copyToClipboard(window.location.origin + '/event/audition-number')
+  copyToClipboard(window.location.origin + '/event/audition-number?event=' + encodeURIComponent(props.eventName))
   auditionLinkCopied.value = true
   setTimeout(() => { auditionLinkCopied.value = false }, 2000)
 }
@@ -1078,6 +1078,7 @@ onMounted(async () => {
       }
     })
     subscribeToChannel(wsClient, '/topic/checkin-preview/', (msg) => {
+      if (msg.eventName && msg.eventName !== props.eventName) return
       if (!msg.participantId) return
       if (msg.cancelled) {
         delete previewingIds[msg.participantId]

--- a/BES-frontend/src/views/HelperSessionView.vue
+++ b/BES-frontend/src/views/HelperSessionView.vue
@@ -38,7 +38,8 @@ function copyToClipboard(text) {
 }
 
 function copyAuditionScreenLink() {
-  copyToClipboard(window.location.origin + '/event/audition-number')
+  if (!authStore.activeEvent?.name) return
+  copyToClipboard(window.location.origin + '/event/audition-number?event=' + encodeURIComponent(authStore.activeEvent.name))
   linkCopied.value = true
   setTimeout(() => { linkCopied.value = false }, 2000)
 }
@@ -110,6 +111,8 @@ function goToEventDetails() {
           @click="copyAuditionScreenLink"
           class="nav-btn"
           :class="linkCopied ? 'nav-btn--copied' : ''"
+          :disabled="!authStore.activeEvent?.name"
+          :style="!authStore.activeEvent?.name ? 'opacity:0.35;cursor:not-allowed' : ''"
         >
           <i class="pi nav-btn-icon" :class="linkCopied ? 'pi-check' : 'pi-hashtag'"></i>
           <span class="nav-btn-label">{{ linkCopied ? 'Link Copied!' : 'Audition Screen' }}</span>

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -465,6 +465,7 @@ public class EventController {
             } else {
                 checkinPreviewService.setPreview(eventName, dto.participantId);
             }
+            dto.eventName = eventName;
             messagingTemplate.convertAndSend("/topic/checkin-preview/", dto);
             return new ResponseEntity<>("ok", HttpStatus.OK);
         } catch (Exception e) {

--- a/BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/CheckinPreviewDto.java
@@ -9,6 +9,7 @@ public class CheckinPreviewDto {
     public List<String> memberNames;
     public List<GenreEntry> genres;
     public Boolean cancelled;
+    public String eventName;
 
     public static class GenreEntry {
         public String genreName;

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -220,7 +220,8 @@ public class EventGenreParticpantService {
                     "audition", participantInEventGenre.getAuditionNumber(),
                     "genre", participantInEventGenre.getEventGenre().getName(),
                     "name", participantInEventGenre.getDisplayName(),
-                    "judge", j != null ? j.getName() : ""));
+                    "judge", j != null ? j.getName() : "",
+                    "eventName", participantInEventGenre.getEvent().getEventName()));
         }
     }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `/topic/checkin-preview/`, `/topic/audition/`, and `/topic/error/` WebSocket broadcasts carried no event identifier, so screens for Event A would receive messages from Event B's check-ins
- **`CheckinPreviewDto`** — added `eventName` field; `EventController` stamps it from the path variable before broadcasting
- **`EventGenreParticpantService`** — added `eventName` to the `/topic/error/` (repeat-audition) broadcast
- **`AuditionNumber.vue`** — switched event source from `authStore.activeEvent` (session-scoped, drifts) to `?event=` query param (URL-scoped, static); all three WS handlers guard against wrong-event messages; shows "No event linked" empty state when param is absent
- **`EventDetails.vue`** — guards `/topic/checkin-preview/` handler with `props.eventName`; copies audition screen link with `?event=<name>` appended
- **`HelperSessionView.vue`** — copies audition screen link with `?event=<name>` appended; disables button when no active event is set

## Test plan

- [ ] Click "Audition Screen" on EventDetails — confirm copied URL contains `?event=<EventName>`
- [ ] Open the copied URL — confirm screen scopes to the correct event and shows "Waiting for check-in…"
- [ ] Open `/event/audition-number` directly (no param) — confirm "No event linked" empty state
- [ ] With two events running simultaneously, check in a participant for Event B — confirm Event A's AuditionNumber screen shows nothing
- [ ] Trigger a repeat-audition scan — confirm the modal only appears on the screen scoped to the correct event
- [ ] In HelperSessionView with no active event — confirm Audition Screen button is greyed out

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)