### PR TITLE
ui: replace confusing swipe labels with nav buttons on EmceeRoundView

### DIFF
--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -199,10 +199,19 @@ const swipeHint = computed(() => {
                 </div>
               </template>
             </div>
-            <div class="flex items-center justify-between px-4 pb-1.5">
-              <span class="type-label text-content-muted">← Prev</span>
-              <span class="type-label text-content-muted">swipe</span>
-              <span class="type-label text-content-muted">Next →</span>
+            <div class="flex items-stretch gap-1.5 px-4 pb-1.5">
+              <button
+                @pointerdown.stop
+                @click="goPrev"
+                :disabled="currentRound <= 1"
+                class="nav-btn type-label"
+              >‹ PREV</button>
+              <button
+                @pointerdown.stop
+                @click="goNext"
+                :disabled="currentRound >= totalRounds"
+                class="nav-btn type-label"
+              >NEXT ›</button>
             </div>
           </div>
         </Transition>
@@ -281,5 +290,27 @@ const swipeHint = computed(() => {
   .emcee-now {
     flex: none;
   }
+}
+
+/* ── Nav buttons ────────────────────────────────────────────────────── */
+.nav-btn {
+  flex: 1;
+  min-height: 48px;
+  clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%);
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  color: var(--accent-color);
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.nav-btn:active:not(:disabled) {
+  background: var(--accent-muted);
+}
+.nav-btn:disabled {
+  opacity: 0.2;
+  pointer-events: none;
 }
 </style>

--- a/docs/superpowers/plans/2026-06-10-emcee-round-view-nav-buttons.md
+++ b/docs/superpowers/plans/2026-06-10-emcee-round-view-nav-buttons.md
@@ -1,0 +1,112 @@
+# EmceeRoundView Nav Button Footer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the three non-interactive, misleading `← Prev / swipe / Next →` span labels at the bottom of the EmceeRoundView card with two large parallelogram `<button>` elements that correctly trigger `goPrev()` and `goNext()`.
+
+**Architecture:** Single-file change in `EmceeRoundView.vue` — swap the footer markup and add scoped CSS for `.nav-btn`. No logic changes; the existing `goNext`/`goPrev` functions and swipe gesture are reused as-is.
+
+**Tech Stack:** Vue 3 (script setup), scoped CSS, PrimeIcons (`pi pi-chevron-left/right`)
+
+---
+
+### Task 1: Replace footer markup and add nav-btn CSS
+
+**Files:**
+- Modify: `BES-frontend/src/components/EmceeRoundView.vue:202-206` (template) and the `<style scoped>` block
+
+- [ ] **Step 1: Replace the footer div (lines 202–206)**
+
+Open `BES-frontend/src/components/EmceeRoundView.vue`. Find:
+
+```html
+            <div class="flex items-center justify-between px-4 pb-1.5">
+              <span class="type-label text-content-muted">← Prev</span>
+              <span class="type-label text-content-muted">swipe</span>
+              <span class="type-label text-content-muted">Next →</span>
+            </div>
+```
+
+Replace with:
+
+```html
+            <div class="flex items-center gap-1.5 px-2.5 pb-2 pt-1">
+              <button
+                class="nav-btn"
+                :disabled="currentRound <= 1"
+                @pointerdown.stop
+                @click="goPrev"
+                aria-label="Previous round"
+              >
+                <i class="pi pi-chevron-left text-xs"></i>
+                <span class="type-label">Prev</span>
+              </button>
+              <button
+                class="nav-btn"
+                :disabled="currentRound >= totalRounds"
+                @pointerdown.stop
+                @click="goNext"
+                aria-label="Next round"
+              >
+                <span class="type-label">Next</span>
+                <i class="pi pi-chevron-right text-xs"></i>
+              </button>
+            </div>
+```
+
+- [ ] **Step 2: Add `.nav-btn` CSS to the scoped style block**
+
+In the `<style scoped>` section (after the existing `.queue-item` rule, before the closing `</style>`), add:
+
+```css
+/* ── Nav buttons ──────────────────────────────────────────────────────── */
+.nav-btn {
+  flex: 1;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  clip-path: polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.65);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.nav-btn:not(:disabled):active {
+  background: var(--accent-muted);
+  color: var(--accent-color);
+}
+.nav-btn:disabled {
+  opacity: 0.2;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+```
+
+- [ ] **Step 3: Run the dev server and verify**
+
+```bash
+cd BES-frontend && npm run dev
+```
+
+Open `http://localhost:5173` and navigate to `/event/audition-list` as an Emcee or Admin with an active event.
+
+Check:
+- Two equal-width buttons appear at the bottom of the NOW card
+- `PREV` button is dimmed (opacity ~20%) on round 1
+- `NEXT` button is dimmed on the last round
+- Tapping `NEXT` advances to the next round correctly
+- Tapping `PREV` goes back correctly
+- Swiping left/right on the card body still navigates (gesture unchanged)
+- No accidental navigation fires when tapping the buttons (pointer isolation)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/components/EmceeRoundView.vue
+git commit -m "ui: replace confusing swipe labels with nav buttons on EmceeRoundView
+
+Closes #122"
+```

--- a/docs/superpowers/specs/2026-06-10-emcee-round-view-nav-buttons.md
+++ b/docs/superpowers/specs/2026-06-10-emcee-round-view-nav-buttons.md
@@ -1,0 +1,68 @@
+# EmceeRoundView — Navigation Footer Redesign
+
+**Issue:** #122
+**Branch:** `ui/emcee-round-view-ux`
+**File:** `BES-frontend/src/components/EmceeRoundView.vue`
+
+## Problem
+
+The card footer currently shows three non-interactive spans:
+
+```html
+<span>← Prev</span>
+<span>swipe</span>
+<span>Next →</span>
+```
+
+The arrow directions are misleading: `← Prev` implies swipe-left for previous, but swiping right goes to previous. `Next →` implies swipe-right for next, but swiping left advances. There are also no tap-to-navigate buttons, making single-handed phone use awkward for an emcee.
+
+## Design
+
+Replace the three spans with two `<button>` elements occupying the full card bottom.
+
+### Buttons
+
+| Button | Label | Action | Disabled when |
+|--------|-------|--------|---------------|
+| Left | `‹ PREV` | `goPrev()` | `currentRound <= 1` |
+| Right | `NEXT ›` | `goNext()` | `currentRound >= totalRounds` |
+
+### Layout
+
+```
+[ ‹ PREV          ] [ NEXT ›          ]
+```
+
+- Both buttons use `flex: 1` — equal width, filling the card bottom edge
+- `min-height: 48px` — thumb-friendly tap target (matches UX rule for emcee/judge touch targets)
+- `gap: 6px` between buttons, `padding: 6px 10px 10px` on container
+
+### Styling
+
+- Parallelogram clip-path: `polygon(5px 0%, 100% 0%, calc(100% - 5px) 100%, 0% 100%)`
+- Background: `rgba(255,255,255,0.05)` — chip fill from design system
+- Border: `rgba(255,255,255,0.08)` — chip border from design system
+- Text: `type-label` tier (10px, Anton SC, 0.18em tracking, uppercase), `rgba(255,255,255,0.65)`
+- Disabled: `opacity: 0.2`, `pointer-events: none`, `cursor: not-allowed`
+- Active press: `background: var(--accent-muted)`, `color: var(--accent-color)`
+
+### Pointer Event Isolation
+
+Each button gets `@pointerdown.stop` to prevent the card's drag gesture (`onPointerDown` → `setPointerCapture`) from firing when the user taps a button. Swipe gesture on the card body remains fully functional.
+
+## What Does Not Change
+
+- Swipe gesture (pointer events on card) — unchanged
+- Animated chevron overlays during drag — unchanged
+- Card header (`Now on Stage` · `Rd X / Y`) — unchanged
+- Queue section — unchanged
+- Timer section — unchanged
+- All other component logic and props — unchanged
+
+## Acceptance Criteria
+
+1. Tapping `PREV` navigates to the previous round; button is visually disabled on round 1
+2. Tapping `NEXT` navigates to the next round; button is visually disabled on the last round
+3. Swiping left/right still navigates (gesture unchanged)
+4. No accidental navigation triggers when tapping buttons (pointer isolation works)
+5. Buttons meet 48px minimum touch target height


### PR DESCRIPTION
## Summary

- Replaces the three non-interactive, misleading `← Prev / swipe / Next →` span labels at the bottom of the EmceeRoundView NOW card with two large parallelogram `<button>` elements
- Left button `‹ PREV` → `goPrev()`, disabled on round 1
- Right button `NEXT ›` → `goNext()`, disabled on last round
- `@pointerdown.stop` on each button prevents the card's drag/swipe gesture from arming on a button tap; navigation fires on `@click` so the user can cancel by sliding off
- Swipe gesture on the card body is unchanged

## Test plan

- [ ] Open `/event/audition-list` as Emcee or Admin with an active event
- [ ] `‹ PREV` is visibly dimmed on round 1; tapping it does nothing
- [ ] `NEXT ›` advances to round 2 on tap; `‹ PREV` becomes active
- [ ] `NEXT ›` is visibly dimmed on the last round
- [ ] Swiping left on the card advances; swiping right goes back
- [ ] Tapping a button does not accidentally trigger a swipe

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)