### PR TITLE
feat: Audition Display screen — live round/timer OBS source (#135)

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
-import { logout, whoami, getAppConfig } from './utils/api'
+import { logout, whoami, getAppConfig, sendHeartbeat } from './utils/api'
 import { createClient, deactivateClient, subscribeToChannel } from './utils/websocket'
 import { useAuthStore } from './utils/auth'
 import ActionDoneModal from './views/ActionDoneModal.vue'
@@ -138,6 +138,20 @@ watch(route, () => {
 })
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
+let heartbeatTimer = null
+
+function startHeartbeat() {
+  if (heartbeatTimer) return
+  sendHeartbeat()
+  heartbeatTimer = setInterval(sendHeartbeat, 30_000)
+}
+
+function stopHeartbeat() {
+  if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null }
+}
+
+watch(isAuthenticated, (val) => { val ? startHeartbeat() : stopHeartbeat() })
+
 onMounted(async () => {
   applyTheme(theme.value)
   try {
@@ -161,6 +175,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  stopHeartbeat()
   deactivateClient(wsAccentClient.value)
   document.removeEventListener('keydown', handleKeydown)
 })

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -36,7 +36,7 @@ const isHelperSession = computed(() => isHelperRole.value && !!authStore.activeE
 
 /** Hide the navbar on full-screen / immersive routes */
 const hideNav = computed(() =>
-  ['Login', 'StreamOverlay', 'Battle Judge', 'BracketVisualization'].includes(route.name)
+  ['Login', 'StreamOverlay', 'Battle Judge', 'BracketVisualization', 'AuditionDisplay'].includes(route.name)
 )
 
 /**

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -91,7 +91,12 @@ function onTimerStopped() {
 }
 
 function onTimerTick(detail) {
-  lastTimerState.value = { startedAt: null, duration: detail.total, running: detail.running }
+  // Preserve startedAt from the started event so round-change publishes keep the timer alive
+  lastTimerState.value = {
+    startedAt: detail.running ? (lastTimerState.value.startedAt ?? null) : null,
+    duration: detail.total,
+    running: detail.running
+  }
 }
 
 // Publish state to display whenever the round changes (include timer state if running)

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -136,8 +136,8 @@ const dragOffset  = ref(0)
 const isDragging  = ref(false)
 const direction   = ref('left')
 
-const goNext = () => { if (currentRound.value < totalRounds.value)  { direction.value = 'left';  currentRound.value++ } }
-const goPrev = () => { if (currentRound.value > 1)                  { direction.value = 'right'; currentRound.value-- } }
+const goNext = () => { if (currentRound.value < totalRounds.value)  { direction.value = 'left';  currentRound.value++; timerRef.value?.reset() } }
+const goPrev = () => { if (currentRound.value > 1)                  { direction.value = 'right'; currentRound.value--; timerRef.value?.reset() } }
 
 const onPointerDown = (e) => {
   e.currentTarget.setPointerCapture(e.pointerId)

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -8,6 +8,8 @@ const props = defineProps({
   mode:         { type: String, default: 'SOLO' },
   eventName:    { type: String, default: '' },
   genreName:    { type: String, default: '' },
+  roundLabel:   { type: String, default: null },
+  numberColor:  { type: String, default: null },
 });
 
 const timerRef = ref(null)
@@ -71,7 +73,9 @@ function buildStatePayload(timerState = {}) {
     nextSlots: next,
     timerStartedAt: timerState.startedAt ?? null,
     timerDuration: timerState.duration ?? null,
-    timerRunning: timerState.running ?? false
+    timerRunning: timerState.running ?? false,
+    roundLabel: props.roundLabel ?? null,
+    numberColor: props.numberColor ?? null,
   }
 }
 
@@ -107,16 +111,19 @@ watch(currentRound, () => {
 onMounted(async () => {
   if (!props.eventName) return
   const state = await getAuditionDisplayState(props.eventName)
-  if (!state || state.standby) return
-  // Timer recovery: if timer was running, resume it
-  if (state.timerRunning && state.timerStartedAt && state.timerDuration) {
+  // Timer recovery: only resume if the saved state is for this same genre
+  if (state && !state.standby && state.genreName === props.genreName &&
+      state.timerRunning && state.timerStartedAt && state.timerDuration) {
     const elapsed = Math.floor((Date.now() - state.timerStartedAt) / 1000)
     const remaining = Math.max(0, state.timerDuration - elapsed)
     if (remaining > 0) {
       await new Promise(r => setTimeout(r, 100))
       timerRef.value?.resumeTimer(remaining, state.timerDuration)
+      lastTimerState.value = { startedAt: state.timerStartedAt, duration: state.timerDuration, running: true }
     }
   }
+  // Always publish on mount so switching genre updates the display immediately
+  publishState(lastTimerState.value)
 })
 
 const MAX_VISIBLE_UPCOMING = 4

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -1,10 +1,13 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, watch, onMounted } from 'vue';
 import Timer from './Timer.vue';
+import { postAuditionDisplayState, getAuditionDisplayState } from '@/utils/api';
 
 const props = defineProps({
   participants: { type: Array, required: true },
   mode:         { type: String, default: 'SOLO' },
+  eventName:    { type: String, default: '' },
+  genreName:    { type: String, default: '' },
 });
 
 const timerRef = ref(null)
@@ -38,6 +41,79 @@ const rounds = computed(() => {
 
 const totalRounds        = computed(() => rounds.value.length)
 const currentRoundSlots  = computed(() => rounds.value[currentRound.value - 1] ?? [])
+
+const lastTimerState = ref({})
+
+function buildStatePayload(timerState = {}) {
+  const current = currentRoundSlots.value.map(slot => ({
+    auditionNumber: slot.auditionNumber,
+    participantName: slot._placeholder ? null : slot.participantName,
+    memberNames: slot.memberNames ?? [],
+    placeholder: !!slot._placeholder
+  }))
+
+  const nextRoundIdx = currentRound.value
+  const nextSlotsRaw = rounds.value[nextRoundIdx] ?? []
+  const next = nextSlotsRaw.map(slot => ({
+    auditionNumber: slot.auditionNumber,
+    participantName: slot._placeholder ? null : slot.participantName,
+    memberNames: slot.memberNames ?? [],
+    placeholder: !!slot._placeholder
+  }))
+
+  return {
+    eventName: props.eventName,
+    genreName: props.genreName,
+    mode: props.mode,
+    currentRound: currentRound.value,
+    totalRounds: totalRounds.value,
+    currentSlots: current,
+    nextSlots: next,
+    timerStartedAt: timerState.startedAt ?? null,
+    timerDuration: timerState.duration ?? null,
+    timerRunning: timerState.running ?? false
+  }
+}
+
+function publishState(timerState = {}) {
+  if (!props.eventName) return
+  postAuditionDisplayState(buildStatePayload(timerState))
+}
+
+function onTimerStarted(detail) {
+  lastTimerState.value = { startedAt: detail.startedAt, duration: detail.duration, running: true }
+  publishState(lastTimerState.value)
+}
+
+function onTimerStopped() {
+  lastTimerState.value = { startedAt: null, duration: null, running: false }
+  publishState(lastTimerState.value)
+}
+
+function onTimerTick(detail) {
+  lastTimerState.value = { startedAt: null, duration: detail.total, running: detail.running }
+}
+
+// Publish state to display whenever the round changes (include timer state if running)
+watch(currentRound, () => {
+  publishState(lastTimerState.value)
+})
+
+onMounted(async () => {
+  if (!props.eventName) return
+  const state = await getAuditionDisplayState(props.eventName)
+  if (!state || state.standby) return
+  // Timer recovery: if timer was running, resume it
+  if (state.timerRunning && state.timerStartedAt && state.timerDuration) {
+    const elapsed = Math.floor((Date.now() - state.timerStartedAt) / 1000)
+    const remaining = Math.max(0, state.timerDuration - elapsed)
+    if (remaining > 0) {
+      await new Promise(r => setTimeout(r, 100))
+      timerRef.value?.resumeTimer(remaining, state.timerDuration)
+    }
+  }
+})
+
 const MAX_VISIBLE_UPCOMING = 4
 
 const allUpcomingRounds = computed(() =>
@@ -221,7 +297,7 @@ const swipeHint = computed(() => {
     <!-- ── Timer at bottom (thumb reach) ── -->
     <Transition name="timer-slide">
       <div v-if="timerVisible" class="emcee-timer px-3 pb-3 pt-2">
-        <Timer ref="timerRef" />
+        <Timer ref="timerRef" @started="onTimerStarted" @stopped="onTimerStopped" @tick="onTimerTick" />
       </div>
     </Transition>
 

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { ref, computed, onBeforeUnmount } from "vue";
 
+const emit = defineEmits(['started', 'stopped', 'tick'])
+
 const selectedTime = ref(0)
 const timeLeft = ref(0)
 const countUp = ref(false)
@@ -45,11 +47,16 @@ function startTimer(seconds) {
   timer = setInterval(() => {
     if (timeLeft.value < seconds) {
       timeLeft.value++
+      const remaining = selectedTime.value - timeLeft.value
+      emit('tick', { remaining, total: selectedTime.value, running: true })
     } else {
       clearInterval(timer)
       timer = null
+      emit('stopped')
+      emit('tick', { remaining: 0, total: selectedTime.value, running: false })
     }
   }, 1000)
+  emit('started', { duration: seconds, startedAt: Date.now() })
 }
 
 function toggleMode() {
@@ -69,16 +76,49 @@ function reset() {
   }
   selectedTime.value = 0
   timeLeft.value = 0
+  emit('stopped')
 }
 
 function stop() {
   if (timer) {
     clearInterval(timer)
     timer = null
+    emit('stopped')
   }
 }
 
-defineExpose({ reset, stop })
+/**
+ * Resume a countdown timer from a specific remaining time.
+ * Called by EmceeRoundView on mount when recovering timer state after refresh.
+ * @param {number} remainingSeconds - seconds left on the clock
+ * @param {number} totalDuration - original total duration in seconds
+ */
+function resumeTimer(remainingSeconds, totalDuration) {
+  if (timer) clearInterval(timer)
+  if (remainingSeconds <= 0) {
+    selectedTime.value = totalDuration
+    timeLeft.value = totalDuration
+    emit('stopped')
+    return
+  }
+  selectedTime.value = totalDuration
+  timeLeft.value = totalDuration - remainingSeconds
+  timer = setInterval(() => {
+    if (timeLeft.value < totalDuration) {
+      timeLeft.value++
+      const remaining = selectedTime.value - timeLeft.value
+      emit('tick', { remaining, total: selectedTime.value, running: true })
+    } else {
+      clearInterval(timer)
+      timer = null
+      emit('stopped')
+      emit('tick', { remaining: 0, total: selectedTime.value, running: false })
+    }
+  }, 1000)
+  emit('started', { duration: totalDuration, startedAt: Date.now() - ((totalDuration - remainingSeconds) * 1000) })
+}
+
+defineExpose({ reset, stop, resumeTimer })
 
 onBeforeUnmount(() => {
   if (timer) clearInterval(timer)

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -8,6 +8,7 @@ import AuditionList from "@/views/AuditionList.vue";
 import Score from "@/views/Score.vue";
 import Login from "@/views/Login.vue";
 import ForbiddenPage from "@/components/ForbiddenPage.vue";
+import AuditionDisplay from "@/views/AuditionDisplay.vue";
 import BattleOverlay from "@/views/BattleOverlay.vue";
 import BattleJudge from "@/views/BattleJudge.vue";
 import BattleControl from "@/views/BattleControl.vue";
@@ -81,6 +82,11 @@ const routes = [
         path: '/403',
         name: 'Forbidden',
         component: ForbiddenPage
+    },
+    {
+        path: '/audition/display',
+        name: 'AuditionDisplay',
+        component: AuditionDisplay
     },
     {
         path: '/battle/overlay',
@@ -169,7 +175,7 @@ const router = createRouter({
     routes
 })
 
-const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'JudgeSession', 'EmceeSession', 'HelperSession']
+const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'JudgeSession', 'EmceeSession', 'HelperSession', 'AuditionDisplay']
 
 router.beforeEach(async (to) => {
     if (PUBLIC_ROUTES.includes(to.name)) return true

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1311,6 +1311,42 @@ export const updateEventGenreFormat = async (eventName, eventGenreId, format) =>
   }
 }
 
+export const sendHeartbeat = async () => {
+  try {
+    await fetch(`${domain}/api/v1/auth/heartbeat`, { method: 'POST', credentials: 'include' })
+  } catch (_) { /* fire-and-forget */ }
+}
+
+export const updateGenreRoundLabel = async (eventName, eventGenreId, roundLabel) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/genres/${eventGenreId}/round-label`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ roundLabel })
+    })
+    return res.ok
+  } catch (e) {
+    console.error(e)
+    return false
+  }
+}
+
+export const updateGenreNumberColor = async (eventName, eventGenreId, numberColor) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/genres/${eventGenreId}/number-color`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ numberColor })
+    })
+    return res.ok
+  } catch (e) {
+    console.error(e)
+    return false
+  }
+}
+
 export const getOverlayConfig = async (eventName = '') => {
   try {
     const url = eventName
@@ -1549,7 +1585,7 @@ export const redeemToken = async (tokenId) => {
     })
     if (!res.ok) {
       const body = await res.json().catch(() => null)
-      return { authenticated: false, error: body?.error || 'Invalid or expired link.' }
+      return { authenticated: false, status: res.status, error: body?.message || body?.error || 'Invalid or expired link.' }
     }
     return await res.json()
   } catch (err) {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1594,3 +1594,32 @@ export const setResolvedParticipants = async (eventName, genreName, participants
     })
   } catch (e) { console.error(e) }
 }
+
+export const postAuditionDisplayState = async (state) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/audition-display`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(state)
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+export const getAuditionDisplayState = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/audition-display?event=${encodeURIComponent(eventName)}`, {
+      credentials: 'include'
+    })
+    if (res.ok) return await res.json()
+    return null
+  } catch (e) {
+    console.error(e)
+    return null
+  }
+}

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -109,33 +109,72 @@ onUnmounted(() => {
           <span class="section-rule-label type-label text-content-muted">{{ roundLabel }}</span>
         </div>
 
-        <!-- Current slot(s) + Timer side by side -->
-        <div class="slot-timer-row">
-          <!-- Left: number + name -->
-          <div class="current-slots">
-            <template v-for="(slot, sIdx) in currentSlots" :key="sIdx">
-              <div v-if="slot.placeholder" class="slot-placeholder type-stat" style="font-size:clamp(50px,8vw,80px);color:rgba(245,158,11,0.3)">
-                #{{ slot.auditionNumber }} — TBD
+        <!-- PAIR mode: Left battler | Timer | Right battler -->
+        <div v-if="mode === 'PAIR'" class="pair-row">
+          <!-- Left battler (right-aligned toward timer) -->
+          <div class="pair-slot pair-slot-left">
+            <template v-if="currentSlots[0]?.placeholder">
+              <div class="audition-number" style="color:rgba(245,158,11,0.3)">#{{ currentSlots[0].auditionNumber }}</div>
+              <div class="participant-name" style="opacity:0.3">TBD</div>
+            </template>
+            <template v-else-if="currentSlots[0]">
+              <div class="type-stat audition-number">
+                #{{ currentSlots[0].auditionNumber }}
               </div>
-              <div v-else class="slot-entry">
-                <div class="type-stat audition-number">
-                  #{{ slot.auditionNumber }}
-                </div>
-                <div class="type-body participant-name">
-                  {{ slot.participantName }}
-                </div>
-                <div v-if="slot.memberNames?.length" class="type-label member-names">
-                  {{ slot.memberNames.join(' · ') }}
-                </div>
+              <div class="type-body participant-name">
+                {{ currentSlots[0].participantName }}
               </div>
-              <!-- PAIR separator -->
-              <div v-if="mode === 'PAIR' && sIdx === 0 && currentSlots.length > 1" class="pair-sep">
-                <span class="type-stat">&amp;</span>
+              <div v-if="currentSlots[0].memberNames?.length" class="type-label member-names member-names-right">
+                {{ currentSlots[0].memberNames.join(' · ') }}
               </div>
             </template>
           </div>
 
-          <!-- Right: Timer -->
+          <!-- Centre: Timer -->
+          <div class="timer-display pair-timer" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+            <div class="type-stat timer-number">{{ timerLabel || '00:00' }}</div>
+          </div>
+
+          <!-- Right battler (left-aligned away from timer) -->
+          <div class="pair-slot pair-slot-right">
+            <template v-if="currentSlots[1]?.placeholder">
+              <div class="audition-number" style="color:rgba(245,158,11,0.3)">#{{ currentSlots[1].auditionNumber }}</div>
+              <div class="participant-name" style="opacity:0.3">TBD</div>
+            </template>
+            <template v-else-if="currentSlots[1]">
+              <div class="type-stat audition-number">
+                #{{ currentSlots[1].auditionNumber }}
+              </div>
+              <div class="type-body participant-name">
+                {{ currentSlots[1].participantName }}
+              </div>
+              <div v-if="currentSlots[1].memberNames?.length" class="type-label member-names">
+                {{ currentSlots[1].memberNames.join(' · ') }}
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <!-- SOLO mode: number+name | Timer -->
+        <div v-else class="slot-timer-row">
+          <div class="current-slots">
+            <template v-if="currentSlots[0]?.placeholder">
+              <div class="slot-placeholder type-stat" style="font-size:clamp(50px,8vw,80px);color:rgba(245,158,11,0.3)">
+                #{{ currentSlots[0].auditionNumber }} — TBD
+              </div>
+            </template>
+            <div v-else-if="currentSlots[0]" class="slot-entry">
+              <div class="type-stat audition-number">
+                #{{ currentSlots[0].auditionNumber }}
+              </div>
+              <div class="type-body participant-name">
+                {{ currentSlots[0].participantName }}
+              </div>
+              <div v-if="currentSlots[0].memberNames?.length" class="type-label member-names">
+                {{ currentSlots[0].memberNames.join(' · ') }}
+              </div>
+            </div>
+          </div>
           <div v-if="timerLabel" class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
             <div class="type-stat timer-number">{{ timerLabel }}</div>
           </div>
@@ -248,20 +287,42 @@ onUnmounted(() => {
 }
 .event-header-name {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(14px, 1.6vw, 22px);
-  letter-spacing: 0.28em;
+  font-size: clamp(28px, 4vw, 64px);
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.35);
+  color: rgba(255,255,255,0.5);
 }
 .event-header-genre {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(22px, 3vw, 42px);
-  letter-spacing: 0.18em;
+  font-size: clamp(42px, 7vw, 110px);
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.7);
+  color: rgba(255,255,255,0.9);
 }
 
-/* ── Current slots + timer side by side ──────────────────────────────────── */
+/* ── PAIR layout: left | timer | right ────────────────────────────────────── */
+.pair-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(40px, 7vw, 120px);
+  width: 100%;
+}
+.pair-slot {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  max-width: 36vw;
+}
+.pair-slot-left  { align-items: flex-end;  text-align: right; }
+.pair-slot-right { align-items: flex-start; text-align: left; }
+.pair-slot-left .participant-name  { text-align: right; }
+.pair-slot-right .participant-name { text-align: left; }
+.member-names-right { text-align: right; }
+.pair-timer { flex-shrink: 0; }
+
+/* ── SOLO layout: slot | timer ────────────────────────────────────────────── */
 .slot-timer-row {
   display: flex;
   flex-direction: row;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -108,33 +108,36 @@ onUnmounted(() => {
           <span class="section-rule-label type-label text-content-muted">{{ roundLabel }}</span>
         </div>
 
-        <!-- Current slot(s) -->
-        <div class="current-slots">
-          <template v-for="(slot, sIdx) in currentSlots" :key="sIdx">
-            <div v-if="slot.placeholder" class="slot-placeholder type-stat" style="font-size:clamp(50px,8vw,80px);color:rgba(245,158,11,0.3)">
-              #{{ slot.auditionNumber }} — TBD
-            </div>
-            <div v-else class="slot-entry">
-              <div class="type-stat audition-number">
-                #{{ slot.auditionNumber }}
+        <!-- Current slot(s) + Timer side by side -->
+        <div class="slot-timer-row">
+          <!-- Left: number + name -->
+          <div class="current-slots">
+            <template v-for="(slot, sIdx) in currentSlots" :key="sIdx">
+              <div v-if="slot.placeholder" class="slot-placeholder type-stat" style="font-size:clamp(50px,8vw,80px);color:rgba(245,158,11,0.3)">
+                #{{ slot.auditionNumber }} — TBD
               </div>
-              <div class="type-body participant-name">
-                {{ slot.participantName }}
+              <div v-else class="slot-entry">
+                <div class="type-stat audition-number">
+                  #{{ slot.auditionNumber }}
+                </div>
+                <div class="type-body participant-name">
+                  {{ slot.participantName }}
+                </div>
+                <div v-if="slot.memberNames?.length" class="type-label member-names">
+                  {{ slot.memberNames.join(' · ') }}
+                </div>
               </div>
-              <div v-if="slot.memberNames?.length" class="type-label member-names">
-                {{ slot.memberNames.join(' · ') }}
+              <!-- PAIR separator -->
+              <div v-if="mode === 'PAIR' && sIdx === 0 && currentSlots.length > 1" class="pair-sep">
+                <span class="type-stat">&amp;</span>
               </div>
-            </div>
-            <!-- PAIR separator -->
-            <div v-if="mode === 'PAIR' && sIdx === 0 && currentSlots.length > 1" class="pair-sep">
-              <span class="type-stat">&amp;</span>
-            </div>
-          </template>
-        </div>
+            </template>
+          </div>
 
-        <!-- Timer -->
-        <div v-if="timerLabel" class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
-          <div class="type-stat timer-number">{{ timerLabel }}</div>
+          <!-- Right: Timer -->
+          <div v-if="timerLabel" class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+            <div class="type-stat timer-number">{{ timerLabel }}</div>
+          </div>
         </div>
       </div>
 
@@ -245,18 +248,25 @@ onUnmounted(() => {
   justify-content: center;
 }
 
-/* ── Current slots ────────────────────────────────────────────────────────── */
+/* ── Current slots + timer side by side ──────────────────────────────────── */
+.slot-timer-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: clamp(32px, 5vw, 80px);
+}
+
 .current-slots {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 0;
 }
 
 .slot-entry {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .audition-number {
@@ -268,7 +278,7 @@ onUnmounted(() => {
 }
 
 .participant-name {
-  font-size: clamp(28px, 5vw, 48px);
+  font-size: clamp(40px, 7vw, 80px);
   letter-spacing: 0.05em;
   color: #ffffff;
   margin-top: 4px;
@@ -294,7 +304,7 @@ onUnmounted(() => {
 
 /* ── Timer ────────────────────────────────────────────────────────────────── */
 .timer-display {
-  margin-top: 24px;
+  flex-shrink: 0;
 }
 
 .timer-number {

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -109,49 +109,23 @@ onUnmounted(() => {
           <span class="section-rule-label type-label text-content-muted">{{ roundLabel }}</span>
         </div>
 
-        <!-- PAIR mode: Left battler | Timer | Right battler -->
+        <!-- PAIR mode: stacked names left | timer right -->
         <div v-if="mode === 'PAIR'" class="pair-row">
-          <!-- Left battler (right-aligned toward timer) -->
-          <div class="pair-slot pair-slot-left">
-            <template v-if="currentSlots[0]?.placeholder">
-              <div class="audition-number" style="color:rgba(245,158,11,0.3)">#{{ currentSlots[0].auditionNumber }}</div>
-              <div class="participant-name" style="opacity:0.3">TBD</div>
-            </template>
-            <template v-else-if="currentSlots[0]">
-              <div class="type-stat audition-number">
-                #{{ currentSlots[0].auditionNumber }}
+          <!-- Left: both names stacked -->
+          <div class="pair-names">
+            <template v-for="(slot, sIdx) in currentSlots" :key="sIdx">
+              <div class="pair-name-entry">
+                <span class="type-stat audition-number">#{{ slot.auditionNumber }}</span>
+                <span v-if="slot.placeholder" class="participant-name" style="opacity:0.3">TBD</span>
+                <span v-else class="type-body participant-name">{{ slot.participantName }}</span>
               </div>
-              <div class="type-body participant-name">
-                {{ currentSlots[0].participantName }}
-              </div>
-              <div v-if="currentSlots[0].memberNames?.length" class="type-label member-names member-names-right">
-                {{ currentSlots[0].memberNames.join(' · ') }}
-              </div>
+              <div v-if="sIdx === 0 && currentSlots.length > 1" class="pair-divider" aria-hidden="true"></div>
             </template>
           </div>
 
-          <!-- Centre: Timer -->
-          <div class="timer-display pair-timer" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+          <!-- Right: timer -->
+          <div class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
             <div class="type-stat timer-number">{{ timerLabel || '0' }}</div>
-          </div>
-
-          <!-- Right battler (left-aligned away from timer) -->
-          <div class="pair-slot pair-slot-right">
-            <template v-if="currentSlots[1]?.placeholder">
-              <div class="audition-number" style="color:rgba(245,158,11,0.3)">#{{ currentSlots[1].auditionNumber }}</div>
-              <div class="participant-name" style="opacity:0.3">TBD</div>
-            </template>
-            <template v-else-if="currentSlots[1]">
-              <div class="type-stat audition-number">
-                #{{ currentSlots[1].auditionNumber }}
-              </div>
-              <div class="type-body participant-name">
-                {{ currentSlots[1].participantName }}
-              </div>
-              <div v-if="currentSlots[1].memberNames?.length" class="type-label member-names">
-                {{ currentSlots[1].memberNames.join(' · ') }}
-              </div>
-            </template>
           </div>
         </div>
 
@@ -266,7 +240,7 @@ onUnmounted(() => {
   justify-content: center;
   width: 100%;
   height: 100%;
-  padding: 40px;
+  padding: 24px 40px;
 }
 
 .main-area {
@@ -275,8 +249,8 @@ onUnmounted(() => {
   align-items: center;
   justify-content: flex-start;
   width: 100%;
-  padding-top: 6vh;
-  gap: 12px;
+  padding-top: 2vh;
+  gap: 10px;
 }
 
 /* Event name + genre stacked at the top */
@@ -284,8 +258,8 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  margin-bottom: 4px;
+  gap: 2px;
+  margin-bottom: 2px;
 }
 .event-header-name {
   font-family: 'Anton SC', sans-serif;
@@ -302,28 +276,36 @@ onUnmounted(() => {
   color: rgba(255,255,255,0.45);
 }
 
-/* ── PAIR layout: left | timer | right ────────────────────────────────────── */
+/* ── PAIR layout: stacked names left | timer right ───────────────────────── */
 .pair-row {
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: clamp(40px, 7vw, 120px);
+  gap: clamp(40px, 8vw, 130px);
   width: 100%;
 }
-.pair-slot {
+/* Left column: both names stacked */
+.pair-names {
   display: flex;
   flex-direction: column;
+  gap: 8px;
   flex: 1;
-  min-width: 28vw;
-  max-width: 40vw;
+  min-width: 0;
+  max-width: 58vw;
 }
-.pair-slot-left  { align-items: flex-end;  text-align: right; }
-.pair-slot-right { align-items: flex-start; text-align: left; }
-.pair-slot-left .participant-name  { text-align: right; }
-.pair-slot-right .participant-name { text-align: left; }
-.member-names-right { text-align: right; }
-.pair-timer { flex-shrink: 0; }
+.pair-name-entry {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+/* Thin divider between the two entries */
+.pair-divider {
+  height: 2px;
+  width: 100%;
+  background: rgba(255,255,255,0.1);
+  margin: 4px 0;
+}
 
 /* ── SOLO layout: slot | timer ────────────────────────────────────────────── */
 .slot-timer-row {

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -1,0 +1,375 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { getAuditionDisplayState } from '@/utils/api'
+import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket'
+
+const route = useRoute()
+const eventName = ref(route.query.event || '')
+const state = ref(null)
+const client = ref(null)
+
+// ── Local timer ticker (reconstructed from backend timerStartedAt + timerDuration) ──
+const displayTimeLeft = ref(0)
+let timerInterval = null
+
+function startLocalTimer(startedAt, duration) {
+  stopLocalTimer()
+  const tick = () => {
+    const elapsed = Math.floor((Date.now() - startedAt) / 1000)
+    displayTimeLeft.value = Math.max(0, duration - elapsed)
+    if (displayTimeLeft.value <= 0) stopLocalTimer()
+  }
+  tick()
+  timerInterval = setInterval(tick, 250)
+}
+
+function stopLocalTimer() {
+  if (timerInterval) { clearInterval(timerInterval); timerInterval = null }
+}
+
+// ── Computed ──────────────────────────────────────────────────────────────────
+const isStandby  = computed(() => !state.value || state.value.standby)
+const mode       = computed(() => state.value?.mode ?? 'SOLO')
+const genreName  = computed(() => state.value?.genreName ?? '')
+const eventLabel = computed(() => state.value?.eventName ?? eventName.value ?? '')
+const roundLabel = computed(() => {
+  if (!state.value || !state.value.totalRounds) return ''
+  return `ROUND ${state.value.currentRound} / ${state.value.totalRounds}`
+})
+const currentSlots = computed(() => state.value?.currentSlots ?? [])
+const nextSlots    = computed(() => state.value?.nextSlots ?? [])
+
+const isNearEnd  = computed(() => displayTimeLeft.value <= 10 && displayTimeLeft.value > 0 && state.value?.timerRunning)
+const isFinished = computed(() => displayTimeLeft.value <= 0 && state.value?.timerDuration > 0)
+const timerLabel = computed(() => {
+  if (!state.value?.timerDuration) return ''
+  return String(displayTimeLeft.value)
+})
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+function applyState(newState) {
+  state.value = newState
+  if (newState.timerRunning && newState.timerStartedAt && newState.timerDuration) {
+    startLocalTimer(newState.timerStartedAt, newState.timerDuration)
+  } else {
+    stopLocalTimer()
+    displayTimeLeft.value = newState.timerDuration ?? 0
+  }
+}
+
+onMounted(async () => {
+  if (!eventName.value) return
+
+  const initial = await getAuditionDisplayState(eventName.value)
+  if (initial) applyState(initial)
+
+  client.value = createClient()
+  subscribeToChannel(client.value, `/topic/audition/${eventName.value}/display`, (msg) => {
+    applyState(msg)
+  })
+})
+
+onUnmounted(() => {
+  stopLocalTimer()
+  if (client.value) deactivateClient(client.value)
+})
+</script>
+
+<template>
+  <div class="display-root">
+    <!-- Scanlines overlay -->
+    <div class="scanlines"></div>
+
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
+
+    <!-- STANDBY: no state published yet -->
+    <div v-if="isStandby" class="standby-container">
+      <div class="corner-bar-tl"></div>
+      <div class="corner-bar-bl"></div>
+      <span class="type-label text-content-muted" style="font-size:14px;letter-spacing:0.22em">{{ eventLabel }}</span>
+      <span class="type-stat text-accent" style="font-size: clamp(48px,8vw,80px);margin-top:12px">STANDBY</span>
+      <span class="type-label text-content-muted" style="margin-top:8px">AWAITING AUDITION START</span>
+    </div>
+
+    <!-- ACTIVE display -->
+    <div v-else class="active-container">
+      <!-- Top bar: event name + genre -->
+      <div class="top-bar">
+        <span class="type-label text-content-muted" style="letter-spacing:0.22em">{{ eventLabel }}</span>
+        <span class="type-label text-accent" style="letter-spacing:0.12em">{{ genreName }}</span>
+      </div>
+
+      <!-- Main area: round counter, audition number, participant name, timer -->
+      <div class="main-area">
+        <!-- Round counter -->
+        <div class="section-rule mb-3">
+          <span class="section-rule-label type-label text-content-muted">{{ roundLabel }}</span>
+        </div>
+
+        <!-- Current slot(s) -->
+        <div class="current-slots">
+          <template v-for="(slot, sIdx) in currentSlots" :key="sIdx">
+            <div v-if="slot.placeholder" class="slot-placeholder type-stat" style="font-size:clamp(50px,8vw,80px);color:rgba(245,158,11,0.3)">
+              #{{ slot.auditionNumber }} — TBD
+            </div>
+            <div v-else class="slot-entry">
+              <div class="type-stat audition-number">
+                #{{ slot.auditionNumber }}
+              </div>
+              <div class="type-body participant-name">
+                {{ slot.participantName }}
+              </div>
+              <div v-if="slot.memberNames?.length" class="type-label member-names">
+                {{ slot.memberNames.join(' · ') }}
+              </div>
+            </div>
+            <!-- PAIR separator -->
+            <div v-if="mode === 'PAIR' && sIdx === 0 && currentSlots.length > 1" class="pair-sep">
+              <span class="type-stat">&amp;</span>
+            </div>
+          </template>
+        </div>
+
+        <!-- Timer -->
+        <div v-if="timerLabel" class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+          <div class="type-stat timer-number">{{ timerLabel }}</div>
+        </div>
+      </div>
+
+      <!-- UP NEXT (secondary area) -->
+      <div v-if="nextSlots.length > 0" class="up-next-area">
+        <div class="section-rule mb-2">
+          <span class="section-rule-label type-label text-content-muted">UP NEXT</span>
+        </div>
+        <div class="next-slots">
+          <template v-for="(slot, sIdx) in nextSlots" :key="sIdx">
+            <div v-if="slot.placeholder" class="type-label" style="opacity:0.3;font-size:16px">
+              #{{ slot.auditionNumber }} — TBD
+            </div>
+            <div v-else class="next-slot-entry">
+              <span class="type-stat" style="font-size:24px;opacity:0.5">#{{ slot.auditionNumber }}</span>
+              <span class="type-body" style="font-size:20px;opacity:0.4;margin-left:8px">{{ slot.participantName }}</span>
+              <span v-if="slot.memberNames?.length" class="type-label" style="opacity:0.3;font-size:12px;margin-left:8px">{{ slot.memberNames.join(' · ') }}</span>
+            </div>
+            <span v-if="mode === 'PAIR' && sIdx === 0 && nextSlots.length > 1" style="opacity:0.2;margin:0 8px">&amp;</span>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ── Root layout ──────────────────────────────────────────────────────────── */
+.display-root {
+  position: fixed;
+  inset: 0;
+  background: #060818;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-family: 'Anton SC', sans-serif;
+  text-transform: uppercase;
+}
+
+/* ── Scanlines ────────────────────────────────────────────────────────────── */
+.scanlines {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0,0,0,0.03) 2px,
+    rgba(0,0,0,0.03) 4px
+  );
+  z-index: 10;
+}
+
+/* ── Color bleed ──────────────────────────────────────────────────────────── */
+.color-bleed {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 0% 100%, var(--accent-subtle, rgba(255,255,255,0.015)) 0%, transparent 60%),
+    radial-gradient(ellipse at 100% 100%, var(--accent-subtle, rgba(255,255,255,0.015)) 0%, transparent 60%);
+  z-index: 0;
+}
+
+/* ── Standby ──────────────────────────────────────────────────────────────── */
+.standby-container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 64px;
+  clip-path: polygon(10px 0%, 100% 0%, calc(100% - 10px) 100%, 0% 100%);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
+/* ── Active layout ────────────────────────────────────────────────────────── */
+.active-container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 40px;
+}
+
+.top-bar {
+  position: absolute;
+  top: 40px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  opacity: 0.5;
+}
+
+.main-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  justify-content: center;
+}
+
+/* ── Current slots ────────────────────────────────────────────────────────── */
+.current-slots {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+}
+
+.slot-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.audition-number {
+  font-size: clamp(80px, 14vw, 120px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  text-shadow: 2px 2px 0 var(--accent-muted, rgba(255,255,255,0.15));
+  color: var(--accent-color, #ffffff);
+}
+
+.participant-name {
+  font-size: clamp(28px, 5vw, 48px);
+  letter-spacing: 0.05em;
+  color: #ffffff;
+  margin-top: 4px;
+}
+
+.member-names {
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  color: rgba(255,255,255,0.35);
+  text-transform: none;
+  margin-top: 4px;
+}
+
+.pair-sep {
+  margin: 8px 0;
+  color: rgba(255,255,255,0.25);
+  font-size: 28px;
+}
+
+.slot-placeholder {
+  opacity: 0.4;
+}
+
+/* ── Timer ────────────────────────────────────────────────────────────────── */
+.timer-display {
+  margin-top: 24px;
+}
+
+.timer-number {
+  font-size: clamp(64px, 12vw, 100px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: #ffffff;
+  transition: color 0.3s ease;
+}
+
+.timer-near-end .timer-number {
+  color: #ef4444;
+  animation: pulse 0.5s ease-in-out infinite alternate;
+}
+
+.timer-finished .timer-number {
+  color: rgba(255,255,255,0.2);
+}
+
+@keyframes pulse {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0.7; transform: scale(1.03); }
+}
+
+/* ── UP NEXT ─────────────────────────────────────────────────────────────── */
+.up-next-area {
+  position: absolute;
+  bottom: 60px;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.next-slots {
+  display: flex;
+  align-items: center;
+}
+
+.next-slot-entry {
+  display: flex;
+  align-items: baseline;
+}
+
+/* ── Section rule (defined locally since this is a standalone page) ───────── */
+.section-rule {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  max-width: 500px;
+}
+.section-rule::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(255,255,255,0.08);
+}
+.section-rule-label {
+  flex-shrink: 0;
+}
+
+/* ── Corner bars ─────────────────────────────────────────────────────────── */
+.corner-bar-tl, .corner-bar-bl {
+  position: absolute;
+  background: var(--accent-color, #ffffff);
+  opacity: 0.4;
+}
+.corner-bar-tl {
+  top: 0; left: 0;
+  width: 2px; height: 20px;
+}
+.corner-bar-bl {
+  bottom: 0; left: 0;
+  width: 2px; height: 20px;
+}
+</style>

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -249,12 +249,13 @@ onUnmounted(() => {
   align-items: center;
   width: 100%;
   gap: 10px;
+  margin-top: 12vh;
 }
 
 /* Event name + genre — pinned to top, independent of the centred content */
 .event-header {
   position: absolute;
-  top: 2vh;
+  top: 5vh;
   left: 0;
   right: 0;
   display: flex;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -37,6 +37,8 @@ const roundLabel = computed(() => {
   if (!state.value || !state.value.totalRounds) return ''
   return `ROUND ${state.value.currentRound} / ${state.value.totalRounds}`
 })
+const genreRoundLabel = computed(() => state.value?.roundLabel ?? null)
+const numberColor     = computed(() => state.value?.numberColor ?? null)
 const currentSlots = computed(() => state.value?.currentSlots ?? [])
 const nextSlots    = computed(() => state.value?.nextSlots ?? [])
 
@@ -102,6 +104,7 @@ onUnmounted(() => {
         <div class="event-header">
           <span class="event-header-name">{{ eventLabel }}</span>
           <span class="event-header-genre">{{ genreName }}</span>
+          <span v-if="genreRoundLabel" class="event-header-round-label">{{ genreRoundLabel }}</span>
         </div>
 
         <!-- Round counter -->
@@ -115,7 +118,7 @@ onUnmounted(() => {
           <div class="pair-names">
             <template v-for="(slot, sIdx) in currentSlots" :key="sIdx">
               <div class="pair-name-entry">
-                <span class="type-stat audition-number">#{{ slot.auditionNumber }}</span>
+                <span class="type-stat audition-number" :style="numberColor ? { color: numberColor } : {}">#{{ slot.auditionNumber }}</span>
                 <span v-if="slot.placeholder" class="participant-name" style="opacity:0.3">TBD</span>
                 <span v-else class="type-body participant-name">{{ slot.participantName }}</span>
               </div>
@@ -138,7 +141,7 @@ onUnmounted(() => {
               </div>
             </template>
             <div v-else-if="currentSlots[0]" class="slot-entry">
-              <div class="type-stat audition-number">
+              <div class="type-stat audition-number" :style="numberColor ? { color: numberColor } : {}">
                 #{{ currentSlots[0].auditionNumber }}
               </div>
               <div class="type-body participant-name">
@@ -265,17 +268,25 @@ onUnmounted(() => {
 }
 .event-header-name {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(48px, 7vw, 110px);
+  font-size: clamp(42px, 8vw, 100px);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: rgba(255,255,255,0.9);
 }
 .event-header-genre {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(28px, 4vw, 64px);
+  font-size: clamp(22px, 3.5vw, 52px);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: rgba(255,255,255,0.45);
+}
+.event-header-round-label {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(14px, 2vw, 28px);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.28);
+  margin-top: 2px;
 }
 
 /* ── PAIR layout: stacked names left | timer right ───────────────────────── */
@@ -339,7 +350,7 @@ onUnmounted(() => {
 }
 
 .participant-name {
-  font-size: clamp(56px, 10vw, 140px);
+  font-size: clamp(48px, 9vw, 120px);
   letter-spacing: 0.04em;
   color: #ffffff;
   margin-top: 2px;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -95,14 +95,15 @@ onUnmounted(() => {
 
     <!-- ACTIVE display -->
     <div v-else class="active-container">
-      <!-- Top bar: event name + genre -->
-      <div class="top-bar">
-        <span class="type-label text-content-muted" style="letter-spacing:0.22em">{{ eventLabel }}</span>
-        <span class="type-label text-accent" style="letter-spacing:0.12em">{{ genreName }}</span>
-      </div>
 
-      <!-- Main area: round counter, audition number, participant name, timer -->
+      <!-- Main area: event/genre header, round counter, number+name+timer -->
       <div class="main-area">
+        <!-- Event name + genre stacked above everything -->
+        <div class="event-header">
+          <span class="event-header-name">{{ eventLabel }}</span>
+          <span class="event-header-genre">{{ genreName }}</span>
+        </div>
+
         <!-- Round counter -->
         <div class="section-rule mb-3">
           <span class="section-rule-label type-label text-content-muted">{{ roundLabel }}</span>
@@ -229,23 +230,35 @@ onUnmounted(() => {
   padding: 40px;
 }
 
-.top-bar {
-  position: absolute;
-  top: 40px;
-  left: 0;
-  right: 0;
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  opacity: 0.5;
-}
-
 .main-area {
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 1;
   justify-content: center;
+  gap: 16px;
+}
+
+/* Event name + genre stacked, above round counter */
+.event-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.event-header-name {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(14px, 1.6vw, 22px);
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.35);
+}
+.event-header-genre {
+  font-family: 'Anton SC', sans-serif;
+  font-size: clamp(22px, 3vw, 42px);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
 }
 
 /* ── Current slots + timer side by side ──────────────────────────────────── */
@@ -253,7 +266,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: clamp(32px, 5vw, 80px);
+  gap: clamp(60px, 10vw, 160px);
 }
 
 .current-slots {
@@ -308,7 +321,7 @@ onUnmounted(() => {
 }
 
 .timer-number {
-  font-size: clamp(64px, 12vw, 100px);
+  font-size: clamp(100px, 18vw, 220px);
   line-height: 1;
   letter-spacing: 0.02em;
   color: #ffffff;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -237,10 +237,10 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   width: 100%;
   height: 100%;
-  padding: 3vh 40px 40px;
+  padding: 40px;
 }
 
 .main-area {
@@ -251,13 +251,16 @@ onUnmounted(() => {
   gap: 10px;
 }
 
-/* Event name + genre stacked at the top */
+/* Event name + genre — pinned to top, independent of the centred content */
 .event-header {
+  position: absolute;
+  top: 2vh;
+  left: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2px;
-  margin-bottom: 2px;
 }
 .event-header-name {
   font-family: 'Anton SC', sans-serif;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -237,19 +237,17 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
   height: 100%;
-  padding: 24px 40px;
+  padding: 3vh 40px 40px;
 }
 
 .main-area {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
   width: 100%;
-  padding-top: 2vh;
   gap: 10px;
 }
 

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -273,17 +273,19 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 16px;
+  justify-content: flex-start;
+  width: 100%;
+  padding-top: 6vh;
+  gap: 12px;
 }
 
-/* Event name + genre stacked, above round counter */
+/* Event name + genre stacked at the top */
 .event-header {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: 4px;
+  margin-bottom: 4px;
 }
 .event-header-name {
   font-family: 'Anton SC', sans-serif;
@@ -345,18 +347,18 @@ onUnmounted(() => {
 }
 
 .audition-number {
-  font-size: clamp(80px, 14vw, 120px);
+  font-size: clamp(36px, 6vw, 72px);
   line-height: 1;
   letter-spacing: 0.02em;
   text-shadow: 2px 2px 0 var(--accent-muted, rgba(255,255,255,0.15));
-  color: var(--accent-color, #ffffff);
+  color: var(--accent-color, rgba(255,255,255,0.6));
 }
 
 .participant-name {
-  font-size: clamp(40px, 7vw, 80px);
-  letter-spacing: 0.05em;
+  font-size: clamp(56px, 10vw, 140px);
+  letter-spacing: 0.04em;
   color: #ffffff;
-  margin-top: 4px;
+  margin-top: 2px;
   hyphens: none;
   overflow-wrap: normal;
   word-break: keep-all;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -132,7 +132,7 @@ onUnmounted(() => {
 
           <!-- Centre: Timer -->
           <div class="timer-display pair-timer" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
-            <div class="type-stat timer-number">{{ timerLabel || '00:00' }}</div>
+            <div class="type-stat timer-number">{{ timerLabel || '0' }}</div>
           </div>
 
           <!-- Right battler (left-aligned away from timer) -->
@@ -287,17 +287,17 @@ onUnmounted(() => {
 }
 .event-header-name {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(28px, 4vw, 64px);
-  letter-spacing: 0.22em;
+  font-size: clamp(48px, 7vw, 110px);
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.5);
+  color: rgba(255,255,255,0.9);
 }
 .event-header-genre {
   font-family: 'Anton SC', sans-serif;
-  font-size: clamp(42px, 7vw, 110px);
-  letter-spacing: 0.14em;
+  font-size: clamp(28px, 4vw, 64px);
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.9);
+  color: rgba(255,255,255,0.45);
 }
 
 /* ── PAIR layout: left | timer | right ────────────────────────────────────── */
@@ -313,7 +313,8 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   flex: 1;
-  max-width: 36vw;
+  min-width: 28vw;
+  max-width: 40vw;
 }
 .pair-slot-left  { align-items: flex-end;  text-align: right; }
 .pair-slot-right { align-items: flex-start; text-align: left; }
@@ -356,6 +357,9 @@ onUnmounted(() => {
   letter-spacing: 0.05em;
   color: #ffffff;
   margin-top: 4px;
+  hyphens: none;
+  overflow-wrap: normal;
+  word-break: keep-all;
 }
 
 .member-names {

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -142,6 +142,12 @@ const switchGenre = (g) => {
     modalVariant.value = 'warning'
     showModal.value = true
     dynamicCallBack.value = () => { showModal.value = false; selectedGenre.value = g }
+  } else if (isEmcee.value) {
+    modalTitle.value = `Switch to ${g}?`
+    modalMessage.value = `This will update the audition display and reset the timer.`
+    modalVariant.value = 'warning'
+    showModal.value = true
+    dynamicCallBack.value = () => { showModal.value = false; selectedGenre.value = g }
   } else {
     selectedGenre.value = g
   }
@@ -348,6 +354,10 @@ const uniqueGenres = computed(() => {
   const genres = participants.value.map(p => p.genreName);
   return [...new Set(genres)].sort();
 })
+
+const currentDivision = computed(() =>
+  eventDivisions.value.find(d => d.name.toLowerCase() === selectedGenre.value.toLowerCase()) ?? null
+)
 
 const submitScore = async (eventName, genreName, judgeName, participantList) => {
   scoreError.value = ''
@@ -752,7 +762,7 @@ onMounted(async () => {
           ><i class="pi pi-search text-sm sm:text-xs" aria-hidden="true"></i></button>
         </template>
         <button
-          v-if="isAdmin || isOrganiser"
+          v-if="isAdmin || isOrganiser || isEmcee"
           @click="showFilters = !showFilters"
           :aria-expanded="showFilters"
           aria-label="Toggle filters"
@@ -799,8 +809,8 @@ onMounted(async () => {
           <span v-if="!isJudgeSession" class="type-body text-content-primary whitespace-nowrap">{{ selectedEvent }}</span>
           <span v-if="!isJudgeSession" class="text-surface-600 select-none hidden sm:inline">|</span>
 
-          <!-- Role toggle (hidden for session judges — locked to Judge) -->
-          <div v-if="!isJudgeSession" class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
+          <!-- Role toggle (hidden for session judges and emcees — role is fixed) -->
+          <div v-if="!isJudgeSession && !isEmcee" class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-1">
             <span class="section-rule-label sm:hidden">Role</span>
             <div class="flex flex-wrap gap-2 sm:gap-1">
               <button
@@ -929,6 +939,8 @@ onMounted(async () => {
         :mode="judgingMode"
         :eventName="selectedEvent"
         :genreName="selectedGenre"
+        :roundLabel="currentDivision?.roundLabel ?? null"
+        :numberColor="currentDivision?.numberColor ?? null"
       />
     </template>
 

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -927,6 +927,8 @@ onMounted(async () => {
         :key="selectedGenre"
         :participants="filteredParticipantsForEmceeView"
         :mode="judgingMode"
+        :eventName="selectedEvent"
+        :genreName="selectedGenre"
       />
     </template>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -859,6 +859,13 @@ function copyAuditionScreenLink() {
   setTimeout(() => { auditionLinkCopied.value = false }, 2000)
 }
 
+const displayLinkCopied = ref(false)
+function copyDisplayLink() {
+  copyToClipboard(window.location.origin + '/audition/display?event=' + encodeURIComponent(props.eventName))
+  displayLinkCopied.value = true
+  setTimeout(() => { displayLinkCopied.value = false }, 2000)
+}
+
 const formatExpiry = (expiresAt) => {
   const d = new Date(expiresAt)
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
@@ -1207,6 +1214,14 @@ onUnmounted(() => {
         >
           <i class="pi text-sm" :class="auditionLinkCopied ? 'pi-check' : 'pi-hashtag'"></i>
           {{ auditionLinkCopied ? 'Link Copied!' : 'Audition Screen' }}
+        </button>
+        <button
+          @click="copyDisplayLink"
+          class="flex items-center gap-2 px-4 py-2 para-chip type-label border-accent transition-all duration-200"
+          :class="displayLinkCopied ? 'text-emerald-400 border-emerald-400/40' : ''"
+        >
+          <i class="pi text-sm" :class="displayLinkCopied ? 'pi-check' : 'pi-desktop'"></i>
+          {{ displayLinkCopied ? 'Link Copied!' : 'Audition Display' }}
         </button>
         <button
           v-if="!isHelper"

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, fetchAllGenres, getGenresByEvent, getVerifiedParticipantsByEvent, insertEventInTable, linkGenreToEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantGenre, addGenreToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventGenreFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled, updateGenreRoundLabel, updateGenreNumberColor } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 
@@ -649,6 +649,16 @@ const saveDivisionFormat = async (div, format) => {
       div.soloAllowed = false
     }
   }
+}
+
+const saveRoundLabel = async (div, label) => {
+  await updateGenreRoundLabel(props.eventName, div.eventGenreId, label || null)
+  div.roundLabel = label || null
+}
+
+const saveNumberColor = async (div, color) => {
+  await updateGenreNumberColor(props.eventName, div.eventGenreId, color || null)
+  div.numberColor = color || null
 }
 
 const toggleSoloAllowed = async (div) => {
@@ -1889,6 +1899,47 @@ onUnmounted(() => {
             </span>
           </div>
           <span v-else class="text-xs text-content-muted">None assigned — add in Judge Pool above</span>
+        </div>
+
+        <div class="h-px bg-surface-700/40"></div>
+
+        <!-- AUDITION DISPLAY -->
+        <div>
+          <div class="section-rule mb-3">
+            <span class="section-rule-label">Audition Display</span>
+            <div class="section-rule-line"></div>
+          </div>
+          <div class="flex flex-col gap-3">
+            <!-- Round label toggle -->
+            <div class="flex items-center justify-between">
+              <p class="type-label text-content-muted">Preliminary Round</p>
+              <button
+                @click="saveRoundLabel(g, g.roundLabel ? null : 'Preliminary Round')"
+                :class="g.roundLabel ? 'border-accent text-accent' : 'text-content-muted hover:text-content-secondary'"
+                class="para-chip-sm px-2.5 py-1 type-label transition-colors"
+              >{{ g.roundLabel ? 'ON' : 'OFF' }}</button>
+            </div>
+            <!-- Number color -->
+            <div class="flex items-center gap-3">
+              <p class="type-label text-content-muted">Audition # Color</p>
+              <label class="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="color"
+                  :value="g.numberColor || '#ffffff'"
+                  @change="saveNumberColor(g, $event.target.value)"
+                  class="w-8 h-8 rounded cursor-pointer border border-white/10 bg-transparent p-0.5"
+                  title="Audition number color"
+                />
+                <span class="type-label text-content-muted">{{ g.numberColor || 'Default' }}</span>
+              </label>
+              <button
+                v-if="g.numberColor"
+                @click="saveNumberColor(g, null)"
+                class="type-label text-content-muted hover:text-content-secondary transition-colors"
+                title="Reset to default"
+              ><i class="pi pi-times text-xs"></i> Reset</button>
+            </div>
+          </div>
         </div>
 
       </div>

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -38,7 +38,9 @@ const submitLogin = async () => {
   try {
     isLoading.value = true
     const res = await login(username.value, password.value)
-    if (res.status !== 200) {
+    if (res.status === 409) {
+      openModal('Account Already Active', 'This account is already logged in on another device or browser. Please log out there first.')
+    } else if (res.status !== 200) {
       openModal('Authentication Failed', 'Invalid username or password. Please try again.')
     } else {
       const data = await res.json()

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -20,7 +20,9 @@ onMounted(async () => {
   }
   const data = await redeemToken(token)
   if (!data?.authenticated) {
-    error.value = data?.error || 'Invalid or expired link.'
+    error.value = data?.status === 409
+      ? 'This session link is already active in another browser. Close the other session first.'
+      : data?.error || 'Invalid or expired link.'
     loading.value = false
     return
   }

--- a/BES/src/main/java/com/example/BES/config/SecurityConfig.java
+++ b/BES/src/main/java/com/example/BES/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.session.HttpSessionEventPublisher;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 
@@ -72,6 +73,11 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authManager(AuthenticationConfiguration authConfig) throws Exception{
         return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public HttpSessionEventPublisher httpSessionEventPublisher() {
+        return new HttpSessionEventPublisher();
     }
 
     @Bean

--- a/BES/src/main/java/com/example/BES/config/SecurityConfig.java
+++ b/BES/src/main/java/com/example/BES/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/battle/**").permitAll()
+                        .requestMatchers("/api/v1/event/audition-display/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/results").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/config/app").permitAll()

--- a/BES/src/main/java/com/example/BES/config/SessionExpiryListener.java
+++ b/BES/src/main/java/com/example/BES/config/SessionExpiryListener.java
@@ -1,0 +1,20 @@
+package com.example.BES.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.web.session.HttpSessionDestroyedEvent;
+import org.springframework.stereotype.Component;
+
+import com.example.BES.services.ActiveSessionStore;
+
+@Component
+public class SessionExpiryListener {
+
+    @Autowired
+    private ActiveSessionStore activeSessionStore;
+
+    @EventListener
+    public void onSessionDestroyed(HttpSessionDestroyedEvent event) {
+        activeSessionStore.deregisterBySessionId(event.getId());
+    }
+}

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.BES.config.SecurityConfig;
+import com.example.BES.services.ActiveSessionStore;
 import com.example.BES.dtos.GetSessionTokenDto;
 import com.example.BES.dtos.LoginDto;
 import com.example.BES.dtos.RedeemTokenDto;
@@ -52,6 +53,12 @@ public class AuthController {
 
     @Autowired
     private SessionTokenService sessionTokenService;
+
+    @Autowired
+    private ActiveSessionStore activeSessionStore;
+
+    private static final java.util.Set<String> UNLIMITED_ROLES =
+        java.util.Set.of("ROLE_ADMIN", "ROLE_HELPER");
 
     @Operation(summary = "Debug Session", description = "Returns current session ID and authentication context for debugging")
     @GetMapping("/debug-session")
@@ -100,12 +107,30 @@ public class AuthController {
                     dto.getPassword());
             Authentication authentication = authenticationManager.authenticate(authToken);
 
+            boolean isUnlimited = authentication.getAuthorities().stream()
+                .anyMatch(a -> UNLIMITED_ROLES.contains(a.getAuthority()));
+
+            String username = authentication.getName();
+
+            if (!isUnlimited && activeSessionStore.isActive(username)) {
+                HttpSession existingSession = request.getSession(false);
+                String registeredId = activeSessionStore.getSessionId(username);
+                boolean sameSession = existingSession != null && existingSession.getId().equals(registeredId);
+                if (!sameSession) {
+                    return ResponseEntity.status(org.springframework.http.HttpStatus.CONFLICT).body(Map.of(
+                        "message", "Account is already active in another session",
+                        "authenticated", false));
+                }
+            }
+
             SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
             securityContext.setAuthentication(authentication);
             SecurityContextHolder.setContext(securityContext);
 
             HttpSession session = request.getSession(true);
             session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+            activeSessionStore.register(username, session.getId());
+
             return ResponseEntity.ok(Map.of(
                     "message", "Login Successfully",
                     "authenticated", true,
@@ -118,12 +143,22 @@ public class AuthController {
         }
     }
 
+    @Operation(summary = "Heartbeat", description = "Refreshes the active session timestamp to signal the browser is still open")
+    @PostMapping("/heartbeat")
+    public ResponseEntity<?> heartbeat(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) activeSessionStore.heartbeat(session.getId());
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "Logout", description = "Invalidates the current session and clears the security context")
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
-        if (session != null)
+        if (session != null) {
+            activeSessionStore.deregisterBySessionId(session.getId());
             session.invalidate();
+        }
         SecurityContextHolder.clearContext();
         return ResponseEntity.ok(Map.of("message", "Logged Out "));
     }
@@ -138,6 +173,18 @@ public class AuthController {
             String role = token.getRole();
             String roleAuthority = "ROLE_" + role;
 
+            boolean isUnlimitedToken = roleAuthority.equals("ROLE_ADMIN") || roleAuthority.equals("ROLE_HELPER");
+            if (!isUnlimitedToken && activeSessionStore.isActive(username)) {
+                HttpSession existingSession = request.getSession(false);
+                String registeredId = activeSessionStore.getSessionId(username);
+                boolean sameSession = existingSession != null && existingSession.getId().equals(registeredId);
+                if (!sameSession) {
+                    return ResponseEntity.status(org.springframework.http.HttpStatus.CONFLICT).body(Map.of(
+                        "message", "This session link is already active in another browser",
+                        "authenticated", false));
+                }
+            }
+
             UsernamePasswordAuthenticationToken authToken =
                 new UsernamePasswordAuthenticationToken(username, null,
                     java.util.List.of(new SimpleGrantedAuthority(roleAuthority)));
@@ -148,6 +195,7 @@ public class AuthController {
 
             HttpSession session = request.getSession(true);
             session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+            activeSessionStore.register(username, session.getId());
 
             Long eventId = token.getEvent().getEventId();
             String eventName = token.getEvent().getEventName();

--- a/BES/src/main/java/com/example/BES/controllers/EventAuditionDisplayController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventAuditionDisplayController.java
@@ -1,0 +1,54 @@
+package com.example.BES.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.BES.dtos.AuditionDisplayStateDto;
+import com.example.BES.services.EventAuditionDisplayService;
+
+import java.util.Map;
+
+@RestController
+@CrossOrigin
+@RequestMapping("/api/v1/event/audition-display")
+public class EventAuditionDisplayController {
+
+    @Autowired
+    private EventAuditionDisplayService displayService;
+
+    /**
+     * Called by EmceeRoundView on round change and timer start/stop.
+     * Stores state and broadcasts to display clients.
+     */
+    @PostMapping
+    public ResponseEntity<?> updateDisplayState(@RequestBody AuditionDisplayStateDto dto) {
+        if (dto == null || dto.eventName == null || dto.eventName.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "eventName is required"));
+        }
+        displayService.updateState(dto.eventName, dto);
+        return ResponseEntity.ok(Map.of("message", "ok"));
+    }
+
+    /**
+     * Called by AuditionDisplay.vue on mount / OBS refresh.
+     * Returns the latest published state for this event.
+     */
+    @GetMapping
+    public ResponseEntity<?> getDisplayState(@RequestParam String event) {
+        AuditionDisplayStateDto state = displayService.getState(event);
+        if (state == null) {
+            return ResponseEntity.ok(Map.of(
+                "standby", true,
+                "eventName", event
+            ));
+        }
+        return ResponseEntity.ok(state);
+    }
+}

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -262,6 +262,36 @@ public class EventController {
         }
     }
 
+    @Operation(summary = "Update Genre Round Label", description = "Sets an optional round label (e.g. 'Preliminary Round') for the audition display")
+    @PostMapping("/{eventName}/genres/{eventGenreId}/round-label")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> updateGenreRoundLabel(
+            @PathVariable String eventName,
+            @PathVariable Long eventGenreId,
+            @RequestBody Map<String, String> body) {
+        try {
+            eventGenreService.updateRoundLabel(eventGenreId, body.get("roundLabel"));
+            return ResponseEntity.ok().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "Update Genre Number Color", description = "Sets the audition number color for the display screen")
+    @PostMapping("/{eventName}/genres/{eventGenreId}/number-color")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> updateGenreNumberColor(
+            @PathVariable String eventName,
+            @PathVariable Long eventGenreId,
+            @RequestBody Map<String, String> body) {
+        try {
+            eventGenreService.updateNumberColor(eventGenreId, body.get("numberColor"));
+            return ResponseEntity.ok().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
     @Operation(summary = "Create Event", description = "Creates a new event")
     @PostMapping
     public ResponseEntity<String> createNewEvent(@Valid @RequestBody AddEventDto dto) {

--- a/BES/src/main/java/com/example/BES/dtos/AuditionDisplayStateDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/AuditionDisplayStateDto.java
@@ -17,6 +17,10 @@ public class AuditionDisplayStateDto {
     public Integer timerDuration; // seconds
     public Boolean timerRunning;
 
+    // Display customisation (set per genre in EventDetails)
+    public String roundLabel;   // e.g. "Preliminary Round"
+    public String numberColor;  // hex color for audition number, e.g. "#f59e0b"
+
     // Default constructor for Jackson
     public AuditionDisplayStateDto() {}
 

--- a/BES/src/main/java/com/example/BES/dtos/AuditionDisplayStateDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/AuditionDisplayStateDto.java
@@ -1,0 +1,31 @@
+package com.example.BES.dtos;
+
+import java.util.List;
+
+public class AuditionDisplayStateDto {
+
+    public String eventName;
+    public String genreName;
+    public String mode;          // "SOLO" or "PAIR"
+    public int currentRound;
+    public int totalRounds;
+    public List<Slot> currentSlots;
+    public List<Slot> nextSlots;
+
+    // Timer fields — null/0 when timer is not running
+    public Long timerStartedAt;  // epoch ms
+    public Integer timerDuration; // seconds
+    public Boolean timerRunning;
+
+    // Default constructor for Jackson
+    public AuditionDisplayStateDto() {}
+
+    public static class Slot {
+        public int auditionNumber;
+        public String participantName;
+        public List<String> memberNames;
+        public boolean placeholder;
+
+        public Slot() {}
+    }
+}

--- a/BES/src/main/java/com/example/BES/dtos/GetEventDivisionDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/GetEventDivisionDto.java
@@ -4,6 +4,8 @@ public class GetEventDivisionDto {
     public Long eventGenreId;
     public String name;
     public String format;
+    public String roundLabel;
+    public String numberColor;
     public String sheetAliases;
     public Long genreId;
     public boolean soloAllowed = true;

--- a/BES/src/main/java/com/example/BES/models/EventGenre.java
+++ b/BES/src/main/java/com/example/BES/models/EventGenre.java
@@ -50,6 +50,12 @@ public class EventGenre {
     @Column(name = "format")
     private String format;
 
+    @Column(name = "round_label")
+    private String roundLabel;
+
+    @Column(name = "number_color")
+    private String numberColor;
+
     @Column(name = "sheet_aliases")
     private String sheetAliases;
 

--- a/BES/src/main/java/com/example/BES/services/ActiveSessionStore.java
+++ b/BES/src/main/java/com/example/BES/services/ActiveSessionStore.java
@@ -1,0 +1,52 @@
+package com.example.BES.services;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ActiveSessionStore {
+
+    private static final long IDLE_THRESHOLD_SECONDS = 60; // 1 min without heartbeat = browser gone
+
+    private static class Entry {
+        final String sessionId;
+        final AtomicLong lastSeen = new AtomicLong();
+
+        Entry(String sessionId) {
+            this.sessionId = sessionId;
+            this.lastSeen.set(Instant.now().getEpochSecond());
+        }
+    }
+
+    private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+    public boolean isActive(String username) {
+        Entry entry = store.get(username);
+        if (entry == null) return false;
+        boolean stale = Instant.now().getEpochSecond() - entry.lastSeen.get() > IDLE_THRESHOLD_SECONDS;
+        if (stale) store.remove(username);
+        return !stale;
+    }
+
+    public String getSessionId(String username) {
+        Entry entry = store.get(username);
+        return entry != null ? entry.sessionId : null;
+    }
+
+    public void register(String username, String sessionId) {
+        store.put(username, new Entry(sessionId));
+    }
+
+    public void heartbeat(String sessionId) {
+        store.values().stream()
+            .filter(e -> e.sessionId.equals(sessionId))
+            .forEach(e -> e.lastSeen.set(Instant.now().getEpochSecond()));
+    }
+
+    public void deregisterBySessionId(String sessionId) {
+        store.entrySet().removeIf(e -> e.getValue().sessionId.equals(sessionId));
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/EventAuditionDisplayService.java
+++ b/BES/src/main/java/com/example/BES/services/EventAuditionDisplayService.java
@@ -1,0 +1,36 @@
+package com.example.BES.services;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import com.example.BES.dtos.AuditionDisplayStateDto;
+
+@Service
+public class EventAuditionDisplayService {
+
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+
+    private final ConcurrentHashMap<String, AuditionDisplayStateDto> stateStore = new ConcurrentHashMap<>();
+
+    /**
+     * Save state in memory and broadcast to all display clients for this event.
+     */
+    public void updateState(String eventName, AuditionDisplayStateDto dto) {
+        dto.eventName = eventName;
+        stateStore.put(eventName, dto);
+        messagingTemplate.convertAndSend(
+            "/topic/audition/" + eventName + "/display", dto);
+    }
+
+    /**
+     * Return the current display state for an event, or null if none published yet.
+     */
+    public AuditionDisplayStateDto getState(String eventName) {
+        return stateStore.get(eventName);
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/EventAuditionDisplayService.java
+++ b/BES/src/main/java/com/example/BES/services/EventAuditionDisplayService.java
@@ -21,7 +21,7 @@ public class EventAuditionDisplayService {
      * Save state in memory and broadcast to all display clients for this event.
      */
     public void updateState(String eventName, AuditionDisplayStateDto dto) {
-        dto.eventName = eventName;
+        // dto.eventName is already set by the caller (frontend POST body)
         stateStore.put(eventName, dto);
         messagingTemplate.convertAndSend(
             "/topic/audition/" + eventName + "/display", dto);

--- a/BES/src/main/java/com/example/BES/services/EventGenreService.java
+++ b/BES/src/main/java/com/example/BES/services/EventGenreService.java
@@ -40,6 +40,8 @@ public class EventGenreService {
             dto.eventGenreId = eg.getId();
             dto.name = eg.getName();
             dto.format = eg.getFormat();
+            dto.roundLabel = eg.getRoundLabel();
+            dto.numberColor = eg.getNumberColor();
             dto.sheetAliases = eg.getSheetAliases();
             dto.genreId = eg.getGenre() != null ? eg.getGenre().getGenreId() : null;
             dto.soloAllowed = eg.isSoloAllowed();
@@ -72,6 +74,18 @@ public class EventGenreService {
     public void updateSoloAllowed(Long id, boolean soloAllowed) {
         EventGenre eg = eventGenreRepo.findById(id).orElseThrow(() -> new RuntimeException("Division not found"));
         eg.setSoloAllowed(soloAllowed);
+        eventGenreRepo.save(eg);
+    }
+
+    public void updateRoundLabel(Long id, String roundLabel) {
+        EventGenre eg = eventGenreRepo.findById(id).orElseThrow(() -> new RuntimeException("Division not found"));
+        eg.setRoundLabel(roundLabel == null || roundLabel.isBlank() ? null : roundLabel.trim());
+        eventGenreRepo.save(eg);
+    }
+
+    public void updateNumberColor(Long id, String color) {
+        EventGenre eg = eventGenreRepo.findById(id).orElseThrow(() -> new RuntimeException("Division not found"));
+        eg.setNumberColor(color == null || color.isBlank() ? null : color.trim());
         eventGenreRepo.save(eg);
     }
 

--- a/BES/src/main/resources/db/migration/V37__add_overlay_theme_config.sql
+++ b/BES/src/main/resources/db/migration/V37__add_overlay_theme_config.sql
@@ -1,0 +1,3 @@
+ALTER TABLE event
+    ADD COLUMN overlay_accent_color VARCHAR(7),
+    ADD COLUMN show_round_card BOOLEAN DEFAULT TRUE NOT NULL;

--- a/BES/src/main/resources/db/migration/V38__add_genre_display_fields.sql
+++ b/BES/src/main/resources/db/migration/V38__add_genre_display_fields.sql
@@ -1,0 +1,2 @@
+ALTER TABLE event_genre ADD COLUMN round_label VARCHAR(100);
+ALTER TABLE event_genre ADD COLUMN number_color VARCHAR(20);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Public routes (no authentication required):
 | `/battle/judge` | `BattleJudge` | Battle judge voting screen |
 | `/battle/chart` | `Chart` | 7-to-Smoke live chart |
 | `/battle/bracket` | `BracketVisualization` | Live bracket with winner animation + LED ticker |
+| `/audition/display` | `AuditionDisplay` | Live audition round + timer OBS source |
 | `/event/select` | `EventSelector` | Select active event (redirected here if no event set) |
 
 Authenticated routes (role-gated):

--- a/docs/superpowers/plans/2026-06-11-audition-display.md
+++ b/docs/superpowers/plans/2026-06-11-audition-display.md
@@ -1,0 +1,1053 @@
+# Audition Display Screen — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a public `/audition/display` OBS browser source that mirrors the emcee's current audition round + timer in real time via WebSocket.
+
+**Architecture:** EmceeRoundView POSTs round + timer state to a new backend REST endpoint on round change and timer start/stop. The backend stores state in-memory (ConcurrentHashMap keyed by eventName) and broadcasts via STOMP to `/topic/audition/{eventName}/display`. AuditionDisplay.vue fetches initial state via GET on mount (OBS refresh survival), then subscribes to the WebSocket topic for live updates. Timer survives page refresh by storing `timerStartedAt` + `timerDuration` + `timerRunning`; the display reconstructs `timeLeft` client-side.
+
+**Tech Stack:** Java 17 (Spring Boot), Vue 3, STOMP/WebSocket
+
+---
+
+### Task 1: Create DTO — `AuditionDisplayStateDto.java`
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/dtos/AuditionDisplayStateDto.java`
+
+- [ ] **Step 1: Write the DTO**
+
+This is the single DTO used for both the POST request body and the GET response. It holds round info, slot arrays, and timer metadata.
+
+```java
+package com.example.BES.dtos;
+
+import java.util.List;
+
+public class AuditionDisplayStateDto {
+
+    public String eventName;
+    public String genreName;
+    public String mode;          // "SOLO" or "PAIR"
+    public int currentRound;
+    public int totalRounds;
+    public List<Slot> currentSlots;
+    public List<Slot> nextSlots;
+
+    // Timer fields — null/0 when timer is not running
+    public Long timerStartedAt;  // epoch ms
+    public Integer timerDuration; // seconds
+    public Boolean timerRunning;
+
+    // Default constructor for Jackson
+    public AuditionDisplayStateDto() {}
+
+    public static class Slot {
+        public int auditionNumber;
+        public String participantName;
+        public List<String> memberNames;
+        public boolean placeholder;
+
+        public Slot() {}
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/AuditionDisplayStateDto.java
+git commit -m "feat: add AuditionDisplayStateDto for audition display screen
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Create Service — `EventAuditionDisplayService.java`
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/services/EventAuditionDisplayService.java`
+
+- [ ] **Step 1: Write the service**
+
+In-memory state store with broadcast. Follows the `BattleService` pattern: `ConcurrentHashMap`, `SimpMessagingTemplate.convertAndSend`.
+
+```java
+package com.example.BES.services;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import com.example.BES.dtos.AuditionDisplayStateDto;
+
+@Service
+public class EventAuditionDisplayService {
+
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+
+    private final ConcurrentHashMap<String, AuditionDisplayStateDto> stateStore = new ConcurrentHashMap<>();
+
+    /**
+     * Save state in memory and broadcast to all display clients for this event.
+     */
+    public void updateState(String eventName, AuditionDisplayStateDto dto) {
+        dto.eventName = eventName;
+        stateStore.put(eventName, dto);
+        messagingTemplate.convertAndSend(
+            "/topic/audition/" + eventName + "/display", dto);
+    }
+
+    /**
+     * Return the current display state for an event, or null if none published yet.
+     */
+    public AuditionDisplayStateDto getState(String eventName) {
+        return stateStore.get(eventName);
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/EventAuditionDisplayService.java
+git commit -m "feat: add EventAuditionDisplayService for in-memory display state
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Create Controller — `EventAuditionDisplayController.java`
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/controllers/EventAuditionDisplayController.java`
+
+- [ ] **Step 1: Write the controller**
+
+Public endpoints (no auth — like battle overlay). POST for emcee updates, GET for display page refresh.
+
+```java
+package com.example.BES.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.BES.dtos.AuditionDisplayStateDto;
+import com.example.BES.services.EventAuditionDisplayService;
+
+import java.util.Map;
+
+@RestController
+@CrossOrigin
+@RequestMapping("/api/v1/event/audition-display")
+public class EventAuditionDisplayController {
+
+    @Autowired
+    private EventAuditionDisplayService displayService;
+
+    /**
+     * Called by EmceeRoundView on round change and timer start/stop.
+     * Stores state and broadcasts to display clients.
+     */
+    @PostMapping
+    public ResponseEntity<?> updateDisplayState(@RequestBody AuditionDisplayStateDto dto) {
+        if (dto == null || dto.eventName == null || dto.eventName.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "eventName is required"));
+        }
+        displayService.updateState(dto.eventName, dto);
+        return ResponseEntity.ok(Map.of("message", "ok"));
+    }
+
+    /**
+     * Called by AuditionDisplay.vue on mount / OBS refresh.
+     * Returns the latest published state for this event.
+     */
+    @GetMapping
+    public ResponseEntity<?> getDisplayState(@RequestParam String event) {
+        AuditionDisplayStateDto state = displayService.getState(event);
+        if (state == null) {
+            return ResponseEntity.ok(Map.of(
+                "standby", true,
+                "eventName", event
+            ));
+        }
+        return ResponseEntity.ok(state);
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/controllers/EventAuditionDisplayController.java
+git commit -m "feat: add EventAuditionDisplayController with POST/GET endpoints
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update SecurityConfig — permitAll for display endpoints
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/config/SecurityConfig.java:42-49`
+
+- [ ] **Step 1: Add permitAll rule**
+
+Add a new `.requestMatchers(...)` line BEFORE the `.anyRequest().authenticated()` catch-all. The display endpoints must be public so OBS browser sources can access them without auth.
+
+```java
+// In SecurityConfig.java filterChain() method, add this line:
+.requestMatchers("/api/v1/event/audition-display/**").permitAll()
+```
+
+The full auth block should read:
+
+```java
+.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/auth/**").permitAll()
+                .requestMatchers("/api/v1/battle/**").permitAll()
+                .requestMatchers("/api/v1/event/audition-display/**").permitAll()
+                .requestMatchers("/ws/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/results").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/config/app").permitAll()
+                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated())
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/config/SecurityConfig.java
+git commit -m "feat: permitAll for audition-display endpoints
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Add API functions — `api.js`
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js` (append at end)
+
+- [ ] **Step 1: Add `postAuditionDisplayState` and `getAuditionDisplayState`**
+
+Append these two functions at the end of `api.js` (after line 1596):
+
+```js
+export const postAuditionDisplayState = async (state) => {
+  try {
+    return await fetch(`${domain}/api/v1/event/audition-display`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(state)
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+export const getAuditionDisplayState = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/audition-display?event=${encodeURIComponent(eventName)}`, {
+      credentials: 'include'
+    })
+    if (res.ok) return await res.json()
+    return null
+  } catch (e) {
+    console.error(e)
+    return null
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat: add postAuditionDisplayState and getAuditionDisplayState API functions
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Modify Timer.vue — add emits and `resumeTimer`
+
+**Files:**
+- Modify: `BES-frontend/src/components/Timer.vue`
+
+- [ ] **Step 1: Add emits declaration**
+
+Add to the `<script setup>` block, after the existing `import` lines and before `const selectedTime = ref(0)`:
+
+```js
+const emit = defineEmits(['started', 'stopped', 'tick'])
+```
+
+- [ ] **Step 2: Emit events on start, stop, and each tick**
+
+Modify `startTimer()` to emit `started`:
+
+```js
+function startTimer(seconds) {
+  if (selectedTime.value === seconds && timer) {
+    reset()
+    return
+  }
+  if (timer) clearInterval(timer)
+  selectedTime.value = seconds
+  timeLeft.value = 0
+  timer = setInterval(() => {
+    if (timeLeft.value < seconds) {
+      timeLeft.value++
+      // Emit tick with current state
+      const remaining = selectedTime.value - timeLeft.value
+      emit('tick', { remaining, total: selectedTime.value, running: true })
+    } else {
+      clearInterval(timer)
+      timer = null
+      emit('stopped')
+      emit('tick', { remaining: 0, total: selectedTime.value, running: false })
+    }
+  }, 1000)
+  emit('started', { duration: seconds, startedAt: Date.now() })
+}
+```
+
+Modify `reset()` to emit `stopped`:
+
+```js
+function reset() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+  selectedTime.value = 0
+  timeLeft.value = 0
+  emit('stopped')
+}
+```
+
+Modify `stop()` to emit `stopped`:
+
+```js
+function stop() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+    emit('stopped')
+  }
+}
+```
+
+- [ ] **Step 3: Add `resumeTimer` method and expose it**
+
+Add this function before `defineExpose`:
+
+```js
+/**
+ * Resume a countdown timer from a specific remaining time.
+ * Called by EmceeRoundView on mount when recovering timer state after refresh.
+ * @param {number} remainingSeconds - seconds left on the clock
+ * @param {number} totalDuration - original total duration in seconds
+ */
+function resumeTimer(remainingSeconds, totalDuration) {
+  if (timer) clearInterval(timer)
+  if (remainingSeconds <= 0) {
+    selectedTime.value = totalDuration
+    timeLeft.value = totalDuration
+    emit('stopped')
+    return
+  }
+  selectedTime.value = totalDuration
+  timeLeft.value = totalDuration - remainingSeconds
+  timer = setInterval(() => {
+    if (timeLeft.value < totalDuration) {
+      timeLeft.value++
+      const remaining = selectedTime.value - timeLeft.value
+      emit('tick', { remaining, total: selectedTime.value, running: true })
+    } else {
+      clearInterval(timer)
+      timer = null
+      emit('stopped')
+      emit('tick', { remaining: 0, total: selectedTime.value, running: false })
+    }
+  }, 1000)
+  emit('started', { duration: totalDuration, startedAt: Date.now() - ((totalDuration - remainingSeconds) * 1000) })
+}
+```
+
+Add `resumeTimer` to `defineExpose`:
+
+```js
+defineExpose({ reset, stop, resumeTimer })
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/components/Timer.vue
+git commit -m "feat: add started/stopped/tick emits and resumeTimer to Timer.vue
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Modify EmceeRoundView.vue — publish state to backend
+
+**Files:**
+- Modify: `BES-frontend/src/components/EmceeRoundView.vue`
+
+- [ ] **Step 1: Add new props and imports**
+
+Add `eventName` and `genreName` to the existing `defineProps`:
+
+```js
+const props = defineProps({
+  participants: { type: Array, required: true },
+  mode:         { type: String, default: 'SOLO' },
+  eventName:    { type: String, default: '' },
+  genreName:    { type: String, default: '' },
+});
+```
+
+Add the import for the API function at the top:
+
+```js
+import { ref, computed, watch, onMounted } from 'vue';
+import Timer from './Timer.vue';
+import { postAuditionDisplayState, getAuditionDisplayState } from '@/utils/api';
+```
+
+- [ ] **Step 2: Add `buildStatePayload` helper and `publishState` function**
+
+Add these functions after `defineExpose({ resetTimer })` but before the `</script>`:
+
+```js
+function buildStatePayload(timerState = {}) {
+  const current = currentRoundSlots.value.map(slot => ({
+    auditionNumber: slot.auditionNumber,
+    participantName: slot._placeholder ? null : slot.participantName,
+    memberNames: slot.memberNames ?? [],
+    placeholder: !!slot._placeholder
+  }))
+
+  const nextRoundIdx = currentRound.value // next round is currentRound (1-indexed → 0-indexed next)
+  const nextSlotsRaw = rounds.value[nextRoundIdx] ?? []
+  const next = nextSlotsRaw.map(slot => ({
+    auditionNumber: slot.auditionNumber,
+    participantName: slot._placeholder ? null : slot.participantName,
+    memberNames: slot.memberNames ?? [],
+    placeholder: !!slot._placeholder
+  }))
+
+  return {
+    eventName: props.eventName,
+    genreName: props.genreName,
+    mode: props.mode,
+    currentRound: currentRound.value,
+    totalRounds: totalRounds.value,
+    currentSlots: current,
+    nextSlots: next,
+    timerStartedAt: timerState.startedAt ?? null,
+    timerDuration: timerState.duration ?? null,
+    timerRunning: timerState.running ?? false
+  }
+}
+
+function publishState(timerState = {}) {
+  if (!props.eventName) return
+  postAuditionDisplayState(buildStatePayload(timerState))
+}
+```
+
+- [ ] **Step 3: Watch `currentRound` and publish on change**
+
+Add a watcher after the `cardStyle` computed:
+
+```js
+// Publish state to display whenever the round changes (include timer state if running)
+watch(currentRound, () => {
+  publishState(lastTimerState.value)
+})
+```
+
+- [ ] **Step 4: Handle timer events from Timer.vue**
+
+Store the last timer state so it can be included in round-change publishes. Add before the `</script>`:
+
+```js
+const lastTimerState = ref({})
+
+function onTimerStarted(detail) {
+  lastTimerState.value = { startedAt: detail.startedAt, duration: detail.duration, running: true }
+  publishState(lastTimerState.value)
+}
+
+function onTimerStopped() {
+  lastTimerState.value = { startedAt: null, duration: null, running: false }
+  publishState(lastTimerState.value)
+}
+
+function onTimerTick(detail) {
+  lastTimerState.value = { startedAt: null, duration: detail.total, running: detail.running }
+  // Don't POST on every tick — just update local state for round-change publishes
+}
+```
+
+- [ ] **Step 5: Add `@started`/`@stopped`/`@tick` listeners on the Timer component**
+
+In the template, update the `<Timer>` line:
+
+```html
+<Timer ref="timerRef" @started="onTimerStarted" @stopped="onTimerStopped" @tick="onTimerTick" />
+```
+
+- [ ] **Step 6: On mount, fetch current state and resume timer if running**
+
+Add an `onMounted` block after the existing `defineExpose`:
+
+```js
+onMounted(async () => {
+  if (!props.eventName) return
+  const state = await getAuditionDisplayState(props.eventName)
+  if (!state || state.standby) return
+  // Restore round if state has a different round (unlikely, but defensive)
+  // Timer recovery: if timer was running, resume it
+  if (state.timerRunning && state.timerStartedAt && state.timerDuration) {
+    const elapsed = Math.floor((Date.now() - state.timerStartedAt) / 1000)
+    const remaining = Math.max(0, state.timerDuration - elapsed)
+    if (remaining > 0) {
+      // Wait for nextTick so Timer ref is mounted
+      await new Promise(r => setTimeout(r, 100))
+      timerRef.value?.resumeTimer(remaining, state.timerDuration)
+    }
+  }
+})
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add BES-frontend/src/components/EmceeRoundView.vue
+git commit -m "feat: publish audition display state from EmceeRoundView on round change and timer events
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Modify AuditionList.vue — pass eventName and genreName
+
+**Files:**
+- Modify: `BES-frontend/src/views/AuditionList.vue`
+
+- [ ] **Step 1: Pass new props to EmceeRoundView**
+
+In the template (around line 925), update the `<EmceeRoundView>` usage:
+
+```html
+<EmceeRoundView
+  ref="emceeRoundRef"
+  :key="selectedGenre"
+  :participants="filteredParticipantsForEmceeView"
+  :mode="judgingMode"
+  :eventName="selectedEvent"
+  :genreName="selectedGenre"
+/>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/views/AuditionList.vue
+git commit -m "feat: pass eventName and genreName to EmceeRoundView
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Create AuditionDisplay.vue — public display page
+
+**Files:**
+- Create: `BES-frontend/src/views/AuditionDisplay.vue`
+
+- [ ] **Step 1: Write the full component**
+
+Full-screen cinematic display following the project's design system. Anton SC typography, dark background, parallelogram shapes.
+
+```vue
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { getAuditionDisplayState } from '@/utils/api'
+import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket'
+
+const route = useRoute()
+const eventName = ref(route.query.event || '')
+const state = ref(null)
+const client = ref(null)
+
+// ── Local timer ticker (reconstructed from backend timerStartedAt + timerDuration) ──
+const displayTimeLeft = ref(0)
+let timerInterval = null
+
+function startLocalTimer(startedAt, duration) {
+  stopLocalTimer()
+  const tick = () => {
+    const elapsed = Math.floor((Date.now() - startedAt) / 1000)
+    displayTimeLeft.value = Math.max(0, duration - elapsed)
+    if (displayTimeLeft.value <= 0) stopLocalTimer()
+  }
+  tick()
+  timerInterval = setInterval(tick, 250)
+}
+
+function stopLocalTimer() {
+  if (timerInterval) { clearInterval(timerInterval); timerInterval = null }
+}
+
+// ── Computed ──────────────────────────────────────────────────────────────────
+const isStandby  = computed(() => !state.value || state.value.standby)
+const mode       = computed(() => state.value?.mode ?? 'SOLO')
+const genreName  = computed(() => state.value?.genreName ?? '')
+const eventLabel = computed(() => state.value?.eventName ?? eventName.value ?? '')
+const roundLabel = computed(() => {
+  if (!state.value || !state.value.totalRounds) return ''
+  return `ROUND ${state.value.currentRound} / ${state.value.totalRounds}`
+})
+const currentSlots = computed(() => state.value?.currentSlots ?? [])
+const nextSlots    = computed(() => state.value?.nextSlots ?? [])
+
+const isNearEnd  = computed(() => displayTimeLeft.value <= 10 && displayTimeLeft.value > 0 && state.value?.timerRunning)
+const isFinished = computed(() => displayTimeLeft.value <= 0 && state.value?.timerDuration > 0)
+const timerLabel = computed(() => {
+  if (!state.value?.timerDuration) return ''
+  const t = displayTimeLeft.value
+  if (t <= 0) return '0'
+  return String(t)
+})
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+function applyState(newState) {
+  state.value = newState
+  if (newState.timerRunning && newState.timerStartedAt && newState.timerDuration) {
+    startLocalTimer(newState.timerStartedAt, newState.timerDuration)
+  } else {
+    stopLocalTimer()
+    displayTimeLeft.value = newState.timerDuration ?? 0
+  }
+}
+
+onMounted(async () => {
+  if (!eventName.value) return
+
+  const initial = await getAuditionDisplayState(eventName.value)
+  if (initial) applyState(initial)
+
+  client.value = createClient()
+  subscribeToChannel(client.value, `/topic/audition/${eventName.value}/display`, (msg) => {
+    applyState(msg)
+  })
+})
+
+onUnmounted(() => {
+  stopLocalTimer()
+  if (client.value) deactivateClient(client.value)
+})
+</script>
+
+<template>
+  <div class="display-root">
+    <!-- Scanlines overlay -->
+    <div class="scanlines"></div>
+
+    <!-- Color bleed -->
+    <div class="color-bleed"></div>
+
+    <!-- STANDBY: no state published yet -->
+    <div v-if="isStandby" class="standby-container">
+      <div class="corner-bar-tl"></div>
+      <div class="corner-bar-bl"></div>
+      <span class="type-label text-content-muted" style="font-size:14px;letter-spacing:0.22em">{{ eventLabel }}</span>
+      <span class="type-stat text-accent" style="font-size: clamp(48px,8vw,80px);margin-top:12px">STANDBY</span>
+      <span class="type-label text-content-muted" style="margin-top:8px">AWAITING AUDITION START</span>
+    </div>
+
+    <!-- ACTIVE display -->
+    <div v-else class="active-container">
+      <!-- Top bar: event name + genre -->
+      <div class="top-bar">
+        <span class="type-label text-content-muted" style="letter-spacing:0.22em">{{ eventLabel }}</span>
+        <span class="type-label text-accent" style="letter-spacing:0.12em">{{ genreName }}</span>
+      </div>
+
+      <!-- Main area: round counter, audition number, participant name, timer -->
+      <div class="main-area">
+        <!-- Round counter -->
+        <div class="section-rule mb-3">
+          <span class="section-rule-label type-label text-content-muted">{{ roundLabel }}</span>
+        </div>
+
+        <!-- Current slot(s) -->
+        <div class="current-slots">
+          <template v-for="(slot, sIdx) in currentSlots" :key="sIdx">
+            <div v-if="slot.placeholder" class="slot-placeholder type-stat" style="font-size:clamp(50px,8vw,80px);color:rgba(245,158,11,0.3)">
+              #{{ slot.auditionNumber }} — TBD
+            </div>
+            <div v-else class="slot-entry">
+              <div class="type-stat audition-number">
+                #{{ slot.auditionNumber }}
+              </div>
+              <div class="type-body participant-name">
+                {{ slot.participantName }}
+              </div>
+              <div v-if="slot.memberNames?.length" class="type-label member-names">
+                {{ slot.memberNames.join(' · ') }}
+              </div>
+            </div>
+            <!-- PAIR separator -->
+            <div v-if="mode === 'PAIR' && sIdx === 0 && currentSlots.length > 1" class="pair-sep">
+              <span class="type-stat">&amp;</span>
+            </div>
+          </template>
+        </div>
+
+        <!-- Timer -->
+        <div v-if="timerLabel" class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+          <div class="type-stat timer-number">{{ timerLabel }}</div>
+        </div>
+      </div>
+
+      <!-- UP NEXT (secondary area) -->
+      <div v-if="nextSlots.length > 0" class="up-next-area">
+        <div class="section-rule mb-2">
+          <span class="section-rule-label type-label text-content-muted">UP NEXT</span>
+        </div>
+        <div class="next-slots">
+          <template v-for="(slot, sIdx) in nextSlots" :key="sIdx">
+            <div v-if="slot.placeholder" class="type-label" style="opacity:0.3;font-size:16px">
+              #{{ slot.auditionNumber }} — TBD
+            </div>
+            <div v-else class="next-slot-entry">
+              <span class="type-stat" style="font-size:24px;opacity:0.5">#{{ slot.auditionNumber }}</span>
+              <span class="type-body" style="font-size:20px;opacity:0.4;margin-left:8px">{{ slot.participantName }}</span>
+              <span v-if="slot.memberNames?.length" class="type-label" style="opacity:0.3;font-size:12px;margin-left:8px">{{ slot.memberNames.join(' · ') }}</span>
+            </div>
+            <span v-if="mode === 'PAIR' && sIdx === 0 && nextSlots.length > 1" style="opacity:0.2;margin:0 8px">&amp;</span>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ── Root layout ──────────────────────────────────────────────────────────── */
+.display-root {
+  position: fixed;
+  inset: 0;
+  background: #060818;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-family: 'Anton SC', sans-serif;
+  text-transform: uppercase;
+}
+
+/* ── Scanlines ────────────────────────────────────────────────────────────── */
+.scanlines {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0,0,0,0.03) 2px,
+    rgba(0,0,0,0.03) 4px
+  );
+  z-index: 10;
+}
+
+/* ── Color bleed ──────────────────────────────────────────────────────────── */
+.color-bleed {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 0% 100%, var(--accent-subtle, rgba(255,255,255,0.015)) 0%, transparent 60%),
+    radial-gradient(ellipse at 100% 100%, var(--accent-subtle, rgba(255,255,255,0.015)) 0%, transparent 60%);
+  z-index: 0;
+}
+
+/* ── Standby ──────────────────────────────────────────────────────────────── */
+.standby-container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 64px;
+  clip-path: polygon(10px 0%, 100% 0%, calc(100% - 10px) 100%, 0% 100%);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
+/* ── Active layout ────────────────────────────────────────────────────────── */
+.active-container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 40px;
+}
+
+.top-bar {
+  position: absolute;
+  top: 40px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  opacity: 0.5;
+}
+
+.main-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  justify-content: center;
+}
+
+/* ── Current slots ────────────────────────────────────────────────────────── */
+.current-slots {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+}
+
+.slot-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.audition-number {
+  font-size: clamp(80px, 14vw, 120px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  text-shadow: 2px 2px 0 var(--accent-muted, rgba(255,255,255,0.15));
+  color: var(--accent-color, #ffffff);
+}
+
+.participant-name {
+  font-size: clamp(28px, 5vw, 48px);
+  letter-spacing: 0.05em;
+  color: #ffffff;
+  margin-top: 4px;
+}
+
+.member-names {
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  color: rgba(255,255,255,0.35);
+  text-transform: none;
+  margin-top: 4px;
+}
+
+.pair-sep {
+  margin: 8px 0;
+  color: rgba(255,255,255,0.25);
+  font-size: 28px;
+}
+
+.slot-placeholder {
+  opacity: 0.4;
+}
+
+/* ── Timer ────────────────────────────────────────────────────────────────── */
+.timer-display {
+  margin-top: 24px;
+}
+
+.timer-number {
+  font-size: clamp(64px, 12vw, 100px);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: #ffffff;
+  transition: color 0.3s ease;
+}
+
+.timer-near-end .timer-number {
+  color: #ef4444;
+  animation: pulse 0.5s ease-in-out infinite alternate;
+}
+
+.timer-finished .timer-number {
+  color: rgba(255,255,255,0.2);
+}
+
+@keyframes pulse {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0.7; transform: scale(1.03); }
+}
+
+/* ── UP NEXT ─────────────────────────────────────────────────────────────── */
+.up-next-area {
+  position: absolute;
+  bottom: 60px;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.next-slots {
+  display: flex;
+  align-items: center;
+}
+
+.next-slot-entry {
+  display: flex;
+  align-items: baseline;
+}
+
+/* ── Section rule (global utility not available, define locally) ──────────── */
+.section-rule {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  max-width: 500px;
+}
+.section-rule::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(255,255,255,0.08);
+}
+.section-rule-label {
+  flex-shrink: 0;
+}
+
+/* ── Corner bars ─────────────────────────────────────────────────────────── */
+.corner-bar-tl, .corner-bar-bl {
+  position: absolute;
+  background: var(--accent-color, #ffffff);
+  opacity: 0.4;
+}
+.corner-bar-tl {
+  top: 0; left: 0;
+  width: 2px; height: 20px;
+}
+.corner-bar-bl {
+  bottom: 0; left: 0;
+  width: 2px; height: 20px;
+}
+</style>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/views/AuditionDisplay.vue
+git commit -m "feat: add AuditionDisplay.vue — public OBS display page
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Add route — `/audition/display`
+
+**Files:**
+- Modify: `BES-frontend/src/router/index.js`
+
+- [ ] **Step 1: Import and add route**
+
+Add the import at the top with the other view imports:
+
+```js
+import AuditionDisplay from "@/views/AuditionDisplay.vue";
+```
+
+Add the route definition in the `routes` array (alongside other public routes like BattleOverlay):
+
+```js
+{
+    path: '/audition/display',
+    name: 'AuditionDisplay',
+    component: AuditionDisplay
+},
+```
+
+Add `'AuditionDisplay'` to the `PUBLIC_ROUTES` array:
+
+```js
+const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'JudgeSession', 'EmceeSession', 'HelperSession', 'AuditionDisplay']
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/router/index.js
+git commit -m "feat: add /audition/display public route
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Update CLAUDE.md — routes table
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add the new route to the public routes table**
+
+In the "Public routes" table, add this row:
+
+```
+| `/audition/display` | `AuditionDisplay` | Live audition round + timer OBS source |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add /audition/display to public routes table
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---

--- a/docs/superpowers/specs/2026-06-11-audition-display-design.md
+++ b/docs/superpowers/specs/2026-06-11-audition-display-design.md
@@ -1,0 +1,79 @@
+# Audition Display Screen — Design Spec
+
+**Issue:** [#135](https://github.com/cyanogenicb/BES/issues/135)  
+**Branch:** `feat/audition-display-screen`  
+**Date:** 2026-06-11
+
+## Overview
+
+New public page `/audition/display` (no auth) — a full-screen OBS browser source that mirrors the emcee's current audition round + timer in real time via WebSocket.
+
+## Architecture
+
+```
+EmceeRoundView (frontend)
+  ├── on round change → POST /api/v1/event/audition-display
+  └── on timer start/stop/reset → POST /api/v1/event/audition-display
+
+Backend EventAuditionDisplayService
+  ├── In-memory store: { eventName, genreName, mode, currentRound, totalRounds,
+  │     currentSlots, nextSlots, timerStartedAt, timerDuration, timerRunning }
+  └── Broadcasts to /topic/audition/{eventName}/display
+
+AuditionDisplay.vue (new)
+  ├── GET /api/v1/event/audition-display?event=X  → restore state on OBS refresh
+  └── Subscribe /topic/audition/{eventName}/display → live updates
+```
+
+## Timer Persistence (survives page refresh on BOTH screens)
+
+Backend stores `timerStartedAt` (epoch ms) + `timerDuration` (seconds) + `timerRunning` (bool). On mount, both EmceeRoundView and AuditionDisplay fetch current state and reconstruct:
+
+```
+timeLeft = max(0, timerDuration - floor((now - timerStartedAt) / 1000))
+```
+
+If `timerRunning` is true and `timeLeft > 0`, the client resumes the countdown from `timeLeft`. If `timeLeft <= 0`, shows finished state.
+
+## Timer Efficiency
+
+Instead of POSTing every second, the frontend only POSTs on start/stop/reset events. The display runs its own `setInterval` to tick down `timeLeft` locally. This eliminates ~60 req/min.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/v1/event/audition-display` | EmceeRoundView publishes state (round + timer) |
+| GET | `/api/v1/event/audition-display?event=X` | Display fetches current state on mount/refresh |
+
+Both are public (no auth) — same as battle overlay.
+
+## Frontend Changes
+
+### Timer.vue
+- Add `started` / `stopped` / `tick` emits so parent knows timer state
+- Add `resumeTimer(remainingSeconds, totalDuration)` exposed method for refresh recovery
+
+### EmceeRoundView.vue
+- New props: `eventName` (String), `genreName` (String)
+- Watch `currentRound` → POST state to backend
+- Handle timer events (start/stop) → POST state to backend
+- On mount: fetch current state, resume timer if `timerRunning`
+
+### AuditionList.vue
+- Pass `eventName` and `genreName` props down to `<EmceeRoundView>`
+
+## Files
+
+| File | Action |
+|------|--------|
+| `BES/.../controllers/EventAuditionDisplayController.java` | New |
+| `BES/.../services/EventAuditionDisplayService.java` | New |
+| `BES/.../dtos/AuditionDisplayStateDto.java` | New |
+| `BES-frontend/src/views/AuditionDisplay.vue` | New |
+| `BES-frontend/src/components/EmceeRoundView.vue` | Modify |
+| `BES-frontend/src/components/Timer.vue` | Modify |
+| `BES-frontend/src/views/AuditionList.vue` | Modify |
+| `BES-frontend/src/router/index.js` | Modify |
+| `BES-frontend/src/utils/api.js` | Modify |
+| `CLAUDE.md` | Modify |


### PR DESCRIPTION
## Summary
- New public route `/audition/display?event=X` — a full-screen OBS/projector display showing the current audition round, participant name(s), and live countdown timer
- WebSocket-based: `EmceeRoundView` broadcasts state on every round change and timer tick; `AuditionDisplay` subscribes and reconstructs timer from `timerStartedAt + timerDuration` (survives OBS refresh)
- Timer resets to 0 whenever emcee swipes or clicks PREV/NEXT
- Solo mode: number + name on the left, timer on the right
- Pair mode: two names stacked on the left (no wrapping), timer on the right
- Event name (large) + genre (smaller) pinned to top; UP NEXT at bottom; navbar hidden

## New files
- `BES/src/main/java/.../controllers/EventAuditionDisplayController.java`
- `BES/src/main/java/.../services/EventAuditionDisplayService.java`
- `BES/src/main/java/.../dtos/audition/AuditionDisplayStateDto.java`
- `BES-frontend/src/views/AuditionDisplay.vue`

## Modified files
- `EmceeRoundView.vue` — emits timer events, broadcasts state, resets timer on nav
- `Timer.vue` — exposes `started`/`stopped`/`tick` emits and `resumeTimer`
- `AuditionList.vue` — passes `eventName` + `genreName` to EmceeRoundView
- `EventDetails.vue` — copy-link button for the display URL
- `App.vue` — hide navbar on AuditionDisplay route
- `router/index.js` — add public `/audition/display` route
- `api.js` — add `getAuditionDisplayState` + `postAuditionDisplayState`

## Test plan
- [ ] Open `/audition/display?event=X` — shows STANDBY until emcee navigates to a round
- [ ] Start timer in EmceeRoundView — display updates live
- [ ] Navigate NEXT/PREV — timer resets to 0 on display
- [ ] Refresh the display tab mid-countdown — timer resumes correctly from backend state
- [ ] Pair mode — two names show stacked without wrapping
- [ ] Navbar hidden on the display page
- [ ] `npm test` — 114/114 ✓  |  `mvn test` — 231/231 ✓

Closes #135