### PR TITLE
ui: improve modal UX — darker backdrop, bottom safe space, remove X buttons

### DIFF
--- a/BES-frontend/src/components/CreateParticipantForm.vue
+++ b/BES-frontend/src/components/CreateParticipantForm.vue
@@ -189,9 +189,9 @@ onMounted(async () => {
     >
     <div
       v-if="props.show"
-      class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      class="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-6 sm:p-4"
     >
-      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="$emit('close')" />
+      <div class="absolute inset-0 bg-black/80 backdrop-blur-sm" @click="$emit('close')" />
       <div class="card-hover relative w-full sm:max-w-md flex flex-col" style="max-height: 85vh;">
         <div class="corner-bar-tl"></div>
         <div class="corner-bar-bl"></div>
@@ -203,12 +203,6 @@ onMounted(async () => {
               <span class="type-body text-content-primary">{{ props.title }}</span>
               <span class="badge-neutral type-label">{{ props.event }}</span>
             </div>
-            <button
-              @click="$emit('close')"
-              class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors"
-            >
-              <i class="pi pi-times text-xs"></i>
-            </button>
           </div>
 
           <!-- Body -->

--- a/BES-frontend/src/components/FeedbackPopout.vue
+++ b/BES-frontend/src/components/FeedbackPopout.vue
@@ -53,11 +53,11 @@ function onNoteInput() {
   >
     <div
       v-if="visible"
-      class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      class="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-6 sm:p-4"
     >
       <!-- Backdrop -->
       <div
-        class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        class="absolute inset-0 bg-black/80 backdrop-blur-sm"
         @click="emit('close')"
       />
 
@@ -80,12 +80,6 @@ function onNoteInput() {
               </span>
             </div>
           </div>
-          <button
-            @click="emit('close')"
-            class="p-1.5 para-chip-sm type-label text-content-muted hover:text-content-primary transition-colors"
-          >
-            <i class="pi pi-times text-sm" />
-          </button>
         </div>
 
         <!-- Tag Groups -->
@@ -135,16 +129,18 @@ function onNoteInput() {
         </div>
 
         <!-- Footer -->
-        <div class="flex gap-3 flex-shrink-0 items-center">
-          <button
-            @click="emit('close')"
-            class="flex-1 py-2 para-chip type-label text-content-muted hover:text-content-primary transition-all"
-          >Done</button>
-          <div class="flex items-center gap-2 type-label text-content-muted">
-            <i v-if="saving" class="pi pi-spin pi-spinner text-accent/60 text-xs"></i>
-            <i v-else-if="selectedTagIds.size > 0 || note.trim()" class="pi pi-check-circle text-emerald-400 text-xs"></i>
-            <span v-if="saving" class="text-accent/60 text-xs normal-case">Saving…</span>
+        <div class="flex flex-col items-center gap-0.5 flex-shrink-0 pt-1 pb-1">
+          <div class="h-5 flex items-center gap-2">
+            <template v-if="saving">
+              <i class="pi pi-spin pi-spinner text-accent/70 text-xs"></i>
+              <span class="type-label text-accent/70 normal-case">Saving…</span>
+            </template>
+            <template v-else-if="selectedTagIds.size > 0 || note.trim()">
+              <i class="pi pi-check-circle text-emerald-400 text-xs"></i>
+              <span class="type-label text-emerald-400 normal-case">Feedback saved</span>
+            </template>
           </div>
+          <p class="type-label text-content-muted/40">Tap outside to close</p>
         </div>
       </div>
     </div>

--- a/BES-frontend/src/components/ScoringCriteriaModal.vue
+++ b/BES-frontend/src/components/ScoringCriteriaModal.vue
@@ -149,10 +149,10 @@ const applyToAllGenres = async () => {
     <Transition name="modal-fade">
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-6 sm:p-4"
       >
         <!-- Backdrop -->
-        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="close" />
+        <div class="absolute inset-0 bg-black/80 backdrop-blur-sm" @click="close" />
 
         <!-- Panel -->
         <div class="card-hover relative w-full sm:max-w-lg flex flex-col max-h-[85vh]">
@@ -166,12 +166,6 @@ const applyToAllGenres = async () => {
               <span class="type-body text-content-primary">Scoring Criteria</span>
               <span class="badge-neutral type-label">{{ props.eventName }}</span>
             </div>
-            <button
-              @click="close"
-              class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors"
-            >
-              <i class="pi pi-times text-xs" />
-            </button>
           </div>
 
           <!-- Genre tabs -->
@@ -326,7 +320,7 @@ const applyToAllGenres = async () => {
           </div>
 
           <!-- Footer actions -->
-          <div class="flex items-center gap-2 flex-shrink-0 px-4 py-3 border-t border-surface-600/30">
+          <div class="flex items-center gap-2 flex-shrink-0 px-4 py-3 border-t border-surface-600/30 flex-wrap">
             <button
               v-if="!showAdd"
               @click="showAdd = true"
@@ -352,6 +346,7 @@ const applyToAllGenres = async () => {
               {{ appliedAll ? 'Copied!' : 'Copy to all genres' }}
             </button>
           </div>
+          <p class="type-label text-content-muted/40 text-center py-1.5 shrink-0">Tap outside to close</p>
         </div>
       </div>
     </Transition>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2237,23 +2237,20 @@ onUnmounted(() => {
     >
       <div
         v-if="showAdjustModal"
-        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-6 sm:p-4"
       >
-        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeAdjustModal" />
+        <div class="absolute inset-0 bg-black/80 backdrop-blur-sm" @click="closeAdjustModal" />
         <div class="card-hover relative w-full sm:max-w-md flex flex-col" style="max-height: 85vh;">
           <div class="corner-bar-tl"></div>
           <div class="corner-bar-bl"></div>
 
           <!-- Header -->
-          <div class="flex items-center justify-between px-4 py-3 border-b border-surface-600/30 shrink-0">
+          <div class="flex items-center px-4 py-3 border-b border-surface-600/30 shrink-0">
             <div class="flex items-center gap-2">
               <i class="pi pi-sliders-h text-content-muted text-xs"></i>
               <span class="type-body text-content-primary">Genre Entries</span>
               <span class="badge-neutral type-label">{{ props.eventName }}</span>
             </div>
-            <button @click="closeAdjustModal" class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors">
-              <i class="pi pi-times text-xs"></i>
-            </button>
           </div>
 
           <!-- Body -->
@@ -2365,6 +2362,7 @@ onUnmounted(() => {
 
 
           </div>
+          <p class="type-label text-content-muted/40 text-center py-2 shrink-0">Tap outside to close</p>
         </div>
       </div>
     </Transition>
@@ -2374,21 +2372,16 @@ onUnmounted(() => {
   <Teleport to="body">
     <Transition enter-active-class="transition duration-150 ease-out" enter-from-class="opacity-0" enter-to-class="opacity-100"
                 leave-active-class="transition duration-100 ease-in" leave-from-class="opacity-100" leave-to-class="opacity-0">
-      <div v-if="genreAddForm.show" class="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-0 sm:p-4">
-        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="genreAddForm.show = false" />
+      <div v-if="genreAddForm.show" class="fixed inset-0 z-[70] flex items-end sm:items-center justify-center pb-6 sm:p-4">
+        <div class="absolute inset-0 bg-black/80 backdrop-blur-sm" @click="genreAddForm.show = false" />
         <div class="card-hover relative w-full sm:max-w-sm flex flex-col" style="max-height:85vh">
           <div class="corner-bar-tl"></div>
           <div class="corner-bar-bl"></div>
 
           <!-- Header -->
-          <div class="flex items-center justify-between px-4 py-3 border-b border-surface-600/30 shrink-0">
-            <div>
-              <p class="type-body text-content-primary">Add Division</p>
-              <p class="type-label text-content-muted mt-0.5">{{ genreAddForm.genre?.name }} · {{ genreAddForm.genre?.format }}</p>
-            </div>
-            <button @click="genreAddForm.show = false" class="para-chip-sm px-2 py-1 type-label text-content-muted hover:text-content-primary transition-colors">
-              <i class="pi pi-times text-xs"></i>
-            </button>
+          <div class="px-4 py-3 border-b border-surface-600/30 shrink-0">
+            <p class="type-body text-content-primary">Add Division</p>
+            <p class="type-label text-content-muted mt-0.5">{{ genreAddForm.genre?.name }} · {{ genreAddForm.genre?.format }}</p>
           </div>
 
           <!-- Body -->


### PR DESCRIPTION
## Summary

- Darkens backdrop from `bg-black/60` → `bg-black/80` so busy backgrounds don't bleed through modal overlays
- Adds `pb-6` bottom padding on mobile so modals sit above browser chrome (no accidental taps on home indicator / nav bar)
- Removes header X buttons — backdrop click already closes, now signposted with "Tap outside to close" hint
- **FeedbackPopout**: removes Done button entirely; replaces with centered "Feedback saved" / "Saving…" status so judges see their save state clearly without an extra tap

## Affected components

| Component | Darker backdrop | Bottom padding | X removed | Tap hint |
|-----------|:-:|:-:|:-:|:-:|
| `FeedbackPopout.vue` | ✅ | ✅ | ✅ | ✅ + save status |
| `ScoringCriteriaModal.vue` | ✅ | ✅ | ✅ | ✅ |
| `CreateParticipantForm.vue` | ✅ | ✅ | ✅ | — (has Cancel) |
| `EventDetails` Genre Entries | ✅ | ✅ | ✅ | ✅ |
| `EventDetails` Add Division | ✅ | ✅ | ✅ | — (has Cancel) |

Confirm/check-in dialogs unchanged — those are destructive confirmations that need explicit buttons.

## Test plan

- [ ] Open Genre Entries modal on mobile — verify bottom clearance and "Tap outside to close" hint visible
- [ ] Tap backdrop — modal closes
- [ ] Open FeedbackPopout — verify no Done button, save status shows after selecting tags/note
- [ ] Open Scoring Criteria modal — verify "Tap outside to close" hint in footer
- [ ] Open Add Walk-in form — verify no X button, Cancel still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)