### PR TITLE
feat: participant management rework — expandable table, edit modal, bulk delete

### DIFF
--- a/BES-frontend/src/components/ConfirmModal.vue
+++ b/BES-frontend/src/components/ConfirmModal.vue
@@ -1,0 +1,66 @@
+<script setup>
+defineProps({
+  show:         { type: Boolean, default: false },
+  title:        { type: String,  default: 'Confirm' },
+  message:      { type: String,  default: '' },
+  confirmLabel: { type: String,  default: 'Confirm' },
+  variant:      { type: String,  default: 'danger' }
+})
+const emit = defineEmits(['confirm', 'cancel'])
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="show" class="confirm-backdrop" @click.self="emit('cancel')">
+      <div class="confirm-modal" role="dialog" aria-modal="true">
+        <div class="confirm-header">
+          <span class="type-label">{{ title }}</span>
+        </div>
+        <div class="confirm-body">
+          <p class="type-body text-content-secondary">{{ message }}</p>
+        </div>
+        <div class="confirm-footer">
+          <button class="btn-ghost" @click="emit('cancel')">Cancel</button>
+          <button
+            :class="variant === 'danger' ? 'btn-danger' : 'btn-warning'"
+            @click="emit('confirm')"
+          >{{ confirmLabel }}</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.confirm-backdrop {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(0,0,0,0.6);
+  display: flex; align-items: center; justify-content: center;
+  padding: 16px;
+}
+.confirm-modal {
+  background: var(--color-surface-800, #1a1a1a);
+  border: 1px solid rgba(255,255,255,0.1);
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  width: 100%; max-width: 440px;
+  padding: 24px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.confirm-header { border-bottom: 1px solid rgba(255,255,255,0.07); padding-bottom: 12px; }
+.confirm-footer { display: flex; gap: 8px; justify-content: flex-end; padding-top: 4px; }
+.btn-ghost {
+  background: none; border: 1px solid rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.55); padding: 6px 16px; font-size: 11px;
+  letter-spacing: 0.1em; text-transform: uppercase; cursor: pointer;
+}
+.btn-danger {
+  background: rgba(239,68,68,0.15); border: 1px solid rgba(239,68,68,0.4);
+  color: #f87171; padding: 6px 16px; font-size: 11px;
+  letter-spacing: 0.1em; text-transform: uppercase; cursor: pointer;
+}
+.btn-warning {
+  background: rgba(245,158,11,0.15); border: 1px solid rgba(245,158,11,0.4);
+  color: #fbbf24; padding: 6px 16px; font-size: 11px;
+  letter-spacing: 0.1em; text-transform: uppercase; cursor: pointer;
+}
+</style>

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -916,6 +916,43 @@ export const removeParticipantGenre = async (participantId, eventId, genreId) =>
   }
 }
 
+export const deleteParticipantFromEvent = async (participantId, eventId) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/participant/${participantId}/${eventId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const updateParticipant = async (participantId, eventId, { name, memberNames = [] }) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/participant/${participantId}/${eventId}`, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, memberNames })
+    })
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const updateParticipantsJudge = async (eventId, updatedList) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/participants-judge/`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ updatedList })
+    })
+  } catch (e) {
+    console.log(e)
+  }
+}
+
 export const addGenreToParticipant = async (participantId, eventId, genreName, entryMode, teamName, teamMembers) => {
   try {
     return await fetch(`${domain}/api/v1/event/participant-genre`, {

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2045,14 +2045,14 @@ onUnmounted(() => {
                   <span v-else class="text-content-muted">Ref code</span>
                 </span>
               </div>
+              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 type-label text-content-muted mt-0.5">
+                <i class="pi pi-users" style="font-size:0.65rem"></i>
+                <span>{{ p.memberNames.join(', ') }}</span>
+              </div>
               <div class="flex flex-wrap gap-1.5 mt-1">
                 <span v-for="e in p.entries" :key="e.genre" class="badge-neutral capitalize">
                   {{ e.genre }}<span style="color:var(--accent-color);margin-left:0.25rem">#{{ e.auditionNumber }}</span>
                 </span>
-              </div>
-              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 type-label text-content-muted mt-0.5">
-                <i class="pi pi-users" style="font-size:0.65rem"></i>
-                <span>{{ p.memberNames.join(', ') }}</span>
               </div>
             </div>
           </template>

--- a/BES-frontend/src/views/UpdateEventDetails.vue
+++ b/BES-frontend/src/views/UpdateEventDetails.vue
@@ -1,220 +1,583 @@
 <script setup>
-import DynamicTable from '@/components/DynamicTable.vue';
-import { onMounted, ref, watch, computed } from 'vue';
+import { onMounted, ref, computed } from 'vue'
+import { useAuthStore } from '@/utils/auth'
+import CreateParticipantForm from '@/components/CreateParticipantForm.vue'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 import ActionDoneModal from './ActionDoneModal.vue'
-import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { useAuthStore } from '@/utils/auth';
-import CreateParticipantForm from '@/components/CreateParticipantForm.vue';
-const authStore = useAuthStore()
-const selectedEvent = computed(() => authStore.activeEvent?.name || localStorage.getItem("selectedEvent") || "")
-const selectedGenre = ref(localStorage.getItem("selectedGenre") || "All")
-const participants = ref([])
-const allJudges = ref([])
-const showCreateNewEntry = ref(false)
+import {
+  getRegisteredParticipantsByEvent,
+  deleteParticipantFromEvent,
+  removeParticipantGenre,
+  updateParticipant,
+  updateParticipantsJudge
+} from '@/utils/api'
 
-const modalTitle = ref("")
-const modalMessage = ref("")
-const modalVariant = ref("success")
-const showModal = ref(false)
-const openModal = (title, message, variant = 'success') => {
-  modalTitle.value = title
-  modalMessage.value = message
-  modalVariant.value = variant
-  showModal.value = true
-}
-const handleAccept = () => {
-  showModal.value = false
-}
+const authStore   = useAuthStore()
+const selectedEvent = computed(() => authStore.activeEvent?.name || localStorage.getItem('selectedEvent') || '')
 
-const uniqueGenres = computed(() => {
-  const genres = participants.value.map(p => p.genreName);
-  return [...new Set(genres)].sort();
+const allJudges   = ref([])
+const rawRows     = ref([])
+const participants = computed(() => groupParticipants(rawRows.value))
+
+const search         = ref('')
+const activeGenre    = ref('All')
+
+const genreList = computed(() => {
+  const names = [...new Set(rawRows.value.map(r => r.genreName))].sort()
+  return ['All', ...names]
 })
 
-const genreOptions = computed(() => ['All', ...uniqueGenres.value])
+const genreCount = (genre) =>
+  genre === 'All'
+    ? participants.value.length
+    : participants.value.filter(p => p.genres.some(g => g.genreName === genre)).length
 
-const filteredParticipants = computed({
-  get() {
-    if (selectedGenre.value === "All") return participants.value;
-    return participants.value.filter(p => p.genreName === selectedGenre.value);
-  },
-  set(updatedSubset) {
-    if (!Array.isArray(participants.value)) return;
-    const byId = new Map(updatedSubset.map(r => [r.rowId, r]));
-    participants.value = participants.value.map(org => {
-      const updated = byId.get(org.rowId)
-      return updated ? { ...org, ...updated } : org
-    })
+const filtered = computed(() => {
+  let list = participants.value
+  if (activeGenre.value !== 'All')
+    list = list.filter(p => p.genres.some(g => g.genreName === activeGenre.value))
+  if (search.value.trim())
+    list = list.filter(p => p.name.toLowerCase().includes(search.value.trim().toLowerCase()))
+  return list
+})
+
+const expanded = ref(new Set())
+const toggle   = (id) => expanded.value.has(id) ? expanded.value.delete(id) : expanded.value.add(id)
+
+const editTarget  = ref(null)
+const editName    = ref('')
+const editMembers = ref([])
+const editError   = ref('')
+const showEdit    = ref(false)
+
+const openEdit = (p) => {
+  const slotCount = parseFormatSize(p.format)
+  const isTeam    = slotCount >= 2
+  editTarget.value  = { ...p, isTeam, slotCount }
+  editName.value    = p.name
+  editMembers.value = isTeam
+    ? Array.from({ length: slotCount }, (_, i) => (p.memberNames[i] ?? ''))
+    : []
+  editError.value   = ''
+  showEdit.value    = true
+}
+
+const validateEdit = () => {
+  if (!editName.value.trim()) return 'Name is required'
+  if (editTarget.value.isTeam) {
+    for (let i = 0; i < editMembers.value.length; i++) {
+      if (!editMembers.value[i].trim()) return `Member ${i + 1} is required`
+    }
   }
-});
+  return ''
+}
 
-const updateParticipantJudge = async () => {
-  try {
-    const updateResponse = await fetch("/api/v1/event/participants-judge/", {
-      method: 'POST',
-      credentials: "include",
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ updatedList: participants.value })
-    })
-    await updateResponse.json()
-    openModal("Judges Updated", "Judge assignments have been saved successfully.", "success")
-  } catch {
-    openModal("Update Failed", "Unable to save changes. Please try again.", "error")
+const submitEdit = async () => {
+  const err = validateEdit()
+  if (err) { editError.value = err; return }
+
+  const res = await updateParticipant(
+    editTarget.value.participantId,
+    editTarget.value.eventId,
+    { name: editName.value.trim(), memberNames: editTarget.value.isTeam ? editMembers.value.map(m => m.trim()) : [] }
+  )
+  if (!res) { editError.value = 'Network error'; return }
+  if (res.status === 422) {
+    const body = await res.json().catch(() => null)
+    editError.value = body || 'Duplicate name'
+    return
+  }
+  if (!res.ok) { editError.value = 'Save failed'; return }
+  showEdit.value = false
+  await reload()
+  openToast('Participant updated')
+}
+
+const confirmState = ref({ show: false, title: '', message: '', onConfirm: null })
+
+const confirmDeleteParticipant = (p) => {
+  const genreList = p.genres.map(g => g.genreName).join(', ')
+  confirmState.value = {
+    show: true,
+    title: 'Delete Participant',
+    message: `Remove "${p.name}" from ${selectedEvent.value}? This will remove them from all genres (${genreList}) and release all audition numbers. This cannot be undone.`,
+    onConfirm: async () => {
+      await deleteParticipantFromEvent(p.participantId, p.eventId)
+      confirmState.value.show = false
+      await reload()
+      openToast('Participant removed')
+    }
   }
 }
 
-watch(selectedEvent, async (newVal) => {
-  if (newVal) {
-    localStorage.setItem("selectedEvent", newVal);
-    await fetchAllParticipantInEvent(newVal)
-  }
-});
-
-watch(selectedGenre, async (newVal) => {
-  if (newVal) {
-    localStorage.setItem("selectedGenre", newVal);
-  }
-}, { immediate: true });
-
-const fetchAllParticipantInEvent = async (eventName) => {
-  try {
-    const res = await fetch(`/api/v1/event/participants/${eventName}`, { credentials: "include" })
-    if (!res.ok) throw new Error('Failed to fetch event data')
-    const result = await res.json()
-    participants.value = result.map((r, i) => ({ ...r, rowId: r.rowId ?? i }))
-  } catch (err) {
-    console.log(err)
+const confirmRemoveGenre = (p, genre) => {
+  confirmState.value = {
+    show: true,
+    title: 'Remove from Genre',
+    message: `Remove "${p.name}" from ${genre.genreName}? Their audition number will be released.`,
+    onConfirm: async () => {
+      await removeParticipantGenre(p.participantId, p.eventId, genre.eventGenreId)
+      confirmState.value.show = false
+      await reload()
+      openToast('Genre removed')
+    }
   }
 }
 
-const fetchAllJudges = async () => {
-  try {
-    const res = await fetch('/api/v1/event/judges', { credentials: "include" })
-    if (!res.ok) throw new Error('Failed to fetch judges')
-    const result = await res.json()
-    allJudges.value = Object.values(result).map(item => item.judgeName)
-  } catch (err) {
-    console.log(err)
+const assignJudge = async (p, genre, judgeName) => {
+  await updateParticipantsJudge(p.eventId, [
+    { eventName: selectedEvent.value, participantName: p.name, genreName: genre.genreName, judgeName }
+  ])
+  await reload()
+}
+
+const toast        = ref('')
+const showToast    = ref(false)
+let   toastTimer   = null
+const openToast = (msg) => {
+  toast.value = msg; showToast.value = true
+  clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => { showToast.value = false }, 2500)
+}
+
+const showCreate = ref(false)
+
+function isTeamFormat(fmt) {
+  if (!fmt) return false
+  return /^\d+v\d+$/i.test(fmt) && fmt.toLowerCase() !== '1v1'
+}
+
+function parseFormatSize(fmt) {
+  if (!fmt) return 0
+  const m = fmt.match(/^(\d+)v\d+$/i)
+  return m ? parseInt(m[1]) : 0
+}
+
+function groupParticipants(rows) {
+  const map = new Map()
+  for (const row of rows) {
+    if (!map.has(row.participantId)) {
+      map.set(row.participantId, {
+        participantId: row.participantId,
+        eventId:       row.eventId,
+        name:          row.participantName,
+        format:        row.format,
+        memberNames:   row.memberNames || [],
+        genres: []
+      })
+    }
+    map.get(row.participantId).genres.push({
+      genreName:    row.genreName,
+      eventGenreId: row.eventGenreId,
+      judgeName:    row.judgeName || '',
+      auditionNumber: row.auditionNumber
+    })
   }
+  return Array.from(map.values())
+}
+
+const reload = async () => {
+  if (!selectedEvent.value) return
+  const res = await getRegisteredParticipantsByEvent(selectedEvent.value)
+  rawRows.value = Array.isArray(res) ? res : []
+}
+
+const fetchJudges = async () => {
+  try {
+    const res = await fetch('/api/v1/event/judges', { credentials: 'include' })
+    if (!res.ok) return
+    const data = await res.json()
+    allJudges.value = Object.values(data).map(j => j.judgeName)
+  } catch { /* silent */ }
 }
 
 onMounted(async () => {
-  if (selectedEvent.value) {
-    await fetchAllParticipantInEvent(selectedEvent.value)
-  }
-  fetchAllJudges()
+  await reload()
+  await fetchJudges()
 })
 </script>
 
 <template>
   <div class="page-container relative">
-  <div class="color-bleed"></div>
-  <div class="relative z-10">
+    <div class="color-bleed"></div>
+    <div class="relative z-10">
 
-    <!-- Page header -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
-      <div>
-        <div class="type-page-title mb-1">Participants</div>
-        <p class="type-label text-content-muted">Assign judges and manage participant entries</p>
-      </div>
-      <button
-        @click="showCreateNewEntry = true"
-        class="bg-accent para-chip type-label text-surface-900 px-4 py-2 flex items-center gap-2"
-      >
-        <i class="pi pi-plus text-xs"></i>
-        Add Participant
-      </button>
-    </div>
-
-    <!-- Filter bar -->
-    <div class="para-chip p-5 mb-6">
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div class="flex flex-col gap-1">
-          <span class="type-label text-content-muted">Event</span>
-          <span class="badge-neutral type-body px-3 py-1.5 self-start">{{ selectedEvent }}</span>
-        </div>
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
         <div>
-          <ReusableDropdown
-            v-model="selectedGenre"
-            labelId="Genre"
-            :options="genreOptions"
-            placeholder="All genres"
-          />
+          <div class="type-page-title mb-1">Participants</div>
+          <p class="type-label text-content-muted">Manage entries, edit names, assign judges</p>
+        </div>
+        <button
+          @click="showCreate = true"
+          class="bg-accent para-chip type-label text-surface-900 px-4 py-2 flex items-center gap-2"
+        >
+          <i class="pi pi-plus text-xs"></i> Add Participant
+        </button>
+      </div>
+
+      <div class="para-chip p-4 mb-6">
+        <input
+          v-model="search"
+          class="search-input"
+          placeholder="Search name..."
+        />
+        <div class="genre-chips">
+          <button
+            v-for="genre in genreList"
+            :key="genre"
+            :class="['genre-chip', activeGenre === genre && 'active']"
+            @click="activeGenre = genre"
+          >
+            {{ genre }}
+            <span class="count-badge">{{ genreCount(genre) }}</span>
+          </button>
+        </div>
+        <div class="flex items-center gap-2 mt-3 pt-3 border-t border-surface-600/30">
+          <i class="pi pi-users text-content-muted text-sm"></i>
+          <span class="type-label text-content-muted">
+            Showing <span class="text-accent">{{ filtered.length }}</span>
+            of <span class="text-accent">{{ participants.length }}</span> participants
+          </span>
         </div>
       </div>
 
-      <!-- Participant count -->
-      <div class="flex items-center gap-2 mt-4 pt-4 border-t border-surface-600/30">
-        <i class="pi pi-users text-content-muted text-sm"></i>
-        <span class="type-label text-content-muted">
-          Showing <span class="text-accent">{{ filteredParticipants.length }}</span>
-          of <span class="text-accent">{{ participants.length }}</span> participants
-        </span>
+      <div class="section-rule mb-4">
+        <span class="section-rule-label">Participants</span>
+        <div class="section-rule-line"></div>
       </div>
-    </div>
 
-    <div class="section-rule mb-4">
-      <span class="section-rule-label">Participants</span>
-      <div class="section-rule-line"></div>
-    </div>
-
-    <div class="mb-6">
-      <DynamicTable
-        v-if="participants.length > 0"
-        v-model:tableValue="filteredParticipants"
-        :tableConfig="[
-          { key: 'eventName',       label: 'Event',  type: 'text',   readonly: true },
-          { key: 'participantName', label: 'Name',   type: 'text',   readonly: true },
-          { key: 'genreName',       label: 'Genre',  type: 'text',   readonly: true },
-          { key: 'judgeName',       label: 'Judge',  type: 'select', options: ['', ...(allJudges || [])] }
-        ]"
-      />
-
-      <!-- Empty state -->
-      <div
-        v-if="participants.length === 0 && selectedEvent"
-        class="flex flex-col items-center justify-center py-20 text-center"
-      >
-        <div class="w-14 h-14 para-chip flex items-center justify-center mb-4">
-          <i class="pi pi-users text-content-muted text-xl"></i>
-        </div>
+      <div v-if="filtered.length === 0" class="empty-state">
+        <i class="pi pi-users text-2xl text-content-muted mb-2"></i>
         <p class="type-body text-content-secondary">No participants found</p>
-        <p class="type-label text-content-muted mt-1">Select a different event or add a participant</p>
       </div>
-    </div>
 
-    <!-- Save action -->
-    <div class="flex justify-end">
-      <button
-        @click="updateParticipantJudge"
-        class="bg-accent para-chip type-label text-surface-900 px-5 py-2 flex items-center gap-2"
-      >
-        <i class="pi pi-check text-xs"></i>
-        Save Judge Assignments
-      </button>
-    </div>
+      <div v-else class="participant-table">
+        <div class="pt-header">
+          <div class="pt-col-expand"></div>
+          <div class="pt-col-name">Name</div>
+          <div class="pt-col-format">Format</div>
+          <div class="pt-col-genres">Genres</div>
+          <div class="pt-col-actions"></div>
+        </div>
 
-  </div><!-- end relative z-10 -->
+        <template v-for="p in filtered" :key="p.participantId">
+          <div class="pt-row">
+            <button class="expand-btn" @click="toggle(p.participantId)">
+              {{ expanded.has(p.participantId) ? '▾' : '▸' }}
+            </button>
+            <div class="pt-col-name">
+              <span class="participant-name">{{ p.name }}</span>
+            </div>
+            <div class="pt-col-format">
+              <span :class="['format-badge', isTeamFormat(p.format) ? 'team' : 'solo']">
+                {{ p.format || 'Solo' }}
+              </span>
+            </div>
+            <div class="pt-col-genres">
+              <span
+                v-for="g in p.genres"
+                :key="g.genreName"
+                class="genre-pill"
+              >{{ g.genreName }}</span>
+            </div>
+            <div class="pt-col-actions">
+              <button class="btn-action" @click="openEdit(p)">
+                <i class="pi pi-pencil"></i> Edit
+              </button>
+              <button class="btn-action danger" @click="confirmDeleteParticipant(p)">
+                <i class="pi pi-trash"></i> Delete
+              </button>
+            </div>
+          </div>
+
+          <template v-if="expanded.has(p.participantId)">
+            <div
+              v-for="genre in p.genres"
+              :key="genre.genreName"
+              class="pt-subrow"
+            >
+              <span class="subrow-indent">↳</span>
+              <span class="genre-pill">{{ genre.genreName }}</span>
+              <span class="subrow-label">Judge:</span>
+              <select
+                class="judge-select"
+                :value="genre.judgeName"
+                @change="assignJudge(p, genre, $event.target.value)"
+              >
+                <option value="">—</option>
+                <option v-for="j in allJudges" :key="j" :value="j">{{ j }}</option>
+              </select>
+              <span v-if="genre.auditionNumber" class="audition-num">#{{ genre.auditionNumber }}</span>
+              <button
+                class="btn-remove-genre"
+                @click="confirmRemoveGenre(p, genre)"
+              >Remove Genre</button>
+            </div>
+          </template>
+        </template>
+      </div>
+
+    </div>
   </div>
 
-  <ActionDoneModal
-    :show="showModal"
-    :title="modalTitle"
-    :variant="modalVariant"
-    @accept="handleAccept"
-    @close="handleAccept"
-  >
-    <p class="type-body text-content-secondary">{{ modalMessage }}</p>
-  </ActionDoneModal>
+  <Teleport to="body">
+    <div v-if="showEdit" class="modal-backdrop" @click.self="showEdit = false">
+      <div class="edit-modal">
+        <div class="modal-header">
+          <span class="type-label">{{ editTarget?.isTeam ? 'Edit Team' : 'Edit Participant' }}</span>
+          <button class="modal-close" @click="showEdit = false">✕</button>
+        </div>
+
+        <div class="modal-body">
+          <div class="field">
+            <label class="field-label">
+              {{ editTarget?.isTeam ? 'Team Name' : 'Name' }}
+              <span class="required">*</span>
+            </label>
+            <input
+              v-model="editName"
+              class="field-input"
+              :placeholder="editTarget?.isTeam ? 'Team name' : 'Participant name'"
+            />
+          </div>
+
+          <template v-if="editTarget?.isTeam">
+            <div class="members-label">Members</div>
+            <div
+              v-for="(_, i) in editMembers"
+              :key="i"
+              class="field"
+            >
+              <label class="field-label">
+                Member {{ i + 1 }} <span class="required">*</span>
+              </label>
+              <input
+                v-model="editMembers[i]"
+                class="field-input"
+                :placeholder="`Member ${i + 1}`"
+              />
+            </div>
+          </template>
+
+          <p v-if="editError" class="field-error">{{ editError }}</p>
+        </div>
+
+        <div class="modal-footer">
+          <button class="btn-ghost" @click="showEdit = false">Cancel</button>
+          <button class="btn-primary" @click="submitEdit">Save</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+
+  <ConfirmModal
+    :show="confirmState.show"
+    :title="confirmState.title"
+    :message="confirmState.message"
+    confirm-label="Confirm"
+    variant="danger"
+    @confirm="confirmState.onConfirm && confirmState.onConfirm()"
+    @cancel="confirmState.show = false"
+  />
 
   <CreateParticipantForm
     :event="selectedEvent"
-    :show="showCreateNewEntry"
+    :show="showCreate"
     title="New participant entry"
-    @createNewEntry="showCreateNewEntry = false"
-    @close="showCreateNewEntry = false"
+    @createNewEntry="showCreate = false; reload()"
+    @close="showCreate = false"
   />
+
+  <Transition name="toast">
+    <div v-if="showToast" class="toast">{{ toast }}</div>
+  </Transition>
 </template>
+
+<style scoped>
+.search-input {
+  width: 100%; max-width: 280px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.8);
+  padding: 7px 12px; font-size: 12px;
+  margin-bottom: 12px;
+}
+.search-input::placeholder { color: rgba(255,255,255,0.25); }
+.genre-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.genre-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 12px; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+  border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.04);
+  color: rgba(255,255,255,0.5); cursor: pointer;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  transition: all 0.15s;
+}
+.genre-chip.active {
+  background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.35);
+  color: rgba(255,255,255,0.9);
+}
+.count-badge {
+  background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.5);
+  font-size: 9px; padding: 0 4px; border-radius: 2px;
+}
+
+.participant-table { display: flex; flex-direction: column; gap: 2px; }
+.pt-header {
+  display: grid;
+  grid-template-columns: 32px 1fr auto auto auto;
+  gap: 8px; align-items: center;
+  padding: 6px 12px;
+  font-size: 9px; letter-spacing: 0.15em; text-transform: uppercase;
+  color: rgba(255,255,255,0.3);
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.pt-row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto auto auto;
+  gap: 8px; align-items: center;
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  transition: background 0.15s;
+}
+.pt-row:hover { background: rgba(255,255,255,0.05); }
+.pt-subrow {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 8px 12px 8px 44px;
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.04);
+  border-top: none; font-size: 12px;
+}
+.expand-btn {
+  background: none; border: 1px solid rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.45); font-size: 10px;
+  width: 24px; height: 24px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+}
+.participant-name {
+  font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: rgba(255,255,255,0.85);
+}
+.format-badge {
+  font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 2px 8px;
+}
+.format-badge.solo {
+  background: rgba(99,102,241,0.12); border: 1px solid rgba(99,102,241,0.3);
+  color: #a5b4fc;
+}
+.format-badge.team {
+  background: rgba(20,184,166,0.12); border: 1px solid rgba(20,184,166,0.3);
+  color: #5eead4;
+}
+.genre-pill {
+  display: inline-block; padding: 1px 8px;
+  background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1);
+  font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em;
+  clip-path: polygon(3px 0%, 100% 0%, calc(100% - 3px) 100%, 0% 100%);
+}
+.pt-col-actions { display: flex; gap: 4px; flex-shrink: 0; }
+.btn-action {
+  background: none; border: 1px solid rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.5); font-size: 10px; letter-spacing: 0.08em;
+  padding: 4px 10px; cursor: pointer; display: flex; align-items: center; gap: 4px;
+  text-transform: uppercase;
+}
+.btn-action:hover { border-color: rgba(255,255,255,0.25); color: rgba(255,255,255,0.8); }
+.btn-action.danger { border-color: rgba(239,68,68,0.2); color: rgba(248,113,113,0.6); }
+.btn-action.danger:hover { border-color: rgba(239,68,68,0.5); color: #f87171; }
+.subrow-indent { color: rgba(255,255,255,0.25); }
+.subrow-label { font-size: 11px; color: rgba(255,255,255,0.3); }
+.judge-select {
+  background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.7); font-size: 11px; padding: 3px 6px;
+}
+.audition-num { font-size: 10px; color: rgba(255,255,255,0.3); letter-spacing: 0.08em; }
+.btn-remove-genre {
+  margin-left: auto; background: none;
+  border: 1px solid rgba(239,68,68,0.2); color: rgba(248,113,113,0.55);
+  font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 3px 8px; cursor: pointer;
+}
+.btn-remove-genre:hover { border-color: rgba(239,68,68,0.45); color: #f87171; }
+
+.empty-state {
+  display: flex; flex-direction: column; align-items: center;
+  justify-content: center; padding: 60px 0; text-align: center;
+}
+
+.modal-backdrop {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(0,0,0,0.6);
+  display: flex; align-items: center; justify-content: center; padding: 16px;
+}
+.edit-modal {
+  background: var(--color-surface-800, #1a1a1a);
+  border: 1px solid rgba(255,255,255,0.1);
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  width: 100%; max-width: 480px;
+  display: flex; flex-direction: column;
+}
+.modal-header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 20px; border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.modal-close {
+  background: none; border: none; color: rgba(255,255,255,0.4);
+  font-size: 13px; cursor: pointer;
+}
+.modal-body { padding: 20px; display: flex; flex-direction: column; gap: 12px; }
+.modal-footer {
+  display: flex; gap: 8px; justify-content: flex-end;
+  padding: 12px 20px; border-top: 1px solid rgba(255,255,255,0.07);
+}
+.field { display: flex; flex-direction: column; gap: 4px; }
+.field-label {
+  font-size: 10px; letter-spacing: 0.15em; text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+}
+.required { color: #f87171; margin-left: 2px; }
+.field-input {
+  background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.85); padding: 8px 10px; font-size: 13px;
+}
+.field-input:focus { outline: none; border-color: rgba(255,255,255,0.3); }
+.members-label {
+  font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: rgba(255,255,255,0.25); padding-top: 4px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}
+.field-error { font-size: 11px; color: #f87171; margin-top: -4px; }
+.btn-ghost {
+  background: none; border: 1px solid rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.55); padding: 7px 18px; font-size: 11px;
+  letter-spacing: 0.1em; text-transform: uppercase; cursor: pointer;
+}
+.btn-primary {
+  background: rgba(255,255,255,0.9); color: #111; border: none;
+  padding: 7px 18px; font-size: 11px; letter-spacing: 0.1em;
+  text-transform: uppercase; cursor: pointer;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+}
+
+.toast {
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+  background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.85); padding: 10px 20px; font-size: 12px;
+  letter-spacing: 0.1em; text-transform: uppercase; z-index: 300;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+}
+.toast-enter-active, .toast-leave-active { transition: opacity 0.2s, transform 0.2s; }
+.toast-enter-from, .toast-leave-to { opacity: 0; transform: translateX(-50%) translateY(8px); }
+
+@media (max-width: 640px) {
+  .pt-header { display: none; }
+  .pt-row {
+    grid-template-columns: 32px 1fr;
+    grid-template-rows: auto auto;
+  }
+  .pt-col-format, .pt-col-genres { grid-column: 2; }
+  .pt-col-actions { grid-column: 1 / -1; justify-content: flex-start; }
+  .pt-subrow { padding-left: 12px; }
+}
+</style>

--- a/BES-frontend/src/views/UpdateEventDetails.vue
+++ b/BES-frontend/src/views/UpdateEventDetails.vue
@@ -3,7 +3,6 @@ import { onMounted, ref, computed } from 'vue'
 import { useAuthStore } from '@/utils/auth'
 import CreateParticipantForm from '@/components/CreateParticipantForm.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
-import ActionDoneModal from './ActionDoneModal.vue'
 import {
   getRegisteredParticipantsByEvent,
   deleteParticipantFromEvent,
@@ -43,6 +42,23 @@ const filtered = computed(() => {
 
 const expanded = ref(new Set())
 const toggle   = (id) => expanded.value.has(id) ? expanded.value.delete(id) : expanded.value.add(id)
+
+const selectedIds  = ref(new Set())
+const allSelected  = computed(() =>
+  filtered.value.length > 0 && filtered.value.every(p => selectedIds.value.has(p.participantId))
+)
+const toggleSelect  = (id) => {
+  const s = new Set(selectedIds.value)
+  s.has(id) ? s.delete(id) : s.add(id)
+  selectedIds.value = s
+}
+const toggleAll = () => {
+  if (allSelected.value) {
+    selectedIds.value = new Set()
+  } else {
+    selectedIds.value = new Set(filtered.value.map(p => p.participantId))
+  }
+}
 
 const editTarget  = ref(null)
 const editName    = ref('')
@@ -94,6 +110,23 @@ const submitEdit = async () => {
 }
 
 const confirmState = ref({ show: false, title: '', message: '', onConfirm: null })
+
+const confirmBulkDelete = () => {
+  const ids = [...selectedIds.value]
+  const targets = participants.value.filter(p => ids.includes(p.participantId))
+  confirmState.value = {
+    show: true,
+    title: `Delete ${ids.length} Participant${ids.length > 1 ? 's' : ''}`,
+    message: `Permanently remove ${ids.length} participant${ids.length > 1 ? 's' : ''} from ${selectedEvent.value}? All genre entries, audition numbers, scores and feedback will be deleted. This cannot be undone.`,
+    onConfirm: async () => {
+      await Promise.all(targets.map(p => deleteParticipantFromEvent(p.participantId, p.eventId)))
+      confirmState.value.show = false
+      selectedIds.value = new Set()
+      await reload()
+      openToast(`${ids.length} participant${ids.length > 1 ? 's' : ''} removed`)
+    }
+  }
+}
 
 const confirmDeleteParticipant = (p) => {
   const genreList = p.genres.map(g => g.genreName).join(', ')
@@ -246,6 +279,21 @@ onMounted(async () => {
         <div class="section-rule-line"></div>
       </div>
 
+      <!-- Bulk action bar -->
+      <Transition name="bulk-bar">
+        <div v-if="selectedIds.size > 0" class="bulk-bar mb-3">
+          <span class="type-label text-content-muted">
+            <span class="text-accent">{{ selectedIds.size }}</span> selected
+          </span>
+          <button class="btn-action danger" @click="confirmBulkDelete">
+            <i class="pi pi-trash"></i> Delete Selected
+          </button>
+          <button class="btn-action" @click="selectedIds = new Set()">
+            Clear
+          </button>
+        </div>
+      </Transition>
+
       <div v-if="filtered.length === 0" class="empty-state">
         <i class="pi pi-users text-2xl text-content-muted mb-2"></i>
         <p class="type-body text-content-secondary">No participants found</p>
@@ -253,6 +301,7 @@ onMounted(async () => {
 
       <div v-else class="participant-table">
         <div class="pt-header">
+          <input type="checkbox" class="row-check" :checked="allSelected" @change="toggleAll" />
           <div class="pt-col-expand"></div>
           <div class="pt-col-name">Name</div>
           <div class="pt-col-format">Format</div>
@@ -261,7 +310,13 @@ onMounted(async () => {
         </div>
 
         <template v-for="p in filtered" :key="p.participantId">
-          <div class="pt-row">
+          <div class="pt-row" :class="selectedIds.has(p.participantId) && 'selected'">
+            <input
+              type="checkbox"
+              class="row-check"
+              :checked="selectedIds.has(p.participantId)"
+              @change="toggleSelect(p.participantId)"
+            />
             <button class="expand-btn" @click="toggle(p.participantId)">
               {{ expanded.has(p.participantId) ? '▾' : '▸' }}
             </button>
@@ -424,7 +479,7 @@ onMounted(async () => {
 .participant-table { display: flex; flex-direction: column; gap: 2px; }
 .pt-header {
   display: grid;
-  grid-template-columns: 32px 1fr auto auto auto;
+  grid-template-columns: 20px 32px 1fr auto auto auto;
   gap: 8px; align-items: center;
   padding: 6px 12px;
   font-size: 9px; letter-spacing: 0.15em; text-transform: uppercase;
@@ -433,7 +488,7 @@ onMounted(async () => {
 }
 .pt-row {
   display: grid;
-  grid-template-columns: 32px 1fr auto auto auto;
+  grid-template-columns: 20px 32px 1fr auto auto auto;
   gap: 8px; align-items: center;
   padding: 10px 12px;
   background: rgba(255,255,255,0.03);
@@ -441,6 +496,16 @@ onMounted(async () => {
   transition: background 0.15s;
 }
 .pt-row:hover { background: rgba(255,255,255,0.05); }
+.pt-row.selected { background: rgba(255,255,255,0.06); border-color: rgba(255,255,255,0.12); }
+.row-check { width: 14px; height: 14px; accent-color: var(--accent-color); cursor: pointer; flex-shrink: 0; }
+.bulk-bar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+}
+.bulk-bar-enter-active, .bulk-bar-leave-active { transition: opacity 0.15s, transform 0.15s; }
+.bulk-bar-enter-from, .bulk-bar-leave-to { opacity: 0; transform: translateY(-4px); }
 .pt-subrow {
   display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
   padding: 8px 12px 8px 44px;
@@ -573,10 +638,10 @@ onMounted(async () => {
 @media (max-width: 640px) {
   .pt-header { display: none; }
   .pt-row {
-    grid-template-columns: 32px 1fr;
+    grid-template-columns: 20px 32px 1fr;
     grid-template-rows: auto auto;
   }
-  .pt-col-format, .pt-col-genres { grid-column: 2; }
+  .pt-col-format, .pt-col-genres { grid-column: 2 / -1; }
   .pt-col-actions { grid-column: 1 / -1; justify-content: flex-start; }
   .pt-subrow { padding-left: 12px; }
 }

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -53,6 +54,7 @@ import com.example.BES.dtos.GetParticipatnScoreDto;
 import com.example.BES.dtos.GetUnverifiedParticipantDto;
 import com.example.BES.dtos.UpdateParticipantGenreDto;
 import com.example.BES.dtos.UpdateParticipantJudgeDto;
+import com.example.BES.dtos.UpdateParticipantDto;
 import com.example.BES.dtos.UpdateParticipantsScoreDto;
 import com.example.BES.dtos.VerifyParticipantDto;
 import com.example.BES.dtos.AddBattleGuestDto;
@@ -628,6 +630,39 @@ public class EventController {
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Operation(summary = "Delete Participant From Event", description = "Removes a participant from an event entirely — all genres, scores, feedback, team members")
+    @DeleteMapping("/participant/{participantId}/{eventId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> deleteParticipantFromEvent(
+            @PathVariable Long participantId,
+            @PathVariable Long eventId) {
+        try {
+            eventGenreParticipantService.deleteParticipantFromEvent(participantId, eventId);
+            return ResponseEntity.ok(gson.toJson("Participant deleted"));
+        } catch (Exception e) {
+            log.error("Error deleting participant", e);
+            return new ResponseEntity<>(gson.toJson("Error deleting participant"), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "Update Participant", description = "Updates participant name (solo) or team name + members (team)")
+    @PutMapping("/participant/{participantId}/{eventId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> updateParticipant(
+            @PathVariable Long participantId,
+            @PathVariable Long eventId,
+            @RequestBody UpdateParticipantDto dto) {
+        try {
+            eventGenreParticipantService.updateParticipant(participantId, eventId, dto);
+            return ResponseEntity.ok(gson.toJson("Participant updated"));
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return new ResponseEntity<>(gson.toJson(e.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
+        } catch (Exception e) {
+            log.error("Error updating participant", e);
+            return new ResponseEntity<>(gson.toJson("Error updating participant"), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/BES/src/main/java/com/example/BES/dtos/UpdateParticipantDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/UpdateParticipantDto.java
@@ -1,0 +1,8 @@
+package com.example.BES.dtos;
+
+import java.util.List;
+
+public class UpdateParticipantDto {
+    public String name;
+    public List<String> memberNames;
+}

--- a/BES/src/main/java/com/example/BES/respositories/EventParticipantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventParticipantRepo.java
@@ -16,4 +16,5 @@ public interface EventParticipantRepo extends JpaRepository<EventParticipant, Lo
     List<EventParticipant> findByEvent(Event event_id);
     List<EventParticipant> findByEventAndPaymentVerifiedFalse(Event event);
     Optional<EventParticipant> findByReferenceCode(String referenceCode);
+    List<EventParticipant> findByParticipant(Participant participant);
 }

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -614,8 +614,11 @@ public class EventGenreParticpantService {
             throw new RuntimeException("Event or Participant not found");
 
         EventParticipant ep = eventParticipantRepo.findByEventAndParticipant(event, participant).orElse(null);
+        List<EventGenreParticipant> egps = repo.findByEventIdAndParticipantId(eventId, participantId);
 
-        boolean isTeam = ep != null && ep.getTeamName() != null && !ep.getTeamName().isBlank();
+        // ep.teamName is not set for sheet-imported teams — also check EGP format
+        boolean isTeam = (ep != null && ep.getTeamName() != null && !ep.getTeamName().isBlank())
+            || egps.stream().anyMatch(egp -> isTeamFormat(egp.getFormat()));
 
         String trimmedName = dto.name.trim();
         if (isTeam) {
@@ -633,17 +636,39 @@ public class EventGenreParticpantService {
         }
 
         if (isTeam) {
+            List<String> additionalMembers = dto.memberNames == null
+                ? new ArrayList<>()
+                : dto.memberNames.stream()
+                    .skip(1) // index 0 = participant.name, always prepended on read — only store the rest
+                    .filter(m -> m != null && !m.isBlank())
+                    .map(String::trim)
+                    .collect(java.util.stream.Collectors.toList());
+
+            // Update leader name (index 0) — keeps participant.participantName and ep.stageName in sync
+            // so both the edit modal and check-in card show the same value
+            if (dto.memberNames != null && !dto.memberNames.isEmpty()) {
+                String leaderName = dto.memberNames.get(0).trim();
+                if (!leaderName.isEmpty()) {
+                    participant.setParticipantName(leaderName);
+                    participantRepo.save(participant);
+                    ep.setStageName(leaderName);
+                }
+            }
+
+            // EP-level: use collection management so orphanRemoval fires correctly
             ep.setTeamName(trimmedName);
             ep.setDisplayName(trimmedName);
+            ep.getTeamMembers().clear();
+            additionalMembers.forEach(m -> ep.getTeamMembers().add(new EventParticipantTeamMember(ep, m)));
             eventParticipantRepo.save(ep);
-            eventParticipantTeamMemberRepo.deleteByEventParticipant(ep);
-            if (dto.memberNames != null) {
-                List<EventParticipantTeamMember> newMembers = dto.memberNames.stream()
-                    .filter(m -> m != null && !m.isBlank())
-                    .map(m -> new EventParticipantTeamMember(ep, m.trim()))
-                    .collect(java.util.stream.Collectors.toList());
-                eventParticipantTeamMemberRepo.saveAll(newMembers);
+
+            // EGP-level: same pattern — clear + re-add via collection, not repo delete
+            for (EventGenreParticipant egp : egps) {
+                egp.setDisplayName(trimmedName);
+                egp.getMembers().clear();
+                additionalMembers.forEach(m -> egp.getMembers().add(new EventGenreParticipantMember(egp, m)));
             }
+            repo.saveAll(egps);
         } else {
             participant.setParticipantName(trimmedName);
             participantRepo.save(participant);
@@ -651,13 +676,11 @@ public class EventGenreParticpantService {
                 ep.setDisplayName(trimmedName);
                 eventParticipantRepo.save(ep);
             }
+            for (EventGenreParticipant egp : egps) {
+                egp.setDisplayName(trimmedName);
+            }
+            repo.saveAll(egps);
         }
-
-        List<EventGenreParticipant> egps = repo.findByEventIdAndParticipantId(eventId, participantId);
-        for (EventGenreParticipant egp : egps) {
-            egp.setDisplayName(trimmedName);
-        }
-        repo.saveAll(egps);
     }
 
     private boolean isTeamFormat(String fmt) {

--- a/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreParticpantService.java
@@ -37,6 +37,11 @@ import com.example.BES.models.EventGenreParticipantMember;
 import com.example.BES.respositories.EventGenreParticipantMemberRepo;
 import com.example.BES.respositories.JudgeRepo;
 import com.example.BES.respositories.ParticipantRepo;
+import com.example.BES.models.EventParticipantTeamMember;
+import com.example.BES.respositories.AuditionFeedbackRepository;
+import com.example.BES.respositories.EventParticipantTeamMemberRepo;
+import com.example.BES.respositories.ScoreRepo;
+import com.example.BES.dtos.UpdateParticipantDto;
 
 @Service
 public class EventGenreParticpantService {
@@ -68,6 +73,15 @@ public class EventGenreParticpantService {
 
     @Autowired
     EventGenreParticipantMemberRepo egpMemberRepo;
+
+    @Autowired
+    ScoreRepo scoreRepo;
+
+    @Autowired
+    AuditionFeedbackRepository auditionFeedbackRepository;
+
+    @Autowired
+    EventParticipantTeamMemberRepo eventParticipantTeamMemberRepo;
 
     public EventGenreParticipant addWalkInToEventGenreParticipant(
             Participant p, String genre, EventParticipant ep,
@@ -561,6 +575,89 @@ public class EventGenreParticpantService {
                         "eventName", d.eventName));
             }
         }
+    }
+
+    @Transactional
+    public void deleteParticipantFromEvent(long participantId, long eventId) {
+        Event event = eventRepo.findById(eventId).orElse(null);
+        Participant participant = participantRepo.findById(participantId).orElse(null);
+        if (event == null || participant == null) return;
+
+        List<EventGenreParticipant> egps = repo.findByEventIdAndParticipantId(eventId, participantId);
+        for (EventGenreParticipant egp : egps) {
+            scoreRepo.deleteAll(scoreRepo.findByEventGenreParticipant(egp));
+            auditionFeedbackRepository.deleteAll(auditionFeedbackRepository.findByEventGenreParticipant(egp));
+        }
+
+        repo.deleteAll(egps);
+
+        EventParticipant ep = eventParticipantRepo.findByEventAndParticipant(event, participant).orElse(null);
+        if (ep != null) {
+            eventParticipantTeamMemberRepo.deleteByEventParticipant(ep);
+            eventParticipantRepo.delete(ep);
+        }
+
+        List<EventParticipant> remaining = eventParticipantRepo.findByParticipant(participant);
+        if (remaining.isEmpty()) {
+            participantRepo.delete(participant);
+        }
+    }
+
+    @Transactional
+    public void updateParticipant(long participantId, long eventId, UpdateParticipantDto dto) {
+        if (dto.name == null || dto.name.isBlank())
+            throw new IllegalArgumentException("Name must not be empty");
+
+        Event event = eventRepo.findById(eventId).orElse(null);
+        Participant participant = participantRepo.findById(participantId).orElse(null);
+        if (event == null || participant == null)
+            throw new RuntimeException("Event or Participant not found");
+
+        EventParticipant ep = eventParticipantRepo.findByEventAndParticipant(event, participant).orElse(null);
+
+        boolean isTeam = ep != null && ep.getTeamName() != null && !ep.getTeamName().isBlank();
+
+        String trimmedName = dto.name.trim();
+        if (isTeam) {
+            boolean duplicate = eventParticipantRepo.findByEvent(event).stream()
+                .filter(e -> !e.getParticipant().getParticipantId().equals(participantId))
+                .anyMatch(e -> trimmedName.equalsIgnoreCase(e.getTeamName()));
+            if (duplicate)
+                throw new IllegalStateException("A team with this name already exists in this event");
+        } else {
+            boolean duplicate = eventParticipantRepo.findByEvent(event).stream()
+                .filter(e -> !e.getParticipant().getParticipantId().equals(participantId))
+                .anyMatch(e -> trimmedName.equalsIgnoreCase(e.getParticipant().getParticipantName()));
+            if (duplicate)
+                throw new IllegalStateException("A participant with this name already exists in this event");
+        }
+
+        if (isTeam) {
+            ep.setTeamName(trimmedName);
+            ep.setDisplayName(trimmedName);
+            eventParticipantRepo.save(ep);
+            eventParticipantTeamMemberRepo.deleteByEventParticipant(ep);
+            if (dto.memberNames != null) {
+                List<EventParticipantTeamMember> newMembers = dto.memberNames.stream()
+                    .filter(m -> m != null && !m.isBlank())
+                    .map(m -> new EventParticipantTeamMember(ep, m.trim()))
+                    .collect(java.util.stream.Collectors.toList());
+                eventParticipantTeamMemberRepo.saveAll(newMembers);
+            }
+        } else {
+            participant.setParticipantName(trimmedName);
+            participantRepo.save(participant);
+            if (ep != null) {
+                ep.setDisplayName(trimmedName);
+                eventParticipantRepo.save(ep);
+            }
+        }
+
+        List<EventGenreParticipant> egps = repo.findByEventIdAndParticipantId(eventId, participantId);
+        for (EventGenreParticipant egp : egps) {
+            egp.setDisplayName(trimmedName);
+        }
+        repo.saveAll(egps);
     }
 
     private boolean isTeamFormat(String fmt) {

--- a/BES/src/main/java/com/example/BES/services/RegistrationService.java
+++ b/BES/src/main/java/com/example/BES/services/RegistrationService.java
@@ -229,11 +229,17 @@ public class RegistrationService {
             String stage = ep.getStageName();
             String display = ep.getDisplayName();
             String name = ep.getParticipant().getParticipantName();
-            dto.label = (stage != null && !stage.isBlank()) ? stage
-                      : (display != null && !display.isBlank()) ? display
-                      : name;
             List<EventGenreParticipant> egps = eventGenreParticipantRepo
                 .findByEventIdAndParticipantId(ep.getEvent().getEventId(), ep.getParticipant().getParticipantId());
+            // Use EGP team name as label for team entries; fall back to EP stage/display/participant name
+            String egpTeamName = egps.stream()
+                .map(EventGenreParticipant::getTeamName)
+                .filter(t -> t != null && !t.isBlank())
+                .findFirst().orElse(null);
+            dto.label = (egpTeamName != null) ? egpTeamName
+                      : (stage != null && !stage.isBlank()) ? stage
+                      : (display != null && !display.isBlank()) ? display
+                      : name;
             // Collect unique member names from EGP members (primary) or EventParticipantTeamMember (fallback)
             java.util.LinkedHashSet<String> memberSet = new java.util.LinkedHashSet<>();
             for (EventGenreParticipant egp : egps) {
@@ -250,7 +256,17 @@ public class RegistrationService {
                     .filter(n -> n != null && !n.isBlank())
                     .forEach(memberSet::add);
             }
-            dto.memberNames = new ArrayList<>(memberSet);
+            // Prepend the leader name (participant name) so memberNames is [leader, member2, ...]
+            // consistent with how the registered list builds member display
+            if (!memberSet.isEmpty()) {
+                String leader = (stage != null && !stage.isBlank()) ? stage : name;
+                java.util.LinkedHashSet<String> fullSet = new java.util.LinkedHashSet<>();
+                fullSet.add(leader);
+                fullSet.addAll(memberSet);
+                dto.memberNames = new ArrayList<>(fullSet);
+            } else {
+                dto.memberNames = new ArrayList<>(memberSet);
+            }
             dto.genres = egps.stream().map(egp -> {
                 GetCheckinListDto.GenreStatus gs = new GetCheckinListDto.GenreStatus();
                 gs.genreName = egp.getEventGenre().getName();

--- a/docs/superpowers/specs/2026-06-08-participant-management-design.md
+++ b/docs/superpowers/specs/2026-06-08-participant-management-design.md
@@ -1,0 +1,203 @@
+# Participant Management Rework
+
+**Date:** 2026-06-08
+**Branch:** `feat/participant-management`
+
+## Overview
+
+Rework `UpdateEventDetails.vue` into a full participant management page. Each participant appears as one expandable row (genres as sub-rows). Supports filtering by genre/name, editing names and team details, removing from individual genres, and deleting entirely from the event.
+
+---
+
+## 1. Page Layout
+
+### Filter Bar
+
+- **Search input** — filters by participant name / team name (client-side, case-insensitive)
+- **Genre chips** — one chip per genre in the event, each showing participant count badge. "All" chip always first and selected by default. Clicking a chip filters the table to that genre. Active chip visually highlighted. Chips wrap on mobile.
+- Search and genre filter combine with AND: "show participants whose name contains X AND who are in genre Y"
+
+### Participant Count
+
+Below filter bar: "Showing N of M participants"
+
+### Table
+
+One row per participant (grouped by `participantId`). Columns:
+
+| Column | Content |
+|--------|---------|
+| Expand toggle | ▸ / ▾ arrow; click to show/hide genre sub-rows |
+| Name | `participantName` for solo; `teamName` for team entries |
+| Format | Badge: `Solo`, `1v1`, `2v2`, `3v3`, `7 to Smoke` etc — derived from the participant's genre format |
+| Genres | Summary chips of all genres the participant is registered in |
+| Actions | `Edit` button + `Delete` button |
+
+**Expanded sub-rows** (one per genre):
+- Genre chip
+- Judge: current judge name or "—"
+- `Change Judge` button — opens judge select (existing dropdown pattern)
+- `Remove Genre` button — triggers confirm prompt
+
+---
+
+## 2. Edit Modal
+
+- Max-width: 480px, centered, responsive (full-width on mobile)
+- Triggered by clicking `Edit` on a participant row
+- Form adapts to participant type:
+
+### Solo / 1v1 / 7-to-Smoke
+
+Single field: **Name** (required)
+
+### Team (NvN format)
+
+- **Team Name** field (required)
+- **N member fields** — fixed count, no add/remove buttons. Count parsed from format string: `2v2 → 2`, `3v3 → 3`. All slots required.
+- Member names are informational — no uniqueness check on members.
+
+### Format detection
+
+If a participant is registered in multiple genres of mixed format (e.g., one solo genre + one 2v2 genre), team format takes precedence for the edit form. Slot count comes from the team format.
+
+### Validation (client-side before save)
+
+- Name / team name: non-empty, no duplicate in same event (excluding self)
+- All member slots: non-empty (count fixed by format)
+- On duplicate: show inline error, do not submit
+
+---
+
+## 3. Confirm Prompts
+
+All destructive actions require a confirm modal before executing.
+
+**Delete Participant:**
+> "Remove [Name] from [Event]? This will remove them from all genres ([Genre 1, Genre 2]) and release all audition numbers. This cannot be undone."
+
+**Remove Genre:**
+> "Remove [Name] from [Genre]? Their audition number will be released."
+
+**Edit save**: no confirm prompt — inline validation only.
+
+---
+
+## 4. Backend
+
+### New: DELETE participant from event
+
+```
+DELETE /api/v1/event/participant/{participantId}/{eventId}
+```
+
+Roles: `Admin`, `Organiser`
+
+**Cascade order (must execute in this order):**
+1. Delete `Score` rows where `participantId` and `eventId` match
+2. Delete `AuditionFeedback` rows for this participant in this event
+3. Delete `EventGenreParticipant` rows (releases audition numbers)
+4. Delete `EventParticipantTeamMember` rows (via `EventParticipant` FK)
+5. Delete `EventParticipant` row
+6. Delete `Participant` row **only if** no other `EventParticipant` references this `participantId`
+
+Returns: `200 OK` on success, `404` if not found.
+
+### New: PUT update participant
+
+```
+PUT /api/v1/event/participant/{participantId}/{eventId}
+```
+
+Roles: `Admin`, `Organiser`
+
+Request body:
+```json
+{
+  "name": "string",         // participant name (solo) or team name (team)
+  "memberNames": ["string"] // omit or empty for solo; required for team
+}
+```
+
+**Backend validation:**
+- `name` non-empty
+- No other `Participant` or `EventParticipant.teamName` with the same name in the same event (excluding self)
+- `memberNames` count must match format slot count for at least one of their genres
+
+**Updates:**
+- Solo: `Participant.participantName`
+- Team: `EventParticipant.teamName` + replace all `EventParticipantTeamMember` rows (delete old, insert new)
+
+Returns: `200 OK` on success, `409` on duplicate name, `422` on validation failure.
+
+### Existing: Remove genre (already exists)
+
+```
+DELETE /api/v1/event/participant-genre/{participantId}/{eventId}/{eventGenreId}
+```
+
+No changes needed.
+
+### Existing: Judge assignment (already exists)
+
+```
+POST /api/v1/event/participants-judge/
+```
+
+No changes needed — still used per genre sub-row.
+
+---
+
+## 5. Frontend
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `BES-frontend/src/views/UpdateEventDetails.vue` | Full rewrite |
+| `BES-frontend/src/components/ConfirmModal.vue` | New reusable confirm dialog |
+| `BES-frontend/src/utils/api.js` | Add `deleteParticipantFromEvent`, `updateParticipant` |
+
+### Data grouping
+
+The existing `GET /api/v1/event/participants/{eventName}` returns one row per participant-genre (`GetEventGenreParticipantDto`). Group by `participantId` on the frontend to build the table structure:
+
+```js
+// grouped shape
+{
+  participantId,
+  name,        // participantName or teamName
+  format,      // from first genre's format field
+  isTeam,      // true if any genre format is NvN
+  memberNames, // from first genre row (shared across genres)
+  genres: [
+    { genreName, genreId, eventGenreId, judgeName, auditionNumber }
+  ]
+}
+```
+
+### ConfirmModal.vue
+
+Reusable component:
+- Props: `show`, `title`, `message`, `confirmLabel` (default "Confirm"), `variant` (default "danger")
+- Emits: `confirm`, `cancel`
+- Used for: delete participant, remove genre
+
+### `api.js` additions
+
+```js
+deleteParticipantFromEvent(participantId, eventId)
+  → DELETE /api/v1/event/participant/{participantId}/{eventId}
+
+updateParticipant(participantId, eventId, { name, memberNames })
+  → PUT /api/v1/event/participant/{participantId}/{eventId}
+```
+
+---
+
+## 6. Out of Scope
+
+- Payment tracking (existing, untouched)
+- Participant verification / email (existing, untouched)
+- Add participant / walk-in (`CreateParticipantForm.vue` reused as-is)
+- Audition number assignment UI (untouched)


### PR DESCRIPTION
## Summary

- **Expandable participant table** in `/event/update-event-details` — each row expands to show genre entries, audition numbers, judge assignment, and team members
- **Inline edit modal** — rename participants/teams, update team member roster; syncs participant name, stage name, EGP display name and member records atomically via collection management (fixes orphan removal)
- **Two-level delete** — per-participant confirmation dialog removes the participant and all linked genre entries, scores, and feedback; bulk-select checkboxes with animated bulk-delete bar for multi-participant removal
- **Team member display fix** — leader name prepended to member list so check-in cards show `[leader, member2, ...]` consistently; member names moved above genre badges in EventDetails check-in view
- **Sheet-imported team detection** — edit now correctly identifies team entries by EGP format, not just EP teamName (which is unset for sheet imports)

## Test plan

- [ ] Import participants from Google Sheets (solo + team formats); confirm expandable rows show correct genre entries and member names
- [ ] Edit a solo participant name — verify participant table, check-in list, and scoreboard all update
- [ ] Edit a team name and member roster — verify team name, leader name, and all member records update across EP and EGP tables
- [ ] Delete a single participant — confirm confirmation modal appears and participant is removed
- [ ] Select multiple participants via checkboxes — confirm bulk-delete bar appears, bulk delete removes all selected
- [ ] Verify lint passes (`npm run lint`) and backend tests pass (`mvn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)