### PR TITLE
fix: remove redundant null checks — resolve SpotBugs CI failures

### DIFF
--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -88,7 +88,7 @@ public class EventGenreParticpantService {
             egp.setParticipant(p);
             egp.setEventGenre(eg);
 
-            String genreFormat = eg != null ? eg.getFormat() : null;
+            String genreFormat = eg.getFormat();
             boolean isTeamFormat = isTeamFormat(genreFormat);
             boolean isTeamEntry = isTeamFormat && !"solo".equalsIgnoreCase(entryMode);
 
@@ -339,7 +339,7 @@ public class EventGenreParticpantService {
         egp.setParticipant(participant);
         egp.setDisplayName(ep != null ? ep.getDisplayName() : participant.getParticipantName());
 
-        String genreFormat = eg != null ? eg.getFormat() : null;
+        String genreFormat = eg.getFormat();
         boolean soloMode = "solo".equalsIgnoreCase(entryMode);
         boolean hasProvidedTeamName = teamName != null && !teamName.isBlank();
 

--- a/BES/src/main/java/com/example/BES/services/RegistrationService.java
+++ b/BES/src/main/java/com/example/BES/services/RegistrationService.java
@@ -138,7 +138,7 @@ public class RegistrationService {
                         egp.setEventGenre(eg);
                         egp.setParticipant(toAddParticipant);
 
-                        String effectiveFormat = eg != null ? eg.getFormat() : null;
+                        String effectiveFormat = eg.getFormat();
                         boolean isTeamFormat = isTeamFormat(effectiveFormat);
                         boolean isTeamEntry = isTeamFormat && "team".equals(participant.getEntryType());
 


### PR DESCRIPTION
## Summary

- Removes 3 dead `eg != null` ternary checks in `EventGenreParticpantService.java` (lines 91, 342) and `RegistrationService.java` (line 141)
- In each case a null guard (`throw` or `continue`) earlier in the same method already proves `eg` is non-null — the null branch was unreachable dead code
- No behaviour change; SpotBugs HIGH-severity `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` warnings cleared

All 3 checks were introduced in commit `1d69d519` ("feat: move team data to EGP level") on 2026-05-30 as defensive ternaries written before the null guards were added.

## Test plan

- [x] `mvn clean package -DskipTests` — compiles clean
- [x] `mvn test` — 231 tests, 0 failures, coverage checks met
- [x] `npm run lint` — 0 warnings
- [x] `npm run build` — success
- [x] `npm test -- --run` — 113 tests, 0 failures

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)