### PR TITLE
fix: remove access code gate from AuditionList score reset

### DIFF
--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, verifyEventAccessCode } from '@/utils/api';
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback } from '@/utils/api';
 import { getFeedbackGroups } from '@/utils/adminApi';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
@@ -39,9 +39,6 @@ const showMiniMenu = ref(false)
 const dynamicCallBack = ref(() => {})
 const emceeRoundRef = ref(null)
 
-const resetConfirmCode = ref("")
-const resetCodeError = ref("")
-const resetCodeChecking = ref(false)
 
 const dynamicRole = async () => {
   const res = await whoami()
@@ -102,34 +99,13 @@ const openModal = (title, message, variant = 'info') => {
 }
 
 const confirmReset = (title, message) => {
-  resetConfirmCode.value = ""
-  resetCodeError.value = ""
-  resetCodeChecking.value = false
   modalTitle.value = title
   modalMessage.value = message
   modalVariant.value = 'warning'
   showModal.value = true
   dynamicCallBack.value = async () => {
-    if (!resetConfirmCode.value.trim()) {
-      resetCodeError.value = "Enter the event access code to confirm."
-      return
-    }
-    resetCodeChecking.value = true
-    resetCodeError.value = ""
-    const activeEvent = authStore.activeEvent
-    if (!activeEvent) {
-      resetCodeError.value = "No active event found."
-      resetCodeChecking.value = false
-      return
-    }
-    const result = await verifyEventAccessCode(activeEvent.id, resetConfirmCode.value.trim())
-    resetCodeChecking.value = false
-    if (result?.valid) {
-      showModal.value = false
-      await resetScore()
-    } else {
-      resetCodeError.value = "Incorrect access code."
-    }
+    showModal.value = false
+    await resetScore()
   }
 }
 
@@ -1108,25 +1084,6 @@ onMounted(async () => {
     @close="() => { showModal = false }"
   >
     <p class="type-body text-content-secondary">{{ modalMessage }}</p>
-    <template v-if="modalVariant === 'warning'">
-      <div class="mt-4">
-        <!-- Visible label: placeholder alone is not a label substitute -->
-        <label for="reset-access-code" class="type-label text-content-muted block mb-2">Event access code</label>
-        <input
-          id="reset-access-code"
-          v-model="resetConfirmCode"
-          type="text"
-          placeholder="Enter access code"
-          class="w-full px-3 py-2.5 type-body bg-surface-800 border border-surface-600 text-content-primary outline-none transition-colors"
-          style="clip-path:polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
-          :disabled="resetCodeChecking"
-          :aria-invalid="resetCodeError ? 'true' : undefined"
-          @keyup.enter="dynamicCallBack()"
-        />
-        <p v-if="resetCodeChecking" class="type-label text-accent mt-2" role="status">Verifying…</p>
-        <p v-if="resetCodeError" class="type-label text-red-400 mt-2" role="alert">{{ resetCodeError }}</p>
-      </div>
-    </template>
   </ActionDoneModal>
 
   <FeedbackPopout


### PR DESCRIPTION
## Summary
- Removes the event access code verification requirement from the score reset flow in `AuditionList.vue`
- Reset (by judges or emcee) now shows a plain "Are you sure?" confirmation modal
- Emcee category switch was already a plain confirm — not affected
- Cleaned up `resetConfirmCode`, `resetCodeError`, `resetCodeChecking` state refs and `verifyEventAccessCode` import

## Audit
- `BattleControl.vue` `confirmResetBracket` already uses plain confirm — no access code gating, no change needed
- Backend `/api/v1/event/verify-access-code` endpoint left in place (still used on `EventDetails` for organisers)

## Test plan
- [ ] As Judge: click Reset Scores → plain confirm modal appears, no access code field → confirm resets scores
- [ ] As Emcee: click Reset Scores → same plain confirm modal
- [ ] Category switch with unsaved scores: still shows unsaved warning modal (no access code)
- [ ] Emcee category switch: still shows "This will update the audition display" confirm (no access code)

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)