### PR TITLE
feat: battle views branding — logo/genre watermark, bracket rework, judge panel animations (#109)

### DIFF
--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -694,6 +694,39 @@ export const getGenreStateFromDb = async (eventName, genreName) => {
   } catch (_e) { return null }
 }
 
+export const uploadBattleLogo = async (eventName, file) => {
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    const url = eventName
+      ? `/api/v1/battle/logo-upload?event=${encodeURIComponent(eventName)}`
+      : '/api/v1/battle/logo-upload'
+    return await fetch(`${domain}${url}`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const deleteBattleLogo = async (eventName) => {
+  try {
+    const url = eventName
+      ? `/api/v1/battle/logo?event=${encodeURIComponent(eventName)}`
+      : '/api/v1/battle/logo'
+    return await fetch(`${domain}${url}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
 export const uploadImage = async(file)=>{
   try{
     const formData = new FormData();

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { addBattleJudge, addBattleGuest, battleJudgeVote, clearBattlePair, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getGenreStateFromDb, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateJudgeWeightage, updateSmokeList, uploadImage } from '@/utils/api'
+import { addBattleJudge, addBattleGuest, battleJudgeVote, clearBattlePair, deleteBattleLogo, getBattleChampions, getBattleGuests, getBattleJudges, getBattlePhase, getBattleState, getGenreStateFromDb, getOverlayConfig, getParticipantScore, getPickupCrews, getRegisteredParticipantsByEvent, removeBattleGuest, removeBattleJudge, resetBattleVotes, revealChampion, dismissChampionReveal, setActiveGenre, setBattlePair, setBattlePhase, setBattleScore, setBracketState, setOverlayConfig, updateJudgeWeightage, updateSmokeList, uploadBattleLogo, uploadImage } from '@/utils/api'
 import { computed, onMounted, onUnmounted, ref, watch, toRaw } from 'vue'
 import { useDropdowns } from '@/utils/dropdown'
 import { useEventUtils } from '@/utils/eventUtils'
@@ -35,7 +35,7 @@ const pendingRoundIdx = ref(null)        // the round index user wants to switch
 const finalTieBlocked = ref(false)
 const revealActive = ref(false)
 let skipSizeChangeClear = false          // guard: suppress clear when topSize changes programmatically
-const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
 const showRecoveryBanner = ref(false)
 let recoveryBannerTimer = null
 const recoveryState      = ref(null)
@@ -382,6 +382,17 @@ const onFileChange = async (e) => {
     }
   }
   e.target.value = ''
+}
+
+const onLogoUpload = async (e) => {
+  const file = e.target.files[0]
+  if (!file) return
+  await uploadBattleLogo(selectedEvent.value, file)
+  e.target.value = ''
+}
+
+const onLogoDelete = async () => {
+  await deleteBattleLogo(selectedEvent.value)
 }
 
 const resetJudgeVote = async () => {
@@ -2661,6 +2672,30 @@ onUnmounted(() => {
               <span class="overlay-toggle-track"></span>
             </label>
           </div>
+          <div class="overlay-setting-row overlay-setting-logo">
+            <span class="overlay-setting-label">Event Logo</span>
+            <div class="logo-upload-group">
+              <img
+                v-if="overlayConfig.logoUrl"
+                :src="overlayConfig.logoUrl"
+                class="logo-preview-thumb"
+                alt="Event logo"
+              />
+              <label class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1.5 cursor-pointer">
+                <i class="pi pi-upload text-xs"></i>
+                {{ overlayConfig.logoUrl ? 'Replace' : 'Upload' }}
+                <input type="file" accept="image/*" @change="onLogoUpload" class="hidden" />
+              </label>
+              <button
+                v-if="overlayConfig.logoUrl"
+                @click="onLogoDelete"
+                class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1.5"
+              >
+                <i class="pi pi-trash text-xs"></i>
+                Remove
+              </button>
+            </div>
+          </div>
         </div>
         <p v-if="overlayConfigError" class="overlay-config-error">{{ overlayConfigError }}</p>
       </details>
@@ -3091,5 +3126,15 @@ onUnmounted(() => {
     font-size: 13px;
     letter-spacing: 0.12em;
   }
+}
+
+.overlay-setting-logo { align-items: flex-start; padding-top: 6px; }
+.logo-upload-group { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.logo-preview-thumb {
+  width: 48px; height: 48px;
+  object-fit: contain;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 4px;
+  background: rgba(255,255,255,0.04);
 }
 </style>

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -160,10 +160,9 @@ const hasCustomWeightage = computed(() =>
 
 const judgePanelClass = computed(() => {
   if (isSmoke.value) return 'smoke-judge-always-on'
-  const classes = [judgeAnim.value]
-  if (judgeRestSide.value === 'right') classes.push('judge-at-bottom', 'judge-at-bottom-right')
-  if (judgeRestSide.value === 'left') classes.push('judge-at-bottom', 'judge-at-bottom-left')
-  return classes.filter(Boolean).join(' ')
+  if (judgeRestSide.value === 'right') return 'judge-rest-right'
+  if (judgeRestSide.value === 'left')  return 'judge-rest-left'
+  return judgeAnim.value
 })
 
 // ── Entrance animation ─────────────────────────────────────────────────────
@@ -237,11 +236,11 @@ const updateBattlePair = async (msg) => {
   // STANDARD MODE: if the judge panel is visible, clean it up before the new pair
   if (!hideJudgeDecision.value) {
     glitching.value = true
-    // Exit from the side the panel is resting on
-    if (judgeRestSide.value === 'right') {
-      judgeAnim.value = 'judge-exit-right'
-    } else if (judgeRestSide.value === 'left') {
-      judgeAnim.value = 'judge-exit-left'
+    // Exit from the side the panel is resting on; clear rest first so judgePanelClass uses judgeAnim
+    if (judgeRestSide.value) {
+      const exitSide = judgeRestSide.value
+      judgeRestSide.value = null
+      judgeAnim.value = exitSide === 'right' ? 'judge-exit-right' : 'judge-exit-left'
     } else {
       judgeAnim.value = 'slide-up'
     }
@@ -377,13 +376,11 @@ const updateScore = async (msg) => {
 
     currentWinner.value = msg.message
 
-    // Determine which side to rest on based on winner
-    const restSide = msg.message === 0 ? 'right' : 'left'
-    judgeAnim.value = restSide === 'right' ? 'judge-retreat-right' : 'judge-retreat-left'
+    // Panel retreats to beside winner name
+    judgeAnim.value = ''
+    judgeRestSide.value = msg.message === 0 ? 'right' : 'left'
     await useDelay().wait(550)
     if (!ok()) return
-    judgeAnim.value = ''
-    judgeRestSide.value = restSide
   }
 
   if (msg.message === 0) {
@@ -689,7 +686,7 @@ onUnmounted(() => {
     <!-- Logo watermark + genre — top center -->
     <div class="logo-watermark">
       <img v-if="logoUrl" :src="logoUrl" class="logo-wm-img" alt="Event logo" />
-      <span v-if="activeGenreName" class="logo-wm-genre">{{ activeGenreName }}</span>
+      <span v-if="activeGenreName && !isBlank" class="logo-wm-genre">{{ activeGenreName }}</span>
     </div>
 
     <!-- Screen-reader live region -->
@@ -952,23 +949,32 @@ onUnmounted(() => {
 /* ── Logo watermark — top center ────────────────────────────── */
 .logo-watermark {
   position: absolute;
-  top: 16px; left: 50%;
+  top: 0;
+  left: 50%;
   transform: translateX(-50%);
-  z-index: 90;
-  display: flex; align-items: center; gap: 12px;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 24px 32px 20px;
   pointer-events: none;
 }
 .logo-wm-img {
-  height: 40px; width: auto;
+  max-height: 240px;
+  max-width: 720px;
+  width: auto;
   object-fit: contain;
-  filter: drop-shadow(0 2px 8px rgba(0,0,0,0.6));
+  filter: drop-shadow(0 0 16px rgba(255,255,255,0.18));
 }
 .logo-wm-genre {
   font-family: 'Anton SC', sans-serif;
-  font-size: 13px; letter-spacing: 0.3em;
-  color: rgba(255,255,255,0.50);
+  font-size: 72px;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  text-shadow: 0 1px 6px rgba(0,0,0,0.8);
+  color: rgba(255,255,255,0.07);
+  text-align: center;
+  text-shadow: 2px 2px 0 rgba(255,255,255,0.1);
 }
 
 /* ── Screen-reader only ─────────────────────────────────────── */
@@ -1247,6 +1253,7 @@ onUnmounted(() => {
   height: 100vh;
   display: flex; flex-direction: column;
   align-items: center; justify-content: flex-end;
+  z-index: 2;
   /* CSS transition for winner expand */
   transition: left 420ms cubic-bezier(0.2, 0, 0.3, 1),
               width 420ms cubic-bezier(0.2, 0, 0.3, 1);
@@ -1599,25 +1606,25 @@ onUnmounted(() => {
   100% { transform: translateY(42vh)  scale(1.38); opacity: 1; }
 }
 
-/* Judge scales back down while retreating to right (left wins) */
-@keyframes judgeRetreatRight {
-  0%   { transform: translateY(42vh) translateX(0) scale(1.38); }
-  100% { transform: translateY(0) translateX(0) scale(1); }
+/* Judge drifts to bottom-right beside winner name (left wins) */
+@keyframes judgeRestRight {
+  0%   { transform: translateX(0)    translateY(42vh) scale(1.38); }
+  100% { transform: translateX(28vw) translateY(74vh) scale(1.5); }
 }
-/* Judge scales back down while retreating to left (right wins) */
-@keyframes judgeRetreatLeft {
-  0%   { transform: translateY(42vh) translateX(0) scale(1.38); }
-  100% { transform: translateY(0) translateX(0) scale(1); }
+/* Judge drifts to bottom-left beside winner name (right wins) */
+@keyframes judgeRestLeft {
+  0%   { transform: translateX(0)     translateY(42vh) scale(1.38); }
+  100% { transform: translateX(-28vw) translateY(74vh) scale(1.5); }
 }
-/* Judge slides off to the right */
+/* Judge exits off the right edge from its resting position */
 @keyframes judgeExitRight {
-  from { transform: translateY(0) translateX(0); }
-  to   { transform: translateY(0) translateX(120%); }
+  0%   { transform: translateX(28vw)  translateY(74vh) scale(1.5); opacity: 1; }
+  100% { transform: translateX(110vw) translateY(74vh) scale(1.2); opacity: 0; }
 }
-/* Judge slides off to the left */
+/* Judge exits off the left edge from its resting position */
 @keyframes judgeExitLeft {
-  from { transform: translateY(0) translateX(0); }
-  to   { transform: translateY(0) translateX(-120%); }
+  0%   { transform: translateX(-28vw)  translateY(74vh) scale(1.5); opacity: 1; }
+  100% { transform: translateX(-110vw) translateY(74vh) scale(1.2); opacity: 0; }
 }
 
 /* Card burst entrance on score reveal */
@@ -1747,17 +1754,10 @@ onUnmounted(() => {
 
 .slide-down        { animation: slideDown        480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
 .slide-up          { animation: slideUp          300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
-.judge-slam-center  { animation: judgeSlamCenter  680ms cubic-bezier(0.2,  0,   0.3, 1) both; }
-.judge-retreat-right { animation: judgeRetreatRight 500ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
-.judge-retreat-left  { animation: judgeRetreatLeft  500ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
-.judge-exit-right    { animation: judgeExitRight    300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
-.judge-exit-left     { animation: judgeExitLeft     300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
-.judge-at-bottom {
-  transform: translateY(0) !important;
-  position: absolute;
-  bottom: 30px;
-}
-.judge-at-bottom-right { right: 30px; left: auto; }
-.judge-at-bottom-left  { left: 30px; right: auto; }
+.judge-slam-center { animation: judgeSlamCenter 680ms cubic-bezier(0.2, 0, 0.3, 1) both; }
+.judge-rest-right  { animation: judgeRestRight  520ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
+.judge-rest-left   { animation: judgeRestLeft   520ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
+.judge-exit-right  { animation: judgeExitRight  280ms cubic-bezier(0.55, 0,   1,   0.45) forwards; }
+.judge-exit-left   { animation: judgeExitLeft   280ms cubic-bezier(0.55, 0,   1,   0.45) forwards; }
 </style>
 

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -12,7 +12,8 @@ const eventName = ref(route.query.event || '')
 const topic = (path) => `/topic/battle/${eventName.value}/${path}`
 
 // ── Overlay config (live from BattleControl + API) ─────────────────────────
-const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
+const logoUrl  = computed(() => overlayConfig.value.logoUrl)
 
 // ── Battle state ───────────────────────────────────────────────────────────
 const imageLeft  = ref(null)
@@ -94,6 +95,8 @@ const activeGenreName = ref('')
 
 // Judge panel visibility: true = off-screen (idle/battle), false = visible (score revealed)
 const hideJudgeDecision = ref(true)
+// judgeRestSide: null | 'left' | 'right' — side of screen where panel rests post-reveal
+const judgeRestSide = ref(null)
 
 // ── Voting state ───────────────────────────────────────────────────────────
 // showVotingIndicator: true when /topic/battle/phase emits VOTING
@@ -157,7 +160,10 @@ const hasCustomWeightage = computed(() =>
 
 const judgePanelClass = computed(() => {
   if (isSmoke.value) return 'smoke-judge-always-on'
-  return judgeAnim.value
+  const classes = [judgeAnim.value]
+  if (judgeRestSide.value === 'right') classes.push('judge-at-bottom', 'judge-at-bottom-right')
+  if (judgeRestSide.value === 'left') classes.push('judge-at-bottom', 'judge-at-bottom-left')
+  return classes.filter(Boolean).join(' ')
 })
 
 // ── Entrance animation ─────────────────────────────────────────────────────
@@ -206,6 +212,7 @@ const updateBattlePair = async (msg) => {
   if (!msg.left && !msg.right) {
     hideJudgeDecision.value  = true
     judgeAnim.value          = ''
+    judgeRestSide.value      = null
     votesVisible.value       = false
     winnerTagVisible.value   = false
     leftWin.value            = false
@@ -230,7 +237,14 @@ const updateBattlePair = async (msg) => {
   // STANDARD MODE: if the judge panel is visible, clean it up before the new pair
   if (!hideJudgeDecision.value) {
     glitching.value = true
-    judgeAnim.value = 'slide-up'
+    // Exit from the side the panel is resting on
+    if (judgeRestSide.value === 'right') {
+      judgeAnim.value = 'judge-exit-right'
+    } else if (judgeRestSide.value === 'left') {
+      judgeAnim.value = 'judge-exit-left'
+    } else {
+      judgeAnim.value = 'slide-up'
+    }
     await useDelay().wait(100)
     if (unmounted) return
 
@@ -249,6 +263,7 @@ const updateBattlePair = async (msg) => {
     glitching.value          = false
     hideJudgeDecision.value  = true
     judgeAnim.value          = ''
+    judgeRestSide.value      = null
     votesVisible.value       = false
     winnerTagVisible.value   = false
     await useDelay().wait(50)
@@ -360,17 +375,15 @@ const updateScore = async (msg) => {
     await useDelay().wait(1500)
     if (!ok()) return
 
-    // Phase 2: panel scales down and retreats to top
-    judgeAnim.value = 'judge-retreat-top'
+    currentWinner.value = msg.message
+
+    // Determine which side to rest on based on winner
+    const restSide = msg.message === 0 ? 'right' : 'left'
+    judgeAnim.value = restSide === 'right' ? 'judge-retreat-right' : 'judge-retreat-left'
     await useDelay().wait(550)
     if (!ok()) return
-    judgeAnim.value = 'judge-at-top'
-
-    // Brief pause before winner reveal
-    await useDelay().wait(150)
-    if (!ok()) return
-
-    currentWinner.value = msg.message
+    judgeAnim.value = ''
+    judgeRestSide.value = restSide
   }
 
   if (msg.message === 0) {
@@ -406,10 +419,12 @@ const restoreRevealedState = (rounds) => {
         leftWin.value    = true
         rightReset.value = true   // slide loser off screen
         vsAnim.value     = 'knock-right'
+        judgeRestSide.value = 'right'
       } else {
         rightWin.value  = true
         leftReset.value = true    // slide loser off screen
         vsAnim.value    = 'knock-left'
+        judgeRestSide.value = 'left'
       }
       winnerTagVisible.value = true
       return
@@ -419,9 +434,6 @@ const restoreRevealedState = (rounds) => {
 
 // ── Mount ──────────────────────────────────────────────────────────────────
 onMounted(async () => {
-  document.documentElement.classList.add('transparent-page')
-  document.body.classList.add('transparent-page')
-
   // Fetch initial overlay config (survives OBS refresh)
   const config = await getOverlayConfig(eventName.value)
   if (config?.showImages !== undefined) overlayConfig.value = config
@@ -452,6 +464,7 @@ onMounted(async () => {
       animToken++
       hideJudgeDecision.value = true
       judgeAnim.value         = ''
+      judgeRestSide.value     = null
       votesVisible.value      = false
       winnerTagVisible.value  = false
       leftWin.value           = false
@@ -552,6 +565,7 @@ onMounted(async () => {
         vsAnim.value      = ''
         winnerTagVisible.value = false
         hideJudgeDecision.value = true
+        judgeRestSide.value = null
         if (freshState.currentPair.left)  imageLeft.value  = await getImage(`${freshState.currentPair.left}.png`).catch(() => null)
         if (freshState.currentPair.right) imageRight.value = await getImage(`${freshState.currentPair.right}.png`).catch(() => null)
         side = champion === leftName.value ? 0 : (champion === rightName.value ? 1 : -1)
@@ -566,6 +580,7 @@ onMounted(async () => {
     if (!ok()) return
     hideJudgeDecision.value = true
     judgeAnim.value = ''
+    judgeRestSide.value = null
     if (side === 0) {
       leftWin.value          = true
       winnerTagVisible.value = true
@@ -622,8 +637,6 @@ onBeforeUnmount(() => {
 })
 
 onUnmounted(() => {
-  document.documentElement.classList.remove('transparent-page')
-  document.body.classList.remove('transparent-page')
   const appRoot = document.getElementById('app')
   if (appRoot) appRoot.style.background = ''
 })
@@ -635,20 +648,11 @@ onUnmounted(() => {
     :class="{ 'stage-shake': stageShaking }"
     :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
   >
-    <!-- Broadcast timer bar (visible when BattleTimer is running) -->
+    <!-- Broadcast timer — text-only top-right -->
     <Transition name="timer-enter">
       <div v-if="showTimer" class="timer-overlay">
-        <div class="timer-bar-container">
-          <div class="timer-progress-track">
-            <div
-              class="timer-progress-fill"
-              :style="{ width: (timerState.totalDuration > 0 ? (timerState.timeLeft / timerState.totalDuration) * 100 : 0) + '%' }"
-              :class="{ 'timer-fill-warning': timerState.timeLeft <= 10 }"
-            ></div>
-          </div>
-          <div class="timer-countdown" :class="{ 'timer-text-warning': timerState.timeLeft <= 10 }">
-            {{ Math.floor(timerState.timeLeft / 60) }}:{{ String(timerState.timeLeft % 60).padStart(2, '0') }}
-          </div>
+        <div class="timer-countdown" :class="{ 'timer-text-warning': timerState.timeLeft <= 10 }">
+          {{ Math.floor(timerState.timeLeft / 60) }}:{{ String(timerState.timeLeft % 60).padStart(2, '0') }}
         </div>
       </div>
     </Transition>
@@ -681,6 +685,12 @@ onUnmounted(() => {
         </div>
       </div>
     </Transition>
+
+    <!-- Logo watermark + genre — top center -->
+    <div class="logo-watermark">
+      <img v-if="logoUrl" :src="logoUrl" class="logo-wm-img" alt="Event logo" />
+      <span v-if="activeGenreName" class="logo-wm-genre">{{ activeGenreName }}</span>
+    </div>
 
     <!-- Screen-reader live region -->
     <div class="sr-only" role="status" aria-live="assertive" aria-atomic="true">
@@ -903,17 +913,6 @@ onUnmounted(() => {
   </div>
 </template>
 
-<style>
-/* ── Transparent background (OBS) — must be global ─────────── */
-html.transparent-page,
-body.transparent-page,
-html.transparent-page #app,
-body.transparent-page #app {
-  background: transparent !important;
-  background-color: transparent !important;
-}
-</style>
-
 <style scoped>
 /* ── Blank announcement ─────────────────────────────────────── */
 .blank-announce {
@@ -950,6 +949,28 @@ body.transparent-page #app {
   50%       { transform: scale(1.12); opacity: 1; }
 }
 
+/* ── Logo watermark — top center ────────────────────────────── */
+.logo-watermark {
+  position: absolute;
+  top: 16px; left: 50%;
+  transform: translateX(-50%);
+  z-index: 90;
+  display: flex; align-items: center; gap: 12px;
+  pointer-events: none;
+}
+.logo-wm-img {
+  height: 40px; width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 8px rgba(0,0,0,0.6));
+}
+.logo-wm-genre {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 13px; letter-spacing: 0.3em;
+  color: rgba(255,255,255,0.50);
+  text-transform: uppercase;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.8);
+}
+
 /* ── Screen-reader only ─────────────────────────────────────── */
 .sr-only {
   position: absolute; width: 1px; height: 1px; padding: 0;
@@ -964,6 +985,7 @@ body.transparent-page #app {
   width: 100vw; height: 100vh;
   overflow: hidden;
   font-family: 'Anton SC', sans-serif;
+  background: #060818;
   /* Default CSS custom properties — overridden by :style binding */
   --left-color: #dc2626;
   --right-color: #2563eb;
@@ -1577,10 +1599,25 @@ body.transparent-page #app {
   100% { transform: translateY(42vh)  scale(1.38); opacity: 1; }
 }
 
-/* Judge scales back down while retreating to top */
-@keyframes judgeRetreatTop {
-  0%   { transform: translateY(42vh) scale(1.38); }
-  100% { transform: translateY(30px) scale(1); }
+/* Judge scales back down while retreating to right (left wins) */
+@keyframes judgeRetreatRight {
+  0%   { transform: translateY(42vh) translateX(0) scale(1.38); }
+  100% { transform: translateY(0) translateX(0) scale(1); }
+}
+/* Judge scales back down while retreating to left (right wins) */
+@keyframes judgeRetreatLeft {
+  0%   { transform: translateY(42vh) translateX(0) scale(1.38); }
+  100% { transform: translateY(0) translateX(0) scale(1); }
+}
+/* Judge slides off to the right */
+@keyframes judgeExitRight {
+  from { transform: translateY(0) translateX(0); }
+  to   { transform: translateY(0) translateX(120%); }
+}
+/* Judge slides off to the left */
+@keyframes judgeExitLeft {
+  from { transform: translateY(0) translateX(0); }
+  to   { transform: translateY(0) translateX(-120%); }
 }
 
 /* Card burst entrance on score reveal */
@@ -1618,18 +1655,14 @@ body.transparent-page #app {
 /* (borderRotate removed — judge card no longer uses rotating glow border) */
 
 
-/* ── Broadcast timer (top center bar) ─────────────── */
-.timer-overlay { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 100; width: 60%; padding: 16px 0 0 0; pointer-events: none; }
-.timer-bar-container { background: rgba(0,0,0,0.75); border: 1px solid rgba(255,255,255,0.1); padding: 8px 20px; clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%); }
-.timer-progress-track { height: 3px; background: rgba(255,255,255,0.08); border-radius: 2px; margin-bottom: 6px; overflow: hidden; }
-.timer-progress-fill { height: 100%; background: var(--accent-color, #fff); transition: width 1s linear; border-radius: 2px; }
-.timer-fill-warning { background: #ef4444; animation: timer-pulse-bar 0.5s ease-in-out infinite alternate; }
-.timer-countdown { font-family: 'Anton SC', sans-serif; font-size: 24px; letter-spacing: 0.06em; color: var(--accent-color, #fff); text-align: center; text-shadow: 0 0 12px var(--accent-muted, rgba(255,255,255,0.25)); }
+/* ── Broadcast timer (text-only top-right) ───────── */
+.timer-overlay { position: absolute; top: 16px; right: 20px; z-index: 100; pointer-events: none; }
+.timer-countdown { font-family: 'Anton SC', sans-serif; font-size: 28px; letter-spacing: 0.08em; color: var(--accent-color, #fff); text-align: right; text-shadow: 0 2px 8px rgba(0,0,0,0.6); }
 .timer-text-warning { color: #ef4444; text-shadow: 0 0 12px rgba(239,68,68,0.5); animation: timer-pulse-text 0.5s ease-in-out infinite alternate; }
 .timer-enter-enter-active { animation: timer-slide-in 300ms cubic-bezier(0.22, 0.61, 0.36, 1); }
 .timer-enter-leave-active { animation: timer-slide-out 200ms ease-in; }
-@keyframes timer-slide-in { from { opacity: 0; transform: translateX(-50%) translateY(-100%); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }
-@keyframes timer-slide-out { from { opacity: 1; transform: translateX(-50%) translateY(0); } to { opacity: 0; transform: translateX(-50%) translateY(-100%); } }
+@keyframes timer-slide-in { from { opacity: 0; transform: translateY(-20px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes timer-slide-out { from { opacity: 1; transform: translateY(0); } to { opacity: 0; transform: translateY(-20px); } }
 
 /* ── Format timer — full-width bottom bar (smoke mode only) ─────── */
 /* Per-round match timer lives at top-center (narrow centered bar). */
@@ -1712,10 +1745,19 @@ body.transparent-page #app {
 .slide-left-out  { animation: hardCutLeft  320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
 .slide-right-out { animation: hardCutRight 320ms cubic-bezier(0.55, 0, 1, 0) forwards; }
 
-.slide-down       { animation: slideDown       480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
-.slide-up         { animation: slideUp         300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
-.judge-slam-center { animation: judgeSlamCenter 680ms cubic-bezier(0.2,  0,   0.3, 1) both; }
-.judge-retreat-top { animation: judgeRetreatTop 500ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
-.judge-at-top      { transform: translateY(30px); }
+.slide-down        { animation: slideDown        480ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
+.slide-up          { animation: slideUp          300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
+.judge-slam-center  { animation: judgeSlamCenter  680ms cubic-bezier(0.2,  0,   0.3, 1) both; }
+.judge-retreat-right { animation: judgeRetreatRight 500ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
+.judge-retreat-left  { animation: judgeRetreatLeft  500ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
+.judge-exit-right    { animation: judgeExitRight    300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
+.judge-exit-left     { animation: judgeExitLeft     300ms cubic-bezier(0.2,  0,   1,   0) forwards; }
+.judge-at-bottom {
+  transform: translateY(0) !important;
+  position: absolute;
+  bottom: 30px;
+}
+.judge-at-bottom-right { right: 30px; left: auto; }
+.judge-at-bottom-left  { left: 30px; right: auto; }
 </style>
 

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -103,40 +103,7 @@ const centerColWidth = computed(() => {
   return '185px'
 })
 
-const formatLabel = (key) => key === 'Top2' ? 'FINAL' : key.replace('Top', 'TOP ')
 
-// ── ticker ────────────────────────────────────────────────
-const nextMatch = computed(() => {
-  if (!bracketState.value?.rounds) return null
-  for (const key of roundKeys.value) {
-    for (const m of getMatches(key)) {
-      if (!m[2] && !isActiveMatch(m) && (m[0] || m[1])) return m
-    }
-  }
-  return null
-})
-
-const activeRoundLabel = computed(() => {
-  if (!activePair.value) return null
-  for (const key of roundKeys.value) {
-    if (getMatches(key).some(m => isActiveMatch(m))) return formatLabel(key)
-  }
-  return null
-})
-
-const tickerItems = computed(() => {
-  const items = []
-  if (activePair.value) {
-    if (activeRoundLabel.value) items.push({ type: 'label', text: activeRoundLabel.value })
-    items.push({ type: 'now', text: `${activePair.value.left}  ⚔  ${activePair.value.right}` })
-  }
-  if (nextMatch.value) {
-    items.push({ type: 'next', text: `${nextMatch.value[0] || '—'}  ⚔  ${nextMatch.value[1] || '—'}` })
-  }
-  if (currentGenre.value) items.push({ type: 'genre', text: currentGenre.value })
-  if (!items.length) items.push({ type: 'label', text: 'LIVE BATTLE' })
-  return items
-})
 
 // ── animation helpers ─────────────────────────────────────
 const sleep = ms => new Promise(r => setTimeout(r, ms))
@@ -503,7 +470,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
       <!-- LEFT half -->
       <div class="bracket-half bracket-left">
         <div v-for="key in sideRoundKeys" :key="key" class="round-col">
-          <div class="round-label">{{ formatLabel(key) }}</div>
           <div class="matches-col">
             <div
               v-for="(match, mIdx) in leftMatches(key)" :key="mIdx"
@@ -545,7 +511,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 
       <!-- CENTER: Final + Champion -->
       <div class="center-col">
-        <div class="round-label">FINAL</div>
         <div class="final-area">
           <div v-if="finalMatch" class="final-match" :class="{ 'match-active': isActiveMatch(finalMatch) }">
             <div
@@ -580,7 +545,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
       <!-- RIGHT half -->
       <div class="bracket-half bracket-right">
         <div v-for="key in rightRoundKeys" :key="key" class="round-col">
-          <div class="round-label">{{ formatLabel(key) }}</div>
           <div class="matches-col">
             <div
               v-for="(match, mIdx) in rightMatches(key)" :key="mIdx"
@@ -675,23 +639,33 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 
 /* ── Logo banner ──────────────────────────────────────── */
 .logo-banner {
-  flex-shrink: 0;
-  display: flex; align-items: center; gap: 12px;
-  padding: 10px 20px;
-  background: linear-gradient(135deg, rgba(6,8,20,0.98) 0%, rgba(8,10,26,0.95) 100%);
-  border-bottom: 1px solid rgba(255,255,255,0.07);
-  position: relative; z-index: 10;
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 24px 32px 20px;
 }
 .logo-banner-img {
-  height: 36px;
+  max-height: 240px;
+  max-width: 720px;
   width: auto;
   object-fit: contain;
+  filter: drop-shadow(0 0 16px rgba(255,255,255,0.18));
 }
 .logo-banner-genre {
   font-family: 'Anton SC', sans-serif;
-  font-size: 13px; letter-spacing: 0.3em;
-  color: rgba(255,255,255,0.45);
+  font-size: 72px;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
+  color: rgba(180,180,180,0.12);
+  text-align: center;
+  text-shadow: none;
 }
 
 /* ── Empty / Smoke ────────────────────────────────────── */
@@ -731,7 +705,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 .mb-4 { margin-bottom: 16px; }
 
 /* ── Bracket layout ───────────────────────────────────── */
-.bracket-area  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); padding: 8px 16px 12px; overflow: hidden; min-height: 0; position: relative; z-index: 1; }
+.bracket-area  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); padding: 8px 16px 12px; overflow: hidden; min-height: 0; position: relative; z-index: 2; }
 .bracket-half  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); min-width: 0; }
 .round-col     { flex: 1; display: flex; flex-direction: column; min-width: 0; position: relative; }
 .matches-col   { flex: 1; display: flex; flex-direction: column; min-height: 0; }

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -6,7 +6,7 @@ import { useRoute } from 'vue-router'
 
 const bracketState   = ref(null)
 const lastBracketSnapshot = ref('')  // JSON diff guard
-const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
 const championReveal = ref(null)   // null = hidden; { genreName, championName } = showing
 const activePair     = ref(null)
 const currentGenre   = ref(null)
@@ -74,7 +74,7 @@ const isActiveMatch = (match) => {
 
 const slotClass = (match, slot, isFinal = false) => {
   if (match[2]) {
-    if (match[2] === match[slot]) return isFinal ? 'slot-winner' : (slot === 0 ? 'slot-winner-left' : 'slot-winner-right')
+    if (match[2] === match[slot]) return isFinal ? 'slot-winner' : 'slot-winner-round'
     if (match[slot]) return 'slot-loser'
     return ''
   }
@@ -466,20 +466,11 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
       </div>
     </Transition>
 
-    <!-- ── Header ─────────────────────────────────────── -->
-    <header class="bracket-header">
-      <div class="header-brand">
-        <span class="brand-dot"></span>
-        <span class="brand-title">LIVE BRACKET</span>
-        <span class="brand-dot"></span>
-      </div>
-      <div v-if="activePair" class="active-pill">
-        <span class="pill-dot"></span>
-        {{ activePair.left }}
-        <span class="vs-sep">vs</span>
-        {{ activePair.right }}
-      </div>
-    </header>
+    <!-- ── Logo banner ────────────────────────────────── -->
+    <div v-if="overlayConfig.logoUrl || currentGenre" class="logo-banner">
+      <img v-if="overlayConfig.logoUrl" :src="overlayConfig.logoUrl" class="logo-banner-img" alt="Event logo" />
+      <span v-if="currentGenre" class="logo-banner-genre">{{ currentGenre }}</span>
+    </div>
 
     <!-- ── Empty state ────────────────────────────────── -->
     <div v-if="isEmpty" class="empty-state">
@@ -631,31 +622,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 
     </div>
 
-    <!-- ── LED Ticker ─────────────────────────────────── -->
-    <div class="ticker-bar">
-      <div class="ticker-label">
-        <span class="ticker-dot"></span>
-        LIVE
-      </div>
-      <div class="ticker-track">
-        <div class="ticker-reel" :style="{ '--item-count': tickerItems.length }">
-          <template v-for="pass in 2" :key="pass">
-            <span
-              v-for="(item, idx) in tickerItems" :key="`${pass}-${idx}`"
-              class="ticker-item" :class="`ticker-${item.type}`"
-            >
-              <span v-if="item.type === 'now'"   class="ticker-tag">NOW BATTLING</span>
-              <span v-else-if="item.type === 'next'"  class="ticker-tag">NEXT UP</span>
-              <span v-else-if="item.type === 'genre'" class="ticker-tag">GENRE</span>
-              <span v-else-if="item.type === 'label'" class="ticker-tag">{{ item.text }}</span>
-              <span v-if="item.type !== 'label'" class="ticker-text">{{ item.text }}</span>
-              <span class="ticker-sep">◆</span>
-            </span>
-          </template>
-        </div>
-      </div>
-    </div>
-
   </div>
 
 </template>
@@ -707,44 +673,26 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   );
 }
 
-/* ── Header ───────────────────────────────────────────── */
-.bracket-header {
-  flex-shrink: 0; height: var(--header-h);
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 0 20px;
+/* ── Logo banner ──────────────────────────────────────── */
+.logo-banner {
+  flex-shrink: 0;
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 20px;
   background: linear-gradient(135deg, rgba(6,8,20,0.98) 0%, rgba(8,10,26,0.95) 100%);
   border-bottom: 1px solid rgba(255,255,255,0.07);
   position: relative; z-index: 10;
 }
-.header-brand { display: flex; align-items: center; gap: 10px; }
-.brand-dot {
-  width: 6px; height: 6px; border-radius: 50%;
-  background: var(--c-accent);
-  box-shadow: 0 0 10px rgba(255,255,255,0.5), 0 0 22px rgba(255,255,255,0.2);
-  animation: dotPulse 2s ease-in-out infinite;
+.logo-banner-img {
+  height: 36px;
+  width: auto;
+  object-fit: contain;
 }
-.brand-title {
+.logo-banner-genre {
   font-family: 'Anton SC', sans-serif;
-  font-size: 13px; letter-spacing: 0.38em;
-  color: rgba(255,255,255,0.42);
+  font-size: 13px; letter-spacing: 0.3em;
+  color: rgba(255,255,255,0.45);
   text-transform: uppercase;
 }
-.active-pill {
-  display: flex; align-items: center; gap: 8px;
-  font-family: 'Anton SC', sans-serif;
-  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
-  color: rgba(255,255,255,0.75);
-  background: rgba(255,255,255,0.06);
-  border: 1px solid rgba(255,255,255,0.18);
-  border-radius: 2px; padding: 4px 16px 4px 12px;
-  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
-}
-.pill-dot {
-  width: 5px; height: 5px; border-radius: 50%;
-  background: rgba(255,255,255,0.7); box-shadow: 0 0 6px rgba(255,255,255,0.5);
-  animation: dotPulse 1s ease-in-out infinite;
-}
-.vs-sep { color: rgba(255,255,255,0.2); font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 400; }
 
 /* ── Empty / Smoke ────────────────────────────────────── */
 .empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; }
@@ -854,25 +802,17 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 }
 .slot-winner .battler-name { color: #fde68a; }
 
-/* Non-final winner — keep their side color */
-.slot-winner-left {
-  background: color-mix(in srgb, var(--left-color) 20%, transparent) !important;
-  border-color: color-mix(in srgb, var(--left-color) 55%, transparent) !important;
-  box-shadow: 0 0 14px color-mix(in srgb, var(--left-color) 25%, transparent) !important;
+/* Non-final winner — neutral white (not side color) */
+.slot-winner-round {
+  background: rgba(255,255,255,0.10) !important;
+  border-color: rgba(255,255,255,0.30) !important;
+  box-shadow: 0 0 14px rgba(255,255,255,0.15) !important;
 }
-.slot-winner-left .battler-name {
-  color: color-mix(in srgb, var(--left-color) 85%, #fff) !important;
-}
-.slot-winner-right {
-  background: color-mix(in srgb, var(--right-color) 20%, transparent) !important;
-  border-color: color-mix(in srgb, var(--right-color) 55%, transparent) !important;
-  box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 25%, transparent) !important;
-}
-.slot-winner-right .battler-name {
-  color: color-mix(in srgb, var(--right-color) 85%, #fff) !important;
+.slot-winner-round .battler-name {
+  color: rgba(255,255,255,0.95) !important;
 }
 
-.slot-loser { background: rgba(255,255,255,0.02) !important; border-color: rgba(255,255,255,0.03) !important; opacity: 0.42; }
+.slot-loser { background: rgba(255,255,255,0.02) !important; border-color: rgba(255,255,255,0.03) !important; opacity: 0.62; }
 .slot-loser  .battler-name { color: var(--c-lose-text); }
 
 .battler-name {
@@ -933,36 +873,6 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
   color: rgba(255,255,255,0.3); opacity: 0.38;
 }
 
-/* ── LED Ticker ───────────────────────────────────────── */
-.ticker-bar {
-  flex-shrink: 0; height: 30px;
-  display: flex; align-items: stretch;
-  background: #030610;
-  border-top: 1px solid rgba(255,255,255,0.07);
-  overflow: hidden; position: relative; z-index: 10;
-}
-.ticker-label {
-  flex-shrink: 0; display: flex; align-items: center; gap: 6px;
-  padding: 0 18px 0 14px;
-  background: rgba(255,255,255,0.9);
-  font-family: 'Anton SC', sans-serif;
-  font-size: 10px; letter-spacing: 0.25em;
-  color: #060818; z-index: 1;
-  clip-path: polygon(0% 0%, calc(100% - 10px) 0%, 100% 50%, calc(100% - 10px) 100%, 0% 100%);
-}
-.ticker-dot   { width: 5px; height: 5px; border-radius: 50%; background: #030610; animation: dotPulse 1s ease-in-out infinite; }
-.ticker-track { flex: 1; overflow: hidden; position: relative; mask-image: linear-gradient(to right, transparent 0%, black 3%, black 97%, transparent 100%); }
-.ticker-reel  { display: inline-flex; align-items: center; white-space: nowrap; height: 100%; animation: tickerScroll calc(var(--item-count, 4) * 8s) linear infinite; }
-.ticker-item  { display: inline-flex; align-items: center; gap: 8px; padding: 0 6px; }
-.ticker-tag   { font-family: 'Anton SC', sans-serif; font-size: 8px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--c-muted); opacity: 0.62; }
-.ticker-now   .ticker-tag  { color: rgba(255,255,255,0.85); opacity: 1; }
-.ticker-next  .ticker-tag  { color: rgba(249,115,22,0.85); opacity: 1; }
-.ticker-genre .ticker-tag  { color: rgba(167,139,250,0.85); opacity: 1; }
-.ticker-text  { font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; letter-spacing: 0.04em; color: var(--c-text); }
-.ticker-now   .ticker-text { color: rgba(255,255,255,0.85); }
-.ticker-next  .ticker-text { color: rgba(249,115,22,0.9); }
-.ticker-genre .ticker-text { color: rgba(167,139,250,0.9); }
-.ticker-sep   { font-size: 7px; color: var(--c-muted); opacity: 0.22; padding: 0 16px; }
 
 /* ── Champion Reveal Overlay ────────────────────────────── */
 .champ-overlay {
@@ -1036,9 +946,5 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 @keyframes dotPulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50%       { opacity: 0.32; transform: scale(0.62); }
-}
-@keyframes tickerScroll {
-  0%   { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
 }
 </style>

--- a/BES-frontend/src/views/__tests__/BattleOverlay.test.js
+++ b/BES-frontend/src/views/__tests__/BattleOverlay.test.js
@@ -36,10 +36,10 @@ describe('BattleOverlay.vue', () => {
     expect(wrapper.exists()).toBe(true)
   })
 
-  it('adds transparent-page class to html on mount', async () => {
+  it('does not add transparent-page class to html on mount', async () => {
     mount(BattleOverlay, { global: { plugins: [router] } })
     await new Promise(r => setTimeout(r, 10))
-    expect(document.documentElement.classList.contains('transparent-page')).toBe(true)
+    expect(document.documentElement.classList.contains('transparent-page')).toBe(false)
   })
 
   it('renders .overlay-root element', async () => {

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -405,6 +405,23 @@ public class BattleController {
         return ResponseEntity.ok(state);
     }
 
+    @PostMapping("/logo-upload")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> uploadLogo(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(required = false) String event) throws IOException {
+        String url = battleService.uploadLogoService(resolveEvent(event), file);
+        return ResponseEntity.ok(Map.of("logoUrl", url));
+    }
+
+    @DeleteMapping("/logo")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> deleteLogo(
+            @RequestParam(required = false) String event) throws IOException {
+        battleService.deleteLogoService(resolveEvent(event));
+        return ResponseEntity.ok(Map.of("message", "Logo deleted"));
+    }
+
     @GetMapping("/state")
     public ResponseEntity<?> getBattleState(@RequestParam(required = false) String event) {
         String eName = resolveEvent(event);

--- a/BES/src/main/java/com/example/BES/models/BattleGenreState.java
+++ b/BES/src/main/java/com/example/BES/models/BattleGenreState.java
@@ -67,6 +67,9 @@ public class BattleGenreState {
     @Column(name = "format_timer_json", columnDefinition = "TEXT")
     private String formatTimerJson;
 
+    @Column(name = "logo_url", length = 512)
+    private String logoUrl;
+
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -1,5 +1,6 @@
 package com.example.BES.services;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,6 +16,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 import com.example.BES.dtos.battle.ChampionRevealDto;
 import com.example.BES.dtos.battle.SetActiveGenreDto;
@@ -364,11 +371,21 @@ public class BattleService {
     }
 
     public Map<String, Object> getOverlayConfig() {
-        return stateFor(resolveEvent(null)).overlayConfig;
+        return getOverlayConfig(resolveEvent(null));
     }
 
     public Map<String, Object> getOverlayConfig(String eventName) {
-        return stateFor(eventName).overlayConfig;
+        EventBattleState s = stateFor(eventName);
+        Map<String, Object> cfg = new HashMap<>(s.overlayConfig);
+        cfg.put("logoUrl", s.logoUrl);
+        return cfg;
+    }
+
+    private void broadcastOverlayConfig(String eventName) {
+        messagingTemplate.convertAndSend(
+            "/topic/battle/" + eventName + "/overlay-config",
+            getOverlayConfig(eventName)
+        );
     }
 
     public void setOverlayConfigService(String eventName, SetOverlayConfigDto dto) {
@@ -378,7 +395,42 @@ public class BattleService {
         newConfig.put("leftColor",  dto.getLeftColor());
         newConfig.put("rightColor", dto.getRightColor());
         s.overlayConfig = newConfig;
-        messagingTemplate.convertAndSend("/topic/battle/" + eventName + "/overlay-config", newConfig);
+        broadcastOverlayConfig(eventName);
+    }
+
+    public String uploadLogoService(String eventName, MultipartFile file) throws IOException {
+        String original = file.getOriginalFilename();
+        String ext = (original != null && original.contains("."))
+            ? original.substring(original.lastIndexOf('.'))
+            : ".png";
+        String safeEvent = eventName.replaceAll("[^a-zA-Z0-9_-]", "_");
+        String filename = "__logo_" + safeEvent + ext;
+
+        Path uploadDir = Paths.get("uploads");
+        if (!Files.exists(uploadDir)) Files.createDirectories(uploadDir);
+        Path dest = uploadDir.resolve(filename).normalize();
+        if (!dest.startsWith(uploadDir.normalize())) throw new IOException("Invalid path");
+        Files.copy(file.getInputStream(), dest, StandardCopyOption.REPLACE_EXISTING);
+
+        EventBattleState s = stateFor(eventName);
+        s.logoUrl = "/api/v1/battle/uploads/" + filename;
+        persistActiveState(eventName);
+        broadcastOverlayConfig(eventName);
+        return s.logoUrl;
+    }
+
+    public void deleteLogoService(String eventName) throws IOException {
+        EventBattleState s = stateFor(eventName);
+        if (s.logoUrl != null) {
+            String filename = s.logoUrl.substring(s.logoUrl.lastIndexOf('/') + 1);
+            Path file = Paths.get("uploads").resolve(filename).normalize();
+            if (file.startsWith(Paths.get("uploads").normalize())) {
+                Files.deleteIfExists(file);
+            }
+        }
+        s.logoUrl = null;
+        persistActiveState(eventName);
+        broadcastOverlayConfig(eventName);
     }
 
     public void broadcastChampionReveal(String eventName, ChampionRevealDto dto) {
@@ -640,6 +692,7 @@ public class BattleService {
             if (s.lastFormatTimerPayload != null) {
                 st.setFormatTimerJson(objectMapper.writeValueAsString(s.lastFormatTimerPayload));
             }
+            st.setLogoUrl(s.logoUrl);
             st.setUpdatedAt(LocalDateTime.now());
             battleGenreStateRepository.save(st);
         } catch (Exception e) {
@@ -699,6 +752,7 @@ public class BattleService {
             } else {
                 s.lastFormatTimerPayload = null;
             }
+            s.logoUrl = dbState.getLogoUrl();
         } catch (Exception e) {
             System.err.println("Failed to load genre state from DB: " + e.getMessage());
             resetToDefaults(eventName);
@@ -755,6 +809,7 @@ public class BattleService {
             "leftColor",  "#dc2626",
             "rightColor", "#2563eb"
         ));
+        String logoUrl = null;
 
         EventBattleState() {
             currentPair = new BattlePair();

--- a/BES/src/main/resources/db/migration/V34__add_logo_url.sql
+++ b/BES/src/main/resources/db/migration/V34__add_logo_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE battle_genre_state ADD COLUMN logo_url VARCHAR(512);

--- a/docs/superpowers/plans/2026-06-08-battle-views-branding.md
+++ b/docs/superpowers/plans/2026-06-08-battle-views-branding.md
@@ -1,0 +1,1006 @@
+# Battle Views Branding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add event logo + active genre display to both battle views, standardize BattleOverlay background, rework bracket slot colors, and redesign the judge panel's post-reveal resting position.
+
+**Architecture:** Bottom-up: DB migration → entity → service (logoUrl field, upload/delete methods) → controller (two new endpoints) → api.js (two new functions) → BattleControl.vue (logo UI in overlay settings) → BracketVisualization.vue (remove header+ticker, add logo-banner, rework slot colors) → BattleOverlay.vue (background, logo watermark, timer reposition, judge panel rework).
+
+**Tech Stack:** Spring Boot (Java), Flyway migrations, Vue 3 Composition API, scoped CSS animations.
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `BES/src/main/resources/db/migration/V34__add_logo_url.sql` | CREATE | Add `logo_url` column |
+| `BES/src/main/java/com/example/BES/models/BattleGenreState.java` | MODIFY | Add `logoUrl` JPA field |
+| `BES/src/main/java/com/example/BES/services/BattleService.java` | MODIFY | Add `logoUrl` to `EventBattleState`; update persist/load/get/broadcast; add upload/delete service methods |
+| `BES/src/main/java/com/example/BES/controllers/BattleController.java` | MODIFY | Add `POST /battle/logo-upload` and `DELETE /battle/logo` endpoints |
+| `BES-frontend/src/utils/api.js` | MODIFY | Add `uploadBattleLogo`, `deleteBattleLogo` |
+| `BES-frontend/src/views/BattleControl.vue` | MODIFY | Logo upload/delete UI in overlay settings panel |
+| `BES-frontend/src/views/BracketVisualization.vue` | MODIFY | Remove header + ticker; add logo-banner; rework `slotClass()`; update CSS |
+| `BES-frontend/src/views/BattleOverlay.vue` | MODIFY | Remove transparent bg; add logo watermark + genre; rework timer; rework judge panel exit/rest animations |
+
+---
+
+## Task 1: DB migration — add logo_url
+
+**Files:**
+- Create: `BES/src/main/resources/db/migration/V34__add_logo_url.sql`
+
+- [ ] **Step 1: Create migration file**
+
+```sql
+ALTER TABLE battle_genre_state ADD COLUMN logo_url VARCHAR(512);
+```
+
+- [ ] **Step 2: Verify migration naming**
+
+Run: `ls BES/src/main/resources/db/migration/ | sort -V | tail -3`
+Expected: `V32__add_tiebreaker_to_battle_genre_state.sql`, `V33__add_format_timer.sql`, `V34__add_logo_url.sql`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/resources/db/migration/V34__add_logo_url.sql
+git commit -m "chore: add logo_url column to battle_genre_state (V34)"
+```
+
+---
+
+## Task 2: Backend — entity, service, controller
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/models/BattleGenreState.java`
+- Modify: `BES/src/main/java/com/example/BES/services/BattleService.java`
+- Modify: `BES/src/main/java/com/example/BES/controllers/BattleController.java`
+
+### Step 1: Add logoUrl field to BattleGenreState entity
+
+- [ ] Open `BES/src/main/java/com/example/BES/models/BattleGenreState.java`. After the `formatTimerJson` field (line ~47), add:
+
+```java
+@Column(name = "logo_url", length = 512)
+private String logoUrl;
+```
+
+Lombok `@Data` generates the getter/setter automatically. No other changes needed in this file.
+
+### Step 2: Add logoUrl to EventBattleState in-memory state
+
+- [ ] In `BES/src/main/java/com/example/BES/services/BattleService.java`, find the `EventBattleState` inner class (around line 738). After the `overlayConfig` field, add:
+
+```java
+String logoUrl = null;
+```
+
+The full block should now read:
+```java
+Map<String, Object> overlayConfig = new HashMap<>(Map.of(
+    "showImages", true,
+    "leftColor",  "#dc2626",
+    "rightColor", "#2563eb"
+));
+String logoUrl = null;
+```
+
+### Step 3: Add broadcastOverlayConfig helper and update getOverlayConfig
+
+- [ ] In `BattleService.java`, find `getOverlayConfig(String eventName)` (around line 370). Replace both overloads:
+
+```java
+public Map<String, Object> getOverlayConfig() {
+    return getOverlayConfig(resolveEvent(null));
+}
+
+public Map<String, Object> getOverlayConfig(String eventName) {
+    EventBattleState s = stateFor(eventName);
+    Map<String, Object> cfg = new HashMap<>(s.overlayConfig);
+    cfg.put("logoUrl", s.logoUrl);
+    return cfg;
+}
+
+private void broadcastOverlayConfig(String eventName) {
+    messagingTemplate.convertAndSend(
+        "/topic/battle/" + eventName + "/overlay-config",
+        getOverlayConfig(eventName)
+    );
+}
+```
+
+### Step 4: Update setOverlayConfigService to use broadcastOverlayConfig
+
+- [ ] Find `setOverlayConfigService` (around line 374). Replace the `messagingTemplate.convertAndSend(...)` call:
+
+```java
+public void setOverlayConfigService(String eventName, SetOverlayConfigDto dto) {
+    EventBattleState s = stateFor(eventName);
+    Map<String, Object> newConfig = new HashMap<>();
+    newConfig.put("showImages", dto.isShowImages());
+    newConfig.put("leftColor",  dto.getLeftColor());
+    newConfig.put("rightColor", dto.getRightColor());
+    s.overlayConfig = newConfig;
+    broadcastOverlayConfig(eventName);
+}
+```
+
+### Step 5: Persist logoUrl in persistActiveState
+
+- [ ] Find `persistActiveState` (around line 609). After `st.setUpdatedAt(LocalDateTime.now());` and before `battleGenreStateRepository.save(st);`, add:
+
+```java
+st.setLogoUrl(s.logoUrl);
+```
+
+### Step 6: Restore logoUrl in loadGenreStateIntoMemory
+
+- [ ] Find `loadGenreStateIntoMemory` (around line 650). After `s.lastFormatTimerPayload = null;` block (the final else in the formatTimer block), add:
+
+```java
+s.logoUrl = dbState.getLogoUrl();
+```
+
+### Step 7: Add uploadLogoService and deleteLogoService
+
+- [ ] In `BattleService.java`, add these two public methods after `setOverlayConfigService`:
+
+```java
+public String uploadLogoService(String eventName, MultipartFile file) throws IOException {
+    String original = file.getOriginalFilename();
+    String ext = (original != null && original.contains("."))
+        ? original.substring(original.lastIndexOf('.'))
+        : ".png";
+    String safeEvent = eventName.replaceAll("[^a-zA-Z0-9_-]", "_");
+    String filename = "__logo_" + safeEvent + ext;
+
+    Path uploadDir = Paths.get("uploads");
+    if (!Files.exists(uploadDir)) Files.createDirectories(uploadDir);
+    Path dest = uploadDir.resolve(filename).normalize();
+    if (!dest.startsWith(uploadDir.normalize())) throw new IOException("Invalid path");
+    Files.copy(file.getInputStream(), dest, StandardCopyOption.REPLACE_EXISTING);
+
+    EventBattleState s = stateFor(eventName);
+    s.logoUrl = "/api/v1/battle/uploads/" + filename;
+    persistActiveState(eventName);
+    broadcastOverlayConfig(eventName);
+    return s.logoUrl;
+}
+
+public void deleteLogoService(String eventName) throws IOException {
+    EventBattleState s = stateFor(eventName);
+    if (s.logoUrl != null) {
+        String filename = s.logoUrl.substring(s.logoUrl.lastIndexOf('/') + 1);
+        Path file = Paths.get("uploads").resolve(filename).normalize();
+        if (file.startsWith(Paths.get("uploads").normalize())) {
+            Files.deleteIfExists(file);
+        }
+    }
+    s.logoUrl = null;
+    persistActiveState(eventName);
+    broadcastOverlayConfig(eventName);
+}
+```
+
+- [ ] Add missing imports to `BattleService.java` if not already present (check top of file):
+
+```java
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import org.springframework.web.multipart.MultipartFile;
+```
+
+### Step 8: Add logo endpoints to BattleController
+
+- [ ] In `BattleController.java`, after the `setOverlayConfig` endpoint (around line 381), add:
+
+```java
+@PostMapping("/logo-upload")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> uploadLogo(
+        @RequestParam("file") MultipartFile file,
+        @RequestParam(required = false) String event) throws IOException {
+    String url = battleService.uploadLogoService(resolveEvent(event), file);
+    return ResponseEntity.ok(Map.of("logoUrl", url));
+}
+
+@DeleteMapping("/logo")
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+public ResponseEntity<?> deleteLogo(
+        @RequestParam(required = false) String event) throws IOException {
+    battleService.deleteLogoService(resolveEvent(event));
+    return ResponseEntity.ok(Map.of("message", "Logo deleted"));
+}
+```
+
+### Step 9: Build and verify
+
+- [ ] Run from `BES/` directory:
+
+```bash
+mvn clean package -DskipTests
+```
+
+Expected: `BUILD SUCCESS`
+
+- [ ] **Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/models/BattleGenreState.java \
+        BES/src/main/java/com/example/BES/services/BattleService.java \
+        BES/src/main/java/com/example/BES/controllers/BattleController.java
+git commit -m "feat: add logo upload/delete endpoints and persist logoUrl in overlay config (#109)"
+```
+
+---
+
+## Task 3: Frontend API functions
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js`
+
+- [ ] **Step 1: Add uploadBattleLogo and deleteBattleLogo after the existing `uploadImage` function**
+
+Find `export const uploadImage` (around line 697). After that entire function, add:
+
+```js
+export const uploadBattleLogo = async (eventName, file) => {
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    const url = eventName
+      ? `/api/v1/battle/logo-upload?event=${encodeURIComponent(eventName)}`
+      : '/api/v1/battle/logo-upload'
+    return await fetch(`${domain}${url}`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const deleteBattleLogo = async (eventName) => {
+  try {
+    const url = eventName
+      ? `/api/v1/battle/logo?event=${encodeURIComponent(eventName)}`
+      : '/api/v1/battle/logo'
+    return await fetch(`${domain}${url}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat: add uploadBattleLogo and deleteBattleLogo API functions (#109)"
+```
+
+---
+
+## Task 4: BattleControl.vue — logo upload/delete UI
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleControl.vue`
+
+- [ ] **Step 1: Import new API functions**
+
+Find the import line at the top of `BattleControl.vue` (line 2) that imports from `@/utils/api`. Add `uploadBattleLogo` and `deleteBattleLogo` to the existing import:
+
+```js
+import { ..., uploadBattleLogo, deleteBattleLogo } from '@/utils/api'
+```
+
+- [ ] **Step 2: Add logo upload handlers in the `<script setup>` section**
+
+Find `const onFileChange = async (e) => {` (around line 376). After that function's closing brace, add:
+
+```js
+const onLogoUpload = async (e) => {
+  const file = e.target.files[0]
+  if (!file) return
+  await uploadBattleLogo(selectedEvent.value, file)
+  e.target.value = ''
+  // overlayConfig.logoUrl is updated via WS broadcast from backend
+}
+
+const onLogoDelete = async () => {
+  await deleteBattleLogo(selectedEvent.value)
+}
+```
+
+- [ ] **Step 3: Add logo UI inside the overlay settings panel**
+
+Find the overlay settings `<div class="overlay-settings-body">` section (around line 2612). Inside that div, after the last `overlay-setting-row` (the Show Images toggle row), add:
+
+```html
+<div class="overlay-setting-row overlay-setting-logo">
+  <span class="overlay-setting-label">Event Logo</span>
+  <div class="logo-upload-group">
+    <img
+      v-if="overlayConfig.logoUrl"
+      :src="overlayConfig.logoUrl"
+      class="logo-preview-thumb"
+      alt="Event logo"
+    />
+    <label class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1.5 cursor-pointer">
+      <i class="pi pi-upload text-xs"></i>
+      {{ overlayConfig.logoUrl ? 'Replace' : 'Upload' }}
+      <input type="file" accept="image/*" @change="onLogoUpload" class="hidden" />
+    </label>
+    <button
+      v-if="overlayConfig.logoUrl"
+      @click="onLogoDelete"
+      class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1.5"
+    >
+      <i class="pi pi-trash text-xs"></i>
+      Remove
+    </button>
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Add logo UI styles**
+
+Find the `<style scoped>` section of `BattleControl.vue`. At the end of the existing styles, add:
+
+```css
+.overlay-setting-logo { align-items: flex-start; padding-top: 6px; }
+.logo-upload-group { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.logo-preview-thumb {
+  width: 48px; height: 48px;
+  object-fit: contain;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 4px;
+  background: rgba(255,255,255,0.04);
+}
+```
+
+- [ ] **Step 5: Verify overlayConfig default includes logoUrl**
+
+Find the `overlayConfig` ref (around line 38):
+```js
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb' })
+```
+
+Change it to:
+```js
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BES-frontend/src/views/BattleControl.vue
+git commit -m "feat: add logo upload/delete UI to BattleControl overlay settings (#109)"
+```
+
+---
+
+## Task 5: BracketVisualization.vue — remove header + ticker, add logo banner, rework slot colors
+
+**Files:**
+- Modify: `BES-frontend/src/views/BracketVisualization.vue`
+
+### Step 1: Update overlayConfig default to include logoUrl
+
+- [ ] Find the `overlayConfig` ref (line 9):
+
+```js
+const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+```
+
+Replace with:
+
+```js
+const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
+```
+
+### Step 2: Update slotClass() to use slot-winner-round
+
+- [ ] Find `const slotClass = (match, slot, isFinal = false)` (around line 75). Replace the winner return:
+
+**Old:**
+```js
+if (match[2] === match[slot]) return isFinal ? 'slot-winner' : (slot === 0 ? 'slot-winner-left' : 'slot-winner-right')
+```
+
+**New:**
+```js
+if (match[2] === match[slot]) return isFinal ? 'slot-winner' : 'slot-winner-round'
+```
+
+### Step 3: Remove the header element from the template
+
+- [ ] Find and remove the entire `<header class="bracket-header">` block (lines 470–482):
+
+```html
+<!-- ── Header ─────────────────────────────────────── -->
+<header class="bracket-header">
+  <div class="header-brand">
+    <span class="brand-dot"></span>
+    <span class="brand-title">LIVE BRACKET</span>
+    <span class="brand-dot"></span>
+  </div>
+  <div v-if="activePair" class="active-pill">
+    <span class="pill-dot"></span>
+    {{ activePair.left }}
+    <span class="vs-sep">vs</span>
+    {{ activePair.right }}
+  </div>
+</header>
+```
+
+### Step 4: Add the logo-banner element in its place
+
+- [ ] Immediately after the champion reveal `</Transition>` block (and before the empty-state `v-if`), add:
+
+```html
+<!-- ── Logo banner ───────────────────────────────── -->
+<div class="logo-banner" aria-hidden="true">
+  <img
+    v-if="overlayConfig.logoUrl"
+    :src="overlayConfig.logoUrl"
+    class="logo-banner-img"
+    alt=""
+  />
+  <span v-if="currentGenre" class="logo-banner-genre">{{ currentGenre }}</span>
+</div>
+```
+
+### Step 5: Remove the ticker-bar element from the template
+
+- [ ] Find and remove the entire `<div class="ticker-bar">` block (lines 635–657 approximately). Remove from `<!-- ── LED Ticker` comment through the closing `</div>`.
+
+### Step 6: Update bracket-area bottom padding
+
+- [ ] Find `.bracket-area` CSS (around line 786):
+
+```css
+.bracket-area  { flex: 1; display: flex; flex-direction: row; gap: var(--col-gap); padding: 8px 16px 12px; ... }
+```
+
+Change `padding: 8px 16px 12px` to `padding: 8px 16px 20px`.
+
+### Step 7: Replace slot-winner-left and slot-winner-right CSS with slot-winner-round
+
+- [ ] Find and remove the `slot-winner-left` block:
+```css
+.slot-winner-left {
+  background: color-mix(in srgb, var(--left-color) 20%, transparent) !important;
+  border-color: color-mix(in srgb, var(--left-color) 55%, transparent) !important;
+  box-shadow: 0 0 14px color-mix(in srgb, var(--left-color) 25%, transparent) !important;
+}
+.slot-winner-left .battler-name {
+  color: color-mix(in srgb, var(--left-color) 85%, #fff) !important;
+}
+```
+
+- [ ] Find and remove the `slot-winner-right` block:
+```css
+.slot-winner-right {
+  background: color-mix(in srgb, var(--right-color) 20%, transparent) !important;
+  border-color: color-mix(in srgb, var(--right-color) 55%, transparent) !important;
+  box-shadow: 0 0 14px color-mix(in srgb, var(--right-color) 25%, transparent) !important;
+}
+.slot-winner-right .battler-name {
+  color: color-mix(in srgb, var(--right-color) 85%, #fff) !important;
+}
+```
+
+- [ ] In their place add the `slot-winner-round` style:
+
+```css
+/* Non-final round winner — generic white/grey */
+.slot-winner-round {
+  background: rgba(255,255,255,0.07) !important;
+  border-color: rgba(255,255,255,0.38) !important;
+  box-shadow: 0 0 10px rgba(255,255,255,0.12) !important;
+}
+.slot-winner-round .battler-name {
+  color: rgba(255,255,255,0.95) !important;
+  opacity: 1;
+}
+```
+
+### Step 8: Update slot-loser opacity
+
+- [ ] Find `.slot-loser` (around line 875):
+
+```css
+.slot-loser { background: rgba(255,255,255,0.02) !important; border-color: rgba(255,255,255,0.03) !important; opacity: 0.42; }
+```
+
+Change `opacity: 0.42` to `opacity: 0.62`.
+
+### Step 9: Remove header/ticker/pill CSS and add logo-banner CSS
+
+- [ ] Find and remove the `/* ── Header ───────────────────────────────────────────── */` CSS block including `.bracket-header`, `.header-brand`, `.brand-dot`, `.brand-title`, `.active-pill`, `.pill-dot`, `.vs-sep`.
+
+- [ ] Find and remove the `/* ── LED Ticker ───────────────────────────────────────── */` CSS block including `.ticker-bar`, `.ticker-label`, `.ticker-dot`, `.ticker-track`, `.ticker-reel`, `.ticker-item`, `.ticker-tag`, `.ticker-now`, `.ticker-next`, `.ticker-genre`, `.ticker-text`, `.ticker-sep`.
+
+- [ ] Remove the `@keyframes tickerScroll` keyframe.
+
+- [ ] Remove the `@keyframes dotPulse` keyframe (was used by brand-dot and pill-dot — check if used elsewhere; if `.slot-glow` doesn't use it, remove it).
+
+- [ ] Add logo-banner CSS. Place it after the `/* ── Root ───────────────────── */` block:
+
+```css
+/* ── Logo banner ─────────────────────────────────── */
+.logo-banner {
+  flex-shrink: 0;
+  height: 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px 20px;
+  position: relative;
+  z-index: 10;
+}
+.logo-banner-img {
+  max-height: 52px;
+  max-width: 240px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 8px rgba(255,255,255,0.12));
+}
+.logo-banner-genre {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.48);
+  text-align: center;
+}
+/* When no logo: show hairline rules either side of genre text */
+.logo-banner:not(:has(.logo-banner-img)) .logo-banner-genre {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  letter-spacing: 0.32em;
+  color: rgba(255,255,255,0.55);
+}
+.logo-banner:not(:has(.logo-banner-img)) .logo-banner-genre::before,
+.logo-banner:not(:has(.logo-banner-img)) .logo-banner-genre::after {
+  content: '';
+  flex: 1;
+  max-width: 80px;
+  height: 1px;
+  background: rgba(255,255,255,0.12);
+}
+```
+
+- [ ] Update `--header-h` CSS token (it's set on `.bracket-root` but no longer used since header is removed). Remove `--header-h: 52px;` from the token block.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add BES-frontend/src/views/BracketVisualization.vue
+git commit -m "feat: remove header+ticker, add logo banner, rework slot colors in BracketVisualization (#109)"
+```
+
+---
+
+## Task 6: BattleOverlay.vue — background, logo watermark, timer, judge panel
+
+**Files:**
+- Modify: `BES-frontend/src/views/BattleOverlay.vue`
+
+### Step 1: Add judgeRestSide reactive ref
+
+- [ ] Find `const judgeAnim = ref('')` in the `<script setup>` section (around line 107). After it, add:
+
+```js
+// judgeRestSide: '' | 'left' | 'right' — where the judge panel rests after score reveal
+const judgeRestSide = ref('')
+```
+
+### Step 2: Update judgePanelClass computed
+
+- [ ] Find `const judgePanelClass = computed(...)` (around line 158). Replace it:
+
+```js
+const judgePanelClass = computed(() => {
+  if (isSmoke.value) return 'smoke-judge-always-on'
+  if (judgeRestSide.value === 'right') return 'judge-rest-right'
+  if (judgeRestSide.value === 'left')  return 'judge-rest-left'
+  return judgeAnim.value
+})
+```
+
+### Step 3: Update updateScore() — replace judge retreat with side-rest
+
+- [ ] Find `updateScore` (around line 326). Find the "Phase 2: panel scales down and retreats to top" block:
+
+```js
+// Phase 2: panel scales down and retreats to top
+judgeAnim.value = 'judge-retreat-top'
+await useDelay().wait(550)
+if (!ok()) return
+judgeAnim.value = 'judge-at-top'
+
+// Brief pause before winner reveal
+await useDelay().wait(150)
+if (!ok()) return
+
+currentWinner.value = msg.message
+```
+
+Replace it with:
+
+```js
+// Phase 2: panel retreats to beside winner name
+judgeAnim.value = ''  // stop slam animation
+judgeRestSide.value = msg.message === 0 ? 'right' : 'left'
+await useDelay().wait(550)  // let rest animation complete
+if (!ok()) return
+
+currentWinner.value = msg.message
+```
+
+### Step 4: Update updateBattlePair() — add side-exit animation
+
+- [ ] Find the judge cleanup block inside `updateBattlePair` (the `if (!hideJudgeDecision.value)` block, around line 231):
+
+```js
+if (!hideJudgeDecision.value) {
+  glitching.value = true
+  judgeAnim.value = 'slide-up'
+  await useDelay().wait(100)
+  if (unmounted) return
+
+  if (currentWinner.value === 0) {
+    leftReset.value = true
+  } else if (currentWinner.value === 1) {
+    rightReset.value = true
+  }
+  vsAnim.value = ''
+
+  await useDelay().wait(280)
+  if (unmounted) return
+  glitching.value          = false
+  hideJudgeDecision.value  = true
+  judgeAnim.value          = ''
+  votesVisible.value       = false
+  winnerTagVisible.value   = false
+  await useDelay().wait(50)
+  if (unmounted) return
+  leftReset.value  = false
+  rightReset.value = false
+}
+```
+
+Replace with:
+
+```js
+if (!hideJudgeDecision.value) {
+  glitching.value = true
+  if (judgeRestSide.value) {
+    judgeAnim.value = judgeRestSide.value === 'right' ? 'judge-exit-right' : 'judge-exit-left'
+    judgeRestSide.value = ''
+  } else {
+    judgeAnim.value = 'slide-up'
+  }
+  await useDelay().wait(100)
+  if (unmounted) return
+
+  if (currentWinner.value === 0) {
+    leftReset.value = true
+  } else if (currentWinner.value === 1) {
+    rightReset.value = true
+  }
+  vsAnim.value = ''
+
+  await useDelay().wait(280)
+  if (unmounted) return
+  glitching.value          = false
+  hideJudgeDecision.value  = true
+  judgeAnim.value          = ''
+  votesVisible.value       = false
+  winnerTagVisible.value   = false
+  await useDelay().wait(50)
+  if (unmounted) return
+  leftReset.value  = false
+  rightReset.value = false
+}
+```
+
+### Step 5: Clear judgeRestSide in LOCKED phase handler
+
+- [ ] Find the LOCKED phase handler (inside `subscribeToChannel(cPhase, topic('phase'), ...)`, around line 450):
+
+```js
+if (msg.phase === 'LOCKED' && prevPhase !== 'LOCKED') {
+  animToken++
+  hideJudgeDecision.value = true
+  judgeAnim.value         = ''
+  votesVisible.value      = false
+  winnerTagVisible.value  = false
+  leftWin.value           = false
+  rightWin.value          = false
+  leftReset.value         = false
+  rightReset.value        = false
+```
+
+Add `judgeRestSide.value = ''` after `judgeAnim.value = ''`:
+
+```js
+if (msg.phase === 'LOCKED' && prevPhase !== 'LOCKED') {
+  animToken++
+  hideJudgeDecision.value = true
+  judgeAnim.value         = ''
+  judgeRestSide.value     = ''
+  votesVisible.value      = false
+  ...
+```
+
+### Step 6: Remove transparent-page logic from onMounted and onUnmounted
+
+- [ ] In `onMounted`, find and remove these two lines:
+
+```js
+document.documentElement.classList.add('transparent-page')
+document.body.classList.add('transparent-page')
+```
+
+- [ ] In `onUnmounted`, find and remove:
+
+```js
+document.documentElement.classList.remove('transparent-page')
+document.body.classList.remove('transparent-page')
+```
+
+The `onUnmounted` block that removes the app background can stay.
+
+### Step 7: Add logo watermark + genre to template
+
+- [ ] In the `<template>`, find the `<!-- Screen-reader live region -->` comment. Immediately **before** it, add:
+
+```html
+<!-- Logo + genre watermark (top center, always visible) -->
+<div class="logo-watermark" aria-hidden="true">
+  <img
+    v-if="overlayConfig.showImages !== undefined && overlayConfig.logoUrl"
+    :src="overlayConfig.logoUrl"
+    class="logo-watermark-img"
+    alt=""
+  />
+  <span v-if="activeGenreName" class="logo-watermark-genre">{{ activeGenreName }}</span>
+</div>
+```
+
+### Step 8: Rework timer element in template
+
+- [ ] Find the `<!-- Broadcast timer bar -->` `<Transition>` block. Replace the entire inner div:
+
+**Old:**
+```html
+<div v-if="showTimer" class="timer-overlay">
+  <div class="timer-bar-container">
+    <div class="timer-progress-track">
+      <div
+        class="timer-progress-fill"
+        :style="{ width: (timerState.totalDuration > 0 ? (timerState.timeLeft / timerState.totalDuration) * 100 : 0) + '%' }"
+        :class="{ 'timer-fill-warning': timerState.timeLeft <= 10 }"
+      ></div>
+    </div>
+    <div class="timer-countdown" :class="{ 'timer-text-warning': timerState.timeLeft <= 10 }">
+      {{ Math.floor(timerState.timeLeft / 60) }}:{{ String(timerState.timeLeft % 60).padStart(2, '0') }}
+    </div>
+  </div>
+</div>
+```
+
+**New:**
+```html
+<div v-if="showTimer" class="timer-overlay">
+  <div class="timer-countdown" :class="{ 'timer-text-warning': timerState.timeLeft <= 10 }">
+    {{ Math.floor(timerState.timeLeft / 60) }}:{{ String(timerState.timeLeft % 60).padStart(2, '0') }}
+  </div>
+</div>
+```
+
+### Step 9: Update global `<style>` block — remove transparent-page rules
+
+- [ ] Find the global `<style>` block (around line 906–915):
+
+```html
+<style>
+/* ── Transparent background (OBS) — must be global ─────────── */
+html.transparent-page,
+body.transparent-page,
+html.transparent-page #app,
+body.transparent-page #app {
+  background: transparent !important;
+  background-color: transparent !important;
+}
+</style>
+```
+
+Remove this entire `<style>` block.
+
+### Step 10: Update scoped CSS — overlay-root background, timer, logo watermark, judge animations
+
+- [ ] In the `<style scoped>` section, find `.overlay-root` (around line 961). Add a background:
+
+```css
+.overlay-root {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw; height: 100vh;
+  overflow: hidden;
+  font-family: 'Anton SC', sans-serif;
+  background: #060818;
+  --left-color: #dc2626;
+  --right-color: #2563eb;
+}
+```
+
+- [ ] Find the `/* ── Broadcast timer (top center bar) ─────────────── */` block. Replace the entire block:
+
+```css
+/* ── Broadcast timer (top right, text-only) ──────────── */
+.timer-overlay {
+  position: absolute;
+  top: 14px; right: 20px;
+  z-index: 100;
+  pointer-events: none;
+}
+.timer-countdown {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 26px;
+  letter-spacing: 0.06em;
+  color: rgba(255,255,255,0.82);
+  text-shadow: 0 0 12px rgba(255,255,255,0.18);
+}
+.timer-text-warning { color: #ef4444; text-shadow: 0 0 12px rgba(239,68,68,0.5); animation: timer-pulse-text 0.5s ease-in-out infinite alternate; }
+.timer-enter-enter-active { animation: timer-slide-in 200ms ease-out; }
+.timer-enter-leave-active { animation: timer-slide-out 160ms ease-in; }
+@keyframes timer-slide-in  { from { opacity: 0; transform: translateX(12px); } to { opacity: 1; transform: translateX(0); } }
+@keyframes timer-slide-out { from { opacity: 1; transform: translateX(0); }   to { opacity: 0; transform: translateX(12px); } }
+@keyframes timer-pulse-text { from { opacity: 0.7; } to { opacity: 1; } }
+```
+
+- [ ] Add logo watermark CSS after the timer block:
+
+```css
+/* ── Logo + genre watermark (top center) ─────────────── */
+.logo-watermark {
+  position: absolute;
+  top: 0; left: 50%;
+  transform: translateX(-50%);
+  z-index: 45;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 0 0;
+}
+.logo-watermark-img {
+  max-height: 38px;
+  max-width: 160px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 6px rgba(255,255,255,0.10));
+}
+.logo-watermark-genre {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.38);
+}
+```
+
+- [ ] Find and remove the `.judge-retreat-top`, `.judge-at-top` CSS classes and the `@keyframes judgeRetreatTop` keyframe (they are replaced by the new side-rest animations).
+
+- [ ] Add new judge rest/exit CSS. Place it after the `.judge-slam-center` utility class:
+
+```css
+/* Judge rests to right (left wins) — slides down + drifts right */
+.judge-rest-right {
+  animation: judgeRestRight 520ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards;
+}
+@keyframes judgeRestRight {
+  0%   { transform: translateX(0)    translateY(42vh) scale(1.38); }
+  100% { transform: translateX(28vw) translateY(74vh) scale(0.72); }
+}
+
+/* Judge rests to left (right wins) */
+.judge-rest-left {
+  animation: judgeRestLeft 520ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards;
+}
+@keyframes judgeRestLeft {
+  0%   { transform: translateX(0)     translateY(42vh) scale(1.38); }
+  100% { transform: translateX(-28vw) translateY(74vh) scale(0.72); }
+}
+
+/* Exit: slide off same side with fade */
+.judge-exit-right {
+  animation: judgeExitRight 280ms cubic-bezier(0.55, 0, 1, 0.45) forwards;
+}
+@keyframes judgeExitRight {
+  0%   { transform: translateX(28vw)  translateY(74vh) scale(0.72); opacity: 1; }
+  100% { transform: translateX(110vw) translateY(74vh) scale(0.5);  opacity: 0; }
+}
+.judge-exit-left {
+  animation: judgeExitLeft 280ms cubic-bezier(0.55, 0, 1, 0.45) forwards;
+}
+@keyframes judgeExitLeft {
+  0%   { transform: translateX(-28vw)  translateY(74vh) scale(0.72); opacity: 1; }
+  100% { transform: translateX(-110vw) translateY(74vh) scale(0.5);  opacity: 0; }
+}
+```
+
+- [ ] Remove the now-unused `.timer-bar-container`, `.timer-progress-track`, `.timer-progress-fill`, `.timer-fill-warning` CSS rules. Also remove `@keyframes timer-pulse-bar` if present.
+
+- [ ] **Commit**
+
+```bash
+git add BES-frontend/src/views/BattleOverlay.vue
+git commit -m "feat: standardize BattleOverlay background, add logo watermark, rework timer and judge panel animations (#109)"
+```
+
+---
+
+## Task 7: Local Docker verify
+
+- [ ] Run the local Docker verification skill to rebuild and confirm all containers are healthy:
+
+```
+/local-docker-verify
+```
+
+Expected: frontend and backend containers healthy, no build errors.
+
+- [ ] Open `http://localhost/battle/bracket?event=<your-test-event>` in a browser.
+  - Confirm: no header bar, no LED ticker, logo banner visible at top center with genre text
+  - Confirm: active pair slots are red/blue, round winners are white-grey, final winner is gold, losers are less dim
+  - Confirm: dark `#060818` background (no transparency)
+
+- [ ] Open `http://localhost/battle/overlay?event=<your-test-event>` in browser.
+  - Confirm: dark `#060818` background
+  - Logo watermark visible at top center when logo is uploaded
+  - Timer shows top-right (text only, no progress bar) when a countdown is active
+
+- [ ] Open `http://localhost/battle/control` and expand Overlay Settings.
+  - Confirm: logo upload/delete controls visible
+  - Upload a test image → confirm logo appears in BracketVisualization and BattleOverlay immediately
+  - Delete the logo → confirm it disappears from both views
+
+---
+
+## Task 8: Judge panel animation smoke test
+
+This task is manual — it cannot be unit-tested because it requires a live battle.
+
+- [ ] In BattleControl, set up a battle with 2 judges, start a VOTING phase, have both judges vote.
+
+- [ ] Click "Reveal Score" → confirm:
+  - Judge panel slams to center (existing behaviour, unchanged)
+  - Votes appear
+  - After 1500ms pause, panel animates to bottom-right (if left wins) or bottom-left (if right wins)
+  - Winner panel expands simultaneously
+  - Panel rests beside winner name at ~74vh, scaled to ~72%
+
+- [ ] Click "Next" (new pair) → confirm:
+  - Judge panel exits to the same side it was resting on (right→slides further right, left→slides further left)
+  - Glitch overlay fires
+  - New pair slams in cleanly
+
+- [ ] Confirm LOCKED phase reset: if operator clicks Next mid-score-reveal, judge panel disappears cleanly (animToken aborts updateScore, LOCKED handler clears judgeRestSide).

--- a/docs/superpowers/specs/2026-06-08-battle-views-branding-design.md
+++ b/docs/superpowers/specs/2026-06-08-battle-views-branding-design.md
@@ -1,0 +1,186 @@
+# Battle Views Branding & Judge Panel Rework
+
+**Date:** 2026-06-08
+**Branch:** `feat/battle-views-branding`
+**Issue:** #109
+
+## Overview
+
+Standardize `BattleOverlay.vue` and `BracketVisualization.vue` by removing the OBS-transparent background, adding event logo + active genre display, reworking the bracket slot color hierarchy, and redesigning the judge panel resting position in the overlay.
+
+---
+
+## 1. BracketVisualization.vue
+
+### Removals
+
+- **Header bar** (`<header class="bracket-header">`) — entire element removed. Includes the LIVE BRACKET wordmark, brand dots, and the active pair pill. Active pair is already visible via slot highlighting.
+- **LED ticker bar** (`<div class="ticker-bar">`) — entire element removed. Genre is now in the logo banner; active pair is visible in the bracket itself.
+
+### Logo Banner (new)
+
+A new `logo-banner` flex row is added at the top of `.bracket-root`, between the old header position and the bracket area:
+
+```
+bracket-root (flex column)
+  └── logo-banner          ← NEW (~80px, flex-shrink: 0)
+  └── bracket-area / empty-state / smoke-wrap
+```
+
+**Logo banner contents (centered):**
+- Event logo `<img>` when `overlayConfig.logoUrl` is set (max-height: ~60px, `object-fit: contain`)
+- Genre name below the logo in Anton SC, letter-spacing 0.22em, muted white (`rgba(255,255,255,0.55)`)
+- If no logo: genre name only, with decorative hairline rule either side (matching existing `judges-line` style)
+- If no logo and no genre: banner still renders (provides consistent spacing)
+
+**Layout after removal:**
+- No header (−52px) + no ticker (−30px) = +82px
+- Logo banner takes back ~80px
+- Net: bracket area fills cleanly; Top32/Top16 slots are not cut off
+
+### Slot Color Hierarchy (reworked)
+
+| Slot State | Class | Style |
+|------------|-------|-------|
+| Active pair — left slot | `slot-active-left` | Left-color red tint, lit border (existing, unchanged) |
+| Active pair — right slot | `slot-active-right` | Right-color blue tint, lit border (existing, unchanged) |
+| Non-final winner | `slot-winner-round` | White border `rgba(255,255,255,0.35)`, subtle white glow, battler-name full opacity white |
+| Final winner (Top2) | `slot-winner` | Gold (existing `rgba(245,158,11,*)` style, unchanged) |
+| Loser | `slot-loser` | `opacity: 0.62` (up from 0.42 — less aggressive dimming) |
+
+**`slotClass()` change:**
+```js
+if (match[2] === match[slot]) return isFinal ? 'slot-winner' : 'slot-winner-round'
+```
+`slot-winner-left` and `slot-winner-right` are removed entirely.
+
+---
+
+## 2. BattleOverlay.vue
+
+### Background
+
+- Remove all `transparent-page` CSS class manipulation (`document.documentElement.classList.add/remove('transparent-page')` in `onMounted`/`onUnmounted`)
+- Remove the global `<style>` block containing `.transparent-page` rules
+- Add `background: #060818` to `.overlay-root` — matches `BracketVisualization.vue`'s root background
+- Smoke mode unaffected: `Chart.vue` has its own `.chart-root { background: #06080e }` which continues to render correctly when embedded
+
+### Logo + Genre Watermark
+
+A compact element at the very top center of `.overlay-root` (always visible, `position: absolute; top: 0; left: 50%; transform: translateX(-50%)`):
+
+- Logo image (~36px tall) + genre text below it in Anton SC ~10px, letter-spacing 0.22em
+- Total height: ~55px
+- `pointer-events: none`, `z-index: 45` (below judge panel at z-index 50, above panels)
+- If no logo: genre text only
+- Appears in both standard and smoke modes
+
+### Timer (reworked)
+
+**Old:** Progress bar + countdown text, wide centered bar at top, `width: 60%`
+
+**New:**
+- Countdown text only — Anton SC, `font-size: 28px`, no track/fill
+- Position: `top-right corner` — `position: absolute; top: 12px; right: 20px; z-index: 100`
+- Warning state (`timeLeft <= 10`): red color + pulse animation (existing keyframe reused)
+- Entrance/exit: existing `Transition name="timer-enter"` kept, animation updated to slide from right edge
+
+### Judge Panel — Resting Position (reworked)
+
+**Current flow:**
+1. Slam to vertical center (`judgeSlamCenter`)
+2. Votes revealed
+3. Retreat to top-center (`judgeRetreatTop` → `judge-at-top`)
+
+**New flow:**
+1. Slam to vertical center (`judgeSlamCenter`) — unchanged
+2. Votes revealed — unchanged (1500ms reading pause)
+3. Retreat to **beside winner name** using winner-aware animation:
+   - Determine side from `msg.message` (0 = left wins, 1 = right wins)
+   - Left wins → new class `judge-rest-right`: panel inner aligns `justify-content: flex-end`, transforms to `translateY(72vh) scale(0.78)` with `padding-right: 5vw`
+   - Right wins → new class `judge-rest-left`: `justify-content: flex-start`, `translateY(72vh) scale(0.78)` with `padding-left: 5vw`
+   - Animation duration: ~500ms, `cubic-bezier(0.34, 1.1, 0.64, 1)` (slight bounce)
+4. `currentWinner` set → winner panels expand — unchanged timing
+
+**New reactive state:** `judgeRestSide` ref (`'' | 'left' | 'right'`) — set alongside `currentWinner`
+
+**Exit animation (in `updateBattlePair`):**
+- Before resetting `judgeAnim`, if `judgeRestSide` is set:
+  - Apply `judge-exit-right` or `judge-exit-left` class (~300ms fade + slide off same edge)
+  - Wait 300ms, then proceed with existing cleanup (reset all refs)
+- `judgeRestSide` cleared to `''` during the same reset block
+
+**`judgePanelClass` computed update:**
+```js
+const judgePanelClass = computed(() => {
+  if (isSmoke.value) return 'smoke-judge-always-on'
+  if (judgeRestSide.value === 'right') return 'judge-rest-right'
+  if (judgeRestSide.value === 'left')  return 'judge-rest-left'
+  return judgeAnim.value
+})
+```
+
+---
+
+## 3. BattleControl.vue — Logo Upload UI
+
+New "Event Logo" section in BattleControl (alongside existing overlay config controls):
+
+- File picker (`accept="image/*"`) + upload button
+- Preview of current logo (if set) — small `<img>` showing `overlayConfig.logoUrl`
+- **Delete button** alongside the preview — calls `DELETE /battle/logo`, clears logo on all views
+- On successful upload: `overlayConfig.logoUrl` updated locally + broadcast via WS
+
+---
+
+## 4. Backend Changes
+
+### Migration
+
+`V34__add_logo_url.sql`:
+```sql
+ALTER TABLE battle_genre_state ADD COLUMN logo_url VARCHAR(512);
+```
+
+### Entity & DTO
+
+- Add `logoUrl` (String, nullable) to `BattleGenreState` entity
+- Add `logoUrl` to `OverlayConfigDto` (request and response)
+
+### Service
+
+- `getOverlayConfig()` — include `logoUrl` in returned DTO
+- `setOverlayConfig()` — include `logoUrl` in update + persist + WS broadcast
+- New `uploadLogo(MultipartFile)` — save file (same storage as battler images), return URL, call `setOverlayConfig` with new `logoUrl`
+- New `deleteLogo()` — set `logoUrl = null`, call `setOverlayConfig`
+
+### Controller (`BattleController`)
+
+- `POST /battle/logo-upload` — `@PreAuthorize("ADMIN or ORGANISER")`, delegates to `uploadLogo()`
+- `DELETE /battle/logo` — `@PreAuthorize("ADMIN or ORGANISER")`, delegates to `deleteLogo()`
+- Existing `POST /battle/overlay-config` already handles `logoUrl` once DTO is updated
+
+### Frontend API (`api.js`)
+
+- `uploadBattleLogo(eventName, file)` — `POST /battle/logo-upload`
+- `deleteBattleLogo(eventName)` — `DELETE /battle/logo`
+
+---
+
+## Implementation Order (bottom-up)
+
+1. DB migration (`V34`)
+2. Entity → DTO → service → controller (logo CRUD)
+3. `api.js` — two new functions
+4. `BattleControl.vue` — logo upload/delete UI
+5. `BracketVisualization.vue` — remove header + ticker, add logo banner, rework slot colors
+6. `BattleOverlay.vue` — background, logo watermark, timer reposition, judge panel rework
+
+---
+
+## Out of Scope
+
+- Logo upload for battler photos (unchanged)
+- Chart.vue (unchanged — already has its own background)
+- BattleJudge.vue (unchanged)
+- Any changes to scoring logic or bracket data structures


### PR DESCRIPTION
## Summary

- **Logo upload/delete** — new `POST /battle/logo-upload` + `DELETE /battle/logo` endpoints (Admin/Organiser only); logo stored on disk and broadcast via WebSocket to all views; upload UI added to BattleControl overlay settings panel
- **BracketVisualization** — removed header bar + LED ticker; added logo/genre watermark overlay at top-center (absolute, non-layout); reworked slot colors (`slot-winner-round` replaces left/right team colors for non-final rounds); loser opacity raised to 0.62
- **BattleOverlay** — removed OBS transparent-page background (now solid `#060818`); logo + genre watermark top-center (hidden during IDLE/waiting); timer reworked to text-only top-right; judge panel now drifts to bottom-right/left beside winner name after score reveal, exits same edge on next pair
- **DB migration** — `V34__add_logo_url.sql` adds `logo_url VARCHAR(512)` to `battle_genre_state`

## Known issues (deferred)
- #110 — Logo upload needs bracket/overlay preview before confirming
- #111 — Logo and genre placement on both views needs further refinement

## Test plan
- [ ] Upload logo in BattleControl → confirm live update on `/battle/bracket` and `/battle/overlay`
- [ ] Delete logo → confirm disappears from both views
- [ ] Bracket: no header bar, no LED ticker, logo+genre watermark visible at top, slot colors correct (white for round winners, gold for final, dimmed losers)
- [ ] Overlay: dark background, logo watermark shows during battle, hidden during IDLE, timer top-right text-only
- [ ] Judge panel: slams center → drifts to bottom-right (left wins) or bottom-left (right wins) → exits same edge on next pair
- [ ] All backend tests pass, frontend lint clean, frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)