### PR TITLE
fix: resolve three UI display issues (#145, #146, #148)

### DIFF
--- a/BES-frontend/src/views/AuditionNumber.vue
+++ b/BES-frontend/src/views/AuditionNumber.vue
@@ -16,6 +16,7 @@ const revealingRef = ref({})        // { [slotId | historyKey]: boolean }
 // Per-slot rolling animation state — keyed by "${slotId}-${categoryName}"
 const fakeNums = ref({})
 const rollingIntervals = {}         // { "${slotId}-${categoryName}": intervalId }
+const rollingCounters = {}          // { "${slotId}-${categoryName}": currentIndex } — sequential rotation
 
 const modalTitle = ref('')
 const modalMessage = ref('')
@@ -34,6 +35,7 @@ function stopRolling(slotId, categoryName) {
   const key = `${slotId}-${categoryName}`
   clearInterval(rollingIntervals[key])
   delete rollingIntervals[key]
+  delete rollingCounters[key]
   const next = { ...fakeNums.value }
   delete next[key]
   fakeNums.value = next
@@ -47,6 +49,7 @@ function stopAllSlotRolling(slotId) {
   allCategoryKeys.forEach(k => {
     clearInterval(rollingIntervals[k])
     delete rollingIntervals[k]
+    delete rollingCounters[k]
   })
   const next = { ...fakeNums.value }
   allCategoryKeys.forEach(k => delete next[k])
@@ -86,8 +89,10 @@ function animateSlot(slotId, msg) {
   cat.rolling = true
   const intervalKey = `${slotId}-${msg.category}`
   clearInterval(rollingIntervals[intervalKey])
+  rollingCounters[intervalKey] = 0
   rollingIntervals[intervalKey] = setInterval(() => {
-    fakeNums.value = { ...fakeNums.value, [intervalKey]: Math.floor(Math.random() * poolSize) + 1 }
+    rollingCounters[intervalKey] = (rollingCounters[intervalKey] + 1) % poolSize
+    fakeNums.value = { ...fakeNums.value, [intervalKey]: rollingCounters[intervalKey] + 1 }
   }, 80)
 
   setTimeout(() => {

--- a/BES-frontend/src/views/EmceeSessionView.vue
+++ b/BES-frontend/src/views/EmceeSessionView.vue
@@ -20,13 +20,20 @@ onMounted(async () => {
   }
   loading.value = false
   sessionReady.value = !!authStore.user && !!authStore.activeEvent
+  if (authStore.activeEvent?.name) {
+    authStore.fetchEventBattleEnabled(authStore.activeEvent.name)
+  }
 })
 
-const LINKS = [
+const ALL_LINKS = [
   { key: 'audition', label: 'Audition List', route: 'Audition List', icon: 'pi-list' },
   { key: 'score',    label: 'Score',         route: 'Score',         icon: 'pi-chart-bar' },
   { key: 'battle',   label: 'Battle Control', route: 'Battle Control', icon: 'pi-bolt' },
 ]
+
+const LINKS = computed(() =>
+  ALL_LINKS.filter(l => l.key !== 'battle' || authStore.activeEventBattleEnabled)
+)
 
 function navigate(routeName) {
   router.push({ name: routeName })

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2112,8 +2112,8 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <!-- Results QR Section (only if feedback enabled) -->
-    <template v-if="feedbackEnabled">
+    <!-- Results QR Section (participant-facing only — hidden for Admin/Organiser/Helper) -->
+    <template v-if="feedbackEnabled && !isAdminOrOrganiser && !isHelper">
       <div class="card-hover p-6 relative mb-6">
         <div class="corner-bar-tl"></div>
         <div class="corner-bar-bl"></div>

--- a/BES-frontend/src/views/JudgeSessionView.vue
+++ b/BES-frontend/src/views/JudgeSessionView.vue
@@ -44,6 +44,7 @@ onMounted(async () => {
     return
   }
   sessionReady.value = true
+  authStore.fetchEventBattleEnabled(authStore.activeEvent.name)
   await loadDivisions()
 })
 
@@ -133,7 +134,7 @@ function navigateToBattle() {
               class="action-btn action-btn--audition"
             >AUDITION</button>
             <button
-              v-if="d.isBattle"
+              v-if="d.isBattle && authStore.activeEventBattleEnabled"
               @click="navigateToBattle()"
               class="action-btn action-btn--battle"
             >BATTLE</button>


### PR DESCRIPTION
## Summary

- **#145** — Replace random slot machine roll with sequential counter rotation so animation stays smooth when pool size is small (1–2 numbers remaining)
- **#146** — Hide the "Your Results" QR block on EventDetails Event Day tab for Admin/Organiser/Helper roles — it is participant-facing only
- **#148** — Tier-gate Battle Control link on Emcee/Judge session views by calling `fetchEventBattleEnabled` on mount and filtering against `activeEventBattleEnabled` (backed by the existing `/battle-enabled` tier endpoint)

## Test plan

- [ ] AuditionNumber screen: check in a participant when only 1–3 numbers remain in the pool — animation should cycle smoothly without stuttering
- [ ] EventDetails Event Day tab as Admin/Organiser/Helper: "Your Results" waiting block should no longer appear
- [ ] EmceeSessionView on a PRO-tier event: Battle Control button should be hidden
- [ ] EmceeSessionView on a MAX-tier event: Battle Control button should be visible
- [ ] JudgeSessionView on a PRO-tier event: BATTLE button should be hidden per division row
- [ ] JudgeSessionView on a MAX-tier event: BATTLE button should be visible per division row

Closes #145, #146, #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)