### PR TITLE
feat: event-scope feedback system toggle (closes #120)

### DIFF
--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -2,9 +2,10 @@
 import { ref, computed, nextTick, onMounted, watch } from 'vue';
 
 const props = defineProps({
-  cards:        { type: Array,  required: true },
-  feedbackData: { type: Object, default: () => new Map() },
-  criteria:     { type: Array,  default: () => [] },
+  cards:           { type: Array,   required: true },
+  feedbackData:    { type: Object,  default: () => new Map() },
+  criteria:        { type: Array,   default: () => [] },
+  feedbackEnabled: { type: Boolean, default: true },
 });
 
 const emit = defineEmits(['open-feedback', 'remove-tag', 'submit', 'reset', 'jump', 'score-change']);
@@ -324,6 +325,7 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
                           style="clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%); background: rgba(245,158,11,0.12); border-color: rgba(245,158,11,0.35); color: rgb(245,158,11);"
                         >10 — Full</button>
                         <button
+                          v-if="props.feedbackEnabled"
                           @click.stop="emit('open-feedback', activeCard)"
                           class="flex-1 flex items-center justify-center gap-1 py-3 para-chip-sm type-label transition-all duration-150"
                           :class="feedbackData?.get(activeCard.auditionNumber) ? 'text-green-400 border-green-500/35' : 'text-content-muted hover:text-content-primary'"
@@ -373,6 +375,7 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
                       style="clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%); background: rgba(245,158,11,0.12); border-color: rgba(245,158,11,0.35); color: rgb(245,158,11);"
                     >10 — Full</button>
                     <button
+                      v-if="props.feedbackEnabled"
                       @click.stop="emit('open-feedback', activeCard)"
                       class="flex-1 flex items-center justify-center gap-1 py-3 para-chip-sm type-label transition-all duration-150"
                       :class="feedbackData?.get(activeCard.auditionNumber) ? 'text-green-400 border-green-500/35' : 'text-content-muted hover:text-content-primary'"

--- a/BES-frontend/src/components/SwipeableCardsV2.vue
+++ b/BES-frontend/src/components/SwipeableCardsV2.vue
@@ -2,9 +2,10 @@
 import { ref, nextTick, onMounted, computed } from 'vue';
 
 const props = defineProps({
-  cards:        { type: Array,  required: true },
-  feedbackData: { type: Object, default: () => new Map() },
-  criteria:     { type: Array,  default: () => [] },
+  cards:           { type: Array,   required: true },
+  feedbackData:    { type: Object,  default: () => new Map() },
+  criteria:        { type: Array,   default: () => [] },
+  feedbackEnabled: { type: Boolean, default: true },
 });
 
 const emit = defineEmits(['update:cards', 'open-feedback', 'remove-tag', 'submit', 'reset', 'jump', 'score-change']);
@@ -262,6 +263,7 @@ onMounted(observeCards)
                         style="clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%); background: rgba(245,158,11,0.12); border-color: rgba(245,158,11,0.35); color: rgb(245,158,11);"
                       >10 — Full</button>
                       <button
+                        v-if="props.feedbackEnabled"
                         @click.stop="emit('open-feedback', card)"
                         class="flex-1 flex items-center justify-center gap-1 py-3 para-chip-sm type-label transition-all duration-150"
                         :class="feedbackData?.get(card.auditionNumber) ? 'text-green-400 border-green-500/35' : 'text-content-muted hover:text-content-primary'"
@@ -311,6 +313,7 @@ onMounted(observeCards)
                     style="clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%); background: rgba(245,158,11,0.12); border-color: rgba(245,158,11,0.35); color: rgb(245,158,11);"
                   >10 — Full</button>
                   <button
+                    v-if="props.feedbackEnabled"
                     @click.stop="emit('open-feedback', card)"
                     class="flex-1 flex items-center justify-center gap-1 py-3 para-chip-sm type-label transition-all duration-150"
                     :class="feedbackData?.get(card.auditionNumber) ? 'text-green-400 border-green-500/35' : 'text-content-muted hover:text-content-primary'"

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1052,6 +1052,35 @@ export const setJudgingMode = async (eventName, mode) => {
   }
 }
 
+export const getFeedbackEnabled = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/feedback-enabled/${encodeURIComponent(eventName)}`, {
+      credentials: 'include'
+    })
+    if (res.ok) return await res.json()
+    return null
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+}
+
+export const setFeedbackEnabled = async (eventName, enabled) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/feedback-enabled`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ eventName, feedbackEnabled: enabled })
+    })
+  } catch (e) {
+    console.log(e)
+  }
+}
+
 export const submitAuditionFeedback = async (eventName, genreName, judgeName, auditionNumber, tagIds, note) => {
   try {
     return await fetch(`${domain}/api/v1/event/feedback`, {

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, verifyEventAccessCode } from '@/utils/api';
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getGenresByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, verifyEventAccessCode } from '@/utils/api';
 import { getFeedbackGroups } from '@/utils/adminApi';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
@@ -25,6 +25,7 @@ const currentJudge = ref(localStorage.getItem("currentJudge") || "")
 const allJudges = ref([])
 const participants = ref([])
 const judgingMode = ref("SOLO")
+const feedbackEnabled = ref(true)
 const eventDivisions = ref([]) // { eventGenreId, name } for current event — used to map division name → ID
 const isAdmin = ref(false)
 const isOrganiser = ref(false)
@@ -244,10 +245,11 @@ watch(selectedEvent, async (newVal, oldVal) => {
       selectedGenre.value = ""
     }
     participants.value = []
-    const [res, modeRes, divRes] = await Promise.all([
+    const [res, modeRes, divRes, feedbackRes] = await Promise.all([
       getRegisteredParticipantsByEvent(newVal),
       getJudgingMode(newVal),
-      getGenresByEvent(newVal)
+      getGenresByEvent(newVal),
+      getFeedbackEnabled(newVal)
     ])
     eventDivisions.value = divRes ?? []
     // Now that divisions are loaded, reload judges for the selected genre (fixes race on page load)
@@ -289,6 +291,7 @@ watch(selectedEvent, async (newVal, oldVal) => {
       if (firstGenre) selectedGenre.value = firstGenre
     }
     if (modeRes?.judgingMode) judgingMode.value = modeRes.judgingMode
+    if (feedbackRes && typeof feedbackRes.feedbackEnabled === 'boolean') feedbackEnabled.value = feedbackRes.feedbackEnabled
     await loadScoresFromDb(newVal, selectedGenre.value, currentJudge.value)
   }
 }, { immediate: true });
@@ -694,6 +697,13 @@ onMounted(async () => {
       if (msg.eventName !== selectedEvent.value) return
       judgingMode.value = msg.judgingMode
     })
+  const c5 = createClient()
+  wsClients.push(c5)
+  subscribeToChannel(c5, "/topic/feedback-enabled/",
+    (msg) => {
+      if (msg.eventName !== selectedEvent.value) return
+      feedbackEnabled.value = !!msg.feedbackEnabled
+    })
 })
 </script>
 
@@ -988,6 +998,7 @@ onMounted(async () => {
         :cards="filteredParticipantsForJudge"
         :feedbackData="feedbackGiven"
         :criteria="criteria"
+        :feedbackEnabled="feedbackEnabled"
         @open-feedback="openFeedbackPopout"
         @remove-tag="removeTag"
         @score-change="autoSave"
@@ -1001,6 +1012,7 @@ onMounted(async () => {
         :cards="filteredParticipantsForJudge"
         :feedbackData="feedbackGiven"
         :criteria="criteria"
+        :feedbackEnabled="feedbackEnabled"
         @open-feedback="openFeedbackPopout"
         @remove-tag="removeTag"
         @score-change="autoSave"

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 
@@ -53,6 +53,8 @@ const eventName = ref(props.eventName.split(" ").join("%20"));
 
 const selectedInitGenres = ref([])
 const paymentRequired = ref(false)
+const feedbackEnabled = ref(true)
+const feedbackSaving = ref(false)
 const sheetCategories = ref([])
 const pendingSuggestionCat = ref(null)
 const divRenameActive = ref(null)
@@ -418,6 +420,25 @@ const refreshParticipant = async () => {
 const refreshFromDb = async () => {
   verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
   unverifiedParticipants.value = await getUnverifiedParticipantsDB(props.eventName)
+}
+
+const onFeedbackEnabledToggle = async (e) => {
+  const next = e.target.checked
+  const prev = feedbackEnabled.value
+  feedbackEnabled.value = next
+  feedbackSaving.value = true
+  try {
+    const res = await setFeedbackEnabled(props.eventName, next)
+    if (!res?.ok) {
+      feedbackEnabled.value = prev
+      openModal('Save Failed', `Could not update feedback setting (${res?.status ?? 'no response'}).`, 'warning')
+    }
+  } catch (err) {
+    feedbackEnabled.value = prev
+    console.error('setFeedbackEnabled error:', err)
+  } finally {
+    feedbackSaving.value = false
+  }
 }
 
 const handleWalkInCreated = async () => {
@@ -1088,6 +1109,8 @@ onMounted(async () => {
       unverifiedParticipants.value = await getUnverifiedParticipantsDB(props.eventName)
       await fetchCheckinList()
       loadSessionTokens()
+      const fb = await getFeedbackEnabled(props.eventName)
+      if (fb && typeof fb.feedbackEnabled === 'boolean') feedbackEnabled.value = fb.feedbackEnabled
     }
   } catch (e) {
     console.error('EventDetails mount error:', e)
@@ -1353,6 +1376,35 @@ onUnmounted(() => {
         </div>
       </div>
 
+
+    <!-- Event Settings (existing event) -->
+    <div v-if="tableExist" class="card-hover p-4 relative mt-6">
+      <div class="corner-bar-tl"></div>
+      <div class="section-rule mb-4">
+        <span class="section-rule-label">Event Settings</span>
+        <div class="section-rule-line"></div>
+      </div>
+      <label
+        class="flex items-center gap-3 px-4 py-3 para-chip cursor-pointer transition-all duration-150 w-fit"
+        :class="feedbackEnabled ? 'border-accent' : ''"
+      >
+        <input
+          type="checkbox"
+          :checked="feedbackEnabled"
+          :disabled="feedbackSaving"
+          @change="onFeedbackEnabledToggle"
+          class="w-4 h-4"
+        />
+        <div>
+          <span class="type-body">Feedback System</span>
+          <p class="type-label mt-0.5" :class="feedbackEnabled ? 'text-content-secondary' : 'text-content-muted'">
+            {{ feedbackEnabled
+              ? 'Judges can submit feedback tags and notes for each participant.'
+              : 'Feedback system is disabled — judges will only see the score keypad.' }}
+          </p>
+        </div>
+      </label>
+    </div>
 
     <!-- Setup section (when no table exists) -->
     <div v-if="!tableExist" class="card-hover p-6 relative">

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -36,6 +36,7 @@ import com.example.BES.dtos.GetScoringCriteriaDto;
 import com.example.BES.dtos.UpdateScoringCriteriaDto;
 import com.example.BES.dtos.GetJudgingModeDto;
 import com.example.BES.dtos.UpdateJudgingModeDto;
+import com.example.BES.dtos.UpdateFeedbackDto;
 import com.example.BES.dtos.UpdateAccessCodeDto;
 import com.example.BES.dtos.VerifyAccessCodeDto;
 // import com.example.BES.dtos.AddJudgesDto;
@@ -195,6 +196,28 @@ public class EventController {
         try {
             eventService.setJudgingMode(dto.eventName, dto.judgingMode);
             return ResponseEntity.ok(java.util.Map.of("message", "Judging mode updated"));
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(java.util.Map.of("error", e.getReason()));
+        }
+    }
+
+    @Operation(summary = "Get Feedback Enabled", description = "Returns whether the feedback button is shown on judge scoring cards for an event")
+    @GetMapping("/feedback-enabled/{eventName}")
+    public ResponseEntity<?> getFeedbackEnabled(@PathVariable String eventName) {
+        try {
+            return new ResponseEntity<>(eventService.getFeedbackEnabled(eventName), HttpStatus.OK);
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        }
+    }
+
+    @Operation(summary = "Set Feedback Enabled", description = "Toggles whether the feedback button is shown on judge scoring cards for an event (admin only)")
+    @PostMapping("/feedback-enabled")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> setFeedbackEnabled(@Valid @RequestBody UpdateFeedbackDto dto) {
+        try {
+            eventService.setFeedbackEnabled(dto.eventName, dto.feedbackEnabled);
+            return ResponseEntity.ok(java.util.Map.of("message", "Feedback enabled updated"));
         } catch (org.springframework.web.server.ResponseStatusException e) {
             return ResponseEntity.status(e.getStatusCode()).body(java.util.Map.of("error", e.getReason()));
         }

--- a/BES/src/main/java/com/example/BES/dtos/AddEventDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/AddEventDto.java
@@ -10,4 +10,5 @@ public class AddEventDto {
     public boolean paymentRequired;
     @Size(max = 255)
     public String accessCode;
+    public boolean feedbackEnabled = true;
 }

--- a/BES/src/main/java/com/example/BES/dtos/GetEventDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetEventDto.java
@@ -5,13 +5,16 @@ public class GetEventDto {
     String name;
     boolean paymentRequired;
     String accessCode;
+    boolean feedbackEnabled = true;
 
     public Long getId() { return id; }
     public String getName() { return name; }
     public boolean isPaymentRequired() { return paymentRequired; }
     public String getAccessCode() { return accessCode; }
+    public boolean isFeedbackEnabled() { return feedbackEnabled; }
     public void setId(Long id) { this.id = id; }
     public void setName(String name) { this.name = name; }
     public void setPaymentRequired(boolean paymentRequired) { this.paymentRequired = paymentRequired; }
     public void setAccessCode(String accessCode) { this.accessCode = accessCode; }
+    public void setFeedbackEnabled(boolean feedbackEnabled) { this.feedbackEnabled = feedbackEnabled; }
 }

--- a/BES/src/main/java/com/example/BES/dtos/GetFeedbackEnabledDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetFeedbackEnabledDto.java
@@ -1,0 +1,11 @@
+package com.example.BES.dtos;
+
+public class GetFeedbackEnabledDto {
+    public String eventName;
+    public boolean feedbackEnabled;
+
+    public GetFeedbackEnabledDto(String eventName, boolean feedbackEnabled) {
+        this.eventName = eventName;
+        this.feedbackEnabled = feedbackEnabled;
+    }
+}

--- a/BES/src/main/java/com/example/BES/dtos/UpdateFeedbackDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/UpdateFeedbackDto.java
@@ -1,0 +1,6 @@
+package com.example.BES.dtos;
+
+public class UpdateFeedbackDto {
+    public String eventName;
+    public boolean feedbackEnabled;
+}

--- a/BES/src/main/java/com/example/BES/models/Event.java
+++ b/BES/src/main/java/com/example/BES/models/Event.java
@@ -32,6 +32,9 @@ public class Event {
     @Column(name = "results_released")
     private boolean resultsReleased = false;
 
+    @Column(name = "feedback_enabled")
+    private boolean feedbackEnabled = true;
+
     @OneToMany(mappedBy = "event")
     private List<EventGenre> eventGenres;
 

--- a/BES/src/main/java/com/example/BES/services/EventService.java
+++ b/BES/src/main/java/com/example/BES/services/EventService.java
@@ -17,6 +17,7 @@ import com.example.BES.models.Account;
 import com.example.BES.models.Event;
 import com.example.BES.dtos.AddEventDto;
 import com.example.BES.dtos.GetEventDto;
+import com.example.BES.dtos.GetFeedbackEnabledDto;
 import com.example.BES.dtos.GetJudgingModeDto;
 import com.example.BES.respositories.AccountRepository;
 import com.example.BES.respositories.EventRepo;
@@ -40,6 +41,7 @@ public class EventService {
         Event newEvent = new Event();
         newEvent.setEventName(dto.eventName);
         newEvent.setPaymentRequired(dto.paymentRequired);
+        newEvent.setFeedbackEnabled(dto.feedbackEnabled);
         if (dto.accessCode != null && dto.accessCode.matches("\\d{4}")) {
             newEvent.setAccessCode(dto.accessCode);
         } else {
@@ -89,6 +91,7 @@ public class EventService {
             dto.setId(event.getEventId());
             dto.setName(event.getEventName());
             dto.setPaymentRequired(event.isPaymentRequired());
+            dto.setFeedbackEnabled(event.isFeedbackEnabled());
             if (includeAccessCode) {
                 dto.setAccessCode(event.getAccessCode());
             }
@@ -116,6 +119,21 @@ public class EventService {
         repo.save(event);
         messagingTemplate.convertAndSend("/topic/judging-mode/",
             java.util.Map.of("eventName", eventName, "judgingMode", mode));
+    }
+
+    public GetFeedbackEnabledDto getFeedbackEnabled(String eventName) {
+        Event event = repo.findByEventName(eventName)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+        return new GetFeedbackEnabledDto(event.getEventName(), event.isFeedbackEnabled());
+    }
+
+    public void setFeedbackEnabled(String eventName, boolean enabled) {
+        Event event = repo.findByEventName(eventName)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+        event.setFeedbackEnabled(enabled);
+        repo.save(event);
+        messagingTemplate.convertAndSend("/topic/feedback-enabled/",
+            java.util.Map.of("eventName", eventName, "feedbackEnabled", enabled));
     }
 
     public void releaseResults(String eventName, boolean released) {

--- a/BES/src/main/resources/db/migration/V35__add_feedback_enabled.sql
+++ b/BES/src/main/resources/db/migration/V35__add_feedback_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE event ADD COLUMN feedback_enabled BOOLEAN DEFAULT TRUE;


### PR DESCRIPTION
## Summary
Per-event `feedbackEnabled` boolean that hides the **Feedback** button on judge scoring cards (`PairScoreCards` + `SwipeableCardsV2`) when an organiser turns it off. The toggle is a UI gate — backend feedback endpoints remain functional regardless.

- Mirrors the existing `judging-mode` pattern across all layers (DTO + service + controller + WebSocket broadcast + frontend fetch + WS sub).
- Default is `TRUE` so existing events keep their current behaviour.
- POST endpoint is `@PreAuthorize("hasRole('ADMIN')")` to match `setJudgingMode`. If Organisers should toggle this too, that's a one-line change.

## Layer-by-layer changes
| Layer | File | Change |
|---|---|---|
| DB | `V35__add_feedback_enabled.sql` | `feedback_enabled BOOLEAN DEFAULT TRUE` |
| Model | `Event.java` | `feedbackEnabled = true` field |
| DTO | `AddEventDto`, `GetEventDto` | Added field + accessor |
| DTO | `UpdateFeedbackDto`, `GetFeedbackEnabledDto` | New |
| Service | `EventService` | `getFeedbackEnabled` / `setFeedbackEnabled` + `/topic/feedback-enabled/` broadcast |
| Controller | `EventController` | `GET /feedback-enabled/{eventName}` + `POST /feedback-enabled` |
| API | `api.js` | `getFeedbackEnabled` / `setFeedbackEnabled` |
| View | `EventDetails.vue` | New **Event Settings** card on Setup tab (existing events only), parallelogram toggle mirroring Payment Required |
| View | `AuditionList.vue` | Fetch on event change, subscribe to `/topic/feedback-enabled/`, pass `:feedbackEnabled` to both score cards |
| Component | `PairScoreCards.vue` + `SwipeableCardsV2.vue` | `feedbackEnabled` prop (default `true`) — `v-if` on Feedback button in single + multi-criteria modes; the remaining "10 — Full" expands via its existing `flex-1` |

## Verification
- Frontend: lint clean, build clean, 114/114 Vitest tests pass
- Backend: 231/231 tests pass (incl. `EventControllerIntegrationTest` 17/17, `EventServiceTest` 13/13), Spotbugs clean
- Docker: rebuilt backend + frontend with `--no-cache`; backend started in 10.9s; Flyway applied V35 successfully; column confirmed in postgres as `feedback_enabled boolean DEFAULT true`

## Test plan
- [ ] As Organiser, open EventDetails → Setup tab → toggle **Feedback System** off → confirm save (no error modal)
- [ ] As Judge on the same event → open Audition List → confirm Feedback button is hidden in single-score mode (SwipeableCardsV2)
- [ ] Switch event to PAIR judging mode → confirm Feedback button is hidden in PairScoreCards too
- [ ] Toggle back on from EventDetails → confirm Judge view updates **live** via WebSocket without refresh
- [ ] Create a fresh event → confirm \`feedbackEnabled\` defaults to true (Feedback button visible)
- [ ] Hard-refresh AuditionList → confirm \`getFeedbackEnabled\` GET restores correct state

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)