### PR TITLE
feat: event-scoped animation theme system (IMPACT + HYPE)

### DIFF
--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -35,7 +35,7 @@ const pendingRoundIdx = ref(null)        // the round index user wants to switch
 const finalTieBlocked = ref(false)
 const revealActive = ref(false)
 let skipSizeChangeClear = false          // guard: suppress clear when topSize changes programmatically
-const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null, animTheme: 'impact' })
 const showRecoveryBanner = ref(false)
 let recoveryBannerTimer = null
 const recoveryState      = ref(null)
@@ -308,6 +308,12 @@ const pushOverlayConfig = async () => {
   }
   overlayConfigError.value = ''
   await setOverlayConfig(overlayConfig.value, selectedEvent.value)
+}
+
+const selectAnimTheme = (theme) => {
+  if (overlayConfig.value.animTheme === theme) return
+  overlayConfig.value.animTheme = theme
+  pushOverlayConfig()
 }
 
 
@@ -1896,7 +1902,7 @@ onMounted(async () => {
     await fetchBattleGuests()
     mountJudgeSyncDone = true
     const savedConfig = await getOverlayConfig()
-    if (savedConfig?.showImages !== undefined) overlayConfig.value = savedConfig
+    if (savedConfig?.showImages !== undefined) overlayConfig.value = { animTheme: 'impact', ...savedConfig }
     if (selectedEvent.value) {
       const champions = await getBattleChampions(selectedEvent.value)
       if (champions && typeof champions === 'object') {
@@ -1930,7 +1936,7 @@ onMounted(async () => {
     battleJudges.value = await getBattleJudges()
     mountJudgeSyncDone = true
     const savedConfig = await getOverlayConfig()
-    if (savedConfig?.showImages !== undefined) overlayConfig.value = savedConfig
+    if (savedConfig?.showImages !== undefined) overlayConfig.value = { animTheme: 'impact', ...savedConfig }
     if (selectedEvent.value) {
       const champions = await getBattleChampions(selectedEvent.value)
       if (champions && typeof champions === 'object') {
@@ -2692,6 +2698,29 @@ onUnmounted(() => {
               <span class="overlay-toggle-track"></span>
             </label>
           </div>
+          <div class="overlay-setting-row">
+            <span class="overlay-setting-label">Animation Theme</span>
+            <div class="anim-theme-group" role="radiogroup" aria-label="Animation theme">
+              <button
+                type="button"
+                role="radio"
+                :aria-checked="overlayConfig.animTheme === 'impact'"
+                :class="['anim-theme-btn', { 'is-active': overlayConfig.animTheme === 'impact' }]"
+                @click="selectAnimTheme('impact')"
+              >
+                IMPACT
+              </button>
+              <button
+                type="button"
+                role="radio"
+                :aria-checked="overlayConfig.animTheme === 'hype'"
+                :class="['anim-theme-btn', { 'is-active': overlayConfig.animTheme === 'hype' }]"
+                @click="selectAnimTheme('hype')"
+              >
+                HYPE
+              </button>
+            </div>
+          </div>
           <div class="overlay-setting-row overlay-setting-logo">
             <span class="overlay-setting-label">Event Logo</span>
             <div class="logo-upload-group">
@@ -3021,6 +3050,25 @@ onUnmounted(() => {
   transition: transform 0.2s;
 }
 .overlay-toggle input:checked + .overlay-toggle-track::after { transform: translateX(16px); }
+.anim-theme-group { display: inline-flex; gap: 6px; }
+.anim-theme-btn {
+  font-family: 'Anton SC', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  padding: 5px 12px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.10);
+  color: rgba(255,255,255,0.65);
+  cursor: pointer;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+.anim-theme-btn:hover { color: #fff; border-color: var(--accent-muted); }
+.anim-theme-btn.is-active {
+  color: #000;
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+}
 .overlay-config-error {
   font-size: 11px;
   color: #f87171;

--- a/BES-frontend/src/views/BattleJudge.vue
+++ b/BES-frontend/src/views/BattleJudge.vue
@@ -16,7 +16,7 @@ const topic = (path) => eventName.value
   : `/topic/battle/${path}`
 
 // ── Overlay config ──────────────────────────────────────────────────────────
-const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb' })
+const overlayConfig = ref({ leftColor: '#dc2626', rightColor: '#2563eb', animTheme: 'impact' })
 
 // ── Battle state ────────────────────────────────────────────────────────────
 const battlePhase      = ref('IDLE')
@@ -299,6 +299,7 @@ onUnmounted(() => {
 <template>
   <div
     class="judge-root"
+    :data-anim-theme="overlayConfig.animTheme || 'impact'"
     :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
     role="main"
     aria-label="Battle Judge voting panel"

--- a/BES-frontend/src/views/BattleOverlay.vue
+++ b/BES-frontend/src/views/BattleOverlay.vue
@@ -12,8 +12,16 @@ const eventName = ref(route.query.event || '')
 const topic = (path) => `/topic/battle/${eventName.value}/${path}`
 
 // ── Overlay config (live from BattleControl + API) ─────────────────────────
-const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
+const overlayConfig = ref({ showImages: true, leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null, animTheme: 'impact' })
 const logoUrl  = computed(() => overlayConfig.value.logoUrl)
+
+// ── Animation theme timing (CSS handles visuals; JS handles delays) ────────
+// IMPACT = current baseline. HYPE = dramatic build-up: longer pauses, second shake burst.
+const THEME_TIMING = {
+  impact: { vsShakeDelay: 340, votePause: 1500, finalPause: 400, secondShake: false },
+  hype:   { vsShakeDelay: 420, votePause: 2500, finalPause: 800, secondShake: true },
+}
+const themeTiming = computed(() => THEME_TIMING[overlayConfig.value.animTheme] || THEME_TIMING.impact)
 
 // ── Battle state ───────────────────────────────────────────────────────────
 const imageLeft  = ref(null)
@@ -171,7 +179,7 @@ const runEntrance = async () => {
   if (unmounted) return
   hideJudgeDecision.value = true
   vsAnim.value = 'rush-in'
-  await useDelay().wait(340) // VS hits undershoot trough at ~340ms
+  await useDelay().wait(themeTiming.value.vsShakeDelay) // VS hits undershoot trough
   if (unmounted) return
   stageShaking.value = true
   await useDelay().wait(120)
@@ -351,7 +359,7 @@ const updateScore = async (msg) => {
 
   if (isFinal.value) {
     // Final: skip judge panel — go straight to winner reveal after a brief pause
-    await useDelay().wait(400)
+    await useDelay().wait(themeTiming.value.finalPause)
     if (!ok()) return
     currentWinner.value = msg.message
   } else {
@@ -367,11 +375,21 @@ const updateScore = async (msg) => {
     if (!ok()) return
     stageShaking.value = false
 
+    // HYPE: second shake burst for extra drama
+    if (themeTiming.value.secondShake) {
+      await useDelay().wait(140)
+      if (!ok()) return
+      stageShaking.value = true
+      await useDelay().wait(100)
+      if (!ok()) return
+      stageShaking.value = false
+    }
+
     // Reveal votes as slam settles
     votesVisible.value = true
 
     // Audience reads the votes
-    await useDelay().wait(1500)
+    await useDelay().wait(themeTiming.value.votePause)
     if (!ok()) return
 
     currentWinner.value = msg.message
@@ -643,6 +661,7 @@ onUnmounted(() => {
   <div
     class="overlay-root"
     :class="{ 'stage-shake': stageShaking }"
+    :data-anim-theme="overlayConfig.animTheme || 'impact'"
     :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor }"
   >
     <!-- Broadcast timer — text-only top-right -->
@@ -1759,5 +1778,39 @@ onUnmounted(() => {
 .judge-rest-left   { animation: judgeRestLeft   520ms cubic-bezier(0.34, 1.1, 0.64, 1) forwards; }
 .judge-exit-right  { animation: judgeExitRight  280ms cubic-bezier(0.55, 0,   1,   0.45) forwards; }
 .judge-exit-left   { animation: judgeExitLeft   280ms cubic-bezier(0.55, 0,   1,   0.45) forwards; }
+
+/* ══════════════════════════════════════════════════
+   ANIMATION THEMES — visual overrides per data-anim-theme
+   IMPACT is the default (no overrides needed).
+   HYPE: oversized winner stamp, longer judge slam, slower retreat for drama.
+   JS timings (vote pause, shake delay, second shake) live in THEME_TIMING.
+══════════════════════════════════════════════════ */
+.overlay-root[data-anim-theme="hype"] .winner-label {
+  animation-duration: 520ms;
+  animation-delay: 350ms;
+}
+.overlay-root[data-anim-theme="hype"] .winner-label-left {
+  text-shadow: 5px 5px 0 var(--left-color),
+               0 0 60px color-mix(in srgb, var(--left-color) 80%, transparent);
+}
+.overlay-root[data-anim-theme="hype"] .winner-label-right {
+  text-shadow: -5px 5px 0 var(--right-color),
+               0 0 60px color-mix(in srgb, var(--right-color) 80%, transparent);
+}
+.overlay-root[data-anim-theme="hype"] .winner-label {
+  animation-name: winnerStampHype;
+}
+@keyframes winnerStampHype {
+  0%   { transform: scale(2.5) translateY(-14px); opacity: 0; filter: blur(8px); }
+  60%  { transform: scale(1.92) translateY(2px);  opacity: 1; filter: blur(0); }
+  100% { transform: scale(2)   translateY(0);     opacity: 1; filter: blur(0); }
+}
+.overlay-root[data-anim-theme="hype"] .judge-slam-center {
+  animation-duration: 900ms;
+}
+.overlay-root[data-anim-theme="hype"] .judge-rest-right,
+.overlay-root[data-anim-theme="hype"] .judge-rest-left {
+  animation-duration: 700ms;
+}
 </style>
 

--- a/BES-frontend/src/views/BracketVisualization.vue
+++ b/BES-frontend/src/views/BracketVisualization.vue
@@ -6,7 +6,7 @@ import { useRoute } from 'vue-router'
 
 const bracketState   = ref(null)
 const lastBracketSnapshot = ref('')  // JSON diff guard
-const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null })
+const overlayConfig  = ref({ leftColor: '#dc2626', rightColor: '#2563eb', logoUrl: null, animTheme: 'impact' })
 const championReveal = ref(null)   // null = hidden; { genreName, championName } = showing
 const activePair     = ref(null)
 const currentGenre   = ref(null)
@@ -415,7 +415,7 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 </script>
 
 <template>
-  <div class="bracket-root" :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor, '--slot-h': slotHeight, '--final-slot-h': finalSlotHeight, '--center-col-w': centerColWidth }">
+  <div class="bracket-root" :data-anim-theme="overlayConfig.animTheme || 'impact'" :style="{ '--left-color': overlayConfig.leftColor, '--right-color': overlayConfig.rightColor, '--slot-h': slotHeight, '--final-slot-h': finalSlotHeight, '--center-col-w': centerColWidth }">
 
     <!-- ── Scanlines overlay ──────────────────────────── -->
     <div class="scanlines" aria-hidden="true"></div>
@@ -920,5 +920,23 @@ onUnmounted(() => { if (wsClient) wsClient.deactivate() })
 @keyframes dotPulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50%       { opacity: 0.32; transform: scale(0.62); }
+}
+
+/* ══════════════════════════════════════════════════
+   ANIMATION THEMES — HYPE: oversized, longer champion reveal
+══════════════════════════════════════════════════ */
+.bracket-root[data-anim-theme="hype"] .champ-reveal-enter-active .champ-name-slam {
+  animation: champNameSlamHype 0.75s cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.5s both;
+}
+.bracket-root[data-anim-theme="hype"] .champ-reveal-enter-active .champ-gold-bar {
+  animation: champBarExpandHype 0.85s ease 0.9s both;
+}
+@keyframes champNameSlamHype {
+  from { opacity: 0; transform: scale(0.5)  translateY(24px); }
+  to   { opacity: 1; transform: scale(1.18) translateY(0); }
+}
+@keyframes champBarExpandHype {
+  from { width: 0;     opacity: 0; }
+  to   { width: 260px; opacity: 1; }
 }
 </style>

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetOverlayConfigDto.java
@@ -17,9 +17,13 @@ public class SetOverlayConfigDto {
     private String rightColor;
     private String eventName;
 
+    @Pattern(regexp = "^(impact|hype)$", message = "animTheme must be 'impact' or 'hype'")
+    private String animTheme;
+
     public String getEventName() { return eventName; }
 
     public Boolean isShowImages() { return showImages; }
     public String getLeftColor()  { return leftColor; }
     public String getRightColor() { return rightColor; }
+    public String getAnimTheme()  { return animTheme; }
 }

--- a/BES/src/main/java/com/example/BES/models/Event.java
+++ b/BES/src/main/java/com/example/BES/models/Event.java
@@ -35,6 +35,9 @@ public class Event {
     @Column(name = "feedback_enabled")
     private boolean feedbackEnabled = true;
 
+    @Column(name = "anim_theme", length = 32)
+    private String animTheme = "impact";
+
     @OneToMany(mappedBy = "event")
     private List<EventGenre> eventGenres;
 

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -378,6 +378,9 @@ public class BattleService {
         EventBattleState s = stateFor(eventName);
         Map<String, Object> cfg = new HashMap<>(s.overlayConfig);
         cfg.put("logoUrl", s.logoUrl);
+        String theme = eventRepo.findByEventNameIgnoreCase(eventName)
+                .map(Event::getAnimTheme).orElse("impact");
+        cfg.put("animTheme", theme != null ? theme : "impact");
         return cfg;
     }
 
@@ -395,6 +398,14 @@ public class BattleService {
         newConfig.put("leftColor",  dto.getLeftColor());
         newConfig.put("rightColor", dto.getRightColor());
         s.overlayConfig = newConfig;
+
+        if (dto.getAnimTheme() != null) {
+            eventRepo.findByEventNameIgnoreCase(eventName).ifPresent(ev -> {
+                ev.setAnimTheme(dto.getAnimTheme());
+                eventRepo.save(ev);
+            });
+        }
+
         broadcastOverlayConfig(eventName);
     }
 

--- a/BES/src/main/resources/db/migration/V36__add_anim_theme_to_event.sql
+++ b/BES/src/main/resources/db/migration/V36__add_anim_theme_to_event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE event ADD COLUMN anim_theme VARCHAR(32) DEFAULT 'impact';

--- a/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/BattleServiceTest.java
@@ -7,12 +7,15 @@ import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetVoteDto;
 import com.example.BES.dtos.battle.UpdateJudgeWeightageDto;
 import com.example.BES.models.Judge;
+import com.example.BES.respositories.EventRepo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Optional;
 
 import java.util.Map;
 
@@ -32,6 +35,9 @@ class BattleServiceTest {
 
     @Mock
     SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    EventRepo eventRepo;
 
     @InjectMocks
     BattleService service;


### PR DESCRIPTION
## Summary
- Adds 2 animation themes (IMPACT default + HYPE) selectable per event from BattleControl's Overlay Settings.
- Theme persists on `event.anim_theme` and broadcasts via the existing `/topic/battle/{event}/overlay-config` channel — `BattleOverlay`, `BracketVisualization`, and `BattleJudge` update reactively via `data-anim-theme`.
- HYPE differences from IMPACT: longer vote pause (2500ms vs 1500ms), second shake burst on judge slam, scaled-up winner stamp, larger/slower champion reveal.

Implements the storage + delivery + 2-theme MVP from #91 (preview tile and the other 6 themes deferred).

## Scope
**Backend**
- `V36__add_anim_theme_to_event.sql` — column with `'impact'` default
- `Event.animTheme`, `SetOverlayConfigDto.animTheme` with `@Pattern(^(impact|hype)$)`
- `BattleService.getOverlayConfig` reads from Event entity, `setOverlayConfigService` saves it

**Frontend**
- `BattleControl.vue` — parallelogram theme buttons in Overlay Settings (matches design system); reuses existing `pushOverlayConfig`
- `BattleOverlay.vue` — `THEME_TIMING` config drives JS waits (`vsShakeDelay`, `votePause`, `finalPause`, `secondShake`); CSS overrides for `[data-anim-theme="hype"]`
- `BracketVisualization.vue` — HYPE-scaled `champNameSlam` + wider gold bar
- `BattleJudge.vue` — attribute applied (no overrides; judge UI stays calm)

## Test plan
- [x] `mvn test -Dtest=BattleServiceTest` — 56 pass (added `@Mock EventRepo`)
- [x] `mvn test -Dtest=BattleControllerIntegrationTest` — pass
- [x] `npm test -- --run` — 114 pass
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [ ] Manual: switch theme in BattleControl → confirm BattleOverlay reflects HYPE timing/visuals
- [ ] Manual: refresh page → confirm theme persists from DB
- [ ] Manual: switch back to IMPACT → confirm baseline restored

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)