### PR TITLE
fix: Helper role can now see results QR in check-in dialog

### DIFF
--- a/BES/src/main/java/com/example/BES/controllers/ResultsController.java
+++ b/BES/src/main/java/com/example/BES/controllers/ResultsController.java
@@ -51,7 +51,7 @@ public class ResultsController {
     }
 
     @GetMapping("/qr")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'HELPER')")
     public ResponseEntity<byte[]> getResultsQr(@RequestParam String ref) {
         try {
             String domain = env.getProperty("DOMAIN", "");


### PR DESCRIPTION
## Summary
- Adds `'HELPER'` to `@PreAuthorize` on `GET /api/v1/results/qr` in `ResultsController.java`
- Helpers were getting a 403 when the check-in confirmation dialog tried to fetch the QR image, so `checkinConfirm.qrImageUrl` was never set and the QR block was never shown

## Root cause
`GET /api/v1/results/qr` was restricted to `ADMIN` and `ORGANISER` only. All other frontend data paths for this flow (participants list, feedback-enabled, checkin-list) already included `HELPER` — the QR endpoint was the only gap.

## Test plan
- [ ] Log in as a Helper and check in a participant
- [ ] Confirm the post-check-in dialog shows the results QR code
- [ ] Confirm Admin/Organiser check-in QR still works

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)