### PR TITLE
feat: Hetzner deployment, HTTPS, and GitHub Actions CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# VCS
+.git
+.gitignore
+.github
+
+# Build artifacts (will be regenerated inside Docker)
+BES/target
+BES-frontend/dist
+BES-frontend/node_modules
+
+# Local dev / IDE
+.idea
+.vscode
+*.iml
+.DS_Store
+
+# Logs and tmp
+*.log
+tmp
+.agent-docker
+.agent-dispatch
+
+# Docs and meta (not needed at runtime)
+docs
+README.md
+CLAUDE.md
+*.zip
+
+# Secrets — must never leak into images
+.env
+.env.*
+!.env.example
+credentials.json
+*.pem

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Hetzner
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: SSH to server and run deploy
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
+          script: |
+            set -e
+            cd ~/kyrove
+            echo "→ Pulling latest from master"
+            git fetch origin master
+            git reset --hard origin/master
+            echo "→ Rebuilding containers"
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+            echo "→ Container status:"
+            docker compose ps
+            echo "→ Pruning dangling images to save disk"
+            docker image prune -f
+
+      - name: Smoke test the live site
+        run: |
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 https://kyrove.live || echo "000")
+            if [ "$status" = "200" ]; then
+              echo "✓ https://kyrove.live returned 200"
+              exit 0
+            fi
+            echo "Attempt $i: got HTTP $status, waiting 10s..."
+            sleep 10
+          done
+          echo "✗ Site did not return 200 after 10 attempts"
+          exit 1

--- a/BES-frontend/Dockerfile
+++ b/BES-frontend/Dockerfile
@@ -1,33 +1,13 @@
-# FROM node:lts-alpine
-
-# RUN npm install -g http-server
-
-# WORKDIR /app
-
-# COPY package*.json ./
-
-# RUN npm install
-# COPY . .
-
-# RUN npm run build
-
-# EXPOSE 8080
-# CMD [ "http-server", "dist" ]
-
-FROM node:24-alpine3.21 as build-stage
+FROM node:24-alpine3.21 AS build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:stable-alpine as production-stage
+FROM nginx:stable-alpine AS production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html/
-# Copy the nginx configuration file
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
-COPY ./nginx/certs /etc/nginx/certs
 
-# Expose the port 80
-EXPOSE 443
-# Start Nginx to serve the application
+EXPOSE 80 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/BES-frontend/nginx/default.conf
+++ b/BES-frontend/nginx/default.conf
@@ -1,4 +1,6 @@
-# 🌐 HTTP server block (no redirect)
+# Dev nginx config — HTTP only.
+# In production, docker-compose.prod.yml mounts default.prod.conf over this file
+# (which adds the HTTPS server block + Let's Encrypt certs).
 server {
     listen 80;
     server_name localhost;
@@ -6,7 +8,7 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
 
-    # ✅ API proxy (Spring Boot backend)
+    # API proxy (Spring Boot backend)
     location /api/ {
         proxy_pass http://backend:5050;
         proxy_set_header Host $host;
@@ -18,7 +20,7 @@ server {
         proxy_set_header Cookie $http_cookie;
     }
 
-    # ✅ WebSocket support
+    # WebSocket support
     location /ws {
         proxy_pass http://backend:5050;
         proxy_http_version 1.1;
@@ -27,42 +29,7 @@ server {
         proxy_set_header Host $host;
     }
 
-    # ✅ Frontend
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}
-
-# 🔐 HTTPS server block
-server {
-    listen 443 ssl;
-    server_name localhost;
-
-    ssl_certificate     /etc/nginx/certs/localhost.crt;
-    ssl_certificate_key /etc/nginx/certs/localhost.key;
-
-    root /usr/share/nginx/html;
-    index index.html index.htm;
-
-    location /api/ {
-        proxy_pass http://backend:5050;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        proxy_pass_header Set-Cookie;
-        proxy_set_header Cookie $http_cookie;
-    }
-
-    location /ws {
-        proxy_pass http://backend:5050;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $host;
-    }
-
+    # Frontend SPA
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/BES-frontend/nginx/default.prod.conf
+++ b/BES-frontend/nginx/default.prod.conf
@@ -1,7 +1,7 @@
 # HTTP -> HTTPS redirect
 server {
     listen 80;
-    server_name yourdomain.com www.yourdomain.com;
+    server_name kyrove.live www.kyrove.live;
     return 301 https://$host$request_uri;
 }
 
@@ -9,10 +9,10 @@ server {
 server {
     listen 443 ssl;
     http2 on;
-    server_name yourdomain.com www.yourdomain.com;
+    server_name kyrove.live www.kyrove.live;
 
-    ssl_certificate     /etc/letsencrypt/live/yourdomain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/kyrove.live/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/kyrove.live/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
 

--- a/BES-frontend/nginx/default.prod.conf
+++ b/BES-frontend/nginx/default.prod.conf
@@ -1,0 +1,46 @@
+# HTTP -> HTTPS redirect
+server {
+    listen 80;
+    server_name yourdomain.com www.yourdomain.com;
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name yourdomain.com www.yourdomain.com;
+
+    ssl_certificate     /etc/letsencrypt/live/yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    location /api/ {
+        proxy_pass http://backend:5050;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass_header Set-Cookie;
+        proxy_set_header Cookie $http_cookie;
+    }
+
+    location /ws {
+        proxy_pass http://backend:5050;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/BES/src/main/java/com/example/BES/config/GoogleDriveConfig.java
+++ b/BES/src/main/java/com/example/BES/config/GoogleDriveConfig.java
@@ -1,6 +1,7 @@
 package com.example.BES.config;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.util.Collections;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
@@ -13,17 +14,31 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @Profile("!test")
 public class GoogleDriveConfig implements GoogleServiceFactory {
-    
+
     @Bean
-    public Drive getDrive(){
-        try{
+    public Drive getDrive() {
+        try {
             GoogleCredential credential = GoogleCredential.fromStream(new FileInputStream(CREDENTIALS_FILE_PATH))
-            .createScoped(Collections.singleton(DriveScopes.DRIVE));
-            return new Drive.Builder(GoogleNetHttpTransport.newTrustedTransport(),
-            JSON_FACTORY,
-            credential)
-            .build();
-        }catch(Exception e){
+                .createScoped(Collections.singleton(DriveScopes.DRIVE));
+            return new Drive.Builder(GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY, credential)
+                .setApplicationName("kyrove")
+                .build();
+        } catch (FileNotFoundException e) {
+            // credentials.json missing (or a directory placeholder created by a Docker bind mount).
+            // Boot without Google Drive features; calls fail at use time rather than crashing startup.
+            System.err.println("WARN: credentials.json not available — Google Drive integration disabled (" + e.getMessage() + ")");
+            return buildPlaceholderDrive();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Drive buildPlaceholderDrive() {
+        try {
+            return new Drive.Builder(GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY, request -> { })
+                .setApplicationName("kyrove-placeholder")
+                .build();
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/BES/src/main/java/com/example/BES/config/GoogleSheetConfig.java
+++ b/BES/src/main/java/com/example/BES/config/GoogleSheetConfig.java
@@ -1,6 +1,7 @@
 package com.example.BES.config;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.util.Collections;
 
 import org.springframework.context.annotation.Bean;
@@ -14,18 +15,30 @@ import com.google.api.services.sheets.v4.SheetsScopes;
 
 @Configuration
 @Profile("!test")
-public class GoogleSheetConfig implements GoogleServiceFactory{
+public class GoogleSheetConfig implements GoogleServiceFactory {
 
     @Bean
-     public Sheets getSheets(){
-        try{
+    public Sheets getSheets() {
+        try {
             GoogleCredential credential = GoogleCredential.fromStream(new FileInputStream(CREDENTIALS_FILE_PATH))
-            .createScoped(Collections.singleton(SheetsScopes.SPREADSHEETS));
-            return new Sheets.Builder(GoogleNetHttpTransport.newTrustedTransport(),
-            JSON_FACTORY,
-            credential)
-            .build();
-        }catch(Exception e){
+                .createScoped(Collections.singleton(SheetsScopes.SPREADSHEETS));
+            return new Sheets.Builder(GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY, credential)
+                .setApplicationName("kyrove")
+                .build();
+        } catch (FileNotFoundException e) {
+            System.err.println("WARN: credentials.json not available — Google Sheets integration disabled (" + e.getMessage() + ")");
+            return buildPlaceholderSheets();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Sheets buildPlaceholderSheets() {
+        try {
+            return new Sheets.Builder(GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY, request -> { })
+                .setApplicationName("kyrove-placeholder")
+                .build();
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
+# --- Build stage: compile the Spring Boot JAR inside Docker ---
+FROM maven:3.9-amazoncorretto-17 AS build
+WORKDIR /build
+
+# Cache deps in their own layer — only re-downloads when pom.xml changes
+COPY BES/pom.xml ./
+RUN mvn -B dependency:go-offline
+
+COPY BES/src ./src
+RUN mvn -B -DskipTests clean package
+
+# --- Runtime stage: JRE only ---
 FROM amazoncorretto:17
-
-# Build JAR on host first: mvn clean package -DskipTests -f backend/pom.xml
-ARG JAR_FILE=BES/target/*.jar
-
-COPY ${JAR_FILE} application.jar
-
-CMD apt-get update -y
-
-ENTRYPOINT [ "java", "-Xmx2048M", "-jar", "/application.jar" ]
+COPY --from=build /build/target/*.jar /application.jar
+ENTRYPOINT ["java", "-Xmx2048M", "-jar", "/application.jar"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,12 @@
+services:
+  frontend:
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./BES-frontend/nginx/default.prod.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: unless-stopped
+
+  backend:
+    restart: unless-stopped
+
+  postgres:
+    restart: unless-stopped

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -495,42 +495,68 @@ The override pattern is Docker's recommended way and keeps dev simple while maki
 
 ---
 
-## Phase 2 — CI/CD with GitHub Actions (deferred, do later)
+## Phase 2 — CI/CD with GitHub Actions
 
-Once the manual deploy is stable, add auto-deploy on push to `master`.
+The workflow at `.github/workflows/deploy.yml` auto-deploys on every push to `master` (typically a merged PR). It SSHes to the server as `deploy`, pulls latest, rebuilds containers, then smoke-tests `https://kyrove.live` from the runner.
 
-### Add repo secrets
-GitHub repo → **Settings → Secrets and variables → Actions**:
-- `HOST` — `<SERVER_IP>`
-- `USERNAME` — `deploy`
-- `SSH_KEY` — full contents of `~/.ssh/id_ed25519` (private key)
+### One-time setup — add three repo secrets
 
-### Add `.github/workflows/deploy.yml`
-```yaml
-name: Deploy to production
+GitHub repo → **Settings → Secrets and variables → Actions → New repository secret**:
 
-on:
-  push:
-    branches: [master]
+| Secret name | Value |
+|-------------|-------|
+| `DEPLOY_HOST` | `5.223.94.4` (your server's IPv4) |
+| `DEPLOY_USER` | `deploy` |
+| `DEPLOY_SSH_KEY` | Full contents of `~/.ssh/id_ed25519` (private key, including BEGIN/END lines) |
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          script: |
-            cd ~/kyrove
-            git pull origin master
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
-            docker compose ps
+To grab the private key on your Mac:
+```bash
+cat ~/.ssh/id_ed25519 | pbcopy   # copies to clipboard, paste into GitHub
 ```
 
-This uses `git pull` on the server (not SCP), keeping `.env` and `credentials.json` in place — they don't need to be in GitHub secrets.
+### How it runs
+
+- **Trigger:** push to `master` (or click "Run workflow" manually from the Actions tab)
+- **Concurrency:** one deploy at a time per branch — if two deploys overlap, the second waits rather than cancelling, so a half-deployed state can't happen
+- **What it does on the server:**
+  ```
+  git fetch origin master && git reset --hard origin/master   # bulletproof against local drift
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+  docker image prune -f                                       # reclaims disk on every deploy
+  ```
+- **Smoke test:** runner does up to 10 retries of `curl https://kyrove.live`, expecting HTTP 200. Fails the workflow if the site doesn't come up.
+
+### Why `git pull` on the server (not SCP / artifact upload)
+
+- `.env` and `credentials.json` stay on the server — they don't need to be in GitHub Actions secrets
+- Build caching works (Maven + npm + Docker layers all cache locally on the server)
+- Rollback is `git reset --hard <previous-sha>` and re-run the workflow — no artifact bookkeeping
+
+### Recommended branch protection (optional but smart)
+
+GitHub repo → **Settings → Branches → Add rule** for `master`:
+- ✓ Require a pull request before merging
+- ✓ Require status checks to pass before merging → tick `CI / Backend / Build`, `CI / Frontend / Build`, etc.
+- ✓ Require branches to be up to date before merging
+
+This prevents accidental direct pushes to `master` (which would trigger a deploy of unreviewed code) and ensures CI passes before the deploy runs.
+
+### If a deploy fails
+
+- **SSH step fails** → check the Actions log. Common: secret typo, server unreachable, full disk.
+  ```bash
+  ssh deploy@5.223.94.4
+  df -h            # disk full?
+  docker compose logs --tail=200 backend
+  ```
+- **Smoke test fails but containers are up** → likely TLS or DNS issue. Hit `https://kyrove.live` in a browser and check the network tab.
+- **Rollback fast** (on the server):
+  ```bash
+  cd ~/kyrove
+  git log --oneline -10
+  git reset --hard <previous-good-sha>
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+  ```
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,6 +13,40 @@ Placeholders used throughout — replace before running:
 
 ---
 
+## Pre-flight checklist — read before starting
+
+Roughly ordered by "how much it'll hurt if you skip it."
+
+### Critical — do these before Phase 1
+
+- [ ] **Back up your SSH private key.** Copy `~/.ssh/id_ed25519` to a safe location (password manager secure note, iCloud Keychain, encrypted USB). It's the only thing standing between you and a locked-out server. If your Mac dies without this, you'll need Hetzner Rescue mode to recover.
+- [ ] **Confirm `.env` and `credentials.json` are gitignored** before doing anything else:
+  ```bash
+  git check-ignore -v .env credentials.json
+  # both must print a .gitignore line. If silent → NOT ignored → add to .gitignore NOW
+  ```
+  Leaking either to a public repo = production passwords exposed.
+- [ ] **Enable 2FA on your Hetzner account** + use a strong unique password. Hetzner Console → Security → Two-factor authentication. Your server is one account compromise away from being deleted.
+- [ ] **Set a strong Hetzner Cloud Console root password.** Even with SSH keys, Rescue mode needs the Console password. Don't reuse the SSH passphrase.
+
+### Will bite you eventually
+
+- [ ] **`EMAIL_PASSWORD` must be a Gmail App Password**, not your real Gmail password. Google blocks plain passwords for SMTP. Generate one at: Google Account → Security → 2-Step Verification → App passwords → "Mail". 16 chars, no spaces.
+- [ ] **`BES_SECURE_COOKIE=true` means sessions only work over HTTPS.** If a user lands on `http://<DOMAIN>` and the HTTP→HTTPS redirect breaks, login fails silently with no useful error. Always test login on the actual HTTPS URL.
+- [ ] **`BES_COOKIE_DOMAIN=<DOMAIN>`** must be the bare domain (e.g. `kyrove.xyz`) — NOT `.kyrove.xyz`, NOT `www.kyrove.xyz`. Mismatches cause silent session loss when redirecting between `@` and `www`.
+- [ ] **Domain auto-renewal.** `.xyz` is ~$1 first year, ~$10/yr after. If it expires, your app goes dark. Either set a calendar reminder ~30 days before expiry, or enable Namecheap auto-renew (Domain List → Manage → Auto-Renew toggle).
+- [ ] **NEVER use `docker compose down -v` in production.** The `-v` flag deletes named volumes, including the postgres DB. Hetzner backups are server-wide and won't help if you accidentally nuke just the DB mid-day.
+- [ ] **First deploy runs Flyway migrations on a fresh DB.** Watch backend logs carefully on first `docker compose up`. If a migration fails, the backend won't start — look for `Migration V##__... failed` lines. Not a code issue, a schema issue.
+
+### Operational gotchas
+
+- [ ] **Phase 3 SSH hardening: confirm `deploy` login works from a second terminal BEFORE running 3.3.** If you lock root out without verifying deploy works, you're locked out entirely. Recovery requires Hetzner Rescue mode.
+- [ ] **Phase 6 certbot needs port 80 free.** If you accidentally `docker compose up` before certbot, you'll get "port already in use." Stop containers first: `docker compose down`.
+- [ ] **Hetzner billing is hourly, capped at monthly.** Destroying the server mid-month saves the rest of the month. Keep a card on file with ≥3 months of buffer.
+- [ ] **After this branch merges to master, Phase 5 instructions become wrong.** It says `git checkout feat/deploy-hetzner-https`. Once merged, clone master instead — update the doc accordingly.
+
+---
+
 ## Phase 0 — Prerequisites (~20 min, can run in parallel)
 
 ### 0a. Buy a domain on Namecheap
@@ -272,6 +306,68 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml restart
 
 ### Hetzner snapshot before risky changes
 Hetzner Console → Server → Snapshots → "Take Snapshot". €0.01/GB/mo.
+
+---
+
+## Architecture — how dev and prod configs differ
+
+Four files are involved. Two are shared; two are environment-specific.
+
+| File | When used | What it controls |
+|------|-----------|------------------|
+| `docker-compose.yml` | Always (dev + prod) | Service definitions: frontend, backend, postgres. Build contexts, env vars, ports, named volumes. |
+| `docker-compose.prod.yml` | Prod only (must pass `-f`) | Overrides on top of the base: bind-mounts `/etc/letsencrypt`, swaps in the prod nginx config, adds `restart: unless-stopped`. |
+| `BES-frontend/nginx/default.conf` | Dev only | `server_name=localhost`, self-signed cert. **Baked into the frontend image at build time.** |
+| `BES-frontend/nginx/default.prod.conf` | Prod only | `server_name=<DOMAIN>`, Let's Encrypt cert paths, HTTP→HTTPS redirect, HTTP/2, longer WebSocket timeouts. **Mounted at runtime**, overriding the baked-in dev config. |
+
+### How they're invoked
+
+**Local dev (your Mac):**
+```bash
+docker compose up --build --no-cache
+```
+Reads only `docker-compose.yml`. The frontend image is built with the dev nginx config baked in. Site at `http://localhost`.
+
+**Production (Hetzner server):**
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+Merges both compose files. At runtime, the bind mount replaces the baked-in dev config with `default.prod.conf` inside the running container. Site at `https://<DOMAIN>`.
+
+The key insight: **the same image works in both** because nginx reads its config from disk at startup — and the prod compose mounts a different file over the same path.
+
+### Workflow impact
+
+| Activity | Change |
+|----------|--------|
+| Running locally | None — same command as before |
+| Editing Vue / Java code | None |
+| Running tests (`mvn test`, `npm test`) | None |
+| Editing nginx routes (e.g. add `/api/v2/...`) | **Update both `default.conf` AND `default.prod.conf`** — see gotcha below |
+| Deploying changes | SSH to server → `git pull` → run the prod compose command (see "Routine operations") |
+
+You don't need to touch `docker-compose.prod.yml` or `default.prod.conf` during normal dev work. They sit there waiting for the server.
+
+### Maintenance gotcha — duplicated nginx routes
+
+The routing rules (`/api/`, `/ws`, fallback `/`) are duplicated in both nginx configs:
+
+```
+default.conf       (dev)        default.prod.conf  (prod)
+├── /api/   →  backend          ├── /api/   →  backend
+├── /ws     →  backend          ├── /ws     →  backend
+└── /       →  SPA              └── /       →  SPA
+```
+
+If you add a new path, update both. **If you forget the prod one, it'll work locally but 404 in production.** There's no automatic sync — this is the one place dev/prod can drift.
+
+### Why this structure (vs alternatives)
+
+- **Not `docker-compose.override.yml`** — Docker auto-loads that in dev too, which would have broken your local workflow.
+- **Not two separate compose files** — would have duplicated all service definitions (env vars, build contexts, ports), creating drift risk.
+- **Not one templated config with `envsubst`** — adds runtime complexity, harder to read, requires entrypoint script changes.
+
+The override pattern is Docker's recommended way and keeps dev simple while making prod explicit.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -309,6 +309,93 @@ Hetzner Console → Server → Snapshots → "Take Snapshot". €0.01/GB/mo.
 
 ---
 
+## Pausing the server to save money
+
+Powered-off servers are still billed at the full hourly rate — Hetzner keeps your CPU/RAM/disk reserved. To actually stop being billed, take a snapshot and delete the server. The snapshot persists at ~**$0.85/mo for the 80 GB disk image**, vs ~$18/mo running.
+
+**Data survives the pause/resume cycle.** The Postgres named volume lives on the host disk under `/var/lib/docker/volumes/kyrove_postgres/_data/`. The snapshot captures that whole disk, so DB rows, uploads, `.env`, `credentials.json`, and the Let's Encrypt cert all come back intact when you restore.
+
+### When pausing is worth it
+
+| Pause duration | Approximate savings | Recommended? |
+|----------------|---------------------|--------------|
+| < 1 week       | ~$4                 | No — leave running |
+| 2 weeks        | ~$8                 | Borderline |
+| 1 month        | ~$17                | Yes |
+| 3+ months      | ~$50+               | Definitely |
+
+### Pause — step by step
+
+**1. On the server**, prepare for snapshot:
+```bash
+ssh deploy@<SERVER_IP>
+cd ~/kyrove
+./scripts/pause.sh
+```
+
+The script runs `docker compose down` (NEVER use `-v` — that would wipe volumes), flushes filesystem buffers with `sync`, and prints the next steps. The DB volume is preserved.
+
+**2. In the Hetzner Console:**
+- Server → **Snapshots** tab → **"Take snapshot"** → name it `kyrove-paused-<date>`
+- Wait 3–5 min until status shows **"Created"**
+- Go to top-level **Snapshots** menu — **verify your snapshot is listed with non-zero size**. Do not skip this. If you delete the server before the snapshot exists, you lose everything.
+
+**3. Delete the server:**
+- Server → **"Delete this server"** → confirm
+- The IPv4 is released. Automated backups (if you had them enabled) disappear too — only snapshots persist.
+
+Your bill drops to ~$0.85/mo.
+
+### Resume — step by step
+
+**1. Create a new server from the snapshot:**
+- Console → **Create Server**
+- Image tab → **"My Images"** → pick your snapshot
+- Location: same as before (Singapore)
+- Type: same or different — you can upsize/downsize at restore time
+- SSH keys: attach yours
+- Create
+
+**2. Note the new IPv4** — it will be different from before. Released IPs are not reserved.
+
+**3. Update DNS in Namecheap:**
+- Domain List → Manage → Advanced DNS → edit the `@` and `www` A records to the new IP
+- Wait ~15 min: `dig +short kyrove.live` should return the new IP before continuing
+
+**4. SSH in and bring the stack up:**
+```bash
+ssh deploy@<NEW_IP>
+cd ~/kyrove
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+docker compose ps           # all 3 services should be Up
+```
+No `--build` needed — the images are inside the snapshot.
+
+**5. Check the TLS cert:**
+```bash
+sudo certbot certificates
+```
+- **Valid for > 7 days** → done.
+- **Expired or near expiry** → renew (briefly stops frontend):
+  ```bash
+  docker compose down
+  sudo certbot renew --force-renewal
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+  ```
+
+### Gotchas
+
+| Gotcha | Prevent by |
+|--------|------------|
+| Snapshot of running Postgres can be inconsistent | Always `./scripts/pause.sh` (runs `docker compose down`) before snapshotting |
+| Delete the server before snapshot creation finishes → lose everything | Verify snapshot is "Created" with non-zero size at top-level Snapshots before deleting |
+| Forget that the new server has a different IP | Update both A records in Namecheap immediately after creating |
+| Let's Encrypt rate limit (5 duplicate certs/week) if you `--force-renewal` too often | Use plain `certbot renew` unless the cert really is expired |
+| Snapshot pile-up (limit ~5 per project) | Delete old snapshots when you take a new one |
+| Long DNS TTL stretches the cutover | Lower TTL to 60s a few hours BEFORE pausing |
+
+---
+
 ## Architecture — how dev and prod configs differ
 
 Four files are involved. Two are shared; two are environment-specific.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,150 +1,354 @@
-# BES Deployment Guide: Free/Low-Cost Hosting with GitHub Actions
+# Kyrove Deployment Guide — Hetzner + HTTPS
 
-This guide will walk you through deploying your Spring Boot + Vue.js + PostgreSQL application. Since you are using Docker Compose, the most straightforward and cost-effective approach is to use a **Virtual Private Server (VPS)**. 
+This is the step-by-step runbook for deploying Kyrove to a public server with a custom domain and HTTPS.
 
-## 1. Hosting Architecture Choice
+**Stack:** Hetzner CX22 (Ubuntu 24.04) · Namecheap domain · Let's Encrypt TLS · Docker Compose · Nginx (in the frontend container)
 
-Because Spring Boot + PostgreSQL can be slightly memory-intensive (often needing at least 1GB to run comfortably), platform-as-a-service free tiers (like Heroku or Render) either don't support Docker-compose easily or will spin down constantly. 
+**Cost:** ~$6/mo server + ~$10/yr domain. No CI/CD in this phase — deploys are `git pull && docker compose up -d --build` on the server.
 
-**Recommended Options:**
-1. **AWS EC2 (Free Tier)**: Free for 12 months (`t2.micro` or `t3.micro` instances provide 1GB RAM).
-2. **Hetzner / DigitalOcean**: If you want something permanent and reliable without a 12-month limit, a basic entry-level server costs about **$4 - $6 / month**.
-
-Since you don't have a domain, you can simply access your website via the **Server's Public IP Address** (e.g., `http://192.168.1.100`).
-
----
-
-## 2. Setting up the Server
-
-Regardless of whether you choose AWS, DigitalOcean, or Hetzner, the steps are largely the same.
-
-### Step 2.1: Spin up the server
-- OS: **Ubuntu 22.04 LTS** or **24.04 LTS**.
-- Once the server is running, note down the **Public IP Address**.
-- You will be given an SSH Key pair during creation. Keep the `.pem` private key safe.
-
-### Step 2.2: Prepare the Server (SSH into it)
-Open your terminal and SSH into the server:
-```bash
-ssh -i /path/to/your-key.pem ubuntu@<YOUR_PUBLIC_IP>
-```
-
-### Step 2.3: Add a Swap File (CRITICAL)
-Servers with 1GB RAM will run out of memory when starting Spring Boot with an active DB. Adding a swap file prevents the server from crashing:
-```bash
-sudo fallocate -l 2G /swapfile
-sudo chmod 600 /swapfile
-sudo mkswap /swapfile
-sudo swapon /swapfile
-# Make it permanent across reboots
-echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
-```
-
-### Step 2.4: Install Docker and Docker Compose
-Run the following commands on your server to install Docker:
-```bash
-# Add Docker's official GPG key:
-sudo apt-get update
-sudo apt-get install ca-certificates curl
-sudo install -m 0755 -d /etc/apt/keyrings
-sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-# Add the repository to Apt sources:
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update
-
-# Install Docker
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-# Make docker run without sudo
-sudo usermod -aG docker $USER
-```
-*(After this, exit the SSH session and log back in so the permissions apply)*
-
-### Step 2.5: Clone your project on the server
-Create the folder where your project will live:
-```bash
-mkdir -p /home/ubuntu/BES
-```
-*(We will let GitHub actions automate placing the files here.)*
+Placeholders used throughout — replace before running:
+- `<SERVER_IP>` — your Hetzner server's IPv4
+- `<DOMAIN>` — your registered domain, e.g. `kyrove.xyz`
+- `<EMAIL>` — your email (for Let's Encrypt + Hetzner)
 
 ---
 
-## 3. GitHub Actions CI/CD Integration
+## Phase 0 — Prerequisites (~20 min, can run in parallel)
 
-We'll set up a GitHub Workflow that triggers every time you push to the `main` branch. It will SSH into your server, copy the latest files, reconstruct your `.env` and `credentials.json` file securely, and restart the Docker containers.
+### 0a. Buy a domain on Namecheap
 
-### Step 3.1: Add Secrets to your GitHub Repository
-Go to your project repository on GitHub web -> **Settings** -> **Secrets and variables** -> **Actions** -> **New repository secret**.
+1. namecheap.com → search a name (`.xyz` ~$1 first year, `.com` ~$10/yr)
+2. Disable upsells at checkout. Keep WhoisGuard (free).
+3. After purchase: **Domain List → Manage** → confirm nameservers say "Namecheap BasicDNS".
 
-Add the following secrets:
-* `HOST`: Your server's Public IP address.
-* `USERNAME`: `ubuntu` (or `root` if using DigitalOcean).
-* `SSH_KEY`: The entire contents of your private `.pem` SSH key file that you downloaded when creating the server.
-* `ENV_FILE`: The contents of your `.env` file (containing EMAIL, SPRING_DATASOURCE_URL, etc.). Set the URL variable inside to `jdbc:postgresql://postgres:5432/<dbname>` and the domain to your public IP.
-* `GOOGLE_CREDENTIALS_JSON`: The entire contents of your `credentials.json` file. (Never commit this to your public codebase).
+### 0b. Create a Hetzner account
 
-### Step 3.2: Create the CI/CD Pipeline Configuration
-Create `.github/workflows/deploy.yml` in your project with the following code.
+1. https://accounts.hetzner.com/signUp
+2. Use a real name matching your card.
+3. **Heads up:** Hetzner may email you within an hour asking for ID verification (passport/IC). Reply promptly. This is the #1 timing blocker — start it first.
 
+### 0c. Generate an SSH key on your Mac (if you don't already have one)
+
+```bash
+ls ~/.ssh/id_ed25519.pub 2>/dev/null || ssh-keygen -t ed25519 -C "kyrove-deploy" -f ~/.ssh/id_ed25519
+cat ~/.ssh/id_ed25519.pub   # copy this for the next step
+```
+
+---
+
+## Phase 1 — Provision the server (~10 min)
+
+Hetzner Cloud Console → **New Project** → name it `kyrove`.
+
+**Add Server:**
+- Location: **Singapore** (or closest to your users)
+- Image: **Ubuntu 24.04**
+- Type: **CX22** (€4.59/mo · 2 vCPU · 4 GB RAM · 40 GB SSD)
+- Networking: **Public IPv4** ✓
+- SSH Keys: paste `id_ed25519.pub`
+- Name: `kyrove-prod`
+- **Enable Backups** (+20% cost, ~$1/mo — recommended)
+
+Copy the **IPv4 address** that appears → this is `<SERVER_IP>`.
+
+Smoke-test from your Mac:
+```bash
+ssh root@<SERVER_IP>
+```
+
+---
+
+## Phase 2 — Point DNS at the server (~5 min + ~15 min wait)
+
+Namecheap → **Domain List → Manage → Advanced DNS**. Delete any default parking records. Add:
+
+| Type | Host | Value         | TTL       |
+|------|------|---------------|-----------|
+| A    | `@`  | `<SERVER_IP>` | Automatic |
+| A    | `www`| `<SERVER_IP>` | Automatic |
+
+Wait ~15 min, then verify from your Mac:
+```bash
+dig +short <DOMAIN>
+dig +short www.<DOMAIN>
+```
+Both must print `<SERVER_IP>` before you proceed — Let's Encrypt will fail otherwise.
+
+---
+
+## Phase 3 — Harden the server (~15 min)
+
+SSH in as root: `ssh root@<SERVER_IP>`
+
+```bash
+# 3.1 — create deploy user
+adduser deploy            # set a strong password when prompted
+usermod -aG sudo deploy
+
+# 3.2 — copy SSH key
+rsync --archive --chown=deploy:deploy ~/.ssh /home/deploy
+```
+
+**Open a SECOND terminal on your Mac** and verify `ssh deploy@<SERVER_IP>` works **before** doing 3.3 — if you lock root out without confirming deploy works, you're locked out entirely.
+
+```bash
+# 3.3 — disable root SSH + password auth (only after deploy login confirmed)
+sed -i 's/^#*PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+systemctl restart ssh
+
+# 3.4 — firewall
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+ufw status
+```
+
+From now on always log in as `deploy`: `ssh deploy@<SERVER_IP>`.
+
+---
+
+## Phase 4 — Install Docker + Certbot (~5 min)
+
+As `deploy`:
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y docker.io docker-compose-v2 git certbot
+sudo usermod -aG docker deploy
+exit                      # log out so the docker group applies
+```
+
+Reconnect and verify:
+```bash
+docker --version
+docker compose version
+```
+
+---
+
+## Phase 5 — Clone the repo + write `.env` (~10 min)
+
+```bash
+cd ~
+git clone https://github.com/bennylim0926/BES.git kyrove
+cd kyrove
+git checkout feat/deploy-hetzner-https     # the branch with prod configs
+cp .env.example .env
+nano .env
+```
+
+In `.env`, set production values. **Generate fresh strong passwords** — don't reuse local dev values.
+
+Required:
+```
+DOMAIN=<DOMAIN>
+BES_COOKIE_DOMAIN=<DOMAIN>
+BES_SECURE_COOKIE=true
+BES_ALLOWED_ORIGINS=https://<DOMAIN>,https://www.<DOMAIN>
+EMAIL=<your gmail>
+EMAIL_PASSWORD=<gmail app password>
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/<dbname>
+SPRING_DATASOURCE_USERNAME=<db user>
+SPRING_DATASOURCE_PASSWORD=<strong password>
+SPRING_DATASOURCE_DBNAME=<dbname>
+BES_ADMIN_PASSWORD=<strong>
+BES_EMCEE_PASSWORD=<strong>
+BES_JUDGE_PASSWORD=<strong>
+BES_ORGANISER_PASSWORD=<strong>
+```
+
+Copy your Google API credentials from your Mac (run on Mac, not server):
+```bash
+scp /Users/bennylim/Documents/BES/credentials.json deploy@<SERVER_IP>:~/kyrove/
+```
+
+---
+
+## Phase 6 — Get the TLS certificate (~5 min)
+
+On the server, with nothing yet bound to port 80:
+```bash
+sudo certbot certonly --standalone \
+  -d <DOMAIN> -d www.<DOMAIN> \
+  --agree-tos -m <EMAIL> --no-eff-email
+```
+
+Verify the cert exists:
+```bash
+sudo ls /etc/letsencrypt/live/<DOMAIN>/
+# expect: fullchain.pem  privkey.pem  cert.pem  chain.pem
+```
+
+---
+
+## Phase 7 — Repo configuration (already in `feat/deploy-hetzner-https`)
+
+Two files were added in this branch — you don't need to write them, just confirm they exist and the domain is correct.
+
+### `docker-compose.prod.yml`
+Mounts the host's `/etc/letsencrypt` into the frontend container and overrides the nginx config.
+
+### `BES-frontend/nginx/default.prod.conf`
+HTTP → HTTPS redirect, real domain `server_name`, Let's Encrypt cert paths, WebSocket upgrade.
+
+If `server_name` still says `yourdomain.com`, swap it from your Mac and push:
+```bash
+sed -i '' 's/yourdomain\.com/<DOMAIN>/g' BES-frontend/nginx/default.prod.conf
+git add BES-frontend/nginx/default.prod.conf
+git commit -m "chore: set production domain"
+git push
+```
+
+Then on the server: `git pull`.
+
+---
+
+## Phase 8 — First deploy (~10 min)
+
+On the server:
+```bash
+cd ~/kyrove
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+docker compose ps           # all 3 services should show "Up"
+docker compose logs -f backend
+# wait for "Started BesApplication" — Ctrl+C
+```
+
+Test from your Mac:
+```bash
+curl -I https://<DOMAIN>     # expect 200, valid cert
+curl -I http://<DOMAIN>      # expect 301 -> https
+```
+
+Open `https://<DOMAIN>` in a browser — green padlock, app loads.
+
+---
+
+## Phase 9 — Auto-renew the TLS cert (~5 min)
+
+Let's Encrypt certs expire every 90 days. Add a renewal cron on the server:
+```bash
+sudo crontab -e
+```
+Add:
+```
+0 3 * * * certbot renew --pre-hook "docker stop bes_frontend" --post-hook "docker start bes_frontend" >> /var/log/certbot-renew.log 2>&1
+```
+
+Dry-run to confirm renewal logic works:
+```bash
+sudo certbot renew --dry-run
+```
+
+---
+
+## Routine operations
+
+### Deploy a new version
+```bash
+ssh deploy@<SERVER_IP>
+cd ~/kyrove
+git pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+### Check logs
+```bash
+docker compose logs -f backend
+docker compose logs -f frontend
+docker compose logs --tail=200 postgres
+```
+
+### Database access (read-only sanity check)
+```bash
+docker compose exec postgres psql -U <db user> -d <dbname>
+```
+
+### Restart everything
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml restart
+```
+
+### Hetzner snapshot before risky changes
+Hetzner Console → Server → Snapshots → "Take Snapshot". €0.01/GB/mo.
+
+---
+
+## Troubleshooting
+
+### `certbot` fails with "DNS problem" / "connection refused on port 80"
+- DNS hasn't propagated yet → re-run `dig +short <DOMAIN>`, must return `<SERVER_IP>`.
+- Something is bound to port 80 already → `sudo ss -tlnp | grep ':80 '`. Stop it before re-running certbot.
+
+### Browser shows "Not secure" or self-signed cert warning
+- The container is still using the localhost cert from the dev `default.conf`.
+- Verify `docker-compose.prod.yml` was actually included on `up`: the command must have **both** `-f` flags.
+- Check inside the container:
+  ```bash
+  docker compose exec frontend cat /etc/nginx/conf.d/default.conf | head -5
+  # should reference /etc/letsencrypt/live/<DOMAIN>/...
+  ```
+
+### WebSocket connections drop after ~60s
+- The 1-hour `proxy_read_timeout` is already set in `default.prod.conf`. If issues persist, check Hetzner cloud firewall isn't dropping idle connections (it shouldn't by default).
+
+### 502 Bad Gateway from `/api/`
+- Backend container probably died — `docker compose logs backend`.
+- Most common cause: bad `SPRING_DATASOURCE_*` values in `.env`, or Flyway migration mismatch.
+
+### Site is suddenly down
+1. `ssh deploy@<SERVER_IP>` — server reachable?
+2. `docker compose ps` — any container exited?
+3. `docker compose logs --tail=200 <service>` — root cause
+4. `sudo systemctl status docker` — is the docker daemon alive?
+5. Worst case: restore from Hetzner backup (Hetzner Console → Server → Backups).
+
+---
+
+## Phase 2 — CI/CD with GitHub Actions (deferred, do later)
+
+Once the manual deploy is stable, add auto-deploy on push to `master`.
+
+### Add repo secrets
+GitHub repo → **Settings → Secrets and variables → Actions**:
+- `HOST` — `<SERVER_IP>`
+- `USERNAME` — `deploy`
+- `SSH_KEY` — full contents of `~/.ssh/id_ed25519` (private key)
+
+### Add `.github/workflows/deploy.yml`
 ```yaml
-name: Deploy to Server
+name: Deploy to production
 
 on:
   push:
-    branches:
-      - main # Triggers on every push to the main branch
+    branches: [master]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Copy files to server via SCP
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          source: "."
-          target: "/home/ubuntu/BES"
-          rm: true # Clean up old files before copying
-
-      - name: Execute deployment commands via SSH
+      - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_KEY }}
           script: |
-            cd /home/ubuntu/BES
-            
-            # Create the .env file from GitHub Secrets
-            echo "${{ secrets.ENV_FILE }}" > .env
-            
-            # Create the credentials.json file securely
-            echo '${{ secrets.GOOGLE_CREDENTIALS_JSON }}' > credentials.json
-            
-            # Re-build and start the containers
-            docker compose down
-            docker compose up -d --build
+            cd ~/kyrove
+            git pull origin master
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+            docker compose ps
 ```
+
+This uses `git pull` on the server (not SCP), keeping `.env` and `credentials.json` in place — they don't need to be in GitHub secrets.
 
 ---
 
-## 4. Verification & Testing
+## What's still deferred
 
-Once you commit and push the newly added `.github/workflows/deploy.yml` to your repository:
+- **Daily DB backup** to Backblaze B2 (`pg_dump` cron). Hetzner backups cover server-level recovery; per-DB dumps are better for fine-grained restore.
+- **Uptime monitoring** — UptimeRobot free tier, 5-min ping on `https://<DOMAIN>`.
+- **Log aggregation** — for now, `docker compose logs` is enough.
 
-1. **Check the Build**: Go to the **Actions** tab in your GitHub repository. You will see the job currently running.
-2. **Access your site**: Once the job successfully completes, open your browser and navigate to `http://<YOUR_PUBLIC_IP>` (since your frontend binds to port 80).
-3. **Continuous Deployment**: Going forward, anytime you make changes to your frontend or backend and push to `main`, GitHub will automatically push the updates to the server and spin up the new version.
-
-### Final Checklist for frontend configuration
-Your frontend code seems to connect to the backend. Make sure your frontend environment variables point your API calls toward `http://<YOUR_PUBLIC_IP>` instead of `localhost`. When deploying to production, this usually involves updating the `.env.production` in your `BES-frontend` folder to use the generic server IP.
+Tackle in this order after CI/CD: DB backups → uptime monitor → log aggregation.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -361,6 +361,12 @@ default.conf       (dev)        default.prod.conf  (prod)
 
 If you add a new path, update both. **If you forget the prod one, it'll work locally but 404 in production.** There's no automatic sync — this is the one place dev/prod can drift.
 
+### Backend builds inside Docker (multi-stage)
+
+The backend `Dockerfile` is multi-stage: a `maven:3.9-amazoncorretto-17` build stage compiles the JAR, then a slim `amazoncorretto:17` runtime stage runs it. You **never need to install Maven or JDK on the server** — `docker compose up --build` handles everything.
+
+Implication for local dev: you can still run `mvn spring-boot:run` from `BES/` for hot reload (per `CLAUDE.md`), but `docker compose up --build` no longer requires `mvn package` first. The Docker build is self-contained.
+
 ### Why this structure (vs alternatives)
 
 - **Not `docker-compose.override.yml`** — Docker auto-loads that in dev too, which would have broken your local workflow.

--- a/scripts/pause.sh
+++ b/scripts/pause.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Prepare the server to be snapshotted + deleted so you stop being billed.
+# Run this on the Hetzner server (as the 'deploy' user) before taking the snapshot.
+#
+# Usage:
+#   cd ~/kyrove
+#   ./scripts/pause.sh
+#
+# Then go to Hetzner Console → Server → Snapshots → "Take snapshot".
+# Wait for status "Created", verify in top-level Snapshots, then delete the server.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "→ Stopping containers (volumes preserved — DB data stays on disk)..."
+docker compose down
+
+echo "→ Flushing filesystem buffers so the snapshot captures a clean state..."
+sudo sync
+
+SNAPSHOT_NAME="kyrove-paused-$(date +%F)"
+cat <<EOF
+
+================================================================
+✓ Server is ready to snapshot.
+
+Next steps (in Hetzner Cloud Console):
+  1. Open your server → "Snapshots" tab → "Take snapshot"
+     Name:  ${SNAPSHOT_NAME}
+  2. Wait until status shows "Created" (3–5 min)
+  3. Go to top-level "Snapshots" — confirm the snapshot is listed
+     with non-zero size. DO NOT skip this step.
+  4. Open your server → "Delete this server"
+
+After deletion you'll be billed only ~\$0.85/mo for the snapshot.
+
+To resume later, see docs/DEPLOYMENT.md → "Pausing the server".
+================================================================
+EOF


### PR DESCRIPTION
## Summary

Closes #38. Production deployment infrastructure for Kyrove — Hetzner CX22 / CPX22 with HTTPS via Let's Encrypt, auto-deploy on push to master via GitHub Actions, and a pause-server-to-save-money runbook.

Site is already live at https://kyrove.live (manual deploy verified end-to-end during this session). Merging this PR triggers the first auto-deploy as a smoke test.

## What's in this PR

### Production stack
- **`docker-compose.prod.yml`** — override that bind-mounts `/etc/letsencrypt` and `default.prod.conf` into the frontend container, adds `restart: unless-stopped`
- **`BES-frontend/nginx/default.prod.conf`** — production nginx: HTTP→HTTPS redirect, real `kyrove.live` `server_name`, Let's Encrypt cert paths, HTTP/2, 1h WebSocket timeouts

### Build pipeline (no Maven on host anymore)
- **`Dockerfile`** rewritten as multi-stage: `maven:3.9-amazoncorretto-17` build stage compiles the JAR, slim `amazoncorretto:17` runs it. Layer caching for deps via separate `pom.xml` copy.
- **`.dockerignore`** excludes `target/`, `node_modules/`, `dist/`, `.git/`, docs, IDE files, and secrets (`.env`, `credentials.json`, `*.pem`)

### Bug fixes uncovered during deploy
- **`BES-frontend/Dockerfile`** — removed `COPY ./nginx/certs` (folder never existed in repo, broke every Docker build), dropped the broken 443 server block from dev `default.conf`, fixed `as`→`AS` casing
- **`GoogleDriveConfig` / `GoogleSheetConfig`** — catch `FileNotFoundException` and boot with a placeholder client when `credentials.json` is missing or a directory (Docker bind-mounts create empty dirs when host path is missing). App no longer crashes at startup; Drive/Sheets calls fail at use time instead.

### CD pipeline
- **`.github/workflows/deploy.yml`** — on push to master, SSH to server via `appleboy/ssh-action@v1.2.0`, `git fetch && git reset --hard origin/master`, rebuild containers, prune dangling images, then smoke-test https://kyrove.live from the runner (10 retries). Concurrency group serialises overlapping deploys.

### Ops tooling
- **`scripts/pause.sh`** — clean container shutdown + filesystem sync, prints next steps for snapshot-and-delete to save ~\$17/mo during quiet periods

### Documentation
- **`docs/DEPLOYMENT.md`** rewritten from scratch (~630 lines) — pre-flight checklist (SSH key backup, gitignore checks, 2FA), Phase 0-9 step-by-step runbook, architecture explanation of dev vs prod configs, pause/resume runbook, GitHub Actions setup, troubleshooting, routine ops

## Test plan
- [x] Backend builds clean in multi-stage Docker locally (Maven build 14s, image ~75MB)
- [x] Frontend builds clean after removing broken cert copy
- [x] Live site responds with valid Let's Encrypt cert at https://kyrove.live
- [x] Admin login works (after fixing the GoogleDriveConfig crash and seeding `admin`)
- [x] HTTP→HTTPS redirect verified (`curl -I http://kyrove.live` returns 301)
- [x] WebSocket upgrade headers verified in prod nginx
- [x] Pre-push checks (CI backend build + tests + frontend tests) pass on every commit in this branch
- [ ] **Merge triggers first GitHub Actions deploy** — workflow runs, server pulls, containers rebuild, smoke test passes
- [ ] Add `DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_SSH_KEY` secrets in repo settings BEFORE merging
- [ ] After successful first auto-deploy, enable branch protection on `master` requiring CI checks + PR review

## Required pre-merge actions

1. Add 3 GitHub Actions secrets (Settings → Secrets and variables → Actions):
   - \`DEPLOY_HOST\` = \`kyrove.live\`
   - \`DEPLOY_USER\` = \`deploy\`
   - \`DEPLOY_SSH_KEY\` = contents of \`~/.ssh/id_ed25519\` (private key)

If the first auto-deploy fails after merging, rollback on the server:
\`\`\`bash
ssh deploy@kyrove.live
cd ~/kyrove
git log --oneline -5
git reset --hard <previous-good-sha>
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)