### PR TITLE
ui: EventDetails UX overhaul — categories, modals, session links, tab-bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ BES-frontend/nginx/certs/*.key
 # Temp / scratch files
 *_body.txt
 test_output.txt
-docs/superpowers/plans/
+docs/superpowers/brainstorm/

--- a/BES-frontend/src/assets/base.css
+++ b/BES-frontend/src/assets/base.css
@@ -238,12 +238,13 @@
     clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
   }
 
-  .badge-primary   { background: rgba(255,255,255,0.08); color: var(--accent-color); border: 1px solid var(--accent-muted); }
+  /* Display badges have NO border — border = interactive, no border = read-only label */
+  .badge-primary   { background: rgba(255,255,255,0.08); color: var(--accent-color); }
   .badge-secondary { @apply bg-accent-100 text-accent-500; }
-  .badge-success   { background: rgba(52,211,153,0.10); color: #34d399; border: 1px solid rgba(52,211,153,0.2); }
-  .badge-warning   { background: rgba(245,158,11,0.08); color: #f59e0b; border: 1px solid rgba(245,158,11,0.2); }
-  .badge-danger    { background: rgba(239,68,68,0.10);  color: #ef4444; border: 1px solid rgba(239,68,68,0.2); }
-  .badge-neutral   { background: rgba(255,255,255,0.10); color: rgba(255,255,255,0.80); border: 1px solid rgba(255,255,255,0.20); }
+  .badge-success   { background: rgba(52,211,153,0.12);  color: #34d399; }
+  .badge-warning   { background: rgba(245,158,11,0.10);  color: #f59e0b; }
+  .badge-danger    { background: rgba(239,68,68,0.12);   color: #ef4444; }
+  .badge-neutral   { background: rgba(255,255,255,0.09); color: rgba(255,255,255,0.75); }
 
   /* Icon wrapper */
   .icon-wrap { }
@@ -331,6 +332,46 @@
     opacity: 0.35;
     cursor: not-allowed;
   }
+
+  /* ── Tab bar navigation (context switcher, not action buttons) ── */
+  .tab-bar {
+    display: flex;
+    flex-wrap: wrap;
+    border-bottom: 1px solid rgba(255,255,255,0.07);
+  }
+  .tab-item {
+    position: relative;
+    padding: 8px 16px 10px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-family: 'Anton SC', sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.35);
+    transition: color 0.15s ease;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+  .tab-item:hover { color: rgba(255,255,255,0.70); }
+  .tab-item.is-active { color: var(--accent-color); }
+  .tab-item::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--accent-color);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  .tab-item.is-active::after { opacity: 1; }
 
   /* Filled accent buttons (bg-accent overrides bg, keep hover/active) */
   button.bg-accent:hover:not(:disabled) {
@@ -769,17 +810,17 @@ html.theme-transition *::after {
   --text-color-secondary: #404040;
 }
 
-/* Icon wrappers and badges — transparent background on light bg */
+/* Icon wrappers and badges — transparent background on light bg, no borders (display-only) */
 [data-theme="light"] .icon-wrap,
 [data-theme="light"] .badge-success,
 [data-theme="light"] .badge-warning,
 [data-theme="light"] .badge-danger,
-[data-theme="light"] .badge-neutral { background-color: transparent !important; }
+[data-theme="light"] .badge-neutral { background-color: transparent !important; border: none !important; }
 
 /* Semantic badge text — darker hues for readability on light bg */
-[data-theme="light"] .badge-success { color: #0f766e !important; border-color: rgba(13,148,136,0.3) !important; }
-[data-theme="light"] .badge-warning { color: #b45309 !important; border-color: rgba(180,83,9,0.3)   !important; }
-[data-theme="light"] .badge-danger  { color: #be123c !important; border-color: rgba(190,18,60,0.3)  !important; }
+[data-theme="light"] .badge-success { color: #0f766e !important; }
+[data-theme="light"] .badge-warning { color: #b45309 !important; }
+[data-theme="light"] .badge-danger  { color: #be123c !important; }
 
 /* Hardcoded semantic text colours — swap light pastels for dark readable hues on light bg */
 [data-theme="light"] .text-teal-300    { color: #0f766e !important; }
@@ -864,13 +905,18 @@ html.theme-transition *::after {
 [data-theme="light"] .section-rule-label { color: rgba(0, 0, 0, 0.35); }
 
 [data-theme="light"] .badge-neutral {
-  background: rgba(0, 0, 0, 0.04);
+  background: transparent;
   color: rgba(0, 0, 0, 0.55);
-  border-color: rgba(0, 0, 0, 0.08);
+  border: none;
 }
 
 [data-theme="light"] .scanlines { opacity: 0.5; }
 [data-theme="light"] .color-bleed { display: none; }
+
+/* Tab bar on light */
+[data-theme="light"] .tab-bar { border-bottom-color: rgba(0,0,0,0.10); }
+[data-theme="light"] .tab-item { color: rgba(0,0,0,0.35); }
+[data-theme="light"] .tab-item:hover { color: rgba(0,0,0,0.70); }
 
 [data-theme="light"] .corner-bar-tl,
 [data-theme="light"] .corner-bar-bl {

--- a/BES-frontend/src/components/CreateParticipantForm.vue
+++ b/BES-frontend/src/components/CreateParticipantForm.vue
@@ -177,14 +177,15 @@ onMounted(async () => {
 
 <template>
   <!-- Main walk-in form -->
-  <Transition
-    enter-active-class="transition duration-200 ease-out"
-    enter-from-class="opacity-0"
-    enter-to-class="opacity-100"
-    leave-active-class="transition duration-150 ease-in"
-    leave-from-class="opacity-100"
-    leave-to-class="opacity-0"
-  >
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
     <div
       v-if="props.show"
       class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
@@ -360,7 +361,8 @@ onMounted(async () => {
           </div>
         </div>
       </div>
-  </Transition>
+    </Transition>
+  </Teleport>
 
   <ActionDoneModal
     :show="showError"

--- a/BES-frontend/src/components/CreateParticipantForm.vue
+++ b/BES-frontend/src/components/CreateParticipantForm.vue
@@ -58,6 +58,15 @@ function updateMemberName(genre, index, value) {
   teamMemberNames[genre] = [...arr]
 }
 
+function toggleGenre(genreName) {
+  const idx = createTable.genres.indexOf(genreName)
+  if (idx >= 0) {
+    createTable.genres.splice(idx, 1)
+  } else {
+    createTable.genres.push(genreName)
+  }
+}
+
 watch(() => createTable.genres.slice(), (selected) => {
   for (const genreName of selected) {
     if (isTeamFormat(genreName)) {
@@ -167,145 +176,191 @@ onMounted(async () => {
 </script>
 
 <template>
-  <ActionDoneModal
-    :show="props.show"
-    :title="props.title"
-    variant="info"
-    acceptLabel="Add Participant"
-    :scrollable="true"
-    :disableAccept="!canSubmit"
-    @accept="submitNewEntry"
-    @close="$emit('close')"
+  <!-- Main walk-in form -->
+  <Transition
+    enter-active-class="transition duration-200 ease-out"
+    enter-from-class="opacity-0"
+    enter-to-class="opacity-100"
+    leave-active-class="transition duration-150 ease-in"
+    leave-from-class="opacity-100"
+    leave-to-class="opacity-0"
   >
-    <div class="space-y-4 mt-1">
-      <!-- Stage name field -->
-      <div>
-        <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1.5">
-          Stage Name
-        </label>
-        <input
-          v-model="name"
-          type="text"
-          placeholder="Enter stage name…"
-          class="input-base"
-          :class="formTouched && !name.trim() ? '!border-red-400/60' : ''"
-          @input="formTouched = true"
-          @keyup.enter="submitNewEntry"
-        />
-      </div>
+    <div
+      v-if="props.show"
+      class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+    >
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="$emit('close')" />
+      <div class="card-hover relative w-full sm:max-w-md flex flex-col" style="max-height: 85vh;">
+        <div class="corner-bar-tl"></div>
+        <div class="corner-bar-bl"></div>
 
-      <!-- Genre checkboxes -- grouped by parent genre -->
-      <div>
-        <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-2">
-          Genres
-        </label>
-        <div class="space-y-3">
-          <template v-for="group in groupedDivisions" :key="group.genreId">
-            <div class="type-label text-content-muted text-xs mb-1 mt-2 first:mt-0">{{ group.label }}</div>
-            <div class="grid grid-cols-1 gap-2">
-              <label
-                v-for="g in group.divisions"
-                :key="g.genreName"
-                class="flex items-center gap-2.5 px-3 py-2.5 rounded-xl border cursor-pointer transition-all"
-                :class="createTable.genres.includes(g.genreName)
-                  ? 'bg-primary-100 border-primary-400 text-primary-400'
-                  : 'bg-surface-800 border-surface-600 text-content-secondary hover:border-surface-500'"
-              >
-                <input
-                  type="checkbox"
-                  :value="g.genreName"
-                  v-model="createTable.genres"
-                  class="w-4 h-4 rounded accent-primary-600"
-                />
-                <span class="text-sm font-medium">{{ g.genreName }}</span>
-                <span
-                  v-if="g.format"
-                  class="ml-auto text-xs font-source opacity-50"
-                >{{ g.format }}</span>
-              </label>
+          <!-- Header -->
+          <div class="flex items-center justify-between px-4 py-3 border-b border-surface-600/30 shrink-0">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-user-plus text-content-muted text-xs"></i>
+              <span class="type-body text-content-primary">{{ props.title }}</span>
+              <span class="badge-neutral type-label">{{ props.event }}</span>
             </div>
-          </template>
-        </div>
-      </div>
-
-      <!-- Per-genre Team|Solo toggles -->
-      <div v-for="g in createTable.genres" :key="g">
-        <template v-if="isTeamFormat(g)">
-          <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-2">
-            {{ g }} Entry Type
-            <span class="ml-1 text-primary-400 normal-case font-normal font-source">{{ selectedFormat(g) }}</span>
-          </label>
-          <div class="flex rounded-xl border border-surface-600/60 overflow-hidden text-sm font-semibold mb-3">
             <button
-              type="button"
-              @click="entryModes[g] = 'team'"
-              class="flex-1 px-4 py-2 transition-all"
-              :class="entryModes[g] === 'team'
-                ? 'bg-primary-600 text-white'
-                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+              @click="$emit('close')"
+              class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors"
             >
-              Team entry
-            </button>
-            <button
-              v-if="isSoloAllowed(g)"
-              type="button"
-              @click="entryModes[g] = 'solo'"
-              class="flex-1 px-4 py-2 border-l border-surface-600/60 transition-all"
-              :class="entryModes[g] === 'solo'
-                ? 'bg-primary-600 text-white'
-                : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
-            >
-              Solo (pickup crew)
+              <i class="pi pi-times text-xs"></i>
             </button>
           </div>
-          <p v-if="entryModes[g] === 'solo'" class="text-xs text-content-muted mt-1.5 mb-2">
-            Auditions individually. Can be grouped into a crew after auditions.
-          </p>
-          <p v-if="!isSoloAllowed(g)" class="text-xs text-amber-400/80 mt-1.5 mb-2">
-            Solo entries not allowed for this division — team entry only.
-          </p>
 
-          <!-- Team name + members for this genre -->
-          <template v-if="entryModes[g] === 'team' && additionalMembersCountForGenre(g) > 0">
-            <div class="mb-2">
-              <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1.5">
-                {{ g }} Team Name
-                <span class="ml-1 text-primary-400 normal-case font-normal font-source">{{ selectedFormat(g) }}</span>
-              </label>
+          <!-- Body -->
+          <div class="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
+
+            <!-- Stage name -->
+            <div>
+              <label class="type-label text-content-muted mb-1.5 block">Stage Name</label>
               <input
-                v-model="teamNames[g]"
+                v-model="name"
                 type="text"
-                placeholder="Enter team name…"
+                placeholder="Enter stage name…"
                 class="input-base"
-                :class="formTouched && !(teamNames[g] || '').trim() ? '!border-red-400/60' : ''"
+                :class="formTouched && !name.trim() ? '!border-red-400/60' : ''"
                 @input="formTouched = true"
+                @keyup.enter="submitNewEntry"
               />
             </div>
+
+            <!-- Division chips -->
             <div>
-              <label class="block text-xs font-semibold text-surface-600 uppercase tracking-wider mb-1">
-                {{ g }} Team Members
-              </label>
-              <p class="text-xs text-surface-500 mb-2">
-                Stage name is Member 1 (representative). Enter the other {{ additionalMembersCountForGenre(g) }}.
-              </p>
-              <div class="space-y-2">
-                <input
-                  v-for="i in additionalMembersCountForGenre(g)"
-                  :key="i"
-                  :value="(teamMemberNames[g] || [])[i - 1] || ''"
-                  @input="updateMemberName(g, i - 1, $event.target.value); formTouched = true"
-                  type="text"
-                  :placeholder="`Member ${i + 1} stage name…`"
-                  class="input-base"
-                  :class="formTouched && !((teamMemberNames[g] || [])[i - 1] || '').trim() ? '!border-red-400/60' : ''"
-                />
+              <div class="flex items-center justify-between mb-2">
+                <label class="type-label text-content-muted">Divisions</label>
+                <span class="type-label text-content-muted">tap to select</span>
+              </div>
+              <div class="flex flex-wrap gap-1.5">
+                <template v-for="group in groupedDivisions" :key="group.genreId">
+                  <button
+                    v-for="g in group.divisions"
+                    :key="g.genreName"
+                    type="button"
+                    @click="toggleGenre(g.genreName)"
+                    class="para-chip-sm px-3 py-1.5 type-label transition-all flex items-center gap-1.5"
+                    :class="createTable.genres.includes(g.genreName)
+                      ? 'text-accent border-[color:var(--accent-muted)] bg-[var(--accent-subtle)]'
+                      : 'text-content-secondary hover:text-accent'"
+                  >
+                    <span
+                      class="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+                      :style="createTable.genres.includes(g.genreName)
+                        ? 'background:var(--accent-color);box-shadow:0 0 5px var(--accent-muted)'
+                        : 'background:rgba(255,255,255,0.2)'"
+                    ></span>
+                    {{ g.genreName }}
+                    <span v-if="g.format" class="opacity-40 normal-case">{{ g.format }}</span>
+                  </button>
+                </template>
               </div>
             </div>
-          </template>
-        </template>
+
+            <!-- Per-genre team details (inline expansion) -->
+            <template v-for="g in createTable.genres" :key="g">
+              <template v-if="isTeamFormat(g)">
+                <div class="section-rule">
+                  <span class="section-rule-label">{{ g }} · {{ selectedFormat(g) }}</span>
+                  <div class="section-rule-line"></div>
+                </div>
+
+                <!-- Solo not allowed warning -->
+                <div
+                  v-if="!isSoloAllowed(g)"
+                  class="flex items-center gap-2 px-3 py-2 para-chip"
+                  style="border-left: 3px solid rgb(251 191 36); background: rgba(251,191,36,0.07);"
+                >
+                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(251,191,36,0.6)"></span>
+                  <span class="type-label text-amber-400">Solo entries not allowed — team entry only.</span>
+                </div>
+
+                <!-- Team / Solo toggle -->
+                <div v-if="isSoloAllowed(g)">
+                  <label class="type-label text-content-muted mb-2 block">Entry Type</label>
+                  <div class="flex border border-surface-600/60 overflow-hidden">
+                    <button
+                      type="button"
+                      @click="entryModes[g] = 'team'"
+                      class="flex-1 px-4 py-2 type-label transition-all"
+                      :class="entryModes[g] === 'team'
+                        ? 'bg-[var(--accent-subtle)] text-accent'
+                        : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                    >
+                      Team
+                    </button>
+                    <button
+                      type="button"
+                      @click="entryModes[g] = 'solo'"
+                      class="flex-1 px-4 py-2 type-label transition-all border-l border-surface-600/60"
+                      :class="entryModes[g] === 'solo'
+                        ? 'bg-[var(--accent-subtle)] text-accent'
+                        : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                    >
+                      Solo
+                    </button>
+                  </div>
+                  <p v-if="entryModes[g] === 'solo'" class="type-label text-content-muted mt-1.5">
+                    Auditions individually. Can be grouped into a crew after auditions.
+                  </p>
+                </div>
+
+                <!-- Team name + members -->
+                <template v-if="entryModes[g] !== 'solo' && additionalMembersCountForGenre(g) > 0">
+                  <div>
+                    <label class="type-label text-content-muted mb-1.5 block">Team Name</label>
+                    <input
+                      v-model="teamNames[g]"
+                      type="text"
+                      placeholder="Enter team name…"
+                      class="input-base"
+                      :class="formTouched && !(teamNames[g] || '').trim() ? '!border-red-400/60' : ''"
+                      @input="formTouched = true"
+                    />
+                  </div>
+                  <div>
+                    <label class="type-label text-content-muted mb-1.5 block">Team Members</label>
+                    <p class="type-label text-content-muted mb-2 normal-case" style="font-size:0.65rem">
+                      {{ name || 'Stage name' }} is Member 1. Enter the other {{ additionalMembersCountForGenre(g) }}.
+                    </p>
+                    <div class="space-y-2">
+                      <input
+                        v-for="i in additionalMembersCountForGenre(g)"
+                        :key="i"
+                        :value="(teamMemberNames[g] || [])[i - 1] || ''"
+                        @input="updateMemberName(g, i - 1, $event.target.value); formTouched = true"
+                        type="text"
+                        :placeholder="`Member ${i + 1} stage name…`"
+                        class="input-base"
+                        :class="formTouched && !((teamMemberNames[g] || [])[i - 1] || '').trim() ? '!border-red-400/60' : ''"
+                      />
+                    </div>
+                  </div>
+                </template>
+              </template>
+            </template>
+
+          </div>
+
+          <!-- Footer -->
+          <div class="flex gap-2 justify-end px-4 py-3 border-t border-surface-600/30 shrink-0">
+            <button
+              @click="$emit('close')"
+              class="para-chip-sm px-4 py-2 type-label text-content-muted hover:text-content-primary transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              @click="submitNewEntry"
+              :disabled="!canSubmit"
+              class="para-chip-sm px-4 py-2 type-label transition-all disabled:opacity-40 disabled:cursor-not-allowed text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)]"
+            >
+              Add Participant
+            </button>
+          </div>
+        </div>
       </div>
-    </div>
-  </ActionDoneModal>
+  </Transition>
 
   <ActionDoneModal
     :show="showError"

--- a/BES-frontend/src/components/CreateParticipantForm.vue
+++ b/BES-frontend/src/components/CreateParticipantForm.vue
@@ -141,6 +141,7 @@ const submitNewEntry = async () => {
   createTable.genres = []
   Object.keys(entryModes).forEach(k => { delete entryModes[k]; delete teamNames[k]; delete teamMemberNames[k] })
   selectedJudge.value = ""
+  formTouched.value = false
   emit("createNewEntry")
   walkinResult.value = results
   if (results.failed.length > 0) {

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { fetchAllEvents } from '@/utils/api'
 import { setActiveEvent } from '@/utils/auth'
 
@@ -56,8 +57,11 @@ function handleTile(tile) {
   emit('close')
 }
 
-const allEvents    = ref([])
-const search       = ref('')
+const router = useRouter()
+const route  = useRoute()
+
+const allEvents = ref([])
+const search    = ref('')
 
 const filteredEvents = computed(() =>
   allEvents.value.filter(e =>
@@ -73,6 +77,9 @@ onMounted(async () => {
 function handleSwitchEvent(event) {
   setActiveEvent(event.id, event.name)
   emit('close')
+  if (route?.name === 'Event Details') {
+    router.push({ name: 'Event Details', params: { eventName: event.name } })
+  }
 }
 </script>
 

--- a/BES-frontend/src/components/ScoringCriteriaModal.vue
+++ b/BES-frontend/src/components/ScoringCriteriaModal.vue
@@ -178,9 +178,8 @@ const applyToAllGenres = async () => {
               :key="tab"
               @click="activeTab = tab"
               class="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label transition-all duration-150"
-              :class="activeTab === tab
-                ? 'bg-accent text-surface-900 border-accent'
-                : 'text-content-muted hover:text-content-primary'"
+              :class="activeTab === tab ? 'text-surface-900' : 'text-content-muted hover:text-content-primary'"
+              :style="activeTab === tab ? 'background:var(--accent-color);border-color:var(--accent-color)' : ''"
             >
               <i v-if="tab === 'event-level'" class="pi pi-globe text-[10px]" />
               {{ tab === 'event-level' ? 'Event Default' : tab }}

--- a/BES-frontend/src/components/ScoringCriteriaModal.vue
+++ b/BES-frontend/src/components/ScoringCriteriaModal.vue
@@ -111,6 +111,7 @@ const remove = async (id) => {
 
 // ── Apply to all genres ───────────────────────────────────────────────────────
 const applyingAll = ref(false)
+const appliedAll = ref(false)
 
 const applyToAllGenres = async () => {
   if (!activeCriteria.value.length) return
@@ -135,6 +136,8 @@ const applyToAllGenres = async () => {
   }))
 
   applyingAll.value = false
+  appliedAll.value = true
+  setTimeout(() => { appliedAll.value = false }, 1500)
 }
 </script>
 
@@ -331,18 +334,20 @@ const applyToAllGenres = async () => {
 
             <div class="flex-1" />
 
-            <!-- Apply to all genres (not shown on Event Default tab) -->
+            <!-- Copy to all genres (not shown on Event Default tab) -->
             <button
               v-if="activeTab !== 'event-level' && genres.length > 1"
               @click="applyToAllGenres"
               :disabled="applyingAll || activeCriteria.length === 0"
-              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent text-content-muted hover:text-accent
+              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent
                      disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
-              title="Copy these criteria to all other genres and Event Default"
+              :class="appliedAll ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
+              title="Replaces criteria in all other genres with these"
             >
               <i v-if="applyingAll" class="pi pi-spin pi-spinner text-xs" />
+              <i v-else-if="appliedAll" class="pi pi-check text-xs" />
               <i v-else class="pi pi-copy text-xs" />
-              Apply to all genres
+              {{ appliedAll ? 'Copied!' : 'Copy to all genres' }}
             </button>
           </div>
         </div>

--- a/BES-frontend/src/components/ScoringCriteriaModal.vue
+++ b/BES-frontend/src/components/ScoringCriteriaModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import { getScoringCriteriaStrict, addScoringCriteria, updateScoringCriteria, deleteScoringCriteria, deleteAllCriteriaForGenre } from '@/utils/api'
 
 const props = defineProps({
@@ -36,11 +36,14 @@ const loadAll = async () => {
 }
 
 watch(() => props.modelValue, (open) => {
+  document.body.style.overflow = open ? 'hidden' : ''
   if (open) {
     activeTab.value = props.genres[0] ?? 'event-level'
     loadAll()
   }
 }, { immediate: false })
+
+onUnmounted(() => { document.body.style.overflow = '' })
 
 // ── Add ───────────────────────────────────────────────────────────────────────
 const newName   = ref('')
@@ -146,33 +149,33 @@ const applyToAllGenres = async () => {
     <Transition name="modal-fade">
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-50 flex items-center justify-center p-4"
-        @click.self="close"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
       >
         <!-- Backdrop -->
         <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="close" />
 
         <!-- Panel -->
-        <div class="card-hover p-6 relative w-full max-w-xl flex flex-col max-h-[85vh]">
+        <div class="card-hover relative w-full sm:max-w-lg flex flex-col max-h-[85vh]">
           <div class="corner-bar-tl"></div>
           <div class="corner-bar-bl"></div>
 
           <!-- Header -->
-          <div class="flex items-center justify-between flex-shrink-0 mb-4">
-            <div>
-              <p class="type-page-title" style="font-size: 18px;">Scoring Criteria</p>
-              <p class="type-label text-content-muted mt-0.5">Define what judges score on. Leave empty for a single 0–10 score.</p>
+          <div class="flex items-center justify-between px-4 py-3 border-b border-surface-600/30 flex-shrink-0">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-sliders-h text-content-muted text-xs"></i>
+              <span class="type-body text-content-primary">Scoring Criteria</span>
+              <span class="badge-neutral type-label">{{ props.eventName }}</span>
             </div>
             <button
               @click="close"
-              class="p-1.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-colors"
+              class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors"
             >
-              <i class="pi pi-times text-sm" />
+              <i class="pi pi-times text-xs" />
             </button>
           </div>
 
           <!-- Genre tabs -->
-          <div class="flex gap-1 px-5 pt-4 pb-0 overflow-x-auto flex-shrink-0" style="scrollbar-width: none;">
+          <div class="flex gap-1 px-4 pt-3 pb-0 overflow-x-auto flex-shrink-0" style="scrollbar-width: none;">
             <button
               v-for="tab in allTabs"
               :key="tab"
@@ -192,17 +195,17 @@ const applyToAllGenres = async () => {
           </div>
 
           <!-- Tab description -->
-          <div class="px-5 pt-3 pb-0 flex-shrink-0">
-            <p v-if="activeTab === 'event-level'" class="text-xs text-content-muted italic">
-              These criteria apply to any genre that doesn't have its own specific criteria set.
+          <div class="px-4 pt-2 pb-0 flex-shrink-0">
+            <p v-if="activeTab === 'event-level'" class="type-label text-content-muted">
+              Applies to any genre without its own criteria.
             </p>
-            <p v-else class="text-xs text-content-muted italic">
-              Criteria specific to <span class="text-primary-400 font-semibold">{{ activeTab }}</span>. Overrides the Event Default.
+            <p v-else class="type-label text-content-muted">
+              Criteria for <span class="text-accent">{{ activeTab }}</span> — overrides event default.
             </p>
           </div>
 
           <!-- Criteria list (scrollable) -->
-          <div class="flex-1 overflow-y-auto px-5 py-4 space-y-2 min-h-0">
+          <div class="flex-1 overflow-y-auto px-4 py-3 space-y-2 min-h-0">
             <div v-if="loading" class="text-xs text-content-muted py-4 text-center">Loading…</div>
 
             <div
@@ -216,20 +219,22 @@ const applyToAllGenres = async () => {
               <div
                 v-for="c in activeCriteria"
                 :key="c.id"
-                class="card-hover p-3 relative"
+                class="para-chip px-3 py-2.5 transition-all duration-150"
+                :class="editingId === c.id
+                  ? 'border-[color:var(--accent-muted)] bg-[var(--accent-subtle)]'
+                  : 'border-surface-600/40'"
               >
                 <!-- View row -->
-                <div
-                  v-if="editingId !== c.id"
-                  class="flex items-center justify-between"
-                >
-                  <div class="flex items-center gap-2 flex-1 min-w-0">
-                    <span class="text-sm font-semibold text-content-primary truncate">{{ c.name }}</span>
-                    <span v-if="c.weight != null" class="badge-neutral type-label shrink-0">
-                      ×{{ c.weight }}
-                    </span>
-                  </div>
-                  <div class="flex items-center gap-1 ml-2 shrink-0">
+                <div v-if="editingId !== c.id" class="flex items-center gap-3">
+                  <span
+                    class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                    :style="c.weight != null
+                      ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
+                      : 'background:rgba(255,255,255,0.15)'"
+                  ></span>
+                  <span class="type-body text-content-primary flex-1 truncate">{{ c.name }}</span>
+                  <span v-if="c.weight != null" class="badge-neutral type-label shrink-0">×{{ c.weight }}</span>
+                  <div class="flex items-center gap-1 shrink-0">
                     <button
                       @click="startEdit(c)"
                       class="p-1.5 para-chip-sm type-label text-content-muted hover:text-accent transition-colors"
@@ -247,7 +252,7 @@ const applyToAllGenres = async () => {
                   </div>
                 </div>
 
-                <!-- Edit row -->
+                <!-- Edit row (inline expansion) -->
                 <div v-else class="space-y-2">
                   <div class="flex gap-2">
                     <input
@@ -285,7 +290,7 @@ const applyToAllGenres = async () => {
             </template>
 
             <!-- Add form -->
-            <div v-if="showAdd" class="card-hover p-3 space-y-2">
+            <div v-if="showAdd" class="para-chip px-3 py-3 space-y-2 border-surface-600/40">
               <div class="flex gap-2">
                 <input
                   v-model="newName"
@@ -321,11 +326,11 @@ const applyToAllGenres = async () => {
           </div>
 
           <!-- Footer actions -->
-          <div class="flex items-center gap-2 flex-shrink-0 pt-4 border-t border-[rgba(255,255,255,0.07)]">
+          <div class="flex items-center gap-2 flex-shrink-0 px-4 py-3 border-t border-surface-600/30">
             <button
               v-if="!showAdd"
               @click="showAdd = true"
-              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent text-content-muted hover:text-accent transition-all duration-150"
+              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label text-content-muted hover:text-accent transition-all duration-150"
             >
               <i class="pi pi-plus text-xs" />
               Add Criterion
@@ -333,13 +338,11 @@ const applyToAllGenres = async () => {
 
             <div class="flex-1" />
 
-            <!-- Copy to all genres (not shown on Event Default tab) -->
             <button
               v-if="activeTab !== 'event-level' && genres.length > 1"
               @click="applyToAllGenres"
               :disabled="applyingAll || activeCriteria.length === 0"
-              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent
-                     disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
+              class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
               :class="appliedAll ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
               title="Replaces criteria in all other genres with these"
             >

--- a/BES-frontend/src/components/ScoringCriteriaModal.vue
+++ b/BES-frontend/src/components/ScoringCriteriaModal.vue
@@ -206,11 +206,11 @@ const applyToAllGenres = async () => {
 
           <!-- Criteria list (scrollable) -->
           <div class="flex-1 overflow-y-auto px-4 py-3 space-y-2 min-h-0">
-            <div v-if="loading" class="text-xs text-content-muted py-4 text-center">Loading…</div>
+            <div v-if="loading" class="type-label text-content-muted py-4 text-center">Loading…</div>
 
             <div
               v-else-if="activeCriteria.length === 0 && !showAdd"
-              class="text-xs text-content-muted italic py-4 text-center"
+              class="type-label text-content-muted py-4 text-center"
             >
               No criteria — judges use a single 0–10 score.
             </div>

--- a/BES-frontend/src/utils/__tests__/CreateParticipantForm.test.js
+++ b/BES-frontend/src/utils/__tests__/CreateParticipantForm.test.js
@@ -19,19 +19,12 @@ import { addWalkinToSystem } from '@/utils/api'
 describe('CreateParticipantForm.vue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    document.body.innerHTML = ''
   })
 
-  it('renders stage name and genre fields', async () => {
+  it('renders stage name input and genre chips when open', async () => {
     const wrapper = mount(CreateParticipantForm, {
-      props: { show: true, event: 'TestEvent' },
-    })
-    await wrapper.vm.$nextTick()
-    const inputs = wrapper.findAll('input')
-    expect(inputs.length).toBeGreaterThan(0)
-  })
-
-  it('shows per-genre toggle for team-format genre', async () => {
-    const wrapper = mount(CreateParticipantForm, {
+      attachTo: document.body,
       props: {
         show: true,
         event: 'TestEvent',
@@ -42,68 +35,101 @@ describe('CreateParticipantForm.vue', () => {
       },
     })
     await wrapper.vm.$nextTick()
-
-    const poppingCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
-    await poppingCheckbox.setValue(true)
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.text()).toContain('Popping Entry Type')
-    expect(wrapper.text()).toContain('3v3')
-
-    const soloBtn = wrapper.findAll('button').filter(b => b.text().includes('Solo'))
-    expect(soloBtn.length).toBeGreaterThanOrEqual(1)
+    // Stage name input (teleported into document.body)
+    expect(document.body.querySelector('input[type="text"]')).not.toBeNull()
+    // Genre chips rendered as buttons (not checkboxes)
+    expect(document.body.querySelector('input[type="checkbox"]')).toBeNull()
+    const genreButtons = Array.from(document.body.querySelectorAll('button')).filter(b => b.textContent.includes('Popping'))
+    expect(genreButtons.length).toBeGreaterThan(0)
   })
 
-  it('submits walk-in with per-genre entry mode', async () => {
+  it('toggleGenre adds and removes genre from createTable.genres', async () => {
     const wrapper = mount(CreateParticipantForm, {
+      attachTo: document.body,
       props: {
         show: true,
         event: 'TestEvent',
-        eventGenres: [
-          { name: 'Popping', format: '3v3' },
-        ],
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
+      },
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.createTable.genres).toEqual([])
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.createTable.genres).toContain('Popping')
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.createTable.genres).not.toContain('Popping')
+  })
+
+  it('shows inline team section when a team-format genre chip is toggled on', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      attachTo: document.body,
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+
+    // Section rule label for the genre (teleported into document.body)
+    expect(document.body.textContent).toContain('Popping')
+    // Team/Solo toggle buttons appear
+    const teamBtn = Array.from(document.body.querySelectorAll('button')).filter(b => b.textContent.trim() === 'Team')
+    expect(teamBtn.length).toBeGreaterThan(0)
+  })
+
+  it('shows team name and member inputs when team mode active', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      attachTo: document.body,
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+
+    // entryModes defaults to 'team' for team-format genre
+    expect(wrapper.vm.entryModes['Popping']).toBe('team')
+    // Team name input and member inputs present (teleported into document.body)
+    const inputs = document.body.querySelectorAll('input[type="text"]')
+    // stage name + team name + 2 members = 4
+    expect(inputs.length).toBe(4)
+  })
+
+  it('submits walk-in with correct args (solo mode)', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      attachTo: document.body,
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
       },
     })
     await wrapper.vm.$nextTick()
 
     wrapper.vm.name = 'Dancer1'
-    const checkbox = wrapper.findAll('input[type="checkbox"]').at(0)
-    await checkbox.setValue(true)
+    wrapper.vm.toggleGenre('Popping')
     await wrapper.vm.$nextTick()
 
     wrapper.vm.entryModes['Popping'] = 'solo'
     await wrapper.vm.$nextTick()
 
-    const okBtns = wrapper.findAll('button').filter(b => b.text().includes('OK'))
-    if (okBtns.length > 0) {
-      await okBtns[0].trigger('click')
-    } else {
-      wrapper.vm.submitNewEntry()
-    }
+    wrapper.vm.submitNewEntry()
     await wrapper.vm.$nextTick()
 
     expect(addWalkinToSystem).toHaveBeenCalledWith(
       'Dancer1', 'TestEvent', 'Popping', '', [], '', 'solo'
     )
-  })
-
-  it('shows team name + member fields when team entry mode selected', async () => {
-    const wrapper = mount(CreateParticipantForm, {
-      props: {
-        show: true,
-        event: 'TestEvent',
-        eventGenres: [
-          { name: 'Popping', format: '3v3' },
-        ],
-      },
-    })
-    await wrapper.vm.$nextTick()
-
-    const checkbox = wrapper.findAll('input[type="checkbox"]').at(0)
-    await checkbox.setValue(true)
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.text()).toContain('Popping Team Name')
-    expect(wrapper.text()).toContain('Enter the other 2')
   })
 })

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -220,13 +220,13 @@ onMounted(async () => {
       </div>
 
       <!-- Section tabs -->
-      <div class="flex flex-wrap gap-2">
+      <div class="tab-bar mb-6">
         <button
           v-for="tab in tabs"
           :key="tab"
           @click="activeTab = tab"
-          class="para-chip-sm type-label px-3 py-1.5 transition-all duration-150"
-          :class="activeTab === tab ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
+          class="tab-item"
+          :class="{ 'is-active': activeTab === tab }"
         >{{ tab }}</button>
       </div>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1287,14 +1287,14 @@ onUnmounted(() => {
         <template v-if="unverifiedParticipants.length > 0">
           <div class="type-stat text-amber-400">{{ unverifiedParticipants.length }}</div>
           <div class="type-label text-amber-400">Pending Verification</div>
-          <div class="type-label text-content-muted mt-1">{{ totalVerified }} verified</div>
+          <div class="type-label text-content-muted mt-1">{{ totalVerified }} form sign-ups verified</div>
         </template>
         <template v-else>
           <div class="flex items-center gap-2 mb-1">
             <span class="inline-block w-2 h-2 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
             <div class="type-stat" style="font-size:28px;">All Verified</div>
           </div>
-          <div class="type-label text-content-muted">{{ totalVerified }} participants</div>
+          <div class="type-label text-content-muted">{{ totalVerified }} form sign-ups</div>
         </template>
       </div>
     </div>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1208,6 +1208,7 @@ const anyModalOpen = computed(() =>
   showModal.value ||
   showCriteriaModal.value ||
   showAdjustModal.value ||
+  showWalkInForm.value ||
   genreAddForm.show ||
   checkinConfirm.value.show ||
   confirmDialog.value.show

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1569,12 +1569,14 @@ onUnmounted(() => {
                   </template>
                 </select>
 
-                <!-- Alias toggle -->
+                <!-- Alias toggle — text link, shown after the remove button -->
                 <button
-                  @click="divAliasExpanded = divAliasExpanded === div.eventGenreId ? null : div.eventGenreId"
-                  class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label text-content-muted hover:text-accent transition-colors"
-                  title="Sheet aliases"
-                ><i class="pi pi-tags text-xs"></i></button>
+                  v-if="divAliasExpanded !== div.eventGenreId && !(div.sheetAliases && div.sheetAliases.split(',').filter(Boolean).length)"
+                  @click="divAliasExpanded = div.eventGenreId; divAliasInput = ''"
+                  class="type-label text-content-muted hover:text-accent transition-colors"
+                  style="font-size:9px;letter-spacing:0.1em;text-decoration:underline;text-underline-offset:2px;"
+                  title="Add a sheet alias manually if the category name doesn't match your sheet exactly"
+                >aliases</button>
 
                 <!-- Solo allowed toggle — only for team formats (XvX where X > 1) -->
                 <button

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1292,7 +1292,7 @@ onUnmounted(() => {
         <template v-else>
           <div class="flex items-center gap-2 mb-1">
             <span class="inline-block w-2 h-2 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
-            <div class="type-stat" style="font-size:28px;">All Verified</div>
+            <div class="type-stat" style="font-size:36px;">All Verified</div>
           </div>
           <div class="type-label text-content-muted">{{ totalVerified }} form sign-ups</div>
         </template>
@@ -1527,7 +1527,7 @@ onUnmounted(() => {
         <!-- Genre group header -->
         <div class="flex items-center gap-2">
           <span class="type-section-header text-content-secondary">{{ group.label }}</span>
-          <span class="badge-neutral type-label px-2 py-0.5 text-xs">{{ group.divisions.length }}</span>
+          <span class="badge-neutral type-label px-2 py-0.5 text-sm">{{ group.divisions.length }}</span>
         </div>
 
         <!-- Division rows -->
@@ -1550,7 +1550,7 @@ onUnmounted(() => {
                   <button
                     @click="divRenameActive = div.eventGenreId; divRenameInput = div.name"
                     class="type-body text-content-secondary hover:text-accent text-left min-w-0 transition-colors"
-                    style="overflow-wrap:break-word;word-break:break-word;font-size:13px;"
+                    style="overflow-wrap:break-word;word-break:break-word;font-size:16px;"
                     title="Click to rename"
                   >{{ div.name }}</button>
                   <!-- Match count dots -->
@@ -1627,13 +1627,13 @@ onUnmounted(() => {
     >
       <div class="flex items-center gap-2 mb-2">
         <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow: 0 0 6px rgba(251,191,36,0.6)"></span>
-        <span class="type-label text-amber-400 text-xs">Unmatched sheet values</span>
+        <span class="type-label text-amber-400 text-sm">Unmatched sheet values</span>
       </div>
       <div class="flex flex-wrap gap-1">
         <span
           v-for="val in unmatchedSheetValues"
           :key="val"
-          class="type-label text-content-muted bg-amber-950/30 px-1.5 py-0.5 para-chip text-xs normal-case"
+          class="type-label text-content-muted bg-amber-950/30 px-2 py-1 para-chip text-sm normal-case"
         >{{ val }}</span>
       </div>
     </div>
@@ -1654,7 +1654,7 @@ onUnmounted(() => {
         <span class="section-rule-label">Judge Pool</span>
         <div class="section-rule-line"></div>
       </div>
-      <p class="type-label text-content-muted mb-4" style="font-size:10px;text-transform:none;letter-spacing:0.03em;">
+      <p class="type-label text-content-muted mb-4" style="text-transform:none;letter-spacing:0.03em;">
         Add your judges here first — then assign them to categories below.
       </p>
 
@@ -1730,7 +1730,7 @@ onUnmounted(() => {
               type="text"
               placeholder="Judge name…"
               autocomplete="off"
-              class="bg-transparent type-body placeholder:text-content-muted focus:outline-none flex-1 min-w-0 text-xs"
+              class="bg-transparent type-body placeholder:text-content-muted focus:outline-none flex-1 min-w-0 text-sm"
               @keyup.enter="submitAddJudgeGlobal()"
             />
             <button
@@ -1739,7 +1739,7 @@ onUnmounted(() => {
               title="Add judge"
             ><i class="pi pi-plus text-xs"></i></button>
           </div>
-          <span v-if="allEventJudges.length === 0" class="type-label text-content-muted" style="font-size:9px;">No judges yet</span>
+          <span v-if="allEventJudges.length === 0" class="type-label text-content-muted" >No judges yet</span>
         </div>
       </div>
     </div>
@@ -1758,7 +1758,7 @@ onUnmounted(() => {
         {{ g.name }}
         <span
           v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name))"
-          class="ml-1.5 text-xs font-normal opacity-60"
+          class="ml-1.5 text-sm font-normal opacity-60"
         >{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).total }}</span>
       </button>
     </div>
@@ -1797,7 +1797,7 @@ onUnmounted(() => {
                   v-for="p in getUnregistered(normalizeGenreName(g.name)).unregistered"
                   :key="p.participantName"
                   class="para-chip-sm px-2 py-0.5 type-label text-amber-400"
-                  style="border-color:rgba(245,158,11,0.25);font-size:10px;"
+                  style="border-color:rgba(245,158,11,0.25);"
                 >{{ p.participantName }}</span>
               </div>
             </div>
@@ -1852,7 +1852,7 @@ onUnmounted(() => {
               class="flex items-center gap-1.5 para-chip px-2.5 py-1"
             >
               <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 5px rgba(52,211,153,0.5)"></span>
-              <span class="type-body text-content-secondary text-xs">{{ j.judgeName }}</span>
+              <span class="type-body text-content-secondary text-sm">{{ j.judgeName }}</span>
             </span>
           </div>
           <span v-else class="text-xs text-content-muted">None assigned — add in Judge Pool above</span>
@@ -1869,7 +1869,7 @@ onUnmounted(() => {
     <div class="section-rule mb-4">
       <span class="section-rule-label">Session Links</span>
       <div class="section-rule-line"></div>
-      <span class="type-label text-content-muted" style="font-size:9px;white-space:nowrap;">auto-generated · refresh to extend</span>
+      <span class="type-label text-content-muted" style="white-space:nowrap;">auto-generated · refresh to extend</span>
     </div>
 
     <div v-if="sessionTokensLoading" class="flex items-center gap-2 type-label text-content-muted py-4">
@@ -1882,13 +1882,13 @@ onUnmounted(() => {
         class="para-chip px-3 py-2 flex items-center gap-3"
       >
         <span
-          class="badge-neutral text-xs shrink-0"
+          class="badge-neutral text-sm shrink-0"
           :class="t.role === 'JUDGE' ? 'badge-accent' : 'badge-neutral'"
         >{{ t.role }}</span>
-        <span v-if="t.judgeName" class="type-body text-content-secondary text-xs truncate">{{ t.judgeName }}</span>
+        <span v-if="t.judgeName" class="type-body text-content-secondary text-sm truncate">{{ t.judgeName }}</span>
         <span class="flex-1"></span>
         <span
-          class="type-label text-xs shrink-0"
+          class="type-label text-sm shrink-0"
           :class="isExpiryWarning(t.expiresAt) ? 'text-amber-400' : 'text-content-muted'"
         >
           {{ formatExpiry(t.expiresAt) }}
@@ -1906,7 +1906,7 @@ onUnmounted(() => {
           title="Copy link"
         ><i class="pi text-xs" :class="copiedTokenId === t.tokenId ? 'pi-check' : 'pi-copy'"></i></button>
       </div>
-      <p class="type-label text-content-muted mt-3" style="font-size:9px;">Judge links are removed automatically when a judge is deleted.</p>
+      <p class="type-label text-content-muted mt-3" >Judge links are removed automatically when a judge is deleted.</p>
     </div>
   </div>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -599,6 +599,14 @@ const allSheetSuggestions = computed(() => {
   return [...new Set(sheetCategories.value)]
 })
 
+// True when any category has more sheet matches than imported participants
+const hasUnimportedParticipants = computed(() => {
+  if (!sheetCategories.value.length) return false
+  return eventGenres.value.some(div =>
+    (matchCounts.value[div.eventGenreId] || 0) > div.participantCount
+  ) || unmatchedSheetValues.value.length > 0
+})
+
 const suggestionCoveredSet = computed(() => {
   const covered = new Set()
   for (const div of eventGenres.value) {
@@ -1227,9 +1235,17 @@ onUnmounted(() => {
           v-if="!isHelper"
           @click="refreshParticipant"
           :disabled="loading"
-          class="flex items-center gap-2 px-4 py-2 bg-accent para-chip type-label disabled:opacity-50 disabled:cursor-not-allowed"
+          class="flex items-center gap-2 px-4 py-2 para-chip type-label disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+          :class="hasUnimportedParticipants && !loading
+            ? 'border-amber-500/60 text-amber-400'
+            : 'bg-accent'"
         >
-          <i class="pi text-sm" :class="loading ? 'pi-spinner pi-spin' : 'pi-cloud-download'"></i>
+          <span
+            v-if="hasUnimportedParticipants && !loading"
+            class="inline-block w-2 h-2 rounded-full bg-amber-400 shrink-0"
+            style="box-shadow:0 0 6px rgba(245,158,11,0.7)"
+          ></span>
+          <i v-else class="pi text-sm" :class="loading ? 'pi-spinner pi-spin' : 'pi-cloud-download'"></i>
           {{ loading ? 'Importing…' : 'Import from Sheets' }}
         </button>
       </div>
@@ -1272,16 +1288,7 @@ onUnmounted(() => {
     <template v-if="activeTab === 'setup'">
 
     <!-- Stat strip -->
-    <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">
-      <div class="stat-card relative">
-        <div class="corner-bar-tl"></div>
-        <div class="type-stat">{{ totalVerified + totalWalkIn }}</div>
-        <div class="type-label">Total</div>
-        <div class="flex gap-3 mt-1">
-          <span class="type-label text-content-muted">Form: {{ totalVerified }}</span>
-          <span class="type-label text-content-muted">Walk-in: {{ totalWalkIn }}</span>
-        </div>
-      </div>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6" style="max-width:360px;">
       <div class="stat-card relative">
         <div class="corner-bar-tl"></div>
         <template v-if="unverifiedParticipants.length > 0">

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1284,9 +1284,18 @@ onUnmounted(() => {
       </div>
       <div class="stat-card relative">
         <div class="corner-bar-tl"></div>
-        <div class="type-stat" :class="unverifiedParticipants.length > 0 ? 'text-red-400' : ''">{{ unverifiedParticipants.length }}</div>
-        <div class="type-label">Pending Verification</div>
-        <div class="type-label text-content-muted mt-1">{{ totalVerified }} verified</div>
+        <template v-if="unverifiedParticipants.length > 0">
+          <div class="type-stat text-amber-400">{{ unverifiedParticipants.length }}</div>
+          <div class="type-label text-amber-400">Pending Verification</div>
+          <div class="type-label text-content-muted mt-1">{{ totalVerified }} verified</div>
+        </template>
+        <template v-else>
+          <div class="flex items-center gap-2 mb-1">
+            <span class="inline-block w-2 h-2 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
+            <div class="type-stat" style="font-size:28px;">All Verified</div>
+          </div>
+          <div class="type-label text-content-muted">{{ totalVerified }} participants</div>
+        </template>
       </div>
     </div>
 
@@ -1545,7 +1554,7 @@ onUnmounted(() => {
                 <template v-if="divRenameActive !== div.eventGenreId">
                   <button
                     @click="divRenameActive = div.eventGenreId; divRenameInput = div.name"
-                    class="type-body text-content-secondary hover:text-accent text-left break-words min-w-0 flex-1 transition-colors"
+                    class="type-body text-content-secondary hover:text-accent text-left break-words min-w-0 flex-1 transition-colors text-sm sm:text-xs"
                     style="overflow-wrap:break-word;word-break:break-word"
                   >{{ div.name }}</button>
                 </template>
@@ -1598,14 +1607,6 @@ onUnmounted(() => {
                   </template>
                 </select>
 
-                <!-- Alias toggle — text link, shown after the remove button -->
-                <button
-                  v-if="divAliasExpanded !== div.eventGenreId && !(div.sheetAliases && div.sheetAliases.split(',').filter(Boolean).length)"
-                  @click="divAliasExpanded = div.eventGenreId; divAliasInput = ''"
-                  class="type-label text-content-muted hover:text-accent transition-colors"
-                  style="font-size:9px;letter-spacing:0.1em;text-decoration:underline;text-underline-offset:2px;"
-                  title="Add a sheet alias manually if the category name doesn't match your sheet exactly"
-                >aliases</button>
 
                 <!-- Solo allowed toggle — only for team formats (XvX where X > 1) -->
                 <button
@@ -1625,29 +1626,6 @@ onUnmounted(() => {
               </div>
             </div>
 
-            <!-- Alias chips (always visible if exist) -->
-            <div v-if="div.sheetAliases && div.sheetAliases.split(',').map(s => s.trim()).filter(Boolean).length" class="flex flex-wrap gap-1">
-              <span
-                v-for="alias in div.sheetAliases.split(',').map(s => s.trim()).filter(Boolean)"
-                :key="alias"
-                class="type-label text-content-muted bg-surface-600/30 px-1.5 py-0.5 para-chip text-xs normal-case flex items-center gap-1"
-              >
-                {{ alias }}
-                <button @click="removeAlias(div, alias)" class="text-content-muted hover:text-red-400 leading-none"><i class="pi pi-times" style="font-size:0.5rem"></i></button>
-              </span>
-            </div>
-
-            <!-- Add alias input row -->
-            <div v-if="divAliasExpanded === div.eventGenreId" class="flex gap-1.5 items-center">
-              <input
-                v-model="divAliasInput"
-                type="text"
-                placeholder="Add alias…"
-                class="input-base flex-1"
-                @keyup.enter="addAlias(div)"
-              />
-              <button @click="addAlias(div)" class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label text-accent"><i class="pi pi-plus text-xs"></i></button>
-            </div>
           </div>
         </div>
 
@@ -1718,7 +1696,7 @@ onUnmounted(() => {
                   ? 'box-shadow:0 0 5px rgba(245,158,11,0.5)'
                   : 'box-shadow:0 0 5px rgba(52,211,153,0.5)'"
               ></span>
-              <span class="type-body text-content-secondary text-xs">{{ j.judgeName }}</span>
+              <span class="type-body text-content-secondary text-sm sm:text-xs">{{ j.judgeName }}</span>
             </div>
             <button
               @click="askRemoveJudgeGlobal(j)"
@@ -1729,7 +1707,7 @@ onUnmounted(() => {
 
           <!-- Assigned categories -->
           <div>
-            <p class="type-label text-content-muted mb-1" style="font-size:9px;">CATEGORIES</p>
+            <p class="type-label text-content-muted mb-1">CATEGORIES</p>
             <div v-if="categoriesAssignedToJudge(j.judgeId).length > 0" class="flex flex-wrap gap-1 mb-1.5">
               <span
                 v-for="cat in categoriesAssignedToJudge(j.judgeId)"
@@ -1818,16 +1796,23 @@ onUnmounted(() => {
         <template v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name))">
           <div>
             <div class="section-rule mb-3">
-              <span class="section-rule-label" style="font-size:9px;">Roster Status</span>
+              <span class="section-rule-label">Roster Status</span>
               <div class="section-rule-line"></div>
             </div>
             <div class="flex items-center gap-2 flex-wrap">
-              <span class="badge-neutral text-xs">{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).total }} total</span>
-              <span class="badge-success">{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).registered }} registered</span>
+              <span class="para-chip-sm px-2.5 py-1 type-label text-content-secondary">{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).total }} total</span>
+              <span class="para-chip-sm px-2.5 py-1 type-label" style="border-color:rgba(52,211,153,0.35);color:#34d399;">
+                <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 mr-1.5 shrink-0" style="box-shadow:0 0 5px rgba(52,211,153,0.5)"></span>
+                {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).registered }} registered
+              </span>
               <span
                 v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered > 0"
-                class="badge-danger"
-              >{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered }} unregistered</span>
+                class="para-chip-sm px-2.5 py-1 type-label"
+                style="border-color:rgba(245,158,11,0.35);color:#f59e0b;"
+              >
+                <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 mr-1.5 shrink-0" style="box-shadow:0 0 5px rgba(245,158,11,0.5)"></span>
+                {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered }} unregistered
+              </span>
             </div>
 
             <!-- Unregistered list -->
@@ -1836,7 +1821,8 @@ onUnmounted(() => {
                 <span
                   v-for="p in getUnregistered(normalizeGenreName(g.name)).unregistered"
                   :key="p.participantName"
-                  class="badge-danger font-source"
+                  class="para-chip-sm px-2 py-0.5 type-label text-amber-400"
+                  style="border-color:rgba(245,158,11,0.25);font-size:10px;"
                 >{{ p.participantName }}</span>
               </div>
             </div>
@@ -1852,7 +1838,7 @@ onUnmounted(() => {
         <div>
           <div class="flex items-center gap-2 mb-2">
             <div class="section-rule mb-0 flex-1">
-              <span class="section-rule-label" style="font-size:9px;">Scoring Criteria</span>
+              <span class="section-rule-label">Scoring Criteria</span>
               <div class="section-rule-line"></div>
             </div>
             <button
@@ -1880,9 +1866,9 @@ onUnmounted(() => {
         <!-- JUDGES (read-only) -->
         <div>
           <div class="section-rule mb-2">
-            <span class="section-rule-label" style="font-size:9px;">Judges</span>
+            <span class="section-rule-label">Judges</span>
             <div class="section-rule-line"></div>
-            <span class="type-label text-content-muted" style="font-size:9px;white-space:nowrap;">manage in judge pool above</span>
+            <span class="type-label text-content-muted" style="white-space:nowrap;">manage in judge pool above</span>
           </div>
           <div v-if="(divisionJudges[g.name] || []).length > 0" class="flex flex-wrap gap-2">
             <span

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -846,14 +846,27 @@ const loadSessionTokens = async () => {
   if (!dbEventId.value) return
   sessionTokensLoading.value = true
   sessionTokens.value = await getSessionTokens(dbEventId.value)
+
   // Auto-generate permanent roles if missing
   const hasEmcee = sessionTokens.value.some(t => t.role === 'EMCEE')
   const hasHelper = sessionTokens.value.some(t => t.role === 'HELPER')
   if (!hasEmcee) await generateToken('EMCEE', dbEventId.value, null)
   if (!hasHelper) await generateToken('HELPER', dbEventId.value, null)
-  if (!hasEmcee || !hasHelper) {
-    sessionTokens.value = await getSessionTokens(dbEventId.value)
+
+  // Auto-repair JUDGE tokens: revoke orphans (no judgeId), create for any judge missing a valid token
+  const judgesWithValidToken = new Set(
+    sessionTokens.value.filter(t => t.role === 'JUDGE' && t.judgeId).map(t => t.judgeId)
+  )
+  const orphanTokens = sessionTokens.value.filter(t => t.role === 'JUDGE' && !t.judgeId)
+  const judgesNeedingTokens = allEventJudges.value.filter(j => !judgesWithValidToken.has(j.judgeId))
+  if (orphanTokens.length > 0 || judgesNeedingTokens.length > 0) {
+    await Promise.all(orphanTokens.map(t => revokeSessionToken(t.tokenId)))
+    await Promise.all(judgesNeedingTokens.map(j => generateToken('JUDGE', dbEventId.value, j.judgeId)))
   }
+
+  const needsRefresh = !hasEmcee || !hasHelper || orphanTokens.length > 0 || judgesNeedingTokens.length > 0
+  if (needsRefresh) sessionTokens.value = await getSessionTokens(dbEventId.value)
+
   sessionTokensLoading.value = false
 }
 
@@ -1191,7 +1204,18 @@ onMounted(async () => {
   }
 })
 
+const anyModalOpen = computed(() =>
+  showModal.value ||
+  showCriteriaModal.value ||
+  showAdjustModal.value ||
+  genreAddForm.show ||
+  checkinConfirm.value.show ||
+  confirmDialog.value.show
+)
+watch(anyModalOpen, (open) => { document.body.style.overflow = open ? 'hidden' : '' })
+
 onUnmounted(() => {
+  document.body.style.overflow = ''
   if (refreshInterval) clearInterval(refreshInterval)
   if (wsClient) deactivateClient(wsClient)
 })
@@ -1252,34 +1276,30 @@ onUnmounted(() => {
     </div>
 
     <!-- Tab toggle -->
-    <div class="flex gap-2 mb-6">
+    <div class="tab-bar mb-6">
       <button
         v-if="!isHelper"
         @click="activeTab = 'setup'"
-        class="para-chip-sm px-5 py-2 type-label transition-all duration-150"
-        :class="activeTab === 'setup'
-          ? 'text-accent border-accent'
-          : 'text-content-muted hover:text-content-primary'"
+        class="tab-item"
+        :class="{ 'is-active': activeTab === 'setup' }"
       >
-        <i class="pi pi-cog text-xs mr-1.5"></i>
+        <i class="pi pi-cog text-xs"></i>
         Setup
       </button>
       <button
         @click="activeTab = 'event-day'"
-        class="para-chip-sm px-5 py-2 type-label transition-all duration-150"
-        :class="activeTab === 'event-day'
-          ? 'text-accent border-accent'
-          : 'text-content-muted hover:text-content-primary'"
+        class="tab-item"
+        :class="{ 'is-active': activeTab === 'event-day' }"
       >
-        <i class="pi pi-calendar text-xs mr-1.5"></i>
+        <i class="pi pi-calendar text-xs"></i>
         Event Day
         <span
           v-if="totalNotShownUp > 0"
-          class="ml-1.5 inline-flex items-center justify-center badge-warning px-1.5 py-0.5 text-[10px]"
+          class="inline-flex items-center justify-center badge-warning px-1.5 py-0.5 text-[10px]"
         >{{ totalNotShownUp }}</span>
         <span
           v-else-if="unverifiedParticipants.length > 0 && activeTab !== 'event-day'"
-          class="ml-1.5 inline-flex items-center justify-center badge-danger px-1.5 py-0.5 text-[10px]"
+          class="inline-flex items-center justify-center badge-danger px-1.5 py-0.5 text-[10px]"
         >{{ unverifiedParticipants.length }}</span>
       </button>
     </div>
@@ -1492,12 +1512,13 @@ onUnmounted(() => {
     </p>
 
     <!-- Sheet suggestions strip — only when sheet is connected -->
-    <div v-if="allSheetSuggestions.length > 0" class="mb-4 p-3 para-chip">
+    <div v-if="allSheetSuggestions.length > 0" class="mb-4 p-3 border border-white/7">
       <p class="type-label text-content-muted mb-3">FROM YOUR SHEET — click to add as a category</p>
       <div class="flex flex-wrap gap-2">
         <span
           v-for="cat in allSheetSuggestions"
           :key="cat"
+          class="relative"
         >
           <!-- Covered: visible but muted with strikethrough -->
           <span
@@ -1505,26 +1526,26 @@ onUnmounted(() => {
             class="para-chip-sm px-3 py-1 type-label text-content-muted opacity-40 line-through"
           >{{ cat }}</span>
           <!-- Uncovered: clearly clickable button -->
-          <span v-else class="relative">
+          <button
+            v-else
+            @click="pendingSuggestionCat = pendingSuggestionCat === cat ? null : cat"
+            class="para-chip-sm px-3 py-1.5 type-label text-content-secondary hover:text-accent transition-colors"
+            style="border-style:dashed;"
+          >+ {{ cat }}</button>
+          <!-- Inline genre picker — rendered outside clip-path ancestor -->
+          <div
+            v-if="pendingSuggestionCat === cat"
+            class="absolute top-full left-0 mt-1 z-50 min-w-[160px]"
+            style="background:var(--color-surface-800,#1a1a1a);border:1px solid rgba(255,255,255,0.12);"
+          >
+            <p class="type-label text-content-muted px-3 pt-2 pb-1">ADD TO GENRE:</p>
             <button
-              @click="pendingSuggestionCat = pendingSuggestionCat === cat ? null : cat"
-              class="para-chip-sm px-3 py-1.5 type-label text-content-secondary hover:text-accent transition-colors"
-              style="border-style:dashed;"
-            >+ {{ cat }}</button>
-            <!-- Inline genre picker -->
-            <div
-              v-if="pendingSuggestionCat === cat"
-              class="absolute top-full left-0 mt-1 z-50 bg-surface-800 border border-surface-600 para-chip p-2 min-w-[160px]"
-            >
-              <p class="type-label text-content-muted mb-1.5">ADD TO GENRE:</p>
-              <button
-                v-for="group in divisionsByGenre"
-                :key="group.genreId"
-                @click="addSuggestionToGenre(group.genreId, group.label)"
-                class="block w-full text-left px-2 py-2 type-body text-content-secondary hover:text-accent transition-colors"
-              >{{ group.label }}</button>
-            </div>
-          </span>
+              v-for="group in divisionsByGenre"
+              :key="group.genreId"
+              @click="addSuggestionToGenre(group.genreId, group.label)"
+              class="block w-full text-left px-3 py-2 type-body text-content-secondary hover:text-accent transition-colors"
+            >{{ group.label }}</button>
+          </div>
         </span>
       </div>
     </div>
@@ -1537,10 +1558,11 @@ onUnmounted(() => {
           <span class="badge-neutral type-label px-2 py-0.5 text-sm">{{ group.divisions.length }}</span>
         </div>
 
-        <!-- Division rows -->
+        <!-- Division cards — 2-col on sm+, full-width on phone -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <div v-for="div in group.divisions" :key="div.eventGenreId">
           <div
-            class="para-chip px-3 py-2.5"
+            class="para-chip p-3 h-full flex flex-col gap-2"
             :class="sheetCategories.length > 0
               ? (matchCounts[div.eventGenreId] || 0) > 0
                 ? (div.participantCount >= (matchCounts[div.eventGenreId] || 0)
@@ -1549,52 +1571,42 @@ onUnmounted(() => {
                 : 'border-l-[3px] border-l-amber-500'
               : div.participantCount > 0 ? 'border-l-[3px] border-l-emerald-500' : ''"
           >
-            <!-- Single inline row: name+counts left, controls right -->
-            <div class="flex items-center gap-2">
-              <!-- Left: name + counts -->
-              <div class="flex items-center gap-2 flex-1 min-w-0">
-                <template v-if="divRenameActive !== div.eventGenreId">
-                  <button
-                    @click="divRenameActive = div.eventGenreId; divRenameInput = div.name"
-                    class="type-body text-content-secondary hover:text-accent text-left min-w-0 transition-colors"
-                    style="overflow-wrap:break-word;word-break:break-word;font-size:16px;"
-                    title="Click to rename"
-                  >{{ div.name }}</button>
-                  <!-- Match count dots -->
-                  <div class="flex items-center gap-2 shrink-0">
-                    <div v-if="div.participantCount > 0" class="flex items-center gap-1 text-emerald-400">
-                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
-                      <span class="type-label">{{ div.participantCount }}</span>
-                    </div>
-                    <div v-if="sheetCategories.length > 0 && ((matchCounts[div.eventGenreId] || 0) - div.participantCount) > 0" class="flex items-center gap-1 text-amber-400">
-                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
-                      <span class="type-label">{{ (matchCounts[div.eventGenreId] || 0) - div.participantCount }}</span>
-                    </div>
-                    <div v-if="sheetCategories.length > 0 && (matchCounts[div.eventGenreId] || 0) === 0 && div.participantCount === 0" class="flex items-center gap-1 text-amber-400">
-                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
-                      <span class="type-label">0</span>
-                    </div>
-                  </div>
-                </template>
-                <template v-else>
-                  <input
-                    v-model="divRenameInput"
-                    type="text"
-                    class="input-base flex-1 min-w-0"
-                    placeholder="Category name"
-                    @keyup.enter="saveDivisionName(div)"
-                    @keyup.escape="divRenameActive = null"
-                    @blur="saveDivisionName(div)"
-                  />
-                </template>
+            <!-- Display mode -->
+            <template v-if="divRenameActive !== div.eventGenreId">
+              <!-- Row 1: name (left) + delete × (top-right, like judge card) -->
+              <div class="flex items-start justify-between gap-2">
+                <button
+                  @click="divRenameActive = div.eventGenreId; divRenameInput = div.name"
+                  class="type-body text-content-secondary hover:text-accent text-left flex-1 min-w-0 leading-snug transition-colors"
+                  title="Click to rename"
+                >{{ div.name }}</button>
+                <button
+                  @click="askRemoveDivision(div)"
+                  class="type-label text-content-muted hover:text-red-400 transition-colors shrink-0 mt-0.5"
+                  title="Remove category"
+                ><i class="pi pi-times text-xs"></i></button>
               </div>
-
-              <!-- Right: format + solo + remove (never wraps) -->
-              <div class="flex items-center gap-1.5 shrink-0">
+              <!-- Row 2: count dots -->
+              <div class="flex items-center gap-2">
+                <div v-if="div.participantCount > 0" class="flex items-center gap-1 text-emerald-400">
+                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
+                  <span class="type-label">{{ div.participantCount }}</span>
+                </div>
+                <div v-if="sheetCategories.length > 0 && ((matchCounts[div.eventGenreId] || 0) - div.participantCount) > 0" class="flex items-center gap-1 text-amber-400">
+                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
+                  <span class="type-label">{{ (matchCounts[div.eventGenreId] || 0) - div.participantCount }}</span>
+                </div>
+                <div v-if="sheetCategories.length > 0 && (matchCounts[div.eventGenreId] || 0) === 0 && div.participantCount === 0" class="flex items-center gap-1 text-amber-400">
+                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
+                  <span class="type-label">0</span>
+                </div>
+              </div>
+              <!-- Row 3: format select + solo toggle -->
+              <div class="flex items-center gap-1.5 mt-auto">
                 <select
                   :value="div.format || ''"
                   @change="saveDivisionFormat(div, $event.target.value)"
-                  class="text-xs px-2 py-1 para-chip-sm bg-transparent text-content-secondary"
+                  class="text-xs px-2 py-1 para-chip-sm bg-transparent text-content-secondary flex-1 min-w-0"
                 >
                   <option value="">No format</option>
                   <template v-for="opt in divFormatOptions" :key="opt">
@@ -1605,19 +1617,38 @@ onUnmounted(() => {
                   v-if="div.format && /^\d+v\d+$/i.test(div.format) && div.format.toLowerCase() !== '1v1'"
                   @click="askToggleSolo(div)"
                   :class="div.soloAllowed ? 'text-content-muted hover:text-amber-400' : 'text-amber-400 hover:text-content-muted'"
-                  class="para-chip-sm px-2 py-1 type-label transition-colors"
+                  class="para-chip-sm px-2 py-1 type-label transition-colors shrink-0"
                   :title="div.soloAllowed ? 'Solo entries allowed' : 'Solo entries blocked'"
                 >{{ div.soloAllowed ? 'SOLO OK' : 'NO SOLO' }}</button>
-                <button
-                  @click="askRemoveDivision(div)"
-                  class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-red-400 transition-colors"
-                  title="Remove category"
-                ><i class="pi pi-times text-xs"></i></button>
               </div>
-            </div>
+            </template>
+
+            <!-- Edit / rename mode -->
+            <template v-else>
+              <input
+                v-model="divRenameInput"
+                type="text"
+                class="input-base w-full"
+                placeholder="Category name"
+                autofocus
+                @keyup.enter="saveDivisionName(div)"
+                @keyup.escape="divRenameActive = null"
+              />
+              <div class="flex items-center gap-2">
+                <button
+                  @click="saveDivisionName(div)"
+                  class="para-chip-sm px-2.5 py-1.5 type-label text-emerald-400 hover:text-emerald-300 transition-colors flex-1 flex items-center justify-center gap-1"
+                ><i class="pi pi-check text-sm"></i> Save</button>
+                <button
+                  @click="divRenameActive = null"
+                  class="para-chip-sm px-2.5 py-1.5 type-label text-content-muted hover:text-content-primary transition-colors flex-1 flex items-center justify-center gap-1"
+                ><i class="pi pi-times text-sm"></i> Cancel</button>
+              </div>
+            </template>
 
           </div>
         </div>
+        </div><!-- end grid -->
 
         <!-- Add division to group -->
         <button
@@ -1702,13 +1733,13 @@ onUnmounted(() => {
               <span
                 v-for="cat in categoriesAssignedToJudge(j.judgeId)"
                 :key="cat.eventGenreId"
-                class="inline-flex items-center gap-1.5 para-chip-sm px-2 py-1 type-label text-content-muted"
+                class="inline-flex items-center gap-2 para-chip-sm px-2.5 py-1.5 type-body text-content-secondary"
               >
                 {{ cat.name }}
                 <button
                   @click="submitRemoveJudge(cat.eventGenreId, j.judgeId)"
                   class="hover:text-red-400 transition-colors leading-none"
-                ><i class="pi pi-times text-xs"></i></button>
+                ><i class="pi pi-times text-sm"></i></button>
               </span>
             </div>
             <p v-else class="type-label text-amber-400 mb-1.5">No categories assigned yet</p>
@@ -1718,7 +1749,7 @@ onUnmounted(() => {
           <select
             v-if="categoriesUnassignedToJudge(j.judgeId).length > 0"
             @change="submitAssignJudge(Number($event.target.value), j.judgeId); $event.target.value = ''"
-            class="w-full px-3 py-2 type-label text-accent bg-surface-800 border border-[color:var(--accent-muted)] para-chip-sm"
+            class="w-full px-3 py-2.5 type-body text-accent bg-surface-800 border border-[color:var(--accent-muted)] para-chip-sm"
           >
             <option value="" disabled selected>+ Assign category</option>
             <option
@@ -1752,20 +1783,18 @@ onUnmounted(() => {
     </div>
 
     <!-- Genre tab bar -->
-    <div class="flex flex-wrap gap-2 mb-4">
+    <div class="tab-bar mb-4">
       <button
         v-for="g in eventGenres"
         :key="g.name"
         @click="activeGenreTab = g.name"
-        class="para-chip-sm px-4 py-2 type-label transition-all duration-150"
-        :class="activeGenreTab === g.name
-          ? 'text-accent border-accent'
-          : 'text-content-muted hover:text-content-primary'"
+        class="tab-item"
+        :class="{ 'is-active': activeGenreTab === g.name }"
       >
         {{ g.name }}
         <span
           v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name))"
-          class="ml-1.5 text-sm font-normal opacity-60"
+          class="opacity-60 text-sm font-normal"
         >{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).total }}</span>
       </button>
     </div>
@@ -1886,34 +1915,36 @@ onUnmounted(() => {
       <div
         v-for="t in sessionTokens"
         :key="t.tokenId"
-        class="para-chip px-3 py-2 flex items-center gap-3"
+        class="para-chip px-3 py-2 flex flex-col gap-1.5"
       >
-        <span
-          class="badge-neutral text-sm shrink-0"
-          :class="t.role === 'JUDGE' ? 'badge-accent' : 'badge-neutral'"
-        >{{ t.role }}</span>
-        <span v-if="t.judgeName" class="type-body text-content-secondary text-sm truncate">{{ t.judgeName }}</span>
-        <span class="flex-1"></span>
-        <span
-          class="type-label text-sm shrink-0"
-          :class="isExpiryWarning(t.expiresAt) ? 'text-amber-400' : 'text-content-muted'"
-        >
-          {{ formatExpiry(t.expiresAt) }}
-          <span v-if="isExpiryWarning(t.expiresAt)"> ⚠</span>
-        </span>
-        <button
-          @click="handleRefreshToken(t)"
-          class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-accent transition-colors shrink-0"
-          title="Refresh link (extends expiry)"
-        ><i class="pi pi-refresh text-xs"></i></button>
-        <button
-          @click="copyTokenLink(t.url, t.tokenId)"
-          class="para-chip-sm px-2 py-1 type-label transition-colors shrink-0"
-          :class="copiedTokenId === t.tokenId ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
-          title="Copy link"
-        ><i class="pi text-xs" :class="copiedTokenId === t.tokenId ? 'pi-check' : 'pi-copy'"></i></button>
+        <!-- Row 1: role badge + name -->
+        <div class="flex items-center gap-2">
+          <span
+            class="badge-neutral text-sm shrink-0"
+            :class="t.role === 'JUDGE' ? 'badge-accent' : 'badge-neutral'"
+          >{{ t.role }}</span>
+          <span v-if="t.judgeName" class="type-body text-content-secondary">{{ t.judgeName }}</span>
+        </div>
+        <!-- Row 2: expiry + actions -->
+        <div class="flex items-center gap-2">
+          <span
+            class="type-label flex-1"
+            :class="isExpiryWarning(t.expiresAt) ? 'text-amber-400' : 'text-content-muted'"
+          >{{ formatExpiry(t.expiresAt) }}<span v-if="isExpiryWarning(t.expiresAt)"> ⚠</span></span>
+          <button
+            @click="handleRefreshToken(t)"
+            class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-accent transition-colors shrink-0"
+            title="Refresh link (extends expiry)"
+          ><i class="pi pi-refresh text-xs"></i></button>
+          <button
+            @click="copyTokenLink(t.url, t.tokenId)"
+            class="para-chip-sm px-2 py-1 type-label transition-colors shrink-0"
+            :class="copiedTokenId === t.tokenId ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
+            title="Copy link"
+          ><i class="pi text-xs" :class="copiedTokenId === t.tokenId ? 'pi-check' : 'pi-copy'"></i></button>
+        </div>
       </div>
-      <p class="type-label text-content-muted mt-3" >Judge links are removed automatically when a judge is deleted.</p>
+      <p class="type-label text-content-muted mt-3">Judge links are removed automatically when a judge is deleted.</p>
     </div>
   </div>
 
@@ -1949,20 +1980,16 @@ onUnmounted(() => {
         <div class="corner-bar-tl"></div>
 
         <!-- Division tabs -->
-        <div class="flex gap-1.5 mb-4 flex-wrap">
+        <div class="tab-bar mb-4">
           <button
             v-for="div in divisionAuditionStats"
             :key="div.name"
             @click="poolTab = div.name"
-            class="para-chip-sm px-3 py-1.5 type-label transition-all duration-150 flex items-center gap-2"
-            :class="(poolTab ?? divisionAuditionStats[0]?.name) === div.name
-              ? 'text-accent border-[color:var(--accent-muted)]'
-              : 'text-content-muted hover:text-content-primary'"
+            class="tab-item"
+            :class="{ 'is-active': (poolTab ?? divisionAuditionStats[0]?.name) === div.name }"
           >
             {{ div.name }}
-            <span class="tabular-nums" :class="(poolTab ?? divisionAuditionStats[0]?.name) === div.name ? 'text-accent/70' : 'text-content-muted/50'">
-              {{ div.drawn.length }}/{{ div.total }}
-            </span>
+            <span class="tabular-nums opacity-60">{{ div.drawn.length }}/{{ div.total }}</span>
           </button>
         </div>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1275,10 +1275,10 @@ onUnmounted(() => {
     <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">
       <div class="stat-card relative">
         <div class="corner-bar-tl"></div>
-        <div class="type-stat">{{ (totalParticipants || 0) + totalWalkIn }}</div>
+        <div class="type-stat">{{ totalVerified + totalWalkIn }}</div>
         <div class="type-label">Total</div>
         <div class="flex gap-3 mt-1">
-          <span class="type-label text-content-muted">Form: {{ totalParticipants || 0 }}</span>
+          <span class="type-label text-content-muted">Form: {{ totalVerified }}</span>
           <span class="type-label text-content-muted">Walk-in: {{ totalWalkIn }}</span>
         </div>
       </div>
@@ -1658,12 +1658,12 @@ onUnmounted(() => {
         Add your judges here first — then assign them to categories below.
       </p>
 
-      <div class="flex flex-wrap gap-3">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <!-- Per-judge card -->
         <div
           v-for="j in allEventJudges"
           :key="j.judgeId"
-          class="para-chip p-3 flex flex-col gap-2 min-w-[160px] flex-1"
+          class="para-chip p-3 flex flex-col gap-2"
           :class="categoriesAssignedToJudge(j.judgeId).length === 0
             ? 'border-l-[3px] border-l-amber-500 bg-amber-950/10'
             : 'border-l-[3px] border-l-emerald-500/40'"
@@ -1707,28 +1707,23 @@ onUnmounted(() => {
             <p v-else class="type-label text-amber-400 mb-1.5">No categories assigned yet</p>
           </div>
 
-          <!-- Assign dropdown -->
-          <div v-if="categoriesUnassignedToJudge(j.judgeId).length > 0" class="relative">
-            <button
-              @click="openJudgeCardDropdown = openJudgeCardDropdown === j.judgeId ? null : j.judgeId"
-              class="para-chip-sm px-3 py-2 type-label text-accent hover:bg-[var(--accent-subtle)] transition-all w-full text-left"
-            ><i class="pi pi-plus text-xs mr-1"></i> Assign category</button>
-            <div
-              v-if="openJudgeCardDropdown === j.judgeId"
-              class="absolute top-full left-0 mt-1 bg-surface-800 border border-surface-600 para-chip p-1.5 z-50 min-w-[160px] max-h-48 overflow-y-auto"
-            >
-              <button
-                v-for="cat in categoriesUnassignedToJudge(j.judgeId)"
-                :key="cat.eventGenreId"
-                @click="submitAssignJudge(cat.eventGenreId, j.judgeId); openJudgeCardDropdown = null"
-                class="block w-full text-left px-3 py-2 type-body text-content-secondary hover:text-content-primary hover:bg-surface-700 transition-colors"
-              >+ {{ cat.name }}</button>
-            </div>
-          </div>
+          <!-- Assign — native select avoids clip-path clipping -->
+          <select
+            v-if="categoriesUnassignedToJudge(j.judgeId).length > 0"
+            @change="submitAssignJudge(Number($event.target.value), j.judgeId); $event.target.value = ''"
+            class="w-full px-3 py-2 type-label text-accent bg-surface-800 border border-[color:var(--accent-muted)] para-chip-sm"
+          >
+            <option value="" disabled selected>+ Assign category</option>
+            <option
+              v-for="cat in categoriesUnassignedToJudge(j.judgeId)"
+              :key="cat.eventGenreId"
+              :value="cat.eventGenreId"
+            >{{ cat.name }}</option>
+          </select>
         </div>
 
         <!-- Add judge card -->
-        <div class="para-chip p-3 flex flex-col items-center justify-center gap-2 min-w-[140px] flex-1" style="border-style:dashed;border-color:rgba(255,255,255,0.1);">
+        <div class="para-chip p-3 flex flex-col items-center justify-center gap-2" style="border-style:dashed;border-color:rgba(255,255,255,0.1);">
           <div class="flex items-center gap-1.5 w-full">
             <input
               v-model="globalJudgeInput"

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -571,7 +571,7 @@ const matchCounts = computed(() => {
     }
     let count = 0
     for (const cat of cats) {
-      if (names.some(n => cat.includes(n))) count++
+      if (names.some(n => cat === n)) count++
     }
     counts[div.eventGenreId] = count
   }
@@ -587,7 +587,7 @@ const unmatchedSheetValues = computed(() => {
       names.push(...div.sheetAliases.split(',').map(a => a.trim().toLowerCase()).filter(Boolean))
     }
     for (const cat of sheetCategories.value) {
-      if (names.some(n => cat.toLowerCase().includes(n))) matched.add(cat.toLowerCase())
+      if (names.some(n => cat.toLowerCase() === n)) matched.add(cat.toLowerCase())
     }
   }
   const unique = [...new Set(sheetCategories.value.map(s => s.toLowerCase()))]

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionAliases, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 
@@ -54,8 +54,6 @@ const eventName = ref(props.eventName.split(" ").join("%20"));
 const selectedInitGenres = ref([])
 const paymentRequired = ref(false)
 const sheetCategories = ref([])
-const divAliasExpanded = ref(null)
-const divAliasInput = ref('')
 const pendingSuggestionCat = ref(null)
 const divRenameActive = ref(null)
 const divRenameInput = ref('')
@@ -95,11 +93,6 @@ const askRemoveDivision = (div) => askConfirm(
   'Remove Category?',
   `"${div.name}" will be permanently removed. Participants already enrolled will block this action — remove them first.`,
   () => removeDivisionFromSection(div.eventGenreId)
-)
-const askRemoveJudge = (g, j) => askConfirm(
-  'Remove Judge?',
-  `Remove ${j.judgeName} from ${g.name}?`,
-  () => submitRemoveJudge(g.eventGenreId, j.judgeId)
 )
 const askRemoveJudgeGlobal = (j) => askConfirm(
   'Remove Judge from Event?',
@@ -172,14 +165,6 @@ const genreCounts = computed(() => {
   })
   return counts
 })
-
-const totalWalkIn = computed(() =>
-  new Set(
-    verifiedDbParticipants.value
-      .filter(p => p.walkin)
-      .map(p => p.participantId)
-  ).size
-)
 
 const totalDbRegistered = computed(() => {
   const grouped = {}
@@ -645,31 +630,13 @@ const saveDivisionFormat = async (div, format) => {
   }
 }
 
-const addAlias = async (div) => {
-  if (!divAliasInput.value.trim()) return
-  const existing = div.sheetAliases ? div.sheetAliases.split(',').map(s => s.trim()).filter(Boolean) : []
-  existing.push(divAliasInput.value.trim())
-  const joined = existing.join(', ')
-  await updateDivisionAliases(props.eventName, div.eventGenreId, joined)
-  div.sheetAliases = joined
-  divAliasInput.value = ''
-}
-
-const removeAlias = async (div, alias) => {
-  const existing = div.sheetAliases ? div.sheetAliases.split(',').map(s => s.trim()).filter(Boolean) : []
-  const updated = existing.filter(a => a !== alias)
-  const joined = updated.join(', ')
-  await updateDivisionAliases(props.eventName, div.eventGenreId, joined)
-  div.sheetAliases = joined
-}
-
 const toggleSoloAllowed = async (div) => {
   const newVal = !div.soloAllowed
   await updateDivisionSoloAllowed(props.eventName, div.eventGenreId, newVal)
   div.soloAllowed = newVal
 }
 
-const addSuggestionToGenre = async (genreId, genreLabel) => {
+const addSuggestionToGenre = async (genreId, _genreLabel) => {
   if (!pendingSuggestionCat.value) return
   const name = pendingSuggestionCat.value
   pendingSuggestionCat.value = null
@@ -721,19 +688,6 @@ const loadJudgesForDivision = async (genre) => {
   divisionJudges.value[genre.name] = await getJudgesByDivision(props.eventName, genre.eventGenreId)
 }
 // Judges not yet assigned to a specific division
-const openAssignDropdown = ref(null)
-const openJudgeCardDropdown = ref(null)
-
-const toggleAssignDropdown = (id) => {
-  openAssignDropdown.value = openAssignDropdown.value === id ? null : id
-}
-
-const unassignedJudges = (genreName) => {
-  const assigned = divisionJudges.value[genreName] || []
-  const assignedIds = new Set(assigned.map(j => j.judgeId))
-  return allEventJudges.value.filter(j => !assignedIds.has(j.judgeId))
-}
-
 const categoriesAssignedToJudge = (judgeId) => {
   const result = []
   for (const [genreName, judges] of Object.entries(divisionJudges.value)) {
@@ -822,26 +776,6 @@ const isAdminOrOrganiser = computed(() => {
 
 const isHelper = computed(() => authStore.user?.role?.[0]?.authority === 'ROLE_HELPER')
 
-const allUniqueJudges = computed(() => {
-  const seen = new Set()
-  const result = []
-  for (const j of allEventJudges.value) {
-    if (!seen.has(j.judgeId)) {
-      seen.add(j.judgeId)
-      result.push(j)
-    }
-  }
-  for (const judges of Object.values(divisionJudges.value)) {
-    for (const j of judges) {
-      if (!seen.has(j.judgeId)) {
-        seen.add(j.judgeId)
-        result.push(j)
-      }
-    }
-  }
-  return result
-})
-
 const loadSessionTokens = async () => {
   if (!dbEventId.value) return
   sessionTokensLoading.value = true
@@ -873,11 +807,6 @@ const loadSessionTokens = async () => {
 const handleRefreshToken = async (token) => {
   await revokeSessionToken(token.tokenId)
   await generateToken(token.role, dbEventId.value, token.judgeId ?? null)
-  await loadSessionTokens()
-}
-
-const handleRevokeToken = async (tokenId) => {
-  await revokeSessionToken(tokenId)
   await loadSessionTokens()
 }
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1479,47 +1479,42 @@ onUnmounted(() => {
       <span class="section-rule-label">Categories</span>
       <div class="section-rule-line"></div>
     </div>
-    <p class="type-label text-content-muted mb-4" style="font-size:10px;text-transform:none;letter-spacing:0.03em;">
+    <p class="type-label text-content-muted mb-4" style="text-transform:none;letter-spacing:0.03em;">
       Categories are competition formats within each genre (e.g. Popping 1v1, Popping 7 to Smoke).
       Names must match your Google Sheet column values exactly.
     </p>
 
     <!-- Sheet suggestions strip — only when sheet is connected -->
     <div v-if="allSheetSuggestions.length > 0" class="mb-4 p-3 para-chip">
-      <p class="type-label text-content-muted mb-2" style="font-size:10px;">FROM YOUR SHEET — click to add as a category</p>
+      <p class="type-label text-content-muted mb-3">FROM YOUR SHEET — click to add as a category</p>
       <div class="flex flex-wrap gap-2">
         <span
           v-for="cat in allSheetSuggestions"
           :key="cat"
         >
-          <!-- Covered: greyed, not clickable -->
+          <!-- Covered: visible but muted with strikethrough -->
           <span
             v-if="suggestionCoveredSet.has(cat)"
-            class="type-label text-content-muted line-through opacity-40"
-            style="font-size:10px;"
+            class="para-chip-sm px-3 py-1 type-label text-content-muted opacity-40 line-through"
           >{{ cat }}</span>
-          <!-- Uncovered: clickable, shows genre picker -->
-          <span
-            v-else
-            class="relative"
-          >
+          <!-- Uncovered: clearly clickable button -->
+          <span v-else class="relative">
             <button
               @click="pendingSuggestionCat = pendingSuggestionCat === cat ? null : cat"
-              class="para-chip-sm px-2.5 py-1 type-label text-content-secondary hover:text-accent transition-colors"
-              style="font-size:10px;border-style:dashed;"
+              class="para-chip-sm px-3 py-1.5 type-label text-content-secondary hover:text-accent transition-colors"
+              style="border-style:dashed;"
             >+ {{ cat }}</button>
             <!-- Inline genre picker -->
             <div
               v-if="pendingSuggestionCat === cat"
               class="absolute top-full left-0 mt-1 z-50 bg-surface-800 border border-surface-600 para-chip p-2 min-w-[160px]"
             >
-              <p class="type-label text-content-muted mb-1.5" style="font-size:9px;">ADD TO GENRE:</p>
+              <p class="type-label text-content-muted mb-1.5">ADD TO GENRE:</p>
               <button
                 v-for="group in divisionsByGenre"
                 :key="group.genreId"
                 @click="addSuggestionToGenre(group.genreId, group.label)"
-                class="block w-full text-left px-2 py-1.5 type-body text-content-secondary hover:text-accent transition-colors"
-                style="font-size:11px;"
+                class="block w-full text-left px-2 py-2 type-body text-content-secondary hover:text-accent transition-colors"
               >{{ group.label }}</button>
             </div>
           </span>
@@ -1538,7 +1533,7 @@ onUnmounted(() => {
         <!-- Division rows -->
         <div v-for="div in group.divisions" :key="div.eventGenreId">
           <div
-            class="para-chip p-3 flex flex-col gap-2"
+            class="para-chip px-3 py-2.5"
             :class="sheetCategories.length > 0
               ? (matchCounts[div.eventGenreId] || 0) > 0
                 ? (div.participantCount >= (matchCounts[div.eventGenreId] || 0)
@@ -1547,80 +1542,68 @@ onUnmounted(() => {
                 : 'border-l-[3px] border-l-amber-500'
               : div.participantCount > 0 ? 'border-l-[3px] border-l-emerald-500' : ''"
           >
-            <!-- Mobile: stacked (name row, then actions row); Tablet+: single inline row -->
-            <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-2">
-              <!-- Name + count badges row -->
+            <!-- Single inline row: name+counts left, controls right -->
+            <div class="flex items-center gap-2">
+              <!-- Left: name + counts -->
               <div class="flex items-center gap-2 flex-1 min-w-0">
                 <template v-if="divRenameActive !== div.eventGenreId">
                   <button
                     @click="divRenameActive = div.eventGenreId; divRenameInput = div.name"
-                    class="type-body text-content-secondary hover:text-accent text-left break-words min-w-0 flex-1 transition-colors text-sm sm:text-xs"
-                    style="overflow-wrap:break-word;word-break:break-word"
+                    class="type-body text-content-secondary hover:text-accent text-left min-w-0 transition-colors"
+                    style="overflow-wrap:break-word;word-break:break-word;font-size:13px;"
+                    title="Click to rename"
                   >{{ div.name }}</button>
+                  <!-- Match count dots -->
+                  <div class="flex items-center gap-2 shrink-0">
+                    <div v-if="div.participantCount > 0" class="flex items-center gap-1 text-emerald-400">
+                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
+                      <span class="type-label">{{ div.participantCount }}</span>
+                    </div>
+                    <div v-if="sheetCategories.length > 0 && ((matchCounts[div.eventGenreId] || 0) - div.participantCount) > 0" class="flex items-center gap-1 text-amber-400">
+                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
+                      <span class="type-label">{{ (matchCounts[div.eventGenreId] || 0) - div.participantCount }}</span>
+                    </div>
+                    <div v-if="sheetCategories.length > 0 && (matchCounts[div.eventGenreId] || 0) === 0 && div.participantCount === 0" class="flex items-center gap-1 text-amber-400">
+                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
+                      <span class="type-label">0</span>
+                    </div>
+                  </div>
                 </template>
                 <template v-else>
                   <input
                     v-model="divRenameInput"
                     type="text"
                     class="input-base flex-1 min-w-0"
-                    placeholder="Division name"
+                    placeholder="Category name"
                     @keyup.enter="saveDivisionName(div)"
                     @keyup.escape="divRenameActive = null"
                     @blur="saveDivisionName(div)"
                   />
                 </template>
-
-                <!-- Match count badges -->
-                <div class="flex items-center gap-2 shrink-0">
-                  <div v-if="div.participantCount > 0" class="flex items-center gap-1 text-emerald-400">
-                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 6px rgba(52,211,153,0.6)"></span>
-                    <span class="type-label text-xs">{{ div.participantCount }}</span>
-                  </div>
-                  <div
-                    v-if="sheetCategories.length > 0 && ((matchCounts[div.eventGenreId] || 0) - div.participantCount) > 0"
-                    class="flex items-center gap-1 text-amber-400"
-                  >
-                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
-                    <span class="type-label text-xs">{{ (matchCounts[div.eventGenreId] || 0) - div.participantCount }}</span>
-                  </div>
-                  <div
-                    v-if="sheetCategories.length > 0 && (matchCounts[div.eventGenreId] || 0) === 0 && div.participantCount === 0"
-                    class="flex items-center gap-1 text-amber-400"
-                  >
-                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(245,158,11,0.6)"></span>
-                    <span class="type-label text-xs">0</span>
-                  </div>
-                </div>
               </div>
 
-              <!-- Actions row: format dropdown + icon buttons -->
-              <div class="flex items-center gap-1.5 flex-wrap">
-                <!-- Format dropdown -->
+              <!-- Right: format + solo + remove (never wraps) -->
+              <div class="flex items-center gap-1.5 shrink-0">
                 <select
                   :value="div.format || ''"
                   @change="saveDivisionFormat(div, $event.target.value)"
-                  class="shrink-0 text-xs px-2 py-1 para-chip-sm bg-transparent text-content-secondary"
+                  class="text-xs px-2 py-1 para-chip-sm bg-transparent text-content-secondary"
                 >
                   <option value="">No format</option>
                   <template v-for="opt in divFormatOptions" :key="opt">
                     <option v-if="opt" :value="opt">{{ opt }}</option>
                   </template>
                 </select>
-
-
-                <!-- Solo allowed toggle — only for team formats (XvX where X > 1) -->
                 <button
                   v-if="div.format && /^\d+v\d+$/i.test(div.format) && div.format.toLowerCase() !== '1v1'"
                   @click="askToggleSolo(div)"
                   :class="div.soloAllowed ? 'text-content-muted hover:text-amber-400' : 'text-amber-400 hover:text-content-muted'"
-                  class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label transition-colors"
+                  class="para-chip-sm px-2 py-1 type-label transition-colors"
                   :title="div.soloAllowed ? 'Solo entries allowed' : 'Solo entries blocked'"
                 >{{ div.soloAllowed ? 'SOLO OK' : 'NO SOLO' }}</button>
-
-                <!-- Remove -->
                 <button
                   @click="askRemoveDivision(div)"
-                  class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label text-content-muted hover:text-red-400 transition-colors"
+                  class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-red-400 transition-colors"
                   title="Remove category"
                 ><i class="pi pi-times text-xs"></i></button>
               </div>
@@ -1708,29 +1691,27 @@ onUnmounted(() => {
           <!-- Assigned categories -->
           <div>
             <p class="type-label text-content-muted mb-1">CATEGORIES</p>
-            <div v-if="categoriesAssignedToJudge(j.judgeId).length > 0" class="flex flex-wrap gap-1 mb-1.5">
+            <div v-if="categoriesAssignedToJudge(j.judgeId).length > 0" class="flex flex-wrap gap-1.5 mb-1.5">
               <span
                 v-for="cat in categoriesAssignedToJudge(j.judgeId)"
                 :key="cat.eventGenreId"
-                class="inline-flex items-center gap-1 para-chip-sm px-1.5 py-0.5 type-label text-content-muted"
-                style="font-size:9px;"
+                class="inline-flex items-center gap-1.5 para-chip-sm px-2 py-1 type-label text-content-muted"
               >
                 {{ cat.name }}
                 <button
                   @click="submitRemoveJudge(cat.eventGenreId, j.judgeId)"
                   class="hover:text-red-400 transition-colors leading-none"
-                ><i class="pi pi-times" style="font-size:0.45rem"></i></button>
+                ><i class="pi pi-times text-xs"></i></button>
               </span>
             </div>
-            <p v-else class="type-label text-amber-400 mb-1.5" style="font-size:9px;">No categories assigned yet</p>
+            <p v-else class="type-label text-amber-400 mb-1.5">No categories assigned yet</p>
           </div>
 
           <!-- Assign dropdown -->
           <div v-if="categoriesUnassignedToJudge(j.judgeId).length > 0" class="relative">
             <button
               @click="openJudgeCardDropdown = openJudgeCardDropdown === j.judgeId ? null : j.judgeId"
-              class="para-chip-sm px-2 py-1 type-label text-accent hover:bg-[var(--accent-subtle)] transition-all w-full text-left"
-              style="font-size:9px;"
+              class="para-chip-sm px-3 py-2 type-label text-accent hover:bg-[var(--accent-subtle)] transition-all w-full text-left"
             ><i class="pi pi-plus text-xs mr-1"></i> Assign category</button>
             <div
               v-if="openJudgeCardDropdown === j.judgeId"
@@ -1740,8 +1721,7 @@ onUnmounted(() => {
                 v-for="cat in categoriesUnassignedToJudge(j.judgeId)"
                 :key="cat.eventGenreId"
                 @click="submitAssignJudge(cat.eventGenreId, j.judgeId); openJudgeCardDropdown = null"
-                class="block w-full text-left px-3 py-1.5 type-body text-content-secondary hover:text-content-primary hover:bg-surface-700 transition-colors"
-                style="font-size:11px;"
+                class="block w-full text-left px-3 py-2 type-body text-content-secondary hover:text-content-primary hover:bg-surface-700 transition-colors"
               >+ {{ cat.name }}</button>
             </div>
           </div>
@@ -1847,18 +1827,18 @@ onUnmounted(() => {
             ><i class="pi pi-sliders-h" style="font-size:0.65rem"></i> Configure</button>
           </div>
           <template v-if="criteriaByGenre[g.name]?.length">
-            <div class="flex flex-wrap gap-1.5">
+            <div class="flex flex-wrap gap-2">
               <span
                 v-for="c in criteriaByGenre[g.name]"
                 :key="c.id"
-                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-700 border border-surface-600/50 text-xs text-content-secondary"
+                class="para-chip-sm px-3 py-1 type-label text-content-secondary inline-flex items-center gap-1.5"
               >
                 {{ c.name }}
-                <span v-if="c.weight != null" class="font-source text-primary-400">×{{ c.weight }}</span>
+                <span v-if="c.weight != null" class="text-content-muted">×{{ c.weight }}</span>
               </span>
             </div>
           </template>
-          <span v-else class="text-xs text-content-muted">Default — single 0–10 score</span>
+          <span v-else class="type-label text-content-muted">Default — single 0–10 score</span>
         </div>
 
         <div class="h-px bg-surface-700/40"></div>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -91,8 +91,8 @@ const confirmNo = () => {
   confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, confirmLabel: 'Confirm', destructive: true }
 }
 const askRemoveDivision = (div) => askConfirm(
-  'Remove Division?',
-  `"${div.name}" will be permanently deleted. Participants already enrolled will block this action — remove them first.`,
+  'Remove Category?',
+  `"${div.name}" will be permanently removed. Participants already enrolled will block this action — remove them first.`,
   () => removeDivisionFromSection(div.eventGenreId)
 )
 const askRemoveJudge = (g, j) => askConfirm(
@@ -108,7 +108,7 @@ const askRemoveJudgeGlobal = (j) => askConfirm(
 const askToggleSolo = (div) => askConfirm(
   div.soloAllowed ? 'Block Solo Entries?' : 'Allow Solo Entries?',
   div.soloAllowed
-    ? `Participants registering for "${div.name}" will no longer be able to select Solo (pickup crew).`
+    ? `Participants in "${div.name}" will no longer be able to register as Solo (pickup crew).`
     : `Solo entries will be permitted for "${div.name}".`,
   () => toggleSoloAllowed(div)
 )
@@ -661,7 +661,7 @@ const addDivisionToGroup = async (genreId, genreLabel) => {
 const removeDivisionFromSection = async (divId) => {
   const res = await deleteDivision(props.eventName, divId)
   if (res && !res.ok) {
-    openModal('Cannot Delete Division', 'This division still has participants enrolled. Remove all participants from the division before deleting it.', 'error')
+    openModal('Cannot Delete Category', 'Remove all participants from the category before deleting it.', 'error')
     return
   }
   eventGenres.value = eventGenres.value.filter(d => d.eventGenreId !== divId)
@@ -1402,10 +1402,14 @@ onUnmounted(() => {
   <div v-if="tableExist && eventGenres.length > 0" class="card-hover p-4 relative mt-6">
     <div class="corner-bar-tl"></div>
 
-    <div class="section-rule mb-4">
-      <span class="section-rule-label">Divisions</span>
+    <div class="section-rule mb-3">
+      <span class="section-rule-label">Categories</span>
       <div class="section-rule-line"></div>
     </div>
+    <p class="type-label text-content-muted mb-4" style="font-size:10px;text-transform:none;letter-spacing:0.03em;">
+      Categories are competition formats within each genre (e.g. Popping 1v1, Popping 7 to Smoke).
+      Names must match your Google Sheet column values exactly.
+    </p>
 
     <div class="space-y-4">
       <div v-for="group in divisionsByGenre" :key="group.genreId" class="space-y-2">
@@ -1507,7 +1511,7 @@ onUnmounted(() => {
                 <button
                   @click="askRemoveDivision(div)"
                   class="para-chip-sm px-3 sm:px-2 py-2.5 sm:py-1 type-label text-content-muted hover:text-red-400 transition-colors"
-                  title="Remove division"
+                  title="Remove category"
                 ><i class="pi pi-times text-xs"></i></button>
               </div>
             </div>
@@ -1542,7 +1546,7 @@ onUnmounted(() => {
         <button
           @click="addDivisionToGroup(group.genreId, group.label)"
           class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-label text-content-muted hover:text-accent transition-all"
-        >+ Add {{ group.label }} division</button>
+        >+ Add {{ group.label }} category</button>
       </div>
     </div>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1717,106 +1717,87 @@ onUnmounted(() => {
     <template v-for="g in eventGenres" :key="g.name + '-content'">
       <div v-if="activeGenreTab === g.name" class="p-5 space-y-4">
 
-        <!-- Participant counts (only when data available) -->
+        <!-- ROSTER STATUS -->
         <template v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name))">
-          <div class="flex items-center gap-2 flex-wrap">
-            <span class="badge-neutral text-xs">Total: {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).total }}</span>
-            <span class="badge-success">
-              Reg: {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).registered }}
-            </span>
-            <span
-              v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered > 0"
-              class="badge-danger"
-            >Unreg: {{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered }}</span>
-          </div>
-
-          <!-- Unregistered list -->
-          <div v-if="getUnregistered(normalizeGenreName(g.name)).unregistered.length > 0">
-            <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-1.5">Unregistered Participants</p>
-            <div class="flex flex-wrap gap-2">
+          <div>
+            <div class="section-rule mb-3">
+              <span class="section-rule-label" style="font-size:9px;">Roster Status</span>
+              <div class="section-rule-line"></div>
+            </div>
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="badge-neutral text-xs">{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).total }} total</span>
+              <span class="badge-success">{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).registered }} registered</span>
               <span
-                v-for="p in getUnregistered(normalizeGenreName(g.name)).unregistered"
-                :key="p.participantName"
-                class="badge-danger font-source"
-              >{{ p.participantName }}</span>
+                v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered > 0"
+                class="badge-danger"
+              >{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered }} unregistered</span>
+            </div>
+
+            <!-- Unregistered list -->
+            <div v-if="getUnregistered(normalizeGenreName(g.name)).unregistered.length > 0" class="mt-2">
+              <div class="flex flex-wrap gap-2">
+                <span
+                  v-for="p in getUnregistered(normalizeGenreName(g.name)).unregistered"
+                  :key="p.participantName"
+                  class="badge-danger font-source"
+                >{{ p.participantName }}</span>
+              </div>
+            </div>
+            <div v-else class="flex items-center gap-2 type-body text-emerald-400 mt-2">
+              <i class="pi pi-check-circle"></i>
+              <span>All participants registered</span>
             </div>
           </div>
-          <div v-else class="flex items-center gap-2 type-body text-emerald-400">
-            <i class="pi pi-check-circle"></i>
-            <span>All participants registered</span>
-          </div>
-
           <div class="h-px bg-surface-700/40"></div>
         </template>
 
-        <!-- Scoring Criteria -->
-        <div class="grid grid-cols-1 gap-3">
-
-          <!-- Scoring Criteria -->
-          <div class="flex flex-col gap-2 p-3 para-chip">
-            <div class="flex items-center justify-between">
-              <p class="type-label text-content-muted">Scoring Criteria</p>
-              <button
-                @click="showCriteriaModal = true"
-                class="para-chip-sm px-2.5 py-1 type-label"
-              ><i class="pi pi-sliders-h" style="font-size:0.65rem"></i> Configure</button>
+        <!-- SCORING CRITERIA -->
+        <div>
+          <div class="flex items-center gap-2 mb-2">
+            <div class="section-rule mb-0 flex-1">
+              <span class="section-rule-label" style="font-size:9px;">Scoring Criteria</span>
+              <div class="section-rule-line"></div>
             </div>
-            <template v-if="criteriaByGenre[g.name]?.length">
-              <div class="flex flex-wrap gap-1.5">
-                <span
-                  v-for="c in criteriaByGenre[g.name]"
-                  :key="c.id"
-                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-700 border border-surface-600/50 text-xs text-content-secondary"
-                >
-                  {{ c.name }}
-                  <span v-if="c.weight != null" class="font-source text-primary-400">×{{ c.weight }}</span>
-                </span>
-              </div>
-            </template>
-            <span v-else class="text-xs text-content-muted">Default (single score)</span>
+            <button
+              @click="showCriteriaModal = true"
+              class="para-chip-sm px-2.5 py-1 type-label shrink-0"
+            ><i class="pi pi-sliders-h" style="font-size:0.65rem"></i> Configure</button>
           </div>
+          <template v-if="criteriaByGenre[g.name]?.length">
+            <div class="flex flex-wrap gap-1.5">
+              <span
+                v-for="c in criteriaByGenre[g.name]"
+                :key="c.id"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-700 border border-surface-600/50 text-xs text-content-secondary"
+              >
+                {{ c.name }}
+                <span v-if="c.weight != null" class="font-source text-primary-400">×{{ c.weight }}</span>
+              </span>
+            </div>
+          </template>
+          <span v-else class="text-xs text-content-muted">Default — single 0–10 score</span>
         </div>
 
-        <!-- Judges (per division) -->
+        <div class="h-px bg-surface-700/40"></div>
+
+        <!-- JUDGES (read-only) -->
         <div>
-          <p class="text-xs font-semibold text-content-muted uppercase tracking-wide mb-2">
-            Judges
-          </p>
-          <div class="flex flex-wrap items-center gap-2">
-            <div
+          <div class="section-rule mb-2">
+            <span class="section-rule-label" style="font-size:9px;">Judges</span>
+            <div class="section-rule-line"></div>
+            <span class="type-label text-content-muted" style="font-size:9px;white-space:nowrap;">manage in judge pool above</span>
+          </div>
+          <div v-if="(divisionJudges[g.name] || []).length > 0" class="flex flex-wrap gap-2">
+            <span
               v-for="j in (divisionJudges[g.name] || [])"
               :key="j.judgeId"
-              class="flex items-center gap-2 para-chip px-2.5 py-1"
+              class="flex items-center gap-1.5 para-chip px-2.5 py-1"
             >
-              <i class="pi pi-user text-content-muted text-xs shrink-0"></i>
-              <span class="type-body text-content-secondary">{{ j.judgeName }}</span>
-              <button
-                @click="askRemoveJudge(g, j)"
-                class="type-label text-content-muted hover:text-content-primary transition-colors"
-                title="Remove from division"
-              ><i class="pi pi-times text-xs"></i></button>
-            </div>
-
-            <!-- Assign from pool dropdown -->
-            <div v-if="unassignedJudges(g.name).length > 0" class="relative">
-              <button
-                @click="toggleAssignDropdown(g.name)"
-                class="para-chip px-2 py-1 type-label text-accent hover:bg-[var(--accent-subtle)] transition-all"
-                title="Assign judge from pool"
-              ><i class="pi pi-plus text-xs"></i> Assign</button>
-              <div
-                v-if="openAssignDropdown === g.name"
-                class="absolute bottom-full left-0 mb-1 bg-surface-800 border border-surface-600 para-chip p-1.5 z-50 min-w-[180px] max-h-48 overflow-y-auto"
-              >
-                <button
-                  v-for="j in unassignedJudges(g.name)"
-                  :key="j.judgeId"
-                  @click="submitAssignJudge(g.eventGenreId, j.judgeId); openAssignDropdown = null"
-                  class="block w-full text-left px-3 py-1.5 type-body text-content-secondary hover:text-content-primary hover:bg-surface-700 transition-colors"
-                >+ {{ j.judgeName }}</button>
-              </div>
-            </div>
+              <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 5px rgba(52,211,153,0.5)"></span>
+              <span class="type-body text-content-secondary text-xs">{{ j.judgeName }}</span>
+            </span>
           </div>
+          <span v-else class="text-xs text-content-muted">None assigned — add in Judge Pool above</span>
         </div>
 
       </div>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -714,6 +714,7 @@ const loadJudgesForDivision = async (genre) => {
 }
 // Judges not yet assigned to a specific division
 const openAssignDropdown = ref(null)
+const openJudgeCardDropdown = ref(null)
 
 const toggleAssignDropdown = (id) => {
   openAssignDropdown.value = openAssignDropdown.value === id ? null : id
@@ -723,6 +724,22 @@ const unassignedJudges = (genreName) => {
   const assigned = divisionJudges.value[genreName] || []
   const assignedIds = new Set(assigned.map(j => j.judgeId))
   return allEventJudges.value.filter(j => !assignedIds.has(j.judgeId))
+}
+
+const categoriesAssignedToJudge = (judgeId) => {
+  const result = []
+  for (const [genreName, judges] of Object.entries(divisionJudges.value)) {
+    if (judges.some(j => j.judgeId === judgeId)) {
+      const genre = eventGenres.value.find(g => g.name === genreName)
+      if (genre) result.push(genre)
+    }
+  }
+  return result
+}
+
+const categoriesUnassignedToJudge = (judgeId) => {
+  const assigned = new Set(categoriesAssignedToJudge(judgeId).map(g => g.eventGenreId))
+  return eventGenres.value.filter(g => !assigned.has(g.eventGenreId))
 }
 
 const submitAddJudgeGlobal = async () => {
@@ -1658,39 +1675,107 @@ onUnmounted(() => {
       <div class="section-rule-line"></div>
     </div>
 
-    <!-- Global Judges -->
-    <div class="mb-5 p-4 para-chip">
-      <p class="type-label text-content-muted mb-3">Event Judges</p>
-      <div class="flex flex-wrap items-center gap-2 mb-3">
+    <!-- Judge Pool -->
+    <div class="mb-5">
+      <div class="section-rule mb-1">
+        <span class="section-rule-label">Judge Pool</span>
+        <div class="section-rule-line"></div>
+      </div>
+      <p class="type-label text-content-muted mb-4" style="font-size:10px;text-transform:none;letter-spacing:0.03em;">
+        Add your judges here first — then assign them to categories below.
+      </p>
+
+      <div class="flex flex-wrap gap-3">
+        <!-- Per-judge card -->
         <div
           v-for="j in allEventJudges"
           :key="j.judgeId"
-          class="flex items-center gap-2 para-chip px-2.5 py-1"
+          class="para-chip p-3 flex flex-col gap-2 min-w-[160px] flex-1"
+          :class="categoriesAssignedToJudge(j.judgeId).length === 0
+            ? 'border-l-[3px] border-l-amber-500 bg-amber-950/10'
+            : 'border-l-[3px] border-l-emerald-500/40'"
         >
-          <i class="pi pi-user text-content-muted text-xs shrink-0"></i>
-          <span class="type-body text-content-secondary">{{ j.judgeName }}</span>
-          <button
-            @click="askRemoveJudgeGlobal(j)"
-            class="type-label text-content-muted hover:text-primary-400 transition-colors"
-            title="Remove from event"
-          ><i class="pi pi-times text-xs"></i></button>
+          <!-- Judge name + remove -->
+          <div class="flex items-center justify-between gap-2">
+            <div class="flex items-center gap-1.5">
+              <span
+                class="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                :class="categoriesAssignedToJudge(j.judgeId).length === 0
+                  ? 'bg-amber-400' : 'bg-emerald-400'"
+                :style="categoriesAssignedToJudge(j.judgeId).length === 0
+                  ? 'box-shadow:0 0 5px rgba(245,158,11,0.5)'
+                  : 'box-shadow:0 0 5px rgba(52,211,153,0.5)'"
+              ></span>
+              <span class="type-body text-content-secondary text-xs">{{ j.judgeName }}</span>
+            </div>
+            <button
+              @click="askRemoveJudgeGlobal(j)"
+              class="type-label text-content-muted hover:text-red-400 transition-colors"
+              title="Remove from event"
+            ><i class="pi pi-times text-xs"></i></button>
+          </div>
+
+          <!-- Assigned categories -->
+          <div>
+            <p class="type-label text-content-muted mb-1" style="font-size:9px;">CATEGORIES</p>
+            <div v-if="categoriesAssignedToJudge(j.judgeId).length > 0" class="flex flex-wrap gap-1 mb-1.5">
+              <span
+                v-for="cat in categoriesAssignedToJudge(j.judgeId)"
+                :key="cat.eventGenreId"
+                class="inline-flex items-center gap-1 para-chip-sm px-1.5 py-0.5 type-label text-content-muted"
+                style="font-size:9px;"
+              >
+                {{ cat.name }}
+                <button
+                  @click="submitRemoveJudge(cat.eventGenreId, j.judgeId)"
+                  class="hover:text-red-400 transition-colors leading-none"
+                ><i class="pi pi-times" style="font-size:0.45rem"></i></button>
+              </span>
+            </div>
+            <p v-else class="type-label text-amber-400 mb-1.5" style="font-size:9px;">No categories assigned yet</p>
+          </div>
+
+          <!-- Assign dropdown -->
+          <div v-if="categoriesUnassignedToJudge(j.judgeId).length > 0" class="relative">
+            <button
+              @click="openJudgeCardDropdown = openJudgeCardDropdown === j.judgeId ? null : j.judgeId"
+              class="para-chip-sm px-2 py-1 type-label text-accent hover:bg-[var(--accent-subtle)] transition-all w-full text-left"
+              style="font-size:9px;"
+            ><i class="pi pi-plus text-xs mr-1"></i> Assign category</button>
+            <div
+              v-if="openJudgeCardDropdown === j.judgeId"
+              class="absolute top-full left-0 mt-1 bg-surface-800 border border-surface-600 para-chip p-1.5 z-50 min-w-[160px] max-h-48 overflow-y-auto"
+            >
+              <button
+                v-for="cat in categoriesUnassignedToJudge(j.judgeId)"
+                :key="cat.eventGenreId"
+                @click="submitAssignJudge(cat.eventGenreId, j.judgeId); openJudgeCardDropdown = null"
+                class="block w-full text-left px-3 py-1.5 type-body text-content-secondary hover:text-content-primary hover:bg-surface-700 transition-colors"
+                style="font-size:11px;"
+              >+ {{ cat.name }}</button>
+            </div>
+          </div>
         </div>
-        <span v-if="allEventJudges.length === 0" class="type-body text-content-muted text-xs">No judges added yet.</span>
-      </div>
-      <div class="flex items-center gap-1.5 para-chip px-2.5 py-1 w-fit">
-        <input
-          v-model="globalJudgeInput"
-          type="text"
-          placeholder="Add judge to event…"
-          autocomplete="off"
-          class="bg-transparent type-body placeholder:text-content-muted focus:outline-none w-56"
-          @keyup.enter="submitAddJudgeGlobal()"
-        />
-        <button
-          @click="submitAddJudgeGlobal()"
-          class="type-label text-accent hover:opacity-80 transition-opacity shrink-0"
-          title="Add to all divisions"
-        ><i class="pi pi-plus text-xs"></i></button>
+
+        <!-- Add judge card -->
+        <div class="para-chip p-3 flex flex-col items-center justify-center gap-2 min-w-[140px] flex-1" style="border-style:dashed;border-color:rgba(255,255,255,0.1);">
+          <div class="flex items-center gap-1.5 w-full">
+            <input
+              v-model="globalJudgeInput"
+              type="text"
+              placeholder="Judge name…"
+              autocomplete="off"
+              class="bg-transparent type-body placeholder:text-content-muted focus:outline-none flex-1 min-w-0 text-xs"
+              @keyup.enter="submitAddJudgeGlobal()"
+            />
+            <button
+              @click="submitAddJudgeGlobal()"
+              class="type-label text-accent hover:opacity-80 transition-opacity shrink-0"
+              title="Add judge"
+            ><i class="pi pi-plus text-xs"></i></button>
+          </div>
+          <span v-if="allEventJudges.length === 0" class="type-label text-content-muted" style="font-size:9px;">No judges yet</span>
+        </div>
       </div>
     </div>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -746,12 +746,23 @@ const submitAddJudgeGlobal = async () => {
   if (!globalJudgeInput.value.trim()) return
   const res = await addJudgeToEvent(props.eventName, globalJudgeInput.value.trim())
   if (res?.ok) {
-    allEventJudges.value = await res.json()
+    const judges = await res.json()
+    allEventJudges.value = judges
+    // Auto-generate session token for the new judge
+    const newJudge = judges[judges.length - 1]
+    if (newJudge && dbEventId.value) {
+      await generateToken('JUDGE', dbEventId.value, newJudge.judgeId)
+      await loadSessionTokens()
+    }
   }
   globalJudgeInput.value = ''
 }
 
 const submitRemoveJudgeGlobal = async (judgeId) => {
+  // Revoke session token for this judge before removing them
+  const judgeToken = sessionTokens.value.find(t => t.role === 'JUDGE' && t.judgeId === judgeId)
+  if (judgeToken) await revokeSessionToken(judgeToken.tokenId)
+
   const res = await removeEventJudge(props.eventName, judgeId)
   if (res?.ok) {
     allEventJudges.value = await res.json()
@@ -760,6 +771,7 @@ const submitRemoveJudgeGlobal = async (judgeId) => {
         divisionJudges.value[genre.name] = await getJudgesByDivision(props.eventName, genre.eventGenreId)
       }
     }
+    await loadSessionTokens()
   }
 }
 
@@ -791,11 +803,9 @@ watch(activeGenreTab, async (tabName) => {
 // ───────────────────────────────────────────────────────────────────────────
 
 // ── Session Links ──────────────────────────────────────────────────────────
-const sessionLinksExpanded = ref(false)
 const sessionTokens = ref([])
 const sessionTokensLoading = ref(false)
-const selectedJudgeId = ref('')
-const generatingRole = ref(null)
+const copiedTokenId = ref(null)
 
 const isAdminOrOrganiser = computed(() => {
   const auth = authStore.user?.role?.[0]?.authority
@@ -828,20 +838,20 @@ const loadSessionTokens = async () => {
   if (!dbEventId.value) return
   sessionTokensLoading.value = true
   sessionTokens.value = await getSessionTokens(dbEventId.value)
+  // Auto-generate permanent roles if missing
+  const hasEmcee = sessionTokens.value.some(t => t.role === 'EMCEE')
+  const hasHelper = sessionTokens.value.some(t => t.role === 'HELPER')
+  if (!hasEmcee) await generateToken('EMCEE', dbEventId.value, null)
+  if (!hasHelper) await generateToken('HELPER', dbEventId.value, null)
+  if (!hasEmcee || !hasHelper) {
+    sessionTokens.value = await getSessionTokens(dbEventId.value)
+  }
   sessionTokensLoading.value = false
 }
 
-const handleGenerateToken = async (role) => {
-  if (!dbEventId.value) return
-  let judgeId = null
-  if (role === 'JUDGE') {
-    judgeId = Number(selectedJudgeId.value)
-    if (!judgeId) return
-  }
-  generatingRole.value = role
-  await generateToken(role, dbEventId.value, judgeId)
-  generatingRole.value = null
-  selectedJudgeId.value = ''
+const handleRefreshToken = async (token) => {
+  await revokeSessionToken(token.tokenId)
+  await generateToken(token.role, dbEventId.value, token.judgeId ?? null)
   await loadSessionTokens()
 }
 
@@ -865,8 +875,10 @@ function copyToClipboard(text) {
   document.body.removeChild(ta)
 }
 
-const copyTokenLink = (url) => {
+const copyTokenLink = (url, tokenId) => {
   copyToClipboard(window.location.origin + url)
+  copiedTokenId.value = tokenId
+  setTimeout(() => { copiedTokenId.value = null }, 2000)
 }
 
 const auditionLinkCopied = ref(false)
@@ -881,9 +893,9 @@ const formatExpiry = (expiresAt) => {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
 }
 
-watch(sessionLinksExpanded, async (val) => {
-  if (val) await loadSessionTokens()
-})
+const isExpiryWarning = (expiresAt) => {
+  return (new Date(expiresAt) - Date.now()) < 3 * 24 * 60 * 60 * 1000
+}
 // ───────────────────────────────────────────────────────────────────────────
 
 const toggleUnverifiedSelect = (participantId) => {
@@ -1889,92 +1901,51 @@ onUnmounted(() => {
     </template>
   </div>
 
-  <!-- Session Links -->
+  <!-- Session Links — always visible, auto-generated -->
   <div v-if="isAdminOrOrganiser && tableExist" class="card-hover p-4 relative mt-6">
     <div class="corner-bar-tl"></div>
-    <button
-      @click="sessionLinksExpanded = !sessionLinksExpanded"
-      :aria-expanded="sessionLinksExpanded"
-      class="w-full flex items-center justify-between text-left"
-    >
-      <div class="flex items-center gap-3">
-        <i class="pi pi-link text-xs" style="color:var(--accent-color)"></i>
-        <span class="type-body text-content-secondary">Session Links</span>
-        <span class="badge-accent">{{ sessionTokens.length }}</span>
-      </div>
-      <i class="pi pi-chevron-down text-content-muted text-xs transition-transform duration-200"
-         :class="{ 'rotate-180': sessionLinksExpanded }"></i>
-    </button>
-    <div v-if="sessionLinksExpanded" class="mt-4 pt-4 border-t border-surface-600/30">
-      <!-- Generate row -->
-      <div class="flex flex-wrap items-center gap-2 mb-4">
-        <button
-          @click="handleGenerateToken('EMCEE')"
-          :disabled="generatingRole === 'EMCEE'"
-          class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
-        >
-          <i class="pi text-xs mr-1" :class="generatingRole === 'EMCEE' ? 'pi-spinner pi-spin' : 'pi-plus'"></i>
-          EMCEE
-        </button>
-        <button
-          @click="handleGenerateToken('HELPER')"
-          :disabled="generatingRole === 'HELPER'"
-          class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
-        >
-          <i class="pi text-xs mr-1" :class="generatingRole === 'HELPER' ? 'pi-spinner pi-spin' : 'pi-plus'"></i>
-          HELPER
-        </button>
-        <select
-          v-model="selectedJudgeId"
-          class="input-base type-label"
-          style="width:auto;min-width:7rem"
-        >
-          <option value="">Select judge…</option>
-          <option v-for="j in allUniqueJudges" :key="j.judgeId" :value="j.judgeId">
-            {{ j.judgeName }}
-          </option>
-        </select>
-        <button
-          @click="handleGenerateToken('JUDGE')"
-          :disabled="generatingRole === 'JUDGE' || !selectedJudgeId"
-          class="para-chip-sm px-3 py-1.5 type-label text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)] transition-all disabled:opacity-40"
-        >
-          <i class="pi text-xs mr-1" :class="generatingRole === 'JUDGE' ? 'pi-spinner pi-spin' : 'pi-plus'"></i>
-          JUDGE
-        </button>
-      </div>
 
-      <!-- Token list -->
-      <div v-if="sessionTokensLoading" class="flex items-center gap-2 type-label text-content-muted py-4">
-        <i class="pi pi-spinner pi-spin text-xs"></i> Loading…
-      </div>
-      <div v-else-if="sessionTokens.length === 0" class="type-label text-content-muted py-4">
-        No active session links
-      </div>
-      <div v-else class="space-y-2">
-        <div
-          v-for="t in sessionTokens"
-          :key="t.tokenId"
-          class="para-chip px-3 py-2 flex items-center gap-3"
+    <div class="section-rule mb-4">
+      <span class="section-rule-label">Session Links</span>
+      <div class="section-rule-line"></div>
+      <span class="type-label text-content-muted" style="font-size:9px;white-space:nowrap;">auto-generated · refresh to extend</span>
+    </div>
+
+    <div v-if="sessionTokensLoading" class="flex items-center gap-2 type-label text-content-muted py-4">
+      <i class="pi pi-spinner pi-spin text-xs"></i> Loading…
+    </div>
+    <div v-else class="space-y-2">
+      <div
+        v-for="t in sessionTokens"
+        :key="t.tokenId"
+        class="para-chip px-3 py-2 flex items-center gap-3"
+      >
+        <span
+          class="badge-neutral text-xs shrink-0"
+          :class="t.role === 'JUDGE' ? 'badge-accent' : 'badge-neutral'"
+        >{{ t.role }}</span>
+        <span v-if="t.judgeName" class="type-body text-content-secondary text-xs truncate">{{ t.judgeName }}</span>
+        <span class="flex-1"></span>
+        <span
+          class="type-label text-xs shrink-0"
+          :class="isExpiryWarning(t.expiresAt) ? 'text-amber-400' : 'text-content-muted'"
         >
-          <span
-            class="badge-neutral text-xs shrink-0"
-            :class="t.role === 'JUDGE' ? 'badge-accent' : 'badge-neutral'"
-          >{{ t.role }}</span>
-          <span v-if="t.judgeName" class="type-body text-content-secondary text-xs truncate">{{ t.judgeName }}</span>
-          <span class="type-label text-content-muted text-xs shrink-0 ml-auto">{{ formatExpiry(t.expiresAt) }}</span>
-          <button
-            @click="copyTokenLink(t.url)"
-            class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-accent transition-colors shrink-0"
-            title="Copy link"
-          ><i class="pi pi-copy text-xs"></i></button>
-          <button
-            @click="handleRevokeToken(t.tokenId)"
-            class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-red-400 transition-colors shrink-0"
-            title="Revoke"
-          ><i class="pi pi-trash text-xs"></i></button>
-        </div>
+          {{ formatExpiry(t.expiresAt) }}
+          <span v-if="isExpiryWarning(t.expiresAt)"> ⚠</span>
+        </span>
+        <button
+          @click="handleRefreshToken(t)"
+          class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-accent transition-colors shrink-0"
+          title="Refresh link (extends expiry)"
+        ><i class="pi pi-refresh text-xs"></i></button>
+        <button
+          @click="copyTokenLink(t.url, t.tokenId)"
+          class="para-chip-sm px-2 py-1 type-label transition-colors shrink-0"
+          :class="copiedTokenId === t.tokenId ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
+          title="Copy link"
+        ><i class="pi text-xs" :class="copiedTokenId === t.tokenId ? 'pi-check' : 'pi-copy'"></i></button>
       </div>
+      <p class="type-label text-content-muted mt-3" style="font-size:9px;">Judge links are removed automatically when a judge is deleted.</p>
     </div>
   </div>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -609,6 +609,13 @@ const saveDivisionName = async (div) => {
 const saveDivisionFormat = async (div, format) => {
   await updateEventGenreFormat(props.eventName, div.eventGenreId, format || null)
   div.format = format || null
+  // Team formats default to no solo
+  if (format && /^\d+v\d+$/i.test(format) && format.toLowerCase() !== '1v1') {
+    if (div.soloAllowed !== false) {
+      await updateDivisionSoloAllowed(props.eventName, div.eventGenreId, false)
+      div.soloAllowed = false
+    }
+  }
 }
 
 const addAlias = async (div) => {

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -56,6 +56,7 @@ const paymentRequired = ref(false)
 const sheetCategories = ref([])
 const divAliasExpanded = ref(null)
 const divAliasInput = ref('')
+const pendingSuggestionCat = ref(null)
 const divRenameActive = ref(null)
 const divRenameInput = ref('')
 const divFormatOptions = ['', '1v1', '2v2', '3v3', '4v4', '5v5', '7 to smoke', 'solo']
@@ -594,6 +595,24 @@ const unmatchedSheetValues = computed(() => {
   return unique.filter(v => !matched.has(v))
 })
 
+const allSheetSuggestions = computed(() => {
+  return [...new Set(sheetCategories.value)]
+})
+
+const suggestionCoveredSet = computed(() => {
+  const covered = new Set()
+  for (const div of eventGenres.value) {
+    const names = [div.name.toLowerCase()]
+    if (div.sheetAliases) {
+      names.push(...div.sheetAliases.split(',').map(a => a.trim().toLowerCase()).filter(Boolean))
+    }
+    for (const cat of sheetCategories.value) {
+      if (names.some(n => cat.toLowerCase() === n)) covered.add(cat)
+    }
+  }
+  return covered
+})
+
 const loadSheetCategories = async () => {
   if (fileId.value) {
     sheetCategories.value = await getSheetCategories(fileId.value)
@@ -640,6 +659,22 @@ const toggleSoloAllowed = async (div) => {
   const newVal = !div.soloAllowed
   await updateDivisionSoloAllowed(props.eventName, div.eventGenreId, newVal)
   div.soloAllowed = newVal
+}
+
+const addSuggestionToGenre = async (genreId, genreLabel) => {
+  if (!pendingSuggestionCat.value) return
+  const name = pendingSuggestionCat.value
+  pendingSuggestionCat.value = null
+  const existingNames = eventGenres.value.map(d => d.name.toLowerCase())
+  let finalName = name
+  let i = 2
+  while (existingNames.includes(finalName.toLowerCase())) {
+    finalName = `${name} ${i++}`
+  }
+  const resp = await addDivision(props.eventName, finalName, null, genreId === 'custom' ? null : genreId)
+  if (resp && resp.ok) {
+    eventGenres.value = await getGenresByEvent(props.eventName)
+  }
 }
 
 const addDivisionToGroup = async (genreId, genreLabel) => {
@@ -1410,6 +1445,49 @@ onUnmounted(() => {
       Categories are competition formats within each genre (e.g. Popping 1v1, Popping 7 to Smoke).
       Names must match your Google Sheet column values exactly.
     </p>
+
+    <!-- Sheet suggestions strip — only when sheet is connected -->
+    <div v-if="allSheetSuggestions.length > 0" class="mb-4 p-3 para-chip">
+      <p class="type-label text-content-muted mb-2" style="font-size:10px;">FROM YOUR SHEET — click to add as a category</p>
+      <div class="flex flex-wrap gap-2">
+        <span
+          v-for="cat in allSheetSuggestions"
+          :key="cat"
+        >
+          <!-- Covered: greyed, not clickable -->
+          <span
+            v-if="suggestionCoveredSet.has(cat)"
+            class="type-label text-content-muted line-through opacity-40"
+            style="font-size:10px;"
+          >{{ cat }}</span>
+          <!-- Uncovered: clickable, shows genre picker -->
+          <span
+            v-else
+            class="relative"
+          >
+            <button
+              @click="pendingSuggestionCat = pendingSuggestionCat === cat ? null : cat"
+              class="para-chip-sm px-2.5 py-1 type-label text-content-secondary hover:text-accent transition-colors"
+              style="font-size:10px;border-style:dashed;"
+            >+ {{ cat }}</button>
+            <!-- Inline genre picker -->
+            <div
+              v-if="pendingSuggestionCat === cat"
+              class="absolute top-full left-0 mt-1 z-50 bg-surface-800 border border-surface-600 para-chip p-2 min-w-[160px]"
+            >
+              <p class="type-label text-content-muted mb-1.5" style="font-size:9px;">ADD TO GENRE:</p>
+              <button
+                v-for="group in divisionsByGenre"
+                :key="group.genreId"
+                @click="addSuggestionToGenre(group.genreId, group.label)"
+                class="block w-full text-left px-2 py-1.5 type-body text-content-secondary hover:text-accent transition-colors"
+                style="font-size:11px;"
+              >{{ group.label }}</button>
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
 
     <div class="space-y-4">
       <div v-for="group in divisionsByGenre" :key="group.genreId" class="space-y-2">

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -204,6 +204,7 @@ public class AuthController {
             GetSessionTokenDto dto = new GetSessionTokenDto();
             dto.tokenId = t.getTokenId();
             dto.role = t.getRole();
+            dto.judgeId = t.getJudge() != null ? t.getJudge().getJudgeId() : null;
             dto.judgeName = t.getJudge() != null ? t.getJudge().getName() : null;
             dto.expiresAt = t.getExpiresAt().toString();
             dto.url = "/auth/token?t=" + t.getTokenId();

--- a/BES/src/main/java/com/example/BES/dtos/GetSessionTokenDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetSessionTokenDto.java
@@ -3,6 +3,7 @@ package com.example.BES.dtos;
 public class GetSessionTokenDto {
     public String tokenId;
     public String role;
+    public Long judgeId;
     public String judgeName;
     public String expiresAt;
     public String url;

--- a/BES/src/main/java/com/example/BES/services/GoogleSheetService.java
+++ b/BES/src/main/java/com/example/BES/services/GoogleSheetService.java
@@ -150,9 +150,11 @@ public class GoogleSheetService {
             for (int i = 1; i < rows.size(); i++) {
                 List<Object> cell = rows.get(i);
                 if (cell != null && !cell.isEmpty() && cell.get(0) != null) {
-                    String val = cell.get(0).toString().trim();
-                    if (!val.isBlank()) {
-                        values.add(val);
+                    String raw = cell.get(0).toString().trim();
+                    if (raw.isBlank()) continue;
+                    for (String part : raw.split(",")) {
+                        String val = part.trim();
+                        if (!val.isBlank()) values.add(val);
                     }
                 }
             }

--- a/BES/src/main/java/com/example/BES/services/SessionTokenService.java
+++ b/BES/src/main/java/com/example/BES/services/SessionTokenService.java
@@ -43,11 +43,8 @@ public class SessionTokenService {
         if (judgeId != null) {
             judge = judgeRepo.findById(judgeId)
                 .orElseThrow(() -> new IllegalArgumentException("Judge not found: " + judgeId));
-            // Validate judge belongs to the event via division assignment (JPA relationship)
-            boolean belongsToEvent = judge.getEventGenres() != null
-                && judge.getEventGenres().stream()
-                    .anyMatch(eg -> eg.getEvent() != null
-                        && eg.getEvent().getEventId().equals(eventId));
+            boolean belongsToEvent = judgeRepo.findJudgesByEventId(eventId).stream()
+                .anyMatch(j -> j.getJudgeId().equals(judgeId));
             if (!belongsToEvent) {
                 throw new IllegalArgumentException("Judge " + judgeId
                     + " does not belong to event " + eventId);

--- a/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
@@ -20,9 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.BES.dtos.LoginDto;
 import com.example.BES.dtos.RedeemTokenDto;
 import com.example.BES.models.Event;
-import com.example.BES.models.EventGenre;
 import com.example.BES.models.Judge;
-import com.example.BES.respositories.EventGenreRepo;
 import com.example.BES.respositories.EventRepo;
 import com.example.BES.respositories.JudgeRepo;
 import com.example.BES.services.SessionTokenService;
@@ -47,9 +45,6 @@ public class AuthControllerIntegrationTest {
     private JudgeRepo judgeRepo;
 
     @Autowired
-    private EventGenreRepo eventGenreRepo;
-
-    @Autowired
     private SessionTokenService sessionTokenService;
 
     private Event testEvent;
@@ -66,16 +61,7 @@ public class AuthControllerIntegrationTest {
         testJudge.setName("Test Judge");
         testJudge = judgeRepo.save(testJudge);
 
-        // Create a division and assign judge to it so the JPA relationship
-        // (judge.eventGenres → EventGenre.event) resolves for SessionTokenService validation
-        EventGenre eg = new EventGenre();
-        eg.setName("Test Division");
-        eg.setEvent(testEvent);
-        eg.setJudges(new java.util.ArrayList<>(java.util.List.of(testJudge)));
-        eg = eventGenreRepo.save(eg);
-        // Ensure the judge entity has the division in its collection
-        testJudge.setEventGenres(new java.util.ArrayList<>(java.util.List.of(eg)));
-        testJudge = judgeRepo.save(testJudge);
+        judgeRepo.insertEventJudge(testEvent.getEventId(), testJudge.getJudgeId());
     }
 
     @Test

--- a/docs/superpowers/plans/2026-06-09-event-details-ux-overhaul.md
+++ b/docs/superpowers/plans/2026-06-09-event-details-ux-overhaul.md
@@ -1,0 +1,852 @@
+# EventDetails UX Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign EventDetails.vue for clarity — judge pool cards, categories rename, session link auto-generation, sheet suggestion chips, and genre tab structure.
+
+**Architecture:** All changes are in two frontend files only. No backend changes. Logic changes (session auto-gen, matching fix, no-solo default) are frontend-only and explicitly user-requested.
+
+**Tech Stack:** Vue 3 (Composition API), Tailwind CSS utility classes, project design system (parallelogram chips via `para-chip`, section rules via `section-rule`, Anton SC typography via `type-*`)
+
+---
+
+## Files Modified
+
+| File | What changes |
+|------|-------------|
+| `BES-frontend/src/views/EventDetails.vue` | Tasks 1–8 |
+| `BES-frontend/src/components/ScoringCriteriaModal.vue` | Task 9 |
+
+---
+
+## Task 1: Fix matching bug — exact case-insensitive equality
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue:564-595`
+
+The current substring match (`cat.includes(n)`) causes false positives: a category named `"1v1"` matches every sheet value containing "1v1". Fix to exact equality. Both sides are already lowercased before comparison.
+
+- [ ] **Open** `BES-frontend/src/views/EventDetails.vue`
+
+- [ ] **Replace** the `matchCounts` computed (lines ~564–579):
+
+```js
+const matchCounts = computed(() => {
+  const counts = {}
+  const cats = sheetCategories.value.map(s => s.toLowerCase())
+  for (const div of eventGenres.value) {
+    const names = [div.name.toLowerCase()]
+    if (div.sheetAliases) {
+      names.push(...div.sheetAliases.split(',').map(a => a.trim().toLowerCase()).filter(Boolean))
+    }
+    let count = 0
+    for (const cat of cats) {
+      if (names.some(n => cat === n)) count++
+    }
+    counts[div.eventGenreId] = count
+  }
+  return counts
+})
+```
+
+- [ ] **Replace** the `unmatchedSheetValues` computed (lines ~581–595):
+
+```js
+const unmatchedSheetValues = computed(() => {
+  if (!sheetCategories.value.length) return []
+  const matched = new Set()
+  for (const div of eventGenres.value) {
+    const names = [div.name.toLowerCase()]
+    if (div.sheetAliases) {
+      names.push(...div.sheetAliases.split(',').map(a => a.trim().toLowerCase()).filter(Boolean))
+    }
+    for (const cat of sheetCategories.value) {
+      if (names.some(n => cat.toLowerCase() === n)) matched.add(cat.toLowerCase())
+    }
+  }
+  const unique = [...new Set(sheetCategories.value.map(s => s.toLowerCase()))]
+  return unique.filter(v => !matched.has(v))
+})
+```
+
+- [ ] **Verify** in browser: connect a sheet, set a category name to exactly match one sheet value. Only that one sheet row should count as matched. A category named `"1v1"` should NOT match `"Hip Hop 1v1"`.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "fix: exact case-insensitive category matching (was substring, caused false positives)"
+```
+
+---
+
+## Task 2: No-solo default when team format selected
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue:609-612`
+
+When a team format (2v2, 3v3, 4v4, 5v5) is selected, immediately set soloAllowed = false. The Solo toggle stays visible for manual override.
+
+- [ ] **Replace** `saveDivisionFormat` (lines ~609–612):
+
+```js
+const saveDivisionFormat = async (div, format) => {
+  await updateEventGenreFormat(props.eventName, div.eventGenreId, format || null)
+  div.format = format || null
+  // Team formats default to no solo
+  if (format && /^\d+v\d+$/i.test(format) && format.toLowerCase() !== '1v1') {
+    if (div.soloAllowed !== false) {
+      await updateDivisionSoloAllowed(props.eventName, div.eventGenreId, false)
+      div.soloAllowed = false
+    }
+  }
+}
+```
+
+- [ ] **Verify** in browser: set a category to `2v2` → solo toggle should immediately switch to "NO SOLO" without needing a page refresh.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "feat: team format categories default to no-solo on format select"
+```
+
+---
+
+## Task 3: Rename "Divisions" → "Categories" in all UI text
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue`
+
+This is UI text only. Do NOT rename JS variables (`divisionsByGenre`, `divRenameActive`, `divFormatOptions`, etc.) — only change the strings that users see.
+
+- [ ] **Find and replace** these exact strings (case-sensitive, in template and JS string literals only):
+
+| Find | Replace |
+|------|---------|
+| `'Remove Division?'` | `'Remove Category?'` |
+| `will be permanently deleted. Participants already enrolled will block this action — remove them first.` | `will be permanently removed. Participants already enrolled will block this action — remove them first.` |
+| `Participants registering for "${div.name}" will no longer be able to select Solo (pickup crew).` | `Participants in "${div.name}" will no longer be able to register as Solo (pickup crew).` |
+| `Solo entries will be permitted for "${div.name}".` | `Solo entries will be permitted for "${div.name}".` *(no change needed)* |
+| `<span class="section-rule-label">Divisions</span>` | `<span class="section-rule-label">Categories</span>` |
+| `` + Add {{ group.label }} division`` | `` + Add {{ group.label }} category`` |
+| `title="Remove division"` | `title="Remove category"` |
+| `Remove all participants from the division before deleting it.` | `Remove all participants from the category before deleting it.` |
+| `Remove ${j.judgeName} from ${g.name}?` | `Remove ${j.judgeName} from ${g.name}?` *(no change — judge confirm message is fine)* |
+
+- [ ] **Add help text** immediately after the `<div class="section-rule mb-4">` that wraps the "Categories" label (the outer card for the Divisions section, around line 1398):
+
+```html
+<div class="section-rule mb-3">
+  <span class="section-rule-label">Categories</span>
+  <div class="section-rule-line"></div>
+</div>
+<p class="type-label text-content-muted mb-4" style="font-size:10px;text-transform:none;letter-spacing:0.03em;">
+  Categories are competition formats within each genre (e.g. Popping 1v1, Popping 7 to Smoke).
+  Names must match your Google Sheet column values exactly.
+</p>
+```
+
+- [ ] **Verify** in browser: section heading says "Categories", add button says "+ Add X category", confirm dialog says "Remove Category?", help text visible.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "ui: rename Divisions to Categories throughout EventDetails"
+```
+
+---
+
+## Task 4: Sheet suggestions strip
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue`
+
+Add a panel showing all unique sheet category values above the per-genre groups. Covered = already has a matching category (greyed out). Uncovered = clickable chips that open a genre picker.
+
+- [ ] **Add computed** `allSheetSuggestions` and `suggestionCoveredSet` after `unmatchedSheetValues` (~line 595):
+
+```js
+const allSheetSuggestions = computed(() => {
+  return [...new Set(sheetCategories.value)]
+})
+
+const suggestionCoveredSet = computed(() => {
+  const covered = new Set()
+  for (const div of eventGenres.value) {
+    const names = [div.name.toLowerCase()]
+    if (div.sheetAliases) {
+      names.push(...div.sheetAliases.split(',').map(a => a.trim().toLowerCase()).filter(Boolean))
+    }
+    for (const cat of sheetCategories.value) {
+      if (names.some(n => cat.toLowerCase() === n)) covered.add(cat)
+    }
+  }
+  return covered
+})
+```
+
+- [ ] **Add state** for the genre picker popover (after the existing `divAliasExpanded` ref, ~line 57):
+
+```js
+const pendingSuggestionCat = ref(null) // sheet value waiting for genre assignment
+```
+
+- [ ] **Add handler** `addSuggestionToGenre` after `addDivisionToGroup` (~line 652):
+
+```js
+const addSuggestionToGenre = async (genreId, genreLabel) => {
+  if (!pendingSuggestionCat.value) return
+  const name = pendingSuggestionCat.value
+  pendingSuggestionCat.value = null
+  // Reuse existing addDivisionToGroup but pass the sheet value as the desired name.
+  // addDivisionToGroup auto-deduplicates; since this name comes from the sheet it
+  // should not collide, but the guard still runs.
+  const existingNames = eventGenres.value.map(d => d.name.toLowerCase())
+  let finalName = name
+  let i = 2
+  while (existingNames.includes(finalName.toLowerCase())) {
+    finalName = `${name} ${i++}`
+  }
+  const resp = await addDivision(props.eventName, finalName, null, genreId === 'custom' ? null : genreId)
+  if (resp && resp.ok) {
+    eventGenres.value = await getGenresByEvent(props.eventName)
+  }
+}
+```
+
+- [ ] **Add suggestions strip** to the template, inside the Categories card, immediately before `<div class="space-y-4">` (the per-genre groups loop, ~line 1403):
+
+```html
+<!-- Sheet suggestions strip — only when sheet is connected -->
+<div v-if="allSheetSuggestions.length > 0" class="mb-4 p-3 para-chip">
+  <p class="type-label text-content-muted mb-2" style="font-size:10px;">FROM YOUR SHEET — click to add as a category</p>
+  <div class="flex flex-wrap gap-2">
+    <span
+      v-for="cat in allSheetSuggestions"
+      :key="cat"
+    >
+      <!-- Covered: greyed, not clickable -->
+      <span
+        v-if="suggestionCoveredSet.has(cat)"
+        class="type-label text-content-muted line-through opacity-40"
+        style="font-size:10px;"
+      >{{ cat }}</span>
+      <!-- Uncovered: clickable, shows genre picker -->
+      <span
+        v-else
+        class="relative"
+      >
+        <button
+          @click="pendingSuggestionCat = pendingSuggestionCat === cat ? null : cat"
+          class="para-chip-sm px-2.5 py-1 type-label text-content-secondary hover:text-accent transition-colors"
+          style="font-size:10px;border-style:dashed;"
+        >+ {{ cat }}</button>
+        <!-- Inline genre picker -->
+        <div
+          v-if="pendingSuggestionCat === cat"
+          class="absolute top-full left-0 mt-1 z-50 bg-surface-800 border border-surface-600 para-chip p-2 min-w-[160px]"
+        >
+          <p class="type-label text-content-muted mb-1.5" style="font-size:9px;">ADD TO GENRE:</p>
+          <button
+            v-for="group in divisionsByGenre"
+            :key="group.genreId"
+            @click="addSuggestionToGenre(group.genreId, group.label)"
+            class="block w-full text-left px-2 py-1.5 type-body text-content-secondary hover:text-accent transition-colors"
+            style="font-size:11px;"
+          >{{ group.label }}</button>
+        </div>
+      </span>
+    </span>
+  </div>
+</div>
+```
+
+- [ ] **Close picker on outside click** — add to the existing `@click.outside` pattern or a simple document click handler. Simplest: add `@click.self` to the backdrop or use `v-click-outside` if already available. The easiest path: add to the existing confirm/modal close patterns. Since the picker auto-closes when the user selects a genre (`pendingSuggestionCat` is cleared), just ensure clicking another chip closes the previous one (already handled since `pendingSuggestionCat` holds only one value).
+
+- [ ] **Verify** in browser: suggestions strip appears when sheet is connected. Covered chips appear greyed out. Clicking an uncovered chip shows the genre picker. Picking a genre creates the category and the chip becomes greyed.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "feat: sheet suggestions strip in Categories section with inline genre picker"
+```
+
+---
+
+## Task 5: Alias — collapse behind text link
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue:1483-1531`
+
+The alias button (`pi-tags` icon) is replaced by a small "add alias" text link shown only when the alias section is expanded or aliases already exist on the row.
+
+- [ ] **Replace** the alias toggle button (currently `<button @click="divAliasExpanded = ..."` with the `pi-tags` icon, ~line 1484):
+
+```html
+<!-- Alias toggle — text link, shown after the remove button -->
+<button
+  v-if="divAliasExpanded !== div.eventGenreId && !(div.sheetAliases && div.sheetAliases.split(',').filter(Boolean).length)"
+  @click="divAliasExpanded = div.eventGenreId; divAliasInput = ''"
+  class="type-label text-content-muted hover:text-accent transition-colors"
+  style="font-size:9px;letter-spacing:0.1em;text-decoration:underline;text-underline-offset:2px;"
+  title="Add a sheet alias manually if the category name doesn't match your sheet exactly"
+>aliases</button>
+```
+
+- [ ] **Verify** alias chips already on a category still render (the existing chips template at ~line 1509 is unchanged — keep it). Existing aliases not removed.
+
+- [ ] **Verify** in browser: no alias button visible by default. Alias chips appear inline if the category already has aliases. "aliases" text link appears to open the add-alias input.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "ui: collapse alias button behind text link in category rows"
+```
+
+---
+
+## Task 6: Genre tab — three labelled sections
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue:1626-1731`
+
+Add section-rule labels (Roster Status / Scoring Criteria / Judges) inside each genre tab. Update badge copy.
+
+- [ ] **Replace** the genre tab content block (inside `<template v-for="g in eventGenres"`, from the `<div v-if="activeGenreTab === g.name"` through its closing tag, ~lines 1626–1731) with:
+
+```html
+<template v-for="g in eventGenres" :key="g.name + '-content'">
+  <div v-if="activeGenreTab === g.name" class="p-5 space-y-4">
+
+    <!-- ROSTER STATUS -->
+    <template v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name))">
+      <div>
+        <div class="section-rule mb-3">
+          <span class="section-rule-label" style="font-size:9px;">Roster Status</span>
+          <div class="section-rule-line"></div>
+        </div>
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="badge-neutral text-xs">{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).total }} total</span>
+          <span class="badge-success">{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).registered }} registered</span>
+          <span
+            v-if="completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered > 0"
+            class="badge-danger"
+          >{{ completeBreakdown.find(b => b.genre === normalizeGenreName(g.name)).unregistered }} unregistered</span>
+        </div>
+
+        <!-- Unregistered list -->
+        <div v-if="getUnregistered(normalizeGenreName(g.name)).unregistered.length > 0" class="mt-2">
+          <div class="flex flex-wrap gap-2">
+            <span
+              v-for="p in getUnregistered(normalizeGenreName(g.name)).unregistered"
+              :key="p.participantName"
+              class="badge-danger font-source"
+            >{{ p.participantName }}</span>
+          </div>
+        </div>
+        <div v-else class="flex items-center gap-2 type-body text-emerald-400 mt-2">
+          <i class="pi pi-check-circle"></i>
+          <span>All participants registered</span>
+        </div>
+      </div>
+      <div class="h-px bg-surface-700/40"></div>
+    </template>
+
+    <!-- SCORING CRITERIA -->
+    <div>
+      <div class="flex items-center gap-2 mb-2">
+        <div class="section-rule mb-0 flex-1">
+          <span class="section-rule-label" style="font-size:9px;">Scoring Criteria</span>
+          <div class="section-rule-line"></div>
+        </div>
+        <button
+          @click="showCriteriaModal = true"
+          class="para-chip-sm px-2.5 py-1 type-label shrink-0"
+        ><i class="pi pi-sliders-h" style="font-size:0.65rem"></i> Configure</button>
+      </div>
+      <template v-if="criteriaByGenre[g.name]?.length">
+        <div class="flex flex-wrap gap-1.5">
+          <span
+            v-for="c in criteriaByGenre[g.name]"
+            :key="c.id"
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-700 border border-surface-600/50 text-xs text-content-secondary"
+          >
+            {{ c.name }}
+            <span v-if="c.weight != null" class="font-source text-primary-400">×{{ c.weight }}</span>
+          </span>
+        </div>
+      </template>
+      <span v-else class="text-xs text-content-muted">Default — single 0–10 score</span>
+    </div>
+
+    <div class="h-px bg-surface-700/40"></div>
+
+    <!-- JUDGES (read-only) -->
+    <div>
+      <div class="section-rule mb-2">
+        <span class="section-rule-label" style="font-size:9px;">Judges</span>
+        <div class="section-rule-line"></div>
+        <span class="type-label text-content-muted" style="font-size:9px;white-space:nowrap;">manage in judge pool above</span>
+      </div>
+      <div v-if="(divisionJudges[g.name] || []).length > 0" class="flex flex-wrap gap-2">
+        <span
+          v-for="j in (divisionJudges[g.name] || [])"
+          :key="j.judgeId"
+          class="flex items-center gap-1.5 para-chip px-2.5 py-1"
+        >
+          <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" style="box-shadow:0 0 5px rgba(52,211,153,0.5)"></span>
+          <span class="type-body text-content-secondary text-xs">{{ j.judgeName }}</span>
+        </span>
+      </div>
+      <span v-else class="text-xs text-content-muted">None assigned — add in Judge Pool above</span>
+    </div>
+
+  </div>
+</template>
+```
+
+- [ ] **Verify** in browser: three clear labelled sections inside each genre tab. Badge text now says "24 total / 22 registered / 2 unregistered". Judges row is read-only chips.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "ui: genre tab three-section layout — Roster Status, Scoring Criteria, Judges (read-only)"
+```
+
+---
+
+## Task 7: Judge Pool → mini-profile cards
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue:1570-1604`
+
+Replace the flat "Event Judges" chip list with a card-per-judge grid. Each card shows the judge's name, their assigned categories, an assign dropdown, and a remove button.
+
+- [ ] **Add state** for the judge pool card assign dropdown (near the existing `openAssignDropdown` ref, ~line 674):
+
+```js
+const openJudgeCardDropdown = ref(null) // judgeId of the card with open assign dropdown
+```
+
+- [ ] **Add computed** `categoriesForJudge` that returns all categories assigned to a given judge (uses existing `divisionJudges` data):
+
+```js
+const categoriesAssignedToJudge = (judgeId) => {
+  const result = []
+  for (const [genreName, judges] of Object.entries(divisionJudges.value)) {
+    if (judges.some(j => j.judgeId === judgeId)) {
+      const genre = eventGenres.value.find(g => g.name === genreName)
+      if (genre) result.push(genre)
+    }
+  }
+  return result
+}
+
+const categoriesUnassignedToJudge = (judgeId) => {
+  const assigned = new Set(categoriesAssignedToJudge(judgeId).map(g => g.eventGenreId))
+  return eventGenres.value.filter(g => !assigned.has(g.eventGenreId))
+}
+```
+
+- [ ] **Replace** the Global Judges block (lines ~1570–1604):
+
+```html
+<!-- Judge Pool -->
+<div class="mb-5">
+  <div class="section-rule mb-1">
+    <span class="section-rule-label">Judge Pool</span>
+    <div class="section-rule-line"></div>
+  </div>
+  <p class="type-label text-content-muted mb-4" style="font-size:10px;text-transform:none;letter-spacing:0.03em;">
+    Add your judges here first — then assign them to categories below.
+  </p>
+
+  <div class="flex flex-wrap gap-3">
+    <!-- Per-judge card -->
+    <div
+      v-for="j in allEventJudges"
+      :key="j.judgeId"
+      class="para-chip p-3 flex flex-col gap-2 min-w-[160px] flex-1"
+      :class="categoriesAssignedToJudge(j.judgeId).length === 0
+        ? 'border-l-[3px] border-l-amber-500 bg-amber-950/10'
+        : 'border-l-[3px] border-l-emerald-500/40'"
+    >
+      <!-- Judge name + remove -->
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex items-center gap-1.5">
+          <span
+            class="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+            :class="categoriesAssignedToJudge(j.judgeId).length === 0
+              ? 'bg-amber-400' : 'bg-emerald-400'"
+            :style="categoriesAssignedToJudge(j.judgeId).length === 0
+              ? 'box-shadow:0 0 5px rgba(245,158,11,0.5)'
+              : 'box-shadow:0 0 5px rgba(52,211,153,0.5)'"
+          ></span>
+          <span class="type-body text-content-secondary text-xs">{{ j.judgeName }}</span>
+        </div>
+        <button
+          @click="askRemoveJudgeGlobal(j)"
+          class="type-label text-content-muted hover:text-red-400 transition-colors"
+          title="Remove from event"
+        ><i class="pi pi-times text-xs"></i></button>
+      </div>
+
+      <!-- Assigned categories -->
+      <div>
+        <p class="type-label text-content-muted mb-1" style="font-size:9px;">CATEGORIES</p>
+        <div v-if="categoriesAssignedToJudge(j.judgeId).length > 0" class="flex flex-wrap gap-1 mb-1.5">
+          <span
+            v-for="cat in categoriesAssignedToJudge(j.judgeId)"
+            :key="cat.eventGenreId"
+            class="inline-flex items-center gap-1 para-chip-sm px-1.5 py-0.5 type-label text-content-muted"
+            style="font-size:9px;"
+          >
+            {{ cat.name }}
+            <button
+              @click="submitRemoveJudge(cat.eventGenreId, j.judgeId)"
+              class="hover:text-red-400 transition-colors leading-none"
+            ><i class="pi pi-times" style="font-size:0.45rem"></i></button>
+          </span>
+        </div>
+        <p v-else class="type-label text-amber-400 mb-1.5" style="font-size:9px;">No categories assigned yet</p>
+      </div>
+
+      <!-- Assign dropdown -->
+      <div v-if="categoriesUnassignedToJudge(j.judgeId).length > 0" class="relative">
+        <button
+          @click="openJudgeCardDropdown = openJudgeCardDropdown === j.judgeId ? null : j.judgeId"
+          class="para-chip-sm px-2 py-1 type-label text-accent hover:bg-[var(--accent-subtle)] transition-all w-full text-left"
+          style="font-size:9px;"
+        ><i class="pi pi-plus text-xs mr-1"></i> Assign category</button>
+        <div
+          v-if="openJudgeCardDropdown === j.judgeId"
+          class="absolute top-full left-0 mt-1 bg-surface-800 border border-surface-600 para-chip p-1.5 z-50 min-w-[160px] max-h-48 overflow-y-auto"
+        >
+          <button
+            v-for="cat in categoriesUnassignedToJudge(j.judgeId)"
+            :key="cat.eventGenreId"
+            @click="submitAssignJudge(cat.eventGenreId, j.judgeId); openJudgeCardDropdown = null"
+            class="block w-full text-left px-3 py-1.5 type-body text-content-secondary hover:text-content-primary hover:bg-surface-700 transition-colors"
+            style="font-size:11px;"
+          >+ {{ cat.name }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Add judge card -->
+    <div class="para-chip p-3 flex flex-col items-center justify-center gap-2 min-w-[140px] flex-1" style="border-style:dashed;border-color:rgba(255,255,255,0.1);">
+      <div class="flex items-center gap-1.5 w-full">
+        <input
+          v-model="globalJudgeInput"
+          type="text"
+          placeholder="Judge name…"
+          autocomplete="off"
+          class="bg-transparent type-body placeholder:text-content-muted focus:outline-none flex-1 min-w-0 text-xs"
+          @keyup.enter="submitAddJudgeGlobal()"
+        />
+        <button
+          @click="submitAddJudgeGlobal()"
+          class="type-label text-accent hover:opacity-80 transition-opacity shrink-0"
+          title="Add judge"
+        ><i class="pi pi-plus text-xs"></i></button>
+      </div>
+      <span v-if="allEventJudges.length === 0" class="type-label text-content-muted" style="font-size:9px;">No judges yet</span>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Verify** in browser: judges appear as cards. Unassigned judge has amber left border + amber dot. Assign dropdown lists only unassigned categories. Removing a category chip via × updates the card immediately.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "ui: judge pool mini-profile cards with inline category assignment"
+```
+
+---
+
+## Task 8: Session Links — auto-generated, refresh-to-extend
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue`
+
+Remove manual generate buttons and expand toggle. Auto-generate EMCEE/HELPER on load, auto-generate JUDGE on judge add, auto-revoke on judge remove. Add Refresh action and expiry colour coding.
+
+- [ ] **Remove** `sessionLinksExpanded` ref (line ~735) and `selectedJudgeId` ref (line ~738) and `generatingRole` ref (line ~739) — these become unused.
+
+- [ ] **Add** copy feedback ref near the existing `auditionLinkCopied` ref (~line 813):
+
+```js
+const copiedTokenId = ref(null)
+```
+
+- [ ] **Replace** `loadSessionTokens` (~lines 768–773) with an auto-generating version:
+
+```js
+const loadSessionTokens = async () => {
+  if (!dbEventId.value) return
+  sessionTokensLoading.value = true
+  sessionTokens.value = await getSessionTokens(dbEventId.value)
+  // Auto-generate permanent roles if missing
+  const hasEmcee = sessionTokens.value.some(t => t.role === 'EMCEE')
+  const hasHelper = sessionTokens.value.some(t => t.role === 'HELPER')
+  if (!hasEmcee) await generateToken('EMCEE', dbEventId.value, null)
+  if (!hasHelper) await generateToken('HELPER', dbEventId.value, null)
+  if (!hasEmcee || !hasHelper) {
+    sessionTokens.value = await getSessionTokens(dbEventId.value)
+  }
+  sessionTokensLoading.value = false
+}
+```
+
+- [ ] **Update** `submitAddJudgeGlobal` (~lines 686–693) to auto-generate a judge token:
+
+```js
+const submitAddJudgeGlobal = async () => {
+  if (!globalJudgeInput.value.trim()) return
+  const res = await addJudgeToEvent(props.eventName, globalJudgeInput.value.trim())
+  if (res?.ok) {
+    const judges = await res.json()
+    allEventJudges.value = judges
+    // Auto-generate session token for the new judge
+    const newJudge = judges[judges.length - 1]
+    if (newJudge && dbEventId.value) {
+      await generateToken('JUDGE', dbEventId.value, newJudge.judgeId)
+      await loadSessionTokens()
+    }
+  }
+  globalJudgeInput.value = ''
+}
+```
+
+- [ ] **Update** `submitRemoveJudgeGlobal` (~lines 695–705) to revoke the judge's token first:
+
+```js
+const submitRemoveJudgeGlobal = async (judgeId) => {
+  // Revoke session token for this judge before removing them
+  const judgeToken = sessionTokens.value.find(t => t.role === 'JUDGE' && t.judgeId === judgeId)
+  if (judgeToken) await revokeSessionToken(judgeToken.tokenId)
+
+  const res = await removeEventJudge(props.eventName, judgeId)
+  if (res?.ok) {
+    allEventJudges.value = await res.json()
+    for (const genre of eventGenres.value) {
+      if (divisionJudges.value[genre.name]) {
+        divisionJudges.value[genre.name] = await getJudgesByDivision(props.eventName, genre.eventGenreId)
+      }
+    }
+    await loadSessionTokens()
+  }
+}
+```
+
+> **Note:** `judgeToken.judgeId` assumes the token DTO includes `judgeId`. Check `getSessionTokens` response shape. If the field is named differently (e.g. `judgeRefId`), use that name. If it's not present, match by `judgeName` against `allEventJudges`.
+
+- [ ] **Add** `handleRefreshToken` after `handleRevokeToken` (~line 792):
+
+```js
+const handleRefreshToken = async (token) => {
+  await revokeSessionToken(token.tokenId)
+  await generateToken(token.role, dbEventId.value, token.judgeId ?? null)
+  await loadSessionTokens()
+}
+```
+
+- [ ] **Update** `copyTokenLink` to accept tokenId for feedback (~line 809):
+
+```js
+const copyTokenLink = (url, tokenId) => {
+  copyToClipboard(window.location.origin + url)
+  copiedTokenId.value = tokenId
+  setTimeout(() => { copiedTokenId.value = null }, 2000)
+}
+```
+
+- [ ] **Add** expiry helper after `formatExpiry` (~line 820):
+
+```js
+const isExpiryWarning = (expiresAt) => {
+  return (new Date(expiresAt) - Date.now()) < 3 * 24 * 60 * 60 * 1000
+}
+```
+
+- [ ] **Remove** the `watch(sessionLinksExpanded, ...)` block (~lines 825–827) — no longer needed since section is always visible.
+
+- [ ] **Replace** the entire Session Links template block (currently ~lines 1735–1822) with:
+
+```html
+<!-- Session Links — always visible, auto-generated -->
+<div v-if="isAdminOrOrganiser && tableExist" class="card-hover p-4 relative mt-6">
+  <div class="corner-bar-tl"></div>
+
+  <div class="section-rule mb-4">
+    <span class="section-rule-label">Session Links</span>
+    <div class="section-rule-line"></div>
+    <span class="type-label text-content-muted" style="font-size:9px;white-space:nowrap;">auto-generated · refresh to extend</span>
+  </div>
+
+  <div v-if="sessionTokensLoading" class="flex items-center gap-2 type-label text-content-muted py-4">
+    <i class="pi pi-spinner pi-spin text-xs"></i> Loading…
+  </div>
+  <div v-else class="space-y-2">
+    <div
+      v-for="t in sessionTokens"
+      :key="t.tokenId"
+      class="para-chip px-3 py-2 flex items-center gap-3"
+    >
+      <span
+        class="badge-neutral text-xs shrink-0"
+        :class="t.role === 'JUDGE' ? 'badge-accent' : 'badge-neutral'"
+      >{{ t.role }}</span>
+      <span v-if="t.judgeName" class="type-body text-content-secondary text-xs truncate">{{ t.judgeName }}</span>
+      <span class="flex-1"></span>
+      <span
+        class="type-label text-xs shrink-0"
+        :class="isExpiryWarning(t.expiresAt) ? 'text-amber-400' : 'text-content-muted'"
+      >
+        {{ formatExpiry(t.expiresAt) }}
+        <span v-if="isExpiryWarning(t.expiresAt)"> ⚠</span>
+      </span>
+      <button
+        @click="handleRefreshToken(t)"
+        class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-accent transition-colors shrink-0"
+        title="Refresh link (extends expiry)"
+      ><i class="pi pi-refresh text-xs"></i></button>
+      <button
+        @click="copyTokenLink(t.url, t.tokenId)"
+        class="para-chip-sm px-2 py-1 type-label transition-colors shrink-0"
+        :class="copiedTokenId === t.tokenId ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
+        title="Copy link"
+      ><i class="pi text-xs" :class="copiedTokenId === t.tokenId ? 'pi-check' : 'pi-copy'"></i></button>
+    </div>
+    <p class="type-label text-content-muted mt-3" style="font-size:9px;">Judge links are removed automatically when a judge is deleted.</p>
+  </div>
+</div>
+```
+
+- [ ] **Verify** in browser:
+  - On page load, EMCEE and HELPER tokens appear automatically (generated if missing)
+  - Add a judge → their token appears in the list
+  - Refresh button → link refreshes, copy button reflects updated URL
+  - Delete a judge → their token disappears
+  - Expiry < 3 days → amber colour + ⚠
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "feat: session links auto-generated, refresh-to-extend, judge tokens tied to judge lifecycle"
+```
+
+---
+
+## Task 9: Scoring Criteria Modal — "Copy to all genres" rename
+
+**Files:** Modify `BES-frontend/src/components/ScoringCriteriaModal.vue`
+
+- [ ] **Add** `appliedAll` ref after `applyingAll` (~line 113):
+
+```js
+const appliedAll = ref(false)
+```
+
+- [ ] **Update** `applyToAllGenres` to set `appliedAll` on success (~line 115):
+
+```js
+const applyToAllGenres = async () => {
+  if (!activeCriteria.value.length) return
+  applyingAll.value = true
+  const source = [...activeCriteria.value]
+  const targets = allTabs.value.filter(t => t !== activeTab.value)
+
+  await Promise.all(targets.map(async (tab) => {
+    const genre = genreNameForTab(tab)
+    await deleteAllCriteriaForGenre(props.eventName, genre)
+    const added = []
+    for (let i = 0; i < source.length; i++) {
+      const r = await addScoringCriteria(props.eventName, {
+        genreName:    genre,
+        name:         source[i].name,
+        weight:       source[i].weight,
+        displayOrder: i,
+      })
+      if (r) added.push(r)
+    }
+    criteriaMap.value[tab] = added
+  }))
+
+  applyingAll.value = false
+  appliedAll.value = true
+  setTimeout(() => { appliedAll.value = false }, 1500)
+}
+```
+
+- [ ] **Replace** the "Apply to all genres" button (~lines 335–346) with:
+
+```html
+<button
+  v-if="activeTab !== 'event-level' && genres.length > 1"
+  @click="applyToAllGenres"
+  :disabled="applyingAll || activeCriteria.length === 0"
+  class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent
+         disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
+  :class="appliedAll ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
+  title="Replaces criteria in all other genres with these"
+>
+  <i v-if="applyingAll" class="pi pi-spin pi-spinner text-xs" />
+  <i v-else-if="appliedAll" class="pi pi-check text-xs" />
+  <i v-else class="pi pi-copy text-xs" />
+  {{ appliedAll ? 'Copied!' : 'Copy to all genres' }}
+</button>
+```
+
+- [ ] **Verify** in browser: button says "Copy to all genres". After clicking, shows "Copied!" in green for 1.5s, then reverts.
+
+- [ ] **Commit:**
+```bash
+git add BES-frontend/src/components/ScoringCriteriaModal.vue
+git commit -m "ui: rename Apply to all genres → Copy to all genres with Copied! confirmation"
+```
+
+---
+
+## Task 10: Assign dropdown direction fix
+
+**Files:** Modify `BES-frontend/src/views/EventDetails.vue:1718`
+
+The assign dropdown in the genre tab (now read-only, but the old dropdown code can be removed since Task 6 and Task 7 replaced the interactive judge assignment with the pool cards). Verify this dropdown no longer exists in the template after Task 7. If it was removed by Task 7, this task is a no-op. If it still exists anywhere, change `bottom-full` → `top-full` and `mb-1` → `mt-1`.
+
+- [ ] **Search** for `bottom-full` in `EventDetails.vue`:
+```bash
+grep -n "bottom-full" BES-frontend/src/views/EventDetails.vue
+```
+If any results remain, replace each:
+```
+class="absolute bottom-full left-0 mb-1 ...
+```
+→
+```
+class="absolute top-full left-0 mt-1 ...
+```
+
+- [ ] **Commit** only if a change was needed:
+```bash
+git add BES-frontend/src/views/EventDetails.vue
+git commit -m "ui: fix judge assign dropdown direction — opens downward not upward"
+```
+
+---
+
+## Self-Review Checklist
+
+| Spec requirement | Task |
+|-----------------|------|
+| Matching bug fix (exact equality) | Task 1 |
+| No-solo default on team format | Task 2 |
+| Divisions → Categories rename + help text | Task 3 |
+| Sheet suggestions strip + genre picker | Task 4 |
+| Alias collapsed behind text link | Task 5 |
+| Genre tab section rules (Roster Status / Scoring Criteria / Judges) | Task 6 |
+| Badge copy: Total → N total, Reg → N registered | Task 6 |
+| Judge Pool mini-profile cards | Task 7 |
+| Per-genre Judges read-only | Task 6 |
+| Session links auto-generate EMCEE/HELPER on load | Task 8 |
+| Session links auto-generate JUDGE on judge add | Task 8 |
+| Session links auto-revoke JUDGE on judge remove | Task 8 |
+| Refresh = revoke + regenerate | Task 8 |
+| Expiry colour coding (amber < 3 days) | Task 8 |
+| Copy feedback (✓ for 2s) | Task 8 |
+| "Copy to all genres" rename + Copied! | Task 9 |
+| Assign dropdown direction fix | Task 10 |

--- a/docs/superpowers/plans/2026-06-10-eventdetails-modal-standardization.md
+++ b/docs/superpowers/plans/2026-06-10-eventdetails-modal-standardization.md
@@ -1,0 +1,851 @@
+# EventDetails Modal Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize the Walk-in Form and Scoring Criteria modals in EventDetails to use the same shell, shape, and typography as the Genre Entries modal.
+
+**Architecture:** Two components are modified — `CreateParticipantForm.vue` (template rewrite: remove ActionDoneModal wrapper, add standardized Teleport shell, replace checkbox genre list with chip toggles) and `ScoringCriteriaModal.vue` (visual update: restructure panel into header/body/footer sections, replace nested card-hover items with para-chip rows). No logic changes in either component. Genre Entries modal is untouched.
+
+**Tech Stack:** Vue 3, Tailwind CSS, PrimeIcons, Vitest + Vue Test Utils
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `BES-frontend/src/components/CreateParticipantForm.vue` | Template rewrite + add `toggleGenre` helper |
+| `BES-frontend/src/components/ScoringCriteriaModal.vue` | Template restructure (visual only, no logic changes) |
+| `BES-frontend/src/utils/__tests__/CreateParticipantForm.test.js` | Update tests to match new chip-based UI |
+
+---
+
+## Task 1: Update CreateParticipantForm tests to match new chip UI
+
+The existing tests use `input[type="checkbox"]` to select genres and check old label text. Update them to match the new chip-button genre selection and new label text before touching the component.
+
+**Files:**
+- Modify: `BES-frontend/src/utils/__tests__/CreateParticipantForm.test.js`
+
+- [ ] **Step 1.1: Replace all three genre-selection tests**
+
+Replace the file content from line 19 onward with:
+
+```js
+describe('CreateParticipantForm.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders stage name input and genre chips when open', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [
+          { name: 'Popping', format: '3v3' },
+          { name: 'Waacking', format: '1v1' },
+        ],
+      },
+    })
+    await wrapper.vm.$nextTick()
+    // Stage name input
+    expect(wrapper.find('input[type="text"]').exists()).toBe(true)
+    // Genre chips rendered as buttons (not checkboxes)
+    expect(wrapper.find('input[type="checkbox"]').exists()).toBe(false)
+    const genreButtons = wrapper.findAll('button').filter(b => b.text().includes('Popping'))
+    expect(genreButtons.length).toBeGreaterThan(0)
+  })
+
+  it('toggleGenre adds and removes genre from createTable.genres', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
+      },
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.createTable.genres).toEqual([])
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.createTable.genres).toContain('Popping')
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.createTable.genres).not.toContain('Popping')
+  })
+
+  it('shows inline team section when a team-format genre chip is toggled on', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+
+    // Section rule label for the genre
+    expect(wrapper.text()).toContain('Popping')
+    // Team/Solo toggle buttons appear
+    const teamBtn = wrapper.findAll('button').filter(b => b.text() === 'Team')
+    expect(teamBtn.length).toBeGreaterThan(0)
+  })
+
+  it('shows team name and member inputs when team mode active', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+
+    // entryModes defaults to 'team' for team-format genre
+    expect(wrapper.vm.entryModes['Popping']).toBe('team')
+    // Team name input and member inputs present
+    const inputs = wrapper.findAll('input[type="text"]')
+    // stage name + team name + 2 members = 4
+    expect(inputs.length).toBe(4)
+  })
+
+  it('submits walk-in with correct args (solo mode)', async () => {
+    const wrapper = mount(CreateParticipantForm, {
+      props: {
+        show: true,
+        event: 'TestEvent',
+        eventGenres: [{ name: 'Popping', format: '3v3' }],
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.name = 'Dancer1'
+    wrapper.vm.toggleGenre('Popping')
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.entryModes['Popping'] = 'solo'
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.submitNewEntry()
+    await wrapper.vm.$nextTick()
+
+    expect(addWalkinToSystem).toHaveBeenCalledWith(
+      'Dancer1', 'TestEvent', 'Popping', '', [], '', 'solo'
+    )
+  })
+})
+```
+
+- [ ] **Step 1.2: Run tests — expect failures**
+
+```bash
+cd BES-frontend && npm test -- --run src/utils/__tests__/CreateParticipantForm.test.js
+```
+
+Expected: most tests fail because `toggleGenre` doesn't exist yet and the template still uses checkboxes.
+
+---
+
+## Task 2: Add `toggleGenre` helper to CreateParticipantForm.vue script
+
+**Files:**
+- Modify: `BES-frontend/src/components/CreateParticipantForm.vue`
+
+- [ ] **Step 2.1: Add `toggleGenre` after the `updateMemberName` function (around line 59)**
+
+```js
+function toggleGenre(genreName) {
+  const idx = createTable.genres.indexOf(genreName)
+  if (idx >= 0) {
+    createTable.genres.splice(idx, 1)
+  } else {
+    createTable.genres.push(genreName)
+  }
+}
+```
+
+- [ ] **Step 2.2: Run the toggleGenre test only — expect pass**
+
+```bash
+cd BES-frontend && npm test -- --run src/utils/__tests__/CreateParticipantForm.test.js -t "toggleGenre"
+```
+
+Expected: `toggleGenre adds and removes genre` → PASS
+
+---
+
+## Task 3: Rebuild CreateParticipantForm.vue template
+
+Replace the entire `<template>` block. The `<script setup>` and ActionDoneModal result dialogs are kept; only the main form shell changes.
+
+**Files:**
+- Modify: `BES-frontend/src/components/CreateParticipantForm.vue`
+
+- [ ] **Step 3.1: Replace the `<template>` block**
+
+Replace everything from `<template>` down to (but not including) the first result `<ActionDoneModal` (the `showError` one) with:
+
+```vue
+<template>
+  <!-- Main walk-in form -->
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="props.show"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      >
+        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="$emit('close')" />
+        <div class="card-hover relative w-full sm:max-w-md flex flex-col" style="max-height: 85vh;">
+          <div class="corner-bar-tl"></div>
+          <div class="corner-bar-bl"></div>
+
+          <!-- Header -->
+          <div class="flex items-center justify-between px-4 py-3 border-b border-surface-600/30 shrink-0">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-user-plus text-content-muted text-xs"></i>
+              <span class="type-body text-content-primary">{{ props.title }}</span>
+              <span class="badge-neutral type-label">{{ props.event }}</span>
+            </div>
+            <button
+              @click="$emit('close')"
+              class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors"
+            >
+              <i class="pi pi-times text-xs"></i>
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
+
+            <!-- Stage name -->
+            <div>
+              <label class="type-label text-content-muted mb-1.5 block">Stage Name</label>
+              <input
+                v-model="name"
+                type="text"
+                placeholder="Enter stage name…"
+                class="input-base"
+                :class="formTouched && !name.trim() ? '!border-red-400/60' : ''"
+                @input="formTouched = true"
+                @keyup.enter="submitNewEntry"
+              />
+            </div>
+
+            <!-- Division chips -->
+            <div>
+              <div class="flex items-center justify-between mb-2">
+                <label class="type-label text-content-muted">Divisions</label>
+                <span class="type-label text-content-muted">tap to select</span>
+              </div>
+              <div class="flex flex-wrap gap-1.5">
+                <template v-for="group in groupedDivisions" :key="group.genreId">
+                  <button
+                    v-for="g in group.divisions"
+                    :key="g.genreName"
+                    type="button"
+                    @click="toggleGenre(g.genreName)"
+                    class="para-chip-sm px-3 py-1.5 type-label transition-all flex items-center gap-1.5"
+                    :class="createTable.genres.includes(g.genreName)
+                      ? 'text-accent border-[color:var(--accent-muted)] bg-[var(--accent-subtle)]'
+                      : 'text-content-secondary hover:text-accent'"
+                  >
+                    <span
+                      class="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+                      :style="createTable.genres.includes(g.genreName)
+                        ? 'background:var(--accent-color);box-shadow:0 0 5px var(--accent-muted)'
+                        : 'background:rgba(255,255,255,0.2)'"
+                    ></span>
+                    {{ g.genreName }}
+                    <span v-if="g.format" class="opacity-40 normal-case">{{ g.format }}</span>
+                  </button>
+                </template>
+              </div>
+            </div>
+
+            <!-- Per-genre team details (inline expansion) -->
+            <template v-for="g in createTable.genres" :key="g">
+              <template v-if="isTeamFormat(g)">
+                <div class="section-rule">
+                  <span class="section-rule-label">{{ g }} · {{ selectedFormat(g) }}</span>
+                  <div class="section-rule-line"></div>
+                </div>
+
+                <!-- Solo not allowed warning -->
+                <div
+                  v-if="!isSoloAllowed(g)"
+                  class="flex items-center gap-2 px-3 py-2 para-chip"
+                  style="border-left: 3px solid rgb(251 191 36); background: rgba(251,191,36,0.07);"
+                >
+                  <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 6px rgba(251,191,36,0.6)"></span>
+                  <span class="type-label text-amber-400">Solo entries not allowed — team entry only.</span>
+                </div>
+
+                <!-- Team / Solo toggle -->
+                <div v-if="isSoloAllowed(g)">
+                  <label class="type-label text-content-muted mb-2 block">Entry Type</label>
+                  <div class="flex border border-surface-600/60 overflow-hidden">
+                    <button
+                      type="button"
+                      @click="entryModes[g] = 'team'"
+                      class="flex-1 px-4 py-2 type-label transition-all"
+                      :class="entryModes[g] === 'team'
+                        ? 'bg-[var(--accent-subtle)] text-accent'
+                        : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                    >
+                      Team
+                    </button>
+                    <button
+                      type="button"
+                      @click="entryModes[g] = 'solo'"
+                      class="flex-1 px-4 py-2 type-label transition-all border-l border-surface-600/60"
+                      :class="entryModes[g] === 'solo'
+                        ? 'bg-[var(--accent-subtle)] text-accent'
+                        : 'bg-surface-800 text-content-secondary hover:bg-surface-700'"
+                    >
+                      Solo
+                    </button>
+                  </div>
+                  <p v-if="entryModes[g] === 'solo'" class="type-label text-content-muted mt-1.5">
+                    Auditions individually. Can be grouped into a crew after auditions.
+                  </p>
+                </div>
+
+                <!-- Team name + members -->
+                <template v-if="entryModes[g] !== 'solo' && additionalMembersCountForGenre(g) > 0">
+                  <div>
+                    <label class="type-label text-content-muted mb-1.5 block">Team Name</label>
+                    <input
+                      v-model="teamNames[g]"
+                      type="text"
+                      placeholder="Enter team name…"
+                      class="input-base"
+                      :class="formTouched && !(teamNames[g] || '').trim() ? '!border-red-400/60' : ''"
+                      @input="formTouched = true"
+                    />
+                  </div>
+                  <div>
+                    <label class="type-label text-content-muted mb-1.5 block">Team Members</label>
+                    <p class="type-label text-content-muted mb-2 normal-case" style="font-size:0.65rem">
+                      {{ name || 'Stage name' }} is Member 1. Enter the other {{ additionalMembersCountForGenre(g) }}.
+                    </p>
+                    <div class="space-y-2">
+                      <input
+                        v-for="i in additionalMembersCountForGenre(g)"
+                        :key="i"
+                        :value="(teamMemberNames[g] || [])[i - 1] || ''"
+                        @input="updateMemberName(g, i - 1, $event.target.value); formTouched = true"
+                        type="text"
+                        :placeholder="`Member ${i + 1} stage name…`"
+                        class="input-base"
+                        :class="formTouched && !((teamMemberNames[g] || [])[i - 1] || '').trim() ? '!border-red-400/60' : ''"
+                      />
+                    </div>
+                  </div>
+                </template>
+              </template>
+            </template>
+
+          </div>
+
+          <!-- Footer -->
+          <div class="flex gap-2 justify-end px-4 py-3 border-t border-surface-600/30 shrink-0">
+            <button
+              @click="$emit('close')"
+              class="para-chip-sm px-4 py-2 type-label text-content-muted hover:text-content-primary transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              @click="submitNewEntry"
+              :disabled="!canSubmit"
+              class="para-chip-sm px-4 py-2 type-label transition-all disabled:opacity-40 disabled:cursor-not-allowed text-accent border-[color:var(--accent-muted)] hover:bg-[var(--accent-subtle)]"
+            >
+              Add Participant
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+```
+
+- [ ] **Step 3.2: Run all CreateParticipantForm tests**
+
+```bash
+cd BES-frontend && npm test -- --run src/utils/__tests__/CreateParticipantForm.test.js
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add BES-frontend/src/components/CreateParticipantForm.vue \
+        BES-frontend/src/utils/__tests__/CreateParticipantForm.test.js
+git commit -m "ui: rebuild CreateParticipantForm with standardized slide-up shell and chip genre selection"
+```
+
+---
+
+## Task 4: Rebuild ScoringCriteriaModal.vue shell + header
+
+Replace the outer panel structure (currently `card-hover p-6` with no sections) with the standardized header/body/footer layout. Slide-up on mobile.
+
+**Files:**
+- Modify: `BES-frontend/src/components/ScoringCriteriaModal.vue`
+
+- [ ] **Step 4.1: Replace the outer `<div>` (panel) and header section**
+
+In the template, find:
+```vue
+<!-- Panel -->
+<div class="card-hover p-6 relative w-full max-w-xl flex flex-col max-h-[85vh]">
+  <div class="corner-bar-tl"></div>
+  <div class="corner-bar-bl"></div>
+
+  <!-- Header -->
+  <div class="flex items-center justify-between flex-shrink-0 mb-4">
+    <div>
+      <p class="type-page-title" style="font-size: 18px;">Scoring Criteria</p>
+      <p class="type-label text-content-muted mt-0.5">Define what judges score on. Leave empty for a single 0–10 score.</p>
+    </div>
+    <button
+      @click="close"
+      class="p-1.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-colors"
+    >
+      <i class="pi pi-times text-sm" />
+    </button>
+  </div>
+```
+
+Replace with:
+```vue
+<!-- Panel -->
+<div class="card-hover relative w-full sm:max-w-lg flex flex-col max-h-[85vh]">
+  <div class="corner-bar-tl"></div>
+  <div class="corner-bar-bl"></div>
+
+  <!-- Header -->
+  <div class="flex items-center justify-between px-4 py-3 border-b border-surface-600/30 flex-shrink-0">
+    <div class="flex items-center gap-2">
+      <i class="pi pi-sliders-h text-content-muted text-xs"></i>
+      <span class="type-body text-content-primary">Scoring Criteria</span>
+      <span class="badge-neutral type-label">{{ props.eventName }}</span>
+    </div>
+    <button
+      @click="close"
+      class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors"
+    >
+      <i class="pi pi-times text-xs" />
+    </button>
+  </div>
+```
+
+- [ ] **Step 4.2: Update the outer modal positioning div to slide-up on mobile**
+
+Find:
+```vue
+<div
+  v-if="modelValue"
+  class="fixed inset-0 z-50 flex items-center justify-center p-4"
+  @click.self="close"
+>
+```
+
+Replace with:
+```vue
+<div
+  v-if="modelValue"
+  class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+>
+```
+
+- [ ] **Step 4.3: Update tab description text**
+
+Find:
+```vue
+<div class="px-5 pt-3 pb-0 flex-shrink-0">
+  <p v-if="activeTab === 'event-level'" class="text-xs text-content-muted italic">
+    These criteria apply to any genre that doesn't have its own specific criteria set.
+  </p>
+  <p v-else class="text-xs text-content-muted italic">
+    Criteria specific to <span class="text-primary-400 font-semibold">{{ activeTab }}</span>. Overrides the Event Default.
+  </p>
+</div>
+```
+
+Replace with:
+```vue
+<div class="px-4 pt-2 pb-0 flex-shrink-0">
+  <p v-if="activeTab === 'event-level'" class="type-label text-content-muted">
+    Applies to any genre without its own criteria.
+  </p>
+  <p v-else class="type-label text-content-muted">
+    Criteria for <span class="text-accent">{{ activeTab }}</span> — overrides event default.
+  </p>
+</div>
+```
+
+- [ ] **Step 4.4: Fix criteria list container padding**
+
+Find:
+```vue
+<div class="flex-1 overflow-y-auto px-5 py-4 space-y-2 min-h-0">
+```
+
+Replace with:
+```vue
+<div class="flex-1 overflow-y-auto px-4 py-3 space-y-2 min-h-0">
+```
+
+- [ ] **Step 4.5: Fix tab row padding**
+
+Find:
+```vue
+<div class="flex gap-1 px-5 pt-4 pb-0 overflow-x-auto flex-shrink-0" style="scrollbar-width: none;">
+```
+
+Replace with:
+```vue
+<div class="flex gap-1 px-4 pt-3 pb-0 overflow-x-auto flex-shrink-0" style="scrollbar-width: none;">
+```
+
+- [ ] **Step 4.6: Run frontend build check**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -20
+```
+
+Expected: build completes without errors.
+
+---
+
+## Task 5: Replace criteria card-hover items with para-chip rows
+
+**Files:**
+- Modify: `BES-frontend/src/components/ScoringCriteriaModal.vue`
+
+- [ ] **Step 5.1: Replace the criteria list items (view + edit rows)**
+
+Find:
+```vue
+<template v-else>
+  <div
+    v-for="c in activeCriteria"
+    :key="c.id"
+    class="card-hover p-3 relative"
+  >
+    <!-- View row -->
+    <div
+      v-if="editingId !== c.id"
+      class="flex items-center justify-between"
+    >
+      <div class="flex items-center gap-2 flex-1 min-w-0">
+        <span class="text-sm font-semibold text-content-primary truncate">{{ c.name }}</span>
+        <span v-if="c.weight != null" class="badge-neutral type-label shrink-0">
+          ×{{ c.weight }}
+        </span>
+      </div>
+      <div class="flex items-center gap-1 ml-2 shrink-0">
+        <button
+          @click="startEdit(c)"
+          class="p-1.5 para-chip-sm type-label text-content-muted hover:text-accent transition-colors"
+          title="Edit"
+        >
+          <i class="pi pi-pencil text-xs" />
+        </button>
+        <button
+          @click="remove(c.id)"
+          class="p-1.5 para-chip-sm type-label text-content-muted hover:text-red-400 transition-colors"
+          title="Delete"
+        >
+          <i class="pi pi-times text-xs" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Edit row -->
+    <div v-else class="space-y-2">
+      <div class="flex gap-2">
+        <input
+          v-model="editName"
+          placeholder="Criterion name"
+          class="flex-1 min-w-0 input-base"
+          @keydown.enter="saveEdit"
+          @keydown.escape="cancelEdit"
+        />
+        <input
+          v-model="editWeight"
+          type="number" min="0" step="0.5" placeholder="Weight"
+          class="input-base"
+          style="width: 6rem; flex-shrink: 0"
+        />
+      </div>
+      <div class="flex gap-2">
+        <button
+          @click="saveEdit"
+          :disabled="editSaving || !editName.trim()"
+          class="flex-1 py-1.5 bg-accent para-chip type-label text-surface-900 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+        >
+          <i v-if="editSaving" class="pi pi-spin pi-spinner mr-1" />
+          Save
+        </button>
+        <button
+          @click="cancelEdit"
+          class="px-3 py-1.5 para-chip type-label border-accent text-content-muted hover:text-content-primary transition-all"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+Replace with:
+```vue
+<template v-else>
+  <div
+    v-for="c in activeCriteria"
+    :key="c.id"
+    class="para-chip px-3 py-2.5 transition-all duration-150"
+    :class="editingId === c.id
+      ? 'border-[color:var(--accent-muted)] bg-[var(--accent-subtle)]'
+      : 'border-surface-600/40'"
+  >
+    <!-- View row -->
+    <div v-if="editingId !== c.id" class="flex items-center gap-3">
+      <span
+        class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+        :style="c.weight != null
+          ? 'background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)'
+          : 'background:rgba(255,255,255,0.15)'"
+      ></span>
+      <span class="type-body text-content-primary flex-1 truncate">{{ c.name }}</span>
+      <span v-if="c.weight != null" class="badge-neutral type-label shrink-0">×{{ c.weight }}</span>
+      <div class="flex items-center gap-1 shrink-0">
+        <button
+          @click="startEdit(c)"
+          class="p-1.5 para-chip-sm type-label text-content-muted hover:text-accent transition-colors"
+          title="Edit"
+        >
+          <i class="pi pi-pencil text-xs" />
+        </button>
+        <button
+          @click="remove(c.id)"
+          class="p-1.5 para-chip-sm type-label text-content-muted hover:text-red-400 transition-colors"
+          title="Delete"
+        >
+          <i class="pi pi-times text-xs" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Edit row (inline expansion) -->
+    <div v-else class="space-y-2">
+      <div class="flex gap-2">
+        <input
+          v-model="editName"
+          placeholder="Criterion name"
+          class="flex-1 min-w-0 input-base"
+          @keydown.enter="saveEdit"
+          @keydown.escape="cancelEdit"
+        />
+        <input
+          v-model="editWeight"
+          type="number" min="0" step="0.5" placeholder="Weight"
+          class="input-base"
+          style="width: 6rem; flex-shrink: 0"
+        />
+      </div>
+      <div class="flex gap-2">
+        <button
+          @click="saveEdit"
+          :disabled="editSaving || !editName.trim()"
+          class="flex-1 py-1.5 bg-accent para-chip type-label text-surface-900 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+        >
+          <i v-if="editSaving" class="pi pi-spin pi-spinner mr-1" />
+          Save
+        </button>
+        <button
+          @click="cancelEdit"
+          class="px-3 py-1.5 para-chip type-label border-accent text-content-muted hover:text-content-primary transition-all"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 5.2: Replace the add form container**
+
+Find:
+```vue
+<!-- Add form -->
+<div v-if="showAdd" class="card-hover p-3 space-y-2">
+```
+
+Replace with:
+```vue
+<!-- Add form -->
+<div v-if="showAdd" class="para-chip px-3 py-3 space-y-2 border-surface-600/40">
+```
+
+---
+
+## Task 6: Update ScoringCriteriaModal footer buttons
+
+**Files:**
+- Modify: `BES-frontend/src/components/ScoringCriteriaModal.vue`
+
+- [ ] **Step 6.1: Replace footer**
+
+Find:
+```vue
+<!-- Footer actions -->
+<div class="flex items-center gap-2 flex-shrink-0 pt-4 border-t border-[rgba(255,255,255,0.07)]">
+  <button
+    v-if="!showAdd"
+    @click="showAdd = true"
+    class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent text-content-muted hover:text-accent transition-all duration-150"
+  >
+    <i class="pi pi-plus text-xs" />
+    Add Criterion
+  </button>
+
+  <div class="flex-1" />
+
+  <!-- Copy to all genres (not shown on Event Default tab) -->
+  <button
+    v-if="activeTab !== 'event-level' && genres.length > 1"
+    @click="applyToAllGenres"
+    :disabled="applyingAll || activeCriteria.length === 0"
+    class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label border-accent
+           disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
+    :class="appliedAll ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
+    title="Replaces criteria in all other genres with these"
+  >
+    <i v-if="applyingAll" class="pi pi-spin pi-spinner text-xs" />
+    <i v-else-if="appliedAll" class="pi pi-check text-xs" />
+    <i v-else class="pi pi-copy text-xs" />
+    {{ appliedAll ? 'Copied!' : 'Copy to all genres' }}
+  </button>
+</div>
+```
+
+Replace with:
+```vue
+<!-- Footer actions -->
+<div class="flex items-center gap-2 flex-shrink-0 px-4 py-3 border-t border-surface-600/30">
+  <button
+    v-if="!showAdd"
+    @click="showAdd = true"
+    class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label text-content-muted hover:text-accent transition-all duration-150"
+  >
+    <i class="pi pi-plus text-xs" />
+    Add Criterion
+  </button>
+
+  <div class="flex-1" />
+
+  <button
+    v-if="activeTab !== 'event-level' && genres.length > 1"
+    @click="applyToAllGenres"
+    :disabled="applyingAll || activeCriteria.length === 0"
+    class="flex items-center gap-1.5 px-3 py-1.5 para-chip-sm type-label disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150"
+    :class="appliedAll ? 'text-emerald-400' : 'text-content-muted hover:text-accent'"
+    title="Replaces criteria in all other genres with these"
+  >
+    <i v-if="applyingAll" class="pi pi-spin pi-spinner text-xs" />
+    <i v-else-if="appliedAll" class="pi pi-check text-xs" />
+    <i v-else class="pi pi-copy text-xs" />
+    {{ appliedAll ? 'Copied!' : 'Copy to all genres' }}
+  </button>
+</div>
+```
+
+- [ ] **Step 6.2: Run full test suite**
+
+```bash
+cd BES-frontend && npm test -- --run
+```
+
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 6.3: Run build check**
+
+```bash
+cd BES-frontend && npm run build 2>&1 | tail -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 6.4: Commit ScoringCriteriaModal changes**
+
+```bash
+git add BES-frontend/src/components/ScoringCriteriaModal.vue
+git commit -m "ui: standardize ScoringCriteriaModal — slide-up shell, icon+badge header, para-chip criteria rows"
+```
+
+---
+
+## Task 7: Visual verification
+
+- [ ] **Step 7.1: Start the dev server**
+
+```bash
+cd BES-frontend && npm run dev
+```
+
+- [ ] **Step 7.2: Open EventDetails for any event and verify Walk-in Form**
+
+Navigate to `/events/<any-event-name>`. Click "Add Walk-in".
+
+Checklist:
+- [ ] Panel slides up from bottom on mobile / centers on desktop
+- [ ] Header: user-plus icon · "Add Walk-in" title · event name badge · × close
+- [ ] Stage name is an `input-base` text field
+- [ ] Genres are displayed as `para-chip-sm` chips with glowing dots (no checkboxes)
+- [ ] Tapping a chip toggles it (accent border + dot when selected, dim when not)
+- [ ] For a team-format genre: selecting it reveals section rule + Team/Solo toggle + team name + member fields inline
+- [ ] Deselecting a genre hides the inline section
+- [ ] "Add Participant" button is disabled until stage name is filled and at least one genre is selected
+
+- [ ] **Step 7.3: Open Scoring Criteria modal and verify**
+
+Click "Configure Criteria" on any genre accordion in EventDetails.
+
+Checklist:
+- [ ] Panel slides up from bottom on mobile / centers on desktop
+- [ ] Header: sliders-h icon · "Scoring Criteria" title · event name badge · × close
+- [ ] Genre tabs are `para-chip-sm` chips; active tab has accent fill
+- [ ] Criteria rows are `para-chip` parallelogram shape (no rounded-xl card)
+- [ ] Rows with weight: glowing accent dot; rows without weight: dim dot
+- [ ] Edit inline expansion works (row expands, Save/Cancel appear)
+- [ ] "Add Criterion" toggle in footer works
+- [ ] "Copy to all genres" button present (when > 1 genre)
+
+- [ ] **Step 7.4: Final commit if any tweaks were made**
+
+```bash
+git add -p
+git commit -m "ui: visual tweaks after manual verification of standardized modals"
+```

--- a/docs/superpowers/specs/2026-06-09-event-details-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-09-event-details-ux-overhaul-design.md
@@ -1,0 +1,193 @@
+# EventDetails UX Overhaul — Design Spec
+**Date:** 2026-06-09
+**Issue:** #123
+**Branch:** `ui/event-details-ux-overhaul`
+**Constraint:** UI-only unless explicitly marked as logic change (user-requested).
+
+---
+
+## 1. Scope Summary
+
+Six focused improvements to `EventDetails.vue` and `ScoringCriteriaModal.vue`. No routing, no new views, no new API endpoints except one session-token auto-generation behaviour change.
+
+---
+
+## 2. Judge Pool — Mini-Profile Cards
+
+### Problem
+Two separate places manage judges: "Event Judges" (global add) and per-genre "Judges" (assign). No explanation of the relationship. New organisers don't know why they add judges twice.
+
+### Design
+Replace the flat "Event Judges" chip list with a **card-per-judge grid**.
+
+**Judge card anatomy:**
+- Judge name with green status dot (amber dot + amber border tint when no categories assigned)
+- "CATEGORIES" label with chips for each assigned category (× to remove — calls `removeJudgeFromDivision`)
+- "Assign…" dropdown listing all event categories not yet assigned to this judge (calls `submitAssignJudge`)
+- "+" placeholder card at the end to add a new judge (inline name input)
+- ✕ remove-from-pool button (top-right of card)
+
+**Section header copy:**
+```
+JUDGE POOL
+Add your judges here first — assign categories below.
+```
+
+**Empty unassigned state:** Amber border + amber dot on the card. "No categories assigned yet" text inside.
+
+### Per-Genre "Judges" Section → Read-only
+The Judges row inside each genre tab becomes a non-interactive chip list:
+```
+JUDGES  ───────────────────  manage in judge pool above
+● Alex Chen   ● Maria L.
+```
+No assign/remove controls. Green dot per judge chip. If no judges assigned, show "None assigned — add in Judge Pool above."
+
+---
+
+## 3. Genre Tab Content — Section Rules
+
+### Problem
+Participant stats (Total/Reg/Unreg), scoring criteria, and judges all appear at equal visual weight inside the genre tab with no grouping.
+
+### Design
+Three explicit sections inside each genre tab, each with a section rule label:
+
+```
+ROSTER STATUS  ────────────────────────
+[ 24 total ]  [ 22 registered ]  [ 2 unregistered ]
+(unregistered participant chips if any)
+─ divider ─
+SCORING CRITERIA  ──────────────────   [ ⚙ CONFIGURE ]
+[ Musicality ×2 ]  [ Timing ×1 ]  [ Execution ×1 ]
+(or: "Default — single 0–10 score" if none set)
+─ divider ─
+JUDGES  ────────────────────  manage in judge pool above
+● Alex Chen   ● Maria L.
+```
+
+Badge label changes: `Total:` → `{n} total`, `Reg:` → `{n} registered`, `Unreg:` → `{n} unregistered` (word, not abbreviation).
+
+---
+
+## 4. Session Links — Auto-Generated, Refresh-to-Extend
+
+### Problem
+Organiser must manually generate tokens per role, then delete and recreate when expired. Judge tokens must be created separately after judges are added. No expiry urgency signal.
+
+### Design (logic changes — user-requested)
+
+**Auto-generation:**
+- On `loadSessionTokens()` (called on mount — section is always visible, expand watcher removed): if no EMCEE token exists → auto-call `generateToken('EMCEE')`. Same for HELPER.
+- On `submitAddJudgeGlobal()` success: immediately auto-call `generateToken('JUDGE', judgeId)` for the new judge.
+- On judge removal (`askRemoveJudgeGlobal` confirmed): revoke that judge's session token before removing the judge.
+
+**UI layout — always-expanded section:**
+```
+SESSION LINKS  ──────────────────  auto-generated · refresh to extend
+
+[ EMCEE ]                   Expires Jun 15      [ ↻ Refresh ]  [ ⎘ Copy ]
+[ HELPER ]                  Expires Jun 9 ⚠     [ ↻ Refresh ]  [ ⎘ Copy ]
+[ JUDGE ]  Alex Chen        Expires Jun 12      [ ↻ Refresh ]  [ ⎘ Copy ]
+[ JUDGE ]  Maria L.         Expires Jun 12      [ ↻ Refresh ]  [ ⎘ Copy ]
+
+Judge links are removed automatically when a judge is deleted.
+```
+
+**Refresh:** `handleRevokeToken(t.tokenId)` → `generateToken(role, judgeId)` → reload list. Copy button always reads from the freshly loaded token.
+
+**Expiry colour:**
+- > 3 days: muted grey date
+- ≤ 3 days: amber date + ⚠ symbol
+
+**Copy feedback:** Same pattern as Audition Screen button — `copiedTokenId` ref, green ✓ icon for 2s.
+
+**Removed:** Manual generate buttons (+ EMCEE, + HELPER, + JUDGE), delete button per token, collapsed expand toggle (section always visible).
+
+---
+
+## 5. Categories Section (renamed from Divisions)
+
+### Terminology
+- **Genre** = top-level discipline (Popping, Hip Hop, House) — unchanged
+- **Category** = competition format within a genre (Popping 1v1, Popping 7 to Smoke)
+- All UI text changes: "Divisions" → "Categories", "division" → "category" throughout `EventDetails.vue`
+
+### Help text (under section rule)
+```
+Categories are competition formats within each genre (e.g. Popping 1v1, Popping 7 to Smoke).
+Names must match your Google Sheet column values exactly — suggestions below are pulled from your sheet.
+```
+
+### Sheet Suggestions Strip (shown when `sheetCategories.length > 0`)
+A panel above the per-genre groups:
+```
+FROM YOUR SHEET — click to add as a category
+[ Popping 1v1 (covered) ]  [ Popping 7 to Smoke (covered) ]  [ + Hip Hop 1v1 ]  [ + House Open ]
+```
+- **Covered** = a category's `name` matches this sheet value exactly (case-insensitive). Shown greyed out with strikethrough, not clickable.
+- **Uncovered** chips = no matching category yet. Clickable. On click → show an inline genre picker popover ("Add to which genre?") listing the available genre groups. Selecting a genre calls `addDivisionToGroup(genreId, chipValue)` with the sheet value as the category name.
+- Strip hidden when no sheet is connected (`sheetCategories.length === 0`).
+
+### Category Row
+```
+● Popping 1v1     [ 18 matched ]   [ 1v1 ▾ ]   [ ✕ ]
+```
+- Green dot = has matched sheet rows; amber dot + amber left border = no match
+- Match count replaces the old green/amber count badges
+- No alias button in normal view (aliases hidden — see below)
+
+### Alias — Hidden by Default
+Aliases were a workaround for name mismatches. With suggestion chips providing the exact sheet value, aliases are an edge case. Collapse aliases behind a small "add alias manually" text link at the bottom of each expanded category row. Alias chips (if any exist) still shown inline on the row.
+
+### Unmatched Sheet Values Strip (bottom of section)
+Same amber strip as current, but now uses **exact case-insensitive equality** (not substring). Each unmatched value is also a clickable "+ add" chip (same as suggestions strip).
+
+### No Solo Default (logic change — user-requested)
+When `saveDivisionFormat` sets format to `2v2`, `3v3`, `4v4`, or `5v5`, immediately call `updateDivisionSoloAllowed(div, false)` after the format save. The Solo toggle remains visible for manual override.
+
+### Matching Bug Fix (logic change — user-requested)
+Change `cat.includes(n)` → `cat.toLowerCase() === n.toLowerCase()` in both `matchCounts` and `unmatchedSheetValues` computed properties. This is the root cause of false positives (e.g., category "1v1" matching "Hip Hop 1v1", "House 1v1", "Popping 1v1" simultaneously).
+
+---
+
+## 6. Scoring Criteria Modal — "Copy to all genres"
+
+### Changes
+- Button label: `Apply to all genres` → `Copy to all genres`
+- Button tooltip: `Replaces criteria in all other genres with these`
+- After `applyToAllGenres()` resolves: show brief `Copied!` state on the button for 1.5s (same pattern as copy buttons elsewhere)
+
+---
+
+## 7. Assign Dropdown Direction Fix
+
+The judge assign dropdown in the genre tab currently opens upward (`bottom-full`). Change to `top-full` (opens downward) so it doesn't get clipped at the bottom of the panel.
+
+---
+
+## 8. Deferred — Display Name for Categories
+
+**Tracked as separate issue.** The concept: `name` = sheet match key (immutable); `displayName` = human-facing label (editable, defaults to `name`). Requires DB migration + DTO changes + updating all display sites (Score.vue, AuditionList.vue, BattleControl.vue, Results.vue). Out of scope for this branch.
+
+---
+
+## Affected Files
+
+| File | Changes |
+|------|---------|
+| `BES-frontend/src/views/EventDetails.vue` | All sections above |
+| `BES-frontend/src/components/ScoringCriteriaModal.vue` | Section 6 only |
+
+No backend changes required for sections 2–3, 5 (UI-only). Sections 4 (session auto-generation) and 5 (matching fix, no-solo default) involve frontend logic changes only — no new endpoints.
+
+---
+
+## Logic Change Checklist (user-requested, frontend only)
+
+- [ ] Session auto-generate EMCEE/HELPER on load if missing
+- [ ] Session auto-generate JUDGE token when judge added to pool
+- [ ] Session auto-revoke JUDGE token when judge removed from pool
+- [ ] Refresh = revoke + regenerate
+- [ ] `matchCounts` / `unmatchedSheetValues`: exact equality, not substring
+- [ ] Team format (2v2+) → soloAllowed defaults to false on format set

--- a/docs/superpowers/specs/2026-06-10-eventdetails-modal-standardization-design.md
+++ b/docs/superpowers/specs/2026-06-10-eventdetails-modal-standardization-design.md
@@ -1,0 +1,91 @@
+# EventDetails Modal Standardization
+
+**Date:** 2026-06-10
+**Branch:** `ui/event-details-ux-overhaul`
+**Scope:** Visual/UX only — no API or logic changes
+
+## Problem
+
+EventDetails.vue contains three popup menus with inconsistent designs:
+
+| Modal | Current shell | Shape | Colors | Mobile |
+|-------|--------------|-------|--------|--------|
+| Walk-in Form | `ActionDoneModal` wrapper | `rounded-xl` | old `primary-*` (red) | always centered |
+| Genre Entries | inline `Teleport` | `para-chip` ✓ | `accent` ✓ | slides up from bottom ✓ |
+| Scoring Criteria | inline `Teleport` | `card-hover` + `rounded` items | mixed | always centered |
+
+Genre Entries is the reference design. Walk-in Form and Scoring Criteria are brought into line.
+
+## Standardized Shell
+
+Every modal uses this structure:
+
+```
+Teleport(body)
+  Transition (opacity 200ms ease-out / 150ms ease-in)
+    fixed inset-0 z-50  flex items-end sm:items-center  justify-center  p-0 sm:p-4
+      backdrop (absolute inset-0 bg-black/60 backdrop-blur-sm, click-to-close)
+      card-hover relative w-full sm:max-w-md flex flex-col  max-height: 85vh
+        corner-bar-tl + corner-bar-bl
+        Header    (flex, px-4 py-3, border-b border-surface-600/30, shrink-0)
+        Body      (flex-1, overflow-y-auto, p-4, space-y-4, min-h-0)
+        Footer    (flex, px-4 py-3, border-t border-surface-600/30, shrink-0)  — only when needed
+```
+
+**Header pattern:** left side = icon + `type-body text-content-primary` title + `badge-neutral` event name badge; right side = `para-chip-sm` close button with `pi-times`.
+
+**Mobile behaviour:** `items-end` on mobile → panel slides up from bottom. `sm:items-center` on desktop → centered. This matches Genre Entries exactly.
+
+## Walk-in Form (`CreateParticipantForm.vue`)
+
+**What changes:** The `ActionDoneModal` wrapper is removed. The component renders its own standardized shell (Teleport + Transition + panel) directly, like Genre Entries.
+
+**Layout inside:**
+
+1. **Stage Name** — `type-label` label + `input-base` field.
+2. **Divisions** — `type-label` label with "tap to select" hint. Genres displayed as `para-chip-sm` chips in a flex-wrap grid. Tapping a chip toggles it (selected = accent border + glowing dot, unselected = surface fill).
+3. **Per-genre team details** — for each selected genre that requires team entry, a section expands inline below the chip grid:
+   - Section rule header: `<GenreName> · <format>` (e.g. "Breaking · 2v2")
+   - Team / Solo toggle (para-chip toggle row, hidden if solo not allowed)
+   - Team Name input (only when team mode active and format requires it)
+   - Member name inputs (one per additional member slot)
+4. **Footer** — Cancel (ghost) left, Add Participant (primary, disabled until `canSubmit`) right.
+
+**Success/error feedback:** The four `ActionDoneModal` result dialogs (success, allExisting, submitError, noName) are retained as-is — they are separate overlays that fire after submission, not part of the form shell.
+
+**Props/emits:** unchanged — `show`, `event`, `eventGenres`, `title`; emits `createNewEntry`, `close`.
+
+## Scoring Criteria (`ScoringCriteriaModal.vue`)
+
+**What changes:** Visual/structural update only. Logic (add, edit, delete, applyToAllGenres) is untouched.
+
+**Header:** Add icon (`pi-chart-bar` or similar) and event name badge to match the shell pattern.
+
+**Genre tabs:** Restyled from current free-floating `px-5` row to `para-chip-sm` chips in a `flex gap-1 px-4 pt-3 pb-0 flex-shrink-0` row. Active tab uses `background: var(--accent-color); color: surface-900`. Criteria count badge uses existing inline `span` but restyled as `bg-white/20 text-white` (active) / `bg-surface-600 text-surface-300` (inactive).
+
+**Criteria rows:** Replace `card-hover p-3` nested cards with `para-chip` rows:
+```
+para-chip  flex items-center gap-3 px-3 py-2.5  (border-surface-600/40 or accent when active)
+  glowing dot  (accent when has weight, dim when no weight)
+  name (type-body text-content-primary)
+  weight badge (badge-neutral, ×N)
+  edit + delete buttons (para-chip-sm icon buttons)
+```
+
+**Add / Edit forms:** Remain as inline expanded sections toggled by `showAdd` / `editingId` (current behaviour). Fields use `input-base`; Save/Cancel buttons use `para-chip`/`para-chip-sm`. No change to interaction model.
+
+**Footer:** retains "Add Criterion" button (left, toggles `showAdd`) and "Copy to all genres" button (right), restyled to `para-chip-sm` with `type-label`.
+
+**Max width:** increase from `max-w-xl` to keep it, but add `sm:max-w-lg` — the tab row benefits from extra width.
+
+## Genre Entries (unchanged)
+
+Already matches the standard. No edits.
+
+## What is NOT changing
+
+- All business logic in `CreateParticipantForm.vue` (submit flow, team member counting, validation)
+- All business logic in `ScoringCriteriaModal.vue` (add/edit/delete/applyToAll)
+- The Genre Add Team Form (`genreAddForm`) — already new design, out of scope
+- The Confirm Dialog and Check-in Dialog in EventDetails.vue — out of scope
+- Backend, API contracts, emits/props interfaces


### PR DESCRIPTION
## Summary

- **EventDetails major UX overhaul**: renamed Divisions → Categories throughout; genre tab 3-section layout (Roster Status, Scoring Criteria, Judges); alias UI removed; stat cards reworked; suggestion strips for sheet categories; responsive text bumps
- **Modal standardisation**: `CreateParticipantForm` and `ScoringCriteriaModal` rebuilt with standardised slide-up shell (icon+badge header, para-chip rows, Teleport for portal rendering)
- **Session links**: auto-generated EMCEE/HELPER permanent tokens and per-judge tokens tied to judge lifecycle; refresh-to-extend UI; `judgeId` exposed in token DTO
- **UI polish**: `EventPanel` now navigates back to Event Details on event switch when already on that page; `AdminPage` tabs use new `.tab-bar` / `.tab-item` CSS utilities; badge borders removed (display-only semantic)
- **Backend**: `SessionTokenService` judge validation tightened to `event_judge` pool; `GoogleSheetService` splits comma-separated category column values; `GetSessionTokenDto` exposes `judgeId`

## Test plan

- [ ] EventDetails: open each genre tab, confirm 3 sections (Roster Status / Scoring Criteria / Judges) render correctly
- [ ] Walk-in modal: open, fill, submit — confirm `formTouched` resets (no stale red border on reopen)
- [ ] Scoring Criteria modal: open, confirm slide-up shell with parallelogram criteria rows
- [ ] Session links section: verify EMCEE, HELPER, and judge tokens auto-generate; Refresh button works
- [ ] AdminPage tabs: click between tabs — confirm underline indicator animates, active tab glows accent
- [ ] EventPanel: while on Event Details page, switch event — confirm redirect to new event's details page
- [ ] Backend tests: `mvn test` — 231/231 pass
- [ ] Frontend tests: `npm test -- --run` — 114/114 pass, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)