### PR TITLE
feat: event-scoped feedback taxonomy

### DIFF
--- a/BES-frontend/src/components/FeedbackPopout.vue
+++ b/BES-frontend/src/components/FeedbackPopout.vue
@@ -108,6 +108,13 @@ function onNoteInput() {
               >
                 <i v-if="selectedTagIds.has(tag.id)" class="pi pi-check" style="font-size: 10px;" />
                 {{ tag.label }}
+                <span
+                  v-if="tag.scope === 'EVENT'"
+                  class="type-label opacity-60 ml-1"
+                  style="font-size: 8px; letter-spacing: 0.18em;"
+                >
+                  EVENT
+                </span>
               </button>
             </div>
           </div>

--- a/BES-frontend/src/utils/adminApi.js
+++ b/BES-frontend/src/utils/adminApi.js
@@ -114,6 +114,14 @@ export const getFeedbackGroups = async () => {
     } catch (_err) { return [] }
 }
 
+export const getFeedbackTagOverrides = async () => {
+    try {
+        const res = await fetch(`${domain}/api/v1/admin/feedback-tags/overrides`, { credentials: 'include' })
+        if (res.ok) return await res.json()
+        return []
+    } catch (_err) { return [] }
+}
+
 export const addFeedbackGroup = async (name) => {
     try {
         return await fetch(`${domain}/api/v1/admin/feedback-group`, {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1649,3 +1649,17 @@ export const getActiveEmceeCategories = async (eventName) => {
     return Array.from(data.categories ?? [])
   } catch (e) { console.error(e); return [] }
 }
+
+// Event-scoped feedback taxonomy (#157). Returns merged groups: global +
+// event-scoped, with event-scoped overriding global by group name. Each group
+// and tag carries a `scope` field of "GLOBAL" or "EVENT".
+export const getEventFeedbackTags = async (eventName) => {
+  if (!eventName) return []
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/feedback-tags`, {
+      credentials: 'include'
+    })
+    if (!res.ok) return []
+    return await res.json()
+  } catch (e) { console.error(e); return [] }
+}

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1663,3 +1663,67 @@ export const getEventFeedbackTags = async (eventName) => {
     return await res.json()
   } catch (e) { console.error(e); return [] }
 }
+
+const feedbackTagsBase = (eventName) =>
+  `${domain}/api/v1/event/${encodeURIComponent(eventName)}/feedback-tags`
+
+export const createEventFeedbackGroup = async (eventName, name) => {
+  try {
+    const res = await fetch(`${feedbackTagsBase(eventName)}/groups`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch (e) { console.error(e); return null }
+}
+
+export const createEventFeedbackTag = async (eventName, groupId, label) => {
+  try {
+    const res = await fetch(`${feedbackTagsBase(eventName)}/tags`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ groupId, label })
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch (e) { console.error(e); return null }
+}
+
+export const updateEventFeedbackTag = async (eventName, tagId, label) => {
+  try {
+    const res = await fetch(`${feedbackTagsBase(eventName)}/tags/${tagId}`, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label })
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch (e) { console.error(e); return null }
+}
+
+export const deleteEventFeedbackTag = async (eventName, tagId) => {
+  try {
+    const res = await fetch(`${feedbackTagsBase(eventName)}/tags/${tagId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch (e) { console.error(e); return null }
+}
+
+export const deleteEventFeedbackGroup = async (eventName, groupId) => {
+  try {
+    const res = await fetch(`${feedbackTagsBase(eventName)}/groups/${groupId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch (e) { console.error(e); return null }
+}

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { deleteImage, deleteScore, getAllImages, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag, getOrganisers, assignOrganiserToEvent, removeOrganiserFromEvent, createOrganiser, deleteOrganiser, setOrganiserTier } from '@/utils/adminApi';
+import { deleteImage, deleteScore, getAllImages, getFeedbackGroups, addFeedbackGroup, deleteFeedbackGroup, addFeedbackTag, deleteFeedbackTag, getFeedbackTagOverrides, getOrganisers, assignOrganiserToEvent, removeOrganiserFromEvent, createOrganiser, deleteOrganiser, setOrganiserTier } from '@/utils/adminApi';
 import { checkInputNull } from '@/utils/utils';
 import { computed, onMounted, ref } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
@@ -21,6 +21,11 @@ const openModal = (title, message, variant = 'info') => {
 const events = ref([])
 const images = ref([])
 const feedbackGroups = ref([])
+const feedbackOverrides = ref([]) // [{ globalGroupId, groupName, overridingEventNames[] }]
+const overridingEventsForGroup = (id) => {
+  const match = feedbackOverrides.value.find(o => o.globalGroupId === id)
+  return match?.overridingEventNames ?? []
+}
 const addGroupInput = ref('')
 const addTagInputs = ref({})  // { [groupId]: string }
 const dynamicHandler = ref(() => {})
@@ -167,6 +172,7 @@ onMounted(async () => {
   events.value = await fetchAllEvents() ?? []
   images.value = await getAllImages() ?? []
   feedbackGroups.value = await getFeedbackGroups() ?? []
+  feedbackOverrides.value = await getFeedbackTagOverrides() ?? []
   organisers.value = await getOrganisers() ?? []
   const cfg = await getAppConfig()
   accentInput.value = cfg?.accentColor ?? '#ffffff'
@@ -254,7 +260,17 @@ onMounted(async () => {
           >
             <div class="corner-bar-tl"></div>
             <div class="flex items-center justify-between mb-3">
-              <span class="type-name text-content-primary">{{ group.name }}</span>
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="type-name text-content-primary truncate">{{ group.name }}</span>
+                <span
+                  v-if="overridingEventsForGroup(group.id).length"
+                  class="para-chip-sm type-label text-accent shrink-0 px-2 py-0.5"
+                  :title="`Overridden in: ${overridingEventsForGroup(group.id).join(', ')}`"
+                  style="font-size: 9px; letter-spacing: 0.18em;"
+                >
+                  OVERRIDDEN IN {{ overridingEventsForGroup(group.id).length }} EVENT{{ overridingEventsForGroup(group.id).length === 1 ? '' : 'S' }}
+                </span>
+              </div>
               <button
                 @click="submitDeleteGroup(group.id)"
                 class="w-8 h-8 flex items-center justify-center text-content-muted hover:text-red-400 hover:bg-red-950 transition-all"

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -1,7 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, claimEmceeCategory, getActiveEmceeCategories } from '@/utils/api';
-import { getFeedbackGroups } from '@/utils/adminApi';
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, claimEmceeCategory, getActiveEmceeCategories, getEventFeedbackTags } from '@/utils/api';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { RouterLink, useRouter, useRoute, onBeforeRouteLeave } from 'vue-router';
@@ -638,7 +637,10 @@ onMounted(async () => {
     const active = await getActiveEmceeCategories(selectedEvent.value)
     activeEmceeCategories.value = new Set(active)
   }
-  const [groupRes, divRes] = await Promise.all([getFeedbackGroups(), getCategoriesByEvent(selectedEvent.value)])
+  const [groupRes, divRes] = await Promise.all([
+    selectedEvent.value ? getEventFeedbackTags(selectedEvent.value) : Promise.resolve([]),
+    getCategoriesByEvent(selectedEvent.value)
+  ])
   tagGroups.value = groupRes ?? []
   eventDivisions.value = divRes ?? []
   // Judge list will be populated by the selectedCategory watch (already runs with { immediate: true })

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted, onBeforeUnmount, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, getCategoriesByEvent, getVerifiedParticipantsByEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantCategory, addCategoryToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventCategoryFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled, getResultsStatus, getParticipantRefs, insertEventInTable } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, getCategoriesByEvent, getVerifiedParticipantsByEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantCategory, addCategoryToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventCategoryFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled, getResultsStatus, getParticipantRefs, insertEventInTable, getEventFeedbackTags, createEventFeedbackGroup, createEventFeedbackTag, updateEventFeedbackTag, deleteEventFeedbackTag, deleteEventFeedbackGroup } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 
@@ -54,6 +54,15 @@ const eventName = ref(props.eventName.split(" ").join("%20"));
 const paymentRequired = ref(false)
 const feedbackEnabled = ref(true)
 const feedbackSaving = ref(false)
+
+// Event-scoped feedback taxonomy (#157)
+const feedbackGroups = ref([])
+const showAddFeedbackGroup = ref(false)
+const newFeedbackGroupName = ref('')
+const addTagForGroupId = ref(null)
+const newFeedbackTagLabel = ref('')
+const editingTagId = ref(null)
+const editingTagLabel = ref('')
 const resultsReleased = ref(false)
 const qrImageUrl = ref('')
 const loadingQr = ref(false)
@@ -446,6 +455,78 @@ const refreshParticipant = async () => {
 const refreshFromDb = async () => {
   verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
   unverifiedParticipants.value = await getUnverifiedParticipantsDB(props.eventName)
+}
+
+// ── Event-scoped feedback taxonomy (#157) ────────────────────────────────
+
+const loadFeedbackGroups = async () => {
+  feedbackGroups.value = await getEventFeedbackTags(props.eventName) ?? []
+}
+
+const onAddFeedbackGroup = async () => {
+  const name = newFeedbackGroupName.value.trim()
+  if (!name) return
+  const updated = await createEventFeedbackGroup(props.eventName, name)
+  if (updated) {
+    feedbackGroups.value = updated
+    newFeedbackGroupName.value = ''
+    showAddFeedbackGroup.value = false
+  } else {
+    openModal('Add Group Failed', 'Could not create feedback group.', 'warning')
+  }
+}
+
+const startAddTag = (groupId) => {
+  addTagForGroupId.value = groupId
+  newFeedbackTagLabel.value = ''
+}
+
+const onAddFeedbackTag = async (groupId) => {
+  const label = newFeedbackTagLabel.value.trim()
+  if (!label) return
+  const updated = await createEventFeedbackTag(props.eventName, groupId, label)
+  if (updated) {
+    feedbackGroups.value = updated
+    addTagForGroupId.value = null
+    newFeedbackTagLabel.value = ''
+  } else {
+    openModal('Add Tag Failed', 'Could not create feedback tag.', 'warning')
+  }
+}
+
+const startEditTag = (tag) => {
+  editingTagId.value = tag.id
+  editingTagLabel.value = tag.label
+}
+
+const onSaveTagEdit = async () => {
+  const label = editingTagLabel.value.trim()
+  if (!label || !editingTagId.value) {
+    editingTagId.value = null
+    return
+  }
+  const updated = await updateEventFeedbackTag(props.eventName, editingTagId.value, label)
+  if (updated) {
+    feedbackGroups.value = updated
+    editingTagId.value = null
+    editingTagLabel.value = ''
+  } else {
+    openModal('Save Failed', 'Could not update feedback tag.', 'warning')
+  }
+}
+
+const onDeleteTag = async (tag) => {
+  if (!confirm(`Delete the feedback tag "${tag.label}"?`)) return
+  const updated = await deleteEventFeedbackTag(props.eventName, tag.id)
+  if (updated) feedbackGroups.value = updated
+  else openModal('Delete Failed', 'Could not delete feedback tag.', 'warning')
+}
+
+const onDeleteGroup = async (group) => {
+  if (!confirm(`Delete the feedback group "${group.name}" and all its event-scoped tags?`)) return
+  const updated = await deleteEventFeedbackGroup(props.eventName, group.id)
+  if (updated) feedbackGroups.value = updated
+  else openModal('Delete Failed', 'Could not delete feedback group.', 'warning')
 }
 
 const onFeedbackEnabledToggle = async (e) => {
@@ -1202,6 +1283,7 @@ onMounted(async () => {
       loadSessionTokens()
       const fb = await getFeedbackEnabled(props.eventName)
       if (fb && typeof fb.feedbackEnabled === 'boolean') feedbackEnabled.value = fb.feedbackEnabled
+      await loadFeedbackGroups()
       // Load results status and participant QR if feedback is enabled
       await loadResultsAndQr()
     }
@@ -1604,6 +1686,133 @@ onUnmounted(() => {
           </p>
         </div>
       </label>
+    </div>
+
+    <!-- Feedback Tags card (#157) — event-scoped taxonomy management -->
+    <div v-if="tableExist && feedbackEnabled" class="card-hover p-4 relative mt-6">
+      <div class="corner-bar-tl"></div>
+      <div class="section-rule mb-3">
+        <span class="section-rule-label">Feedback Tags</span>
+        <div class="section-rule-line"></div>
+        <button
+          v-if="!showAddFeedbackGroup"
+          @click="showAddFeedbackGroup = true; newFeedbackGroupName = ''"
+          class="para-chip-sm px-3 py-1.5 type-label shrink-0"
+        >
+          <i class="pi pi-plus mr-1" style="font-size:0.7rem"></i>Add Group
+        </button>
+      </div>
+
+      <p class="type-prose-sm text-content-muted mb-3">
+        Global tags from <span class="type-label">/admin</span> are inherited automatically.
+        Add event-specific groups and tags here — they will only appear for this event.
+      </p>
+
+      <!-- Inline add-group form -->
+      <div v-if="showAddFeedbackGroup" class="flex items-center gap-2 mb-4">
+        <input
+          v-model="newFeedbackGroupName"
+          @keyup.enter="onAddFeedbackGroup"
+          placeholder="Group name (e.g. Locking-specific)"
+          class="input-base flex-1"
+        />
+        <button @click="onAddFeedbackGroup" class="para-chip-sm px-3 py-1.5 type-label text-accent">Save</button>
+        <button @click="showAddFeedbackGroup = false; newFeedbackGroupName = ''" class="para-chip-sm px-3 py-1.5 type-label text-content-muted">Cancel</button>
+      </div>
+
+      <!-- Empty state -->
+      <p v-if="!feedbackGroups.length" class="type-prose text-content-muted">
+        No feedback groups yet — use global tags from /admin, or add event-specific ones here.
+      </p>
+
+      <!-- Group list -->
+      <div v-else class="space-y-4">
+        <div v-for="group in feedbackGroups" :key="`${group.scope}-${group.id}`" class="para-chip p-3">
+          <div class="flex items-center justify-between mb-2 gap-2">
+            <div class="flex items-center gap-2 min-w-0">
+              <span class="type-name truncate">{{ group.name }}</span>
+              <span
+                v-if="group.scope === 'GLOBAL'"
+                class="type-label opacity-60 shrink-0"
+                style="font-size: 9px; letter-spacing: 0.18em;"
+              >GLOBAL (INHERITED)</span>
+              <span
+                v-else
+                class="type-label text-accent shrink-0"
+                style="font-size: 9px; letter-spacing: 0.18em;"
+              >EVENT</span>
+            </div>
+            <div class="flex items-center gap-1 shrink-0">
+              <button
+                v-if="group.scope === 'EVENT'"
+                @click="startAddTag(group.id)"
+                class="para-chip-sm px-2 py-1 type-label"
+                title="Add tag"
+              ><i class="pi pi-plus" style="font-size:0.65rem"></i></button>
+              <button
+                v-if="group.scope === 'EVENT'"
+                @click="onDeleteGroup(group)"
+                class="para-chip-sm px-2 py-1 type-label text-red-400"
+                title="Delete group"
+              ><i class="pi pi-trash" style="font-size:0.65rem"></i></button>
+              <span
+                v-else
+                class="type-prose-sm text-content-muted"
+                title="Manage in /admin"
+              >manage in /admin</span>
+            </div>
+          </div>
+
+          <!-- Inline add-tag form for this group -->
+          <div v-if="addTagForGroupId === group.id" class="flex items-center gap-2 mb-2">
+            <input
+              v-model="newFeedbackTagLabel"
+              @keyup.enter="onAddFeedbackTag(group.id)"
+              placeholder="Tag label"
+              class="input-base flex-1"
+            />
+            <button @click="onAddFeedbackTag(group.id)" class="para-chip-sm px-3 py-1 type-label text-accent">Save</button>
+            <button @click="addTagForGroupId = null" class="para-chip-sm px-3 py-1 type-label text-content-muted">Cancel</button>
+          </div>
+
+          <!-- Tag chips -->
+          <div class="flex flex-wrap gap-2">
+            <template v-for="tag in (group.tags || [])" :key="`${tag.scope}-${tag.id}`">
+              <!-- Editing mode -->
+              <div v-if="editingTagId === tag.id" class="flex items-center gap-1">
+                <input
+                  v-model="editingTagLabel"
+                  @keyup.enter="onSaveTagEdit"
+                  @keyup.escape="editingTagId = null"
+                  class="input-base py-1 px-2"
+                  style="width: 12rem;"
+                />
+                <button @click="onSaveTagEdit" class="para-chip-sm px-2 py-1 type-label text-accent">Save</button>
+                <button @click="editingTagId = null" class="para-chip-sm px-2 py-1 type-label text-content-muted">×</button>
+              </div>
+              <!-- Display mode -->
+              <span
+                v-else
+                class="para-chip-sm type-name-sm px-2.5 py-1 inline-flex items-center gap-1.5"
+                :class="tag.scope === 'EVENT' ? 'text-content-primary' : 'text-content-muted'"
+              >
+                {{ tag.label }}
+                <template v-if="tag.scope === 'EVENT'">
+                  <button @click="startEditTag(tag)" class="opacity-70 hover:opacity-100" title="Edit">
+                    <i class="pi pi-pencil" style="font-size:0.6rem"></i>
+                  </button>
+                  <button @click="onDeleteTag(tag)" class="opacity-70 hover:opacity-100 text-red-400" title="Delete">
+                    <i class="pi pi-times" style="font-size:0.65rem"></i>
+                  </button>
+                </template>
+              </span>
+            </template>
+            <span v-if="!(group.tags || []).length" class="type-prose-sm text-content-muted">
+              No tags in this group yet.
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
 
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -129,7 +129,7 @@ const revealingRef = ref(null) // name of participant whose ref code is being he
 const activeTab = ref(authStore.user?.role?.[0]?.authority === 'ROLE_HELPER' ? 'event-day' : 'setup') // 'setup' | 'event-day'
 // Setup tab is split into three sub-tabs to keep each screen scannable.
 // Persisted per event so switching events does not leak prior state.
-const setupSubTab = ref('categories') // 'categories' | 'judges' | 'links'
+const setupSubTab = ref('categories') // 'categories' | 'judges' | 'links' | 'feedback'
 // The single currently-expanded division inside the categories accordion (by eventCategoryId).
 const expandedDivisionId = ref(null)
 const toggleDivision = (id) => {
@@ -1269,7 +1269,7 @@ onMounted(async () => {
       await Promise.all(eventCategories.value.map(loadJudgesForDivision))
       // Restore per-event setup sub-tab + auto-expand the first division.
       const savedSub = localStorage.getItem(`setupSubTab_${props.eventName}`)
-      if (savedSub === 'categories' || savedSub === 'genres' || savedSub === 'judges' || savedSub === 'links') {
+      if (savedSub === 'categories' || savedSub === 'genres' || savedSub === 'judges' || savedSub === 'links' || savedSub === 'feedback') {
         setupSubTab.value = savedSub
       }
       expandedDivisionId.value = eventCategories.value[0].eventCategoryId
@@ -1688,132 +1688,6 @@ onUnmounted(() => {
       </label>
     </div>
 
-    <!-- Feedback Tags card (#157) — event-scoped taxonomy management -->
-    <div v-if="tableExist && feedbackEnabled" class="card-hover p-4 relative mt-6">
-      <div class="corner-bar-tl"></div>
-      <div class="section-rule mb-3">
-        <span class="section-rule-label">Feedback Tags</span>
-        <div class="section-rule-line"></div>
-        <button
-          v-if="!showAddFeedbackGroup"
-          @click="showAddFeedbackGroup = true; newFeedbackGroupName = ''"
-          class="para-chip-sm px-3 py-1.5 type-label shrink-0"
-        >
-          <i class="pi pi-plus mr-1" style="font-size:0.7rem"></i>Add Group
-        </button>
-      </div>
-
-      <p class="type-prose-sm text-content-muted mb-3">
-        Global tags from <span class="type-label">/admin</span> are inherited automatically.
-        Add event-specific groups and tags here — they will only appear for this event.
-      </p>
-
-      <!-- Inline add-group form -->
-      <div v-if="showAddFeedbackGroup" class="flex items-center gap-2 mb-4">
-        <input
-          v-model="newFeedbackGroupName"
-          @keyup.enter="onAddFeedbackGroup"
-          placeholder="Group name (e.g. Locking-specific)"
-          class="input-base flex-1"
-        />
-        <button @click="onAddFeedbackGroup" class="para-chip-sm px-3 py-1.5 type-label text-accent">Save</button>
-        <button @click="showAddFeedbackGroup = false; newFeedbackGroupName = ''" class="para-chip-sm px-3 py-1.5 type-label text-content-muted">Cancel</button>
-      </div>
-
-      <!-- Empty state -->
-      <p v-if="!feedbackGroups.length" class="type-prose text-content-muted">
-        No feedback groups yet — use global tags from /admin, or add event-specific ones here.
-      </p>
-
-      <!-- Group list -->
-      <div v-else class="space-y-4">
-        <div v-for="group in feedbackGroups" :key="`${group.scope}-${group.id}`" class="para-chip p-3">
-          <div class="flex items-center justify-between mb-2 gap-2">
-            <div class="flex items-center gap-2 min-w-0">
-              <span class="type-name truncate">{{ group.name }}</span>
-              <span
-                v-if="group.scope === 'GLOBAL'"
-                class="type-label opacity-60 shrink-0"
-                style="font-size: 9px; letter-spacing: 0.18em;"
-              >GLOBAL (INHERITED)</span>
-              <span
-                v-else
-                class="type-label text-accent shrink-0"
-                style="font-size: 9px; letter-spacing: 0.18em;"
-              >EVENT</span>
-            </div>
-            <div class="flex items-center gap-1 shrink-0">
-              <button
-                v-if="group.scope === 'EVENT'"
-                @click="startAddTag(group.id)"
-                class="para-chip-sm px-2 py-1 type-label"
-                title="Add tag"
-              ><i class="pi pi-plus" style="font-size:0.65rem"></i></button>
-              <button
-                v-if="group.scope === 'EVENT'"
-                @click="onDeleteGroup(group)"
-                class="para-chip-sm px-2 py-1 type-label text-red-400"
-                title="Delete group"
-              ><i class="pi pi-trash" style="font-size:0.65rem"></i></button>
-              <span
-                v-else
-                class="type-prose-sm text-content-muted"
-                title="Manage in /admin"
-              >manage in /admin</span>
-            </div>
-          </div>
-
-          <!-- Inline add-tag form for this group -->
-          <div v-if="addTagForGroupId === group.id" class="flex items-center gap-2 mb-2">
-            <input
-              v-model="newFeedbackTagLabel"
-              @keyup.enter="onAddFeedbackTag(group.id)"
-              placeholder="Tag label"
-              class="input-base flex-1"
-            />
-            <button @click="onAddFeedbackTag(group.id)" class="para-chip-sm px-3 py-1 type-label text-accent">Save</button>
-            <button @click="addTagForGroupId = null" class="para-chip-sm px-3 py-1 type-label text-content-muted">Cancel</button>
-          </div>
-
-          <!-- Tag chips -->
-          <div class="flex flex-wrap gap-2">
-            <template v-for="tag in (group.tags || [])" :key="`${tag.scope}-${tag.id}`">
-              <!-- Editing mode -->
-              <div v-if="editingTagId === tag.id" class="flex items-center gap-1">
-                <input
-                  v-model="editingTagLabel"
-                  @keyup.enter="onSaveTagEdit"
-                  @keyup.escape="editingTagId = null"
-                  class="input-base py-1 px-2"
-                  style="width: 12rem;"
-                />
-                <button @click="onSaveTagEdit" class="para-chip-sm px-2 py-1 type-label text-accent">Save</button>
-                <button @click="editingTagId = null" class="para-chip-sm px-2 py-1 type-label text-content-muted">×</button>
-              </div>
-              <!-- Display mode -->
-              <span
-                v-else
-                class="para-chip-sm type-name-sm px-2.5 py-1 inline-flex items-center gap-1.5"
-                :class="tag.scope === 'EVENT' ? 'text-content-primary' : 'text-content-muted'"
-              >
-                {{ tag.label }}
-                <template v-if="tag.scope === 'EVENT'">
-                  <button @click="startEditTag(tag)" class="opacity-70 hover:opacity-100" title="Edit">
-                    <i class="pi pi-pencil" style="font-size:0.6rem"></i>
-                  </button>
-                  <button @click="onDeleteTag(tag)" class="opacity-70 hover:opacity-100 text-red-400" title="Delete">
-                    <i class="pi pi-times" style="font-size:0.65rem"></i>
-                  </button>
-                </template>
-              </span>
-            </template>
-            <span v-if="!(group.tags || []).length" class="type-prose-sm text-content-muted">
-              No tags in this group yet.
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
 
 
   <!-- Empty state: no participants -->
@@ -1833,6 +1707,7 @@ onUnmounted(() => {
       v-for="sub in [
         { key: 'categories', label: 'Categories' },
         { key: 'judges', label: 'Judges' },
+        { key: 'feedback', label: 'Feedback Tags' },
         { key: 'links',  label: 'Share Links' },
       ]"
       :key="sub.key"
@@ -2341,6 +2216,143 @@ onUnmounted(() => {
   </div>
   </template>
   <!-- ── END Share Links sub-tab ──────────────────────────────────────────── -->
+
+
+  <!-- ── Sub-tab: Feedback Tags (#157) ────────────────────────────────────── -->
+  <template v-if="setupSubTab === 'feedback'">
+    <div v-if="tableExist && feedbackEnabled" class="card-hover p-4 relative mt-6">
+      <div class="corner-bar-tl"></div>
+      <div class="section-rule mb-3">
+        <span class="section-rule-label">Feedback Tags</span>
+        <div class="section-rule-line"></div>
+        <button
+          v-if="!showAddFeedbackGroup"
+          @click="showAddFeedbackGroup = true; newFeedbackGroupName = ''"
+          class="para-chip-sm px-3 py-1.5 type-label shrink-0"
+        >
+          <i class="pi pi-plus mr-1" style="font-size:0.7rem"></i>Add Group
+        </button>
+      </div>
+
+      <p class="type-prose-sm text-content-muted mb-3">
+        Global tags from <span class="type-label">/admin</span> are inherited automatically.
+        Add event-specific groups and tags here — they will only appear for this event.
+      </p>
+
+      <!-- Inline add-group form -->
+      <div v-if="showAddFeedbackGroup" class="flex items-center gap-2 mb-4">
+        <input
+          v-model="newFeedbackGroupName"
+          @keyup.enter="onAddFeedbackGroup"
+          placeholder="Group name (e.g. Locking-specific)"
+          class="input-base flex-1"
+        />
+        <button @click="onAddFeedbackGroup" class="para-chip-sm px-3 py-1.5 type-label text-accent">Save</button>
+        <button @click="showAddFeedbackGroup = false; newFeedbackGroupName = ''" class="para-chip-sm px-3 py-1.5 type-label text-content-muted">Cancel</button>
+      </div>
+
+      <!-- Empty state -->
+      <p v-if="!feedbackGroups.length" class="type-prose text-content-muted">
+        No feedback groups yet — use global tags from /admin, or add event-specific ones here.
+      </p>
+
+      <!-- Group list -->
+      <div v-else class="space-y-4">
+        <div v-for="group in feedbackGroups" :key="`${group.scope}-${group.id}`" class="para-chip p-3">
+          <div class="flex items-center justify-between mb-2 gap-2">
+            <div class="flex items-center gap-2 min-w-0">
+              <span class="type-name truncate">{{ group.name }}</span>
+              <span
+                v-if="group.scope === 'GLOBAL'"
+                class="type-label opacity-60 shrink-0"
+                style="font-size: 9px; letter-spacing: 0.18em;"
+              >GLOBAL (INHERITED)</span>
+              <span
+                v-else
+                class="type-label text-accent shrink-0"
+                style="font-size: 9px; letter-spacing: 0.18em;"
+              >EVENT</span>
+            </div>
+            <div class="flex items-center gap-1 shrink-0">
+              <button
+                v-if="group.scope === 'EVENT'"
+                @click="startAddTag(group.id)"
+                class="para-chip-sm px-2 py-1 type-label"
+                title="Add tag"
+              ><i class="pi pi-plus" style="font-size:0.65rem"></i></button>
+              <button
+                v-if="group.scope === 'EVENT'"
+                @click="onDeleteGroup(group)"
+                class="para-chip-sm px-2 py-1 type-label text-red-400"
+                title="Delete group"
+              ><i class="pi pi-trash" style="font-size:0.65rem"></i></button>
+              <span
+                v-else
+                class="type-prose-sm text-content-muted"
+                title="Manage in /admin"
+              >manage in /admin</span>
+            </div>
+          </div>
+
+          <!-- Inline add-tag form for this group -->
+          <div v-if="addTagForGroupId === group.id" class="flex items-center gap-2 mb-2">
+            <input
+              v-model="newFeedbackTagLabel"
+              @keyup.enter="onAddFeedbackTag(group.id)"
+              placeholder="Tag label"
+              class="input-base flex-1"
+            />
+            <button @click="onAddFeedbackTag(group.id)" class="para-chip-sm px-3 py-1 type-label text-accent">Save</button>
+            <button @click="addTagForGroupId = null" class="para-chip-sm px-3 py-1 type-label text-content-muted">Cancel</button>
+          </div>
+
+          <!-- Tag chips -->
+          <div class="flex flex-wrap gap-2">
+            <template v-for="tag in (group.tags || [])" :key="`${tag.scope}-${tag.id}`">
+              <!-- Editing mode -->
+              <div v-if="editingTagId === tag.id" class="flex items-center gap-1">
+                <input
+                  v-model="editingTagLabel"
+                  @keyup.enter="onSaveTagEdit"
+                  @keyup.escape="editingTagId = null"
+                  class="input-base py-1 px-2"
+                  style="width: 12rem;"
+                />
+                <button @click="onSaveTagEdit" class="para-chip-sm px-2 py-1 type-label text-accent">Save</button>
+                <button @click="editingTagId = null" class="para-chip-sm px-2 py-1 type-label text-content-muted">×</button>
+              </div>
+              <!-- Display mode -->
+              <span
+                v-else
+                class="para-chip-sm type-name-sm px-2.5 py-1 inline-flex items-center gap-1.5"
+                :class="tag.scope === 'EVENT' ? 'text-content-primary' : 'text-content-muted'"
+              >
+                {{ tag.label }}
+                <template v-if="tag.scope === 'EVENT'">
+                  <button @click="startEditTag(tag)" class="opacity-70 hover:opacity-100" title="Edit">
+                    <i class="pi pi-pencil" style="font-size:0.6rem"></i>
+                  </button>
+                  <button @click="onDeleteTag(tag)" class="opacity-70 hover:opacity-100 text-red-400" title="Delete">
+                    <i class="pi pi-times" style="font-size:0.65rem"></i>
+                  </button>
+                </template>
+              </span>
+            </template>
+            <span v-if="!(group.tags || []).length" class="type-prose-sm text-content-muted">
+              No tags in this group yet.
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Feedback disabled: tab content unavailable -->
+    <div v-else-if="tableExist" class="card p-6 text-center mt-6">
+      <p class="type-body text-content-muted mb-2">Feedback system is disabled for this event.</p>
+      <p class="type-prose-sm">Enable it in Event Settings above to manage event-scoped feedback tags.</p>
+    </div>
+  </template>
+  <!-- ── END Feedback Tags sub-tab ────────────────────────────────────────── -->
 
   </template>
   <!-- ── END SETUP TAB ─────────────────────────────────────────────────────── -->

--- a/BES/src/main/java/com/example/BES/controllers/AdminController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AdminController.java
@@ -32,8 +32,10 @@ import com.example.BES.dtos.admin.UpdateJudgeDto;
 import com.example.BES.dtos.admin.UpdateOrganiserTierDto;
 import com.example.BES.models.Account;
 import com.example.BES.models.Judge;
+import com.example.BES.dtos.admin.FeedbackTagOverrideDto;
 import com.example.BES.services.AccountService;
 import com.example.BES.services.AuditionFeedbackService;
+import com.example.BES.services.EventFeedbackTagService;
 import com.example.BES.services.JudgeService;
 import com.example.BES.services.ScoreService;
 
@@ -51,6 +53,9 @@ public class AdminController {
 
     @Autowired
     AuditionFeedbackService feedbackService;
+
+    @Autowired
+    EventFeedbackTagService eventFeedbackTagService;
 
     @Autowired
     AccountService accountService;
@@ -82,6 +87,11 @@ public class AdminController {
     public ResponseEntity<?> deleteFeedbackTag(@Valid @RequestBody DeleteFeedbackTagDto dto) {
         feedbackService.deleteFeedbackTag(dto.getId());
         return ResponseEntity.ok(Map.of("message", "deleted"));
+    }
+
+    @GetMapping("/feedback-tags/overrides")
+    public ResponseEntity<List<FeedbackTagOverrideDto>> getFeedbackTagOverrides() {
+        return ResponseEntity.ok(eventFeedbackTagService.getOverrides());
     }
 
     @PostMapping("/judge")

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -28,6 +28,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.BES.dtos.event.AddEventFeedbackGroupDto;
+import com.example.BES.dtos.event.AddEventFeedbackTagDto;
+import com.example.BES.dtos.event.EventFeedbackGroupDto;
+import com.example.BES.dtos.event.UpdateEventFeedbackTagDto;
 import com.example.BES.dtos.AddCategoryToEventDto;
 import com.example.BES.dtos.AddDivisionDto;
 import com.example.BES.dtos.AddEventDto;
@@ -63,6 +67,7 @@ import com.example.BES.models.Participant;
 import com.example.BES.dtos.CreatePickupCrewDto;
 import com.example.BES.dtos.GetPickupCrewDto;
 import com.example.BES.services.AuditionFeedbackService;
+import com.example.BES.services.EventFeedbackTagService;
 import com.example.BES.services.BattleGuestService;
 import com.example.BES.services.CheckinPreviewService;
 import com.example.BES.services.EventCategoryParticipantService;
@@ -128,6 +133,9 @@ public class EventController {
 
     @Autowired
     AuditionFeedbackService feedbackService;
+
+    @Autowired
+    EventFeedbackTagService eventFeedbackTagService;
 
     @Autowired
     ScoringCriteriaService scoringCriteriaService;
@@ -1044,6 +1052,84 @@ public class EventController {
             return ResponseEntity.ok(Map.of("message", "Audition numbers released"));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    // ── Event-scoped feedback taxonomy (#157) ────────────────────────────
+
+    @GetMapping("/{eventName}/feedback-tags")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'JUDGE', 'HELPER')")
+    public ResponseEntity<?> getEventFeedbackTags(@PathVariable String eventName) {
+        try {
+            List<EventFeedbackGroupDto> groups = eventFeedbackTagService.getResolvedGroups(eventName);
+            return ResponseEntity.ok(groups);
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        }
+    }
+
+    @PostMapping("/{eventName}/feedback-tags/groups")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> addEventFeedbackGroup(
+            @PathVariable String eventName,
+            @Valid @RequestBody AddEventFeedbackGroupDto dto) {
+        try {
+            return ResponseEntity.ok(eventFeedbackTagService.addEventScopedGroup(eventName, dto.getName()));
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        }
+    }
+
+    @PostMapping("/{eventName}/feedback-tags/tags")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> addEventFeedbackTag(
+            @PathVariable String eventName,
+            @Valid @RequestBody AddEventFeedbackTagDto dto) {
+        try {
+            return ResponseEntity.ok(
+                eventFeedbackTagService.addEventScopedTag(eventName, dto.getGroupId(), dto.getLabel())
+            );
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        }
+    }
+
+    @PutMapping("/{eventName}/feedback-tags/tags/{tagId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> updateEventFeedbackTag(
+            @PathVariable String eventName,
+            @PathVariable Long tagId,
+            @Valid @RequestBody UpdateEventFeedbackTagDto dto) {
+        try {
+            return ResponseEntity.ok(
+                eventFeedbackTagService.updateEventScopedTag(eventName, tagId, dto.getLabel())
+            );
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        }
+    }
+
+    @DeleteMapping("/{eventName}/feedback-tags/tags/{tagId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> deleteEventFeedbackTag(
+            @PathVariable String eventName,
+            @PathVariable Long tagId) {
+        try {
+            return ResponseEntity.ok(eventFeedbackTagService.deleteEventScopedTag(eventName, tagId));
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        }
+    }
+
+    @DeleteMapping("/{eventName}/feedback-tags/groups/{groupId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    public ResponseEntity<?> deleteEventFeedbackGroup(
+            @PathVariable String eventName,
+            @PathVariable Long groupId) {
+        try {
+            return ResponseEntity.ok(eventFeedbackTagService.deleteEventScopedGroup(eventName, groupId));
+        } catch (org.springframework.web.server.ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
         }
     }
 }

--- a/BES/src/main/java/com/example/BES/dtos/admin/FeedbackTagOverrideDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/admin/FeedbackTagOverrideDto.java
@@ -1,0 +1,19 @@
+package com.example.BES.dtos.admin;
+
+import java.util.List;
+
+public class FeedbackTagOverrideDto {
+    private Long globalGroupId;
+    private String groupName;
+    private List<String> overridingEventNames;
+
+    public FeedbackTagOverrideDto(Long globalGroupId, String groupName, List<String> overridingEventNames) {
+        this.globalGroupId = globalGroupId;
+        this.groupName = groupName;
+        this.overridingEventNames = overridingEventNames;
+    }
+
+    public Long getGlobalGroupId() { return globalGroupId; }
+    public String getGroupName() { return groupName; }
+    public List<String> getOverridingEventNames() { return overridingEventNames; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/event/AddEventFeedbackGroupDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/event/AddEventFeedbackGroupDto.java
@@ -1,0 +1,12 @@
+package com.example.BES.dtos.event;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class AddEventFeedbackGroupDto {
+    @NotBlank @Size(max = 255)
+    private String name;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/event/AddEventFeedbackTagDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/event/AddEventFeedbackTagDto.java
@@ -1,0 +1,17 @@
+package com.example.BES.dtos.event;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class AddEventFeedbackTagDto {
+    @NotNull
+    private Long groupId;
+    @NotBlank @Size(max = 255)
+    private String label;
+
+    public Long getGroupId() { return groupId; }
+    public String getLabel() { return label; }
+    public void setGroupId(Long groupId) { this.groupId = groupId; }
+    public void setLabel(String label) { this.label = label; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/event/EventFeedbackGroupDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/event/EventFeedbackGroupDto.java
@@ -1,0 +1,22 @@
+package com.example.BES.dtos.event;
+
+import java.util.List;
+
+public class EventFeedbackGroupDto {
+    private Long id;
+    private String name;
+    private String scope; // "GLOBAL" or "EVENT"
+    private List<EventFeedbackTagDto> tags;
+
+    public EventFeedbackGroupDto(Long id, String name, String scope, List<EventFeedbackTagDto> tags) {
+        this.id = id;
+        this.name = name;
+        this.scope = scope;
+        this.tags = tags;
+    }
+
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public String getScope() { return scope; }
+    public List<EventFeedbackTagDto> getTags() { return tags; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/event/EventFeedbackTagDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/event/EventFeedbackTagDto.java
@@ -1,0 +1,20 @@
+package com.example.BES.dtos.event;
+
+public class EventFeedbackTagDto {
+    private Long id;
+    private String label;
+    private Long groupId;
+    private String scope; // "GLOBAL" or "EVENT"
+
+    public EventFeedbackTagDto(Long id, String label, Long groupId, String scope) {
+        this.id = id;
+        this.label = label;
+        this.groupId = groupId;
+        this.scope = scope;
+    }
+
+    public Long getId() { return id; }
+    public String getLabel() { return label; }
+    public Long getGroupId() { return groupId; }
+    public String getScope() { return scope; }
+}

--- a/BES/src/main/java/com/example/BES/dtos/event/UpdateEventFeedbackTagDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/event/UpdateEventFeedbackTagDto.java
@@ -1,0 +1,12 @@
+package com.example.BES.dtos.event;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class UpdateEventFeedbackTagDto {
+    @NotBlank @Size(max = 255)
+    private String label;
+
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+}

--- a/BES/src/main/java/com/example/BES/models/FeedbackTag.java
+++ b/BES/src/main/java/com/example/BES/models/FeedbackTag.java
@@ -20,4 +20,8 @@ public class FeedbackTag {
     @ManyToOne
     @JoinColumn(name = "group_id", nullable = false)
     private FeedbackTagGroup group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
 }

--- a/BES/src/main/java/com/example/BES/models/FeedbackTagGroup.java
+++ b/BES/src/main/java/com/example/BES/models/FeedbackTagGroup.java
@@ -19,6 +19,10 @@ public class FeedbackTagGroup {
 
     private String name;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FeedbackTag> tags;
 }

--- a/BES/src/main/java/com/example/BES/respositories/FeedbackTagGroupRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/FeedbackTagGroupRepository.java
@@ -4,6 +4,14 @@ import com.example.BES.models.FeedbackTagGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface FeedbackTagGroupRepository extends JpaRepository<FeedbackTagGroup, Long> {
+
+    List<FeedbackTagGroup> findByEventIsNull();
+
+    List<FeedbackTagGroup> findByEventEventId(Long eventId);
+
+    List<FeedbackTagGroup> findByEventEventIdOrEventIsNull(Long eventId);
 }

--- a/BES/src/main/java/com/example/BES/respositories/FeedbackTagRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/FeedbackTagRepository.java
@@ -10,4 +10,10 @@ import java.util.List;
 @Repository
 public interface FeedbackTagRepository extends JpaRepository<FeedbackTag, Long> {
     List<FeedbackTag> findByGroup(FeedbackTagGroup group);
+
+    List<FeedbackTag> findByEventIsNull();
+
+    List<FeedbackTag> findByEventEventId(Long eventId);
+
+    List<FeedbackTag> findByEventEventIdOrEventIsNull(Long eventId);
 }

--- a/BES/src/main/java/com/example/BES/services/AuditionFeedbackService.java
+++ b/BES/src/main/java/com/example/BES/services/AuditionFeedbackService.java
@@ -58,7 +58,9 @@ public class AuditionFeedbackService {
     }
 
     public List<GetFeedbackGroupDto> getAllFeedbackGroups() {
-        List<FeedbackTagGroup> groups = tagGroupRepo.findAll();
+        // Admin sees only global (event_id IS NULL) groups. Event-scoped groups are
+        // managed on EventDetails via EventFeedbackTagService.
+        List<FeedbackTagGroup> groups = tagGroupRepo.findByEventIsNull();
         List<GetFeedbackGroupDto> result = new ArrayList<>();
         for (FeedbackTagGroup g : groups) {
             List<GetFeedbackTagDto> tagDtos = new ArrayList<>();

--- a/BES/src/main/java/com/example/BES/services/EventFeedbackTagService.java
+++ b/BES/src/main/java/com/example/BES/services/EventFeedbackTagService.java
@@ -1,0 +1,151 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.event.EventFeedbackGroupDto;
+import com.example.BES.dtos.event.EventFeedbackTagDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.FeedbackTag;
+import com.example.BES.models.FeedbackTagGroup;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.FeedbackTagGroupRepository;
+import com.example.BES.respositories.FeedbackTagRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class EventFeedbackTagService {
+
+    static final String SCOPE_GLOBAL = "GLOBAL";
+    static final String SCOPE_EVENT = "EVENT";
+
+    @Autowired
+    EventRepo eventRepo;
+
+    @Autowired
+    FeedbackTagGroupRepository tagGroupRepo;
+
+    @Autowired
+    FeedbackTagRepository tagRepo;
+
+    /**
+     * Returns the resolved taxonomy for an event: global groups + event-scoped groups.
+     * If a global group and an event-scoped group share a (case-insensitive) name, the
+     * event-scoped group fully replaces the global group — its tags are the only tags
+     * shown for that group name.
+     */
+    public List<EventFeedbackGroupDto> getResolvedGroups(String eventName) {
+        Event event = requireEvent(eventName);
+
+        Map<String, EventFeedbackGroupDto> byName = new LinkedHashMap<>();
+
+        for (FeedbackTagGroup g : tagGroupRepo.findByEventIsNull()) {
+            byName.put(g.getName().toLowerCase(), toDto(g, SCOPE_GLOBAL));
+        }
+        // Event-scoped groups override global groups with the same name.
+        for (FeedbackTagGroup g : tagGroupRepo.findByEventEventId(event.getEventId())) {
+            byName.put(g.getName().toLowerCase(), toDto(g, SCOPE_EVENT));
+        }
+        return new ArrayList<>(byName.values());
+    }
+
+    public List<EventFeedbackGroupDto> addEventScopedGroup(String eventName, String name) {
+        Event event = requireEvent(eventName);
+        FeedbackTagGroup group = new FeedbackTagGroup();
+        group.setName(name);
+        group.setEvent(event);
+        tagGroupRepo.save(group);
+        return getResolvedGroups(eventName);
+    }
+
+    public List<EventFeedbackGroupDto> addEventScopedTag(String eventName, Long groupId, String label) {
+        Event event = requireEvent(eventName);
+        FeedbackTagGroup group = tagGroupRepo.findById(groupId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found"));
+        if (group.getEvent() == null || !group.getEvent().getEventId().equals(event.getEventId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot add a tag to a group that is not event-scoped to this event");
+        }
+        FeedbackTag tag = new FeedbackTag();
+        tag.setLabel(label);
+        tag.setGroup(group);
+        tag.setEvent(event);
+        tagRepo.save(tag);
+        return getResolvedGroups(eventName);
+    }
+
+    public List<EventFeedbackGroupDto> updateEventScopedTag(String eventName, Long tagId, String label) {
+        Event event = requireEvent(eventName);
+        FeedbackTag tag = tagRepo.findById(tagId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Tag not found"));
+        requireOwnedByEvent(tag, event);
+        tag.setLabel(label);
+        tagRepo.save(tag);
+        return getResolvedGroups(eventName);
+    }
+
+    public List<EventFeedbackGroupDto> deleteEventScopedTag(String eventName, Long tagId) {
+        Event event = requireEvent(eventName);
+        FeedbackTag tag = tagRepo.findById(tagId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Tag not found"));
+        requireOwnedByEvent(tag, event);
+        tagRepo.delete(tag);
+        return getResolvedGroups(eventName);
+    }
+
+    public List<EventFeedbackGroupDto> deleteEventScopedGroup(String eventName, Long groupId) {
+        Event event = requireEvent(eventName);
+        FeedbackTagGroup group = tagGroupRepo.findById(groupId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found"));
+        requireOwnedByEvent(group, event);
+        tagGroupRepo.delete(group);
+        return getResolvedGroups(eventName);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private Event requireEvent(String eventName) {
+        return eventRepo.findByEventName(eventName)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found: " + eventName));
+    }
+
+    private void requireOwnedByEvent(FeedbackTag tag, Event event) {
+        if (tag.getEvent() == null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot modify a global tag via event endpoint — use /admin");
+        }
+        if (!tag.getEvent().getEventId().equals(event.getEventId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Tag belongs to a different event");
+        }
+    }
+
+    private void requireOwnedByEvent(FeedbackTagGroup group, Event event) {
+        if (group.getEvent() == null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot modify a global group via event endpoint — use /admin");
+        }
+        if (!group.getEvent().getEventId().equals(event.getEventId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Group belongs to a different event");
+        }
+    }
+
+    private EventFeedbackGroupDto toDto(FeedbackTagGroup group, String scope) {
+        List<EventFeedbackTagDto> tags = new ArrayList<>();
+        if (group.getTags() != null) {
+            for (FeedbackTag t : group.getTags()) {
+                tags.add(new EventFeedbackTagDto(
+                        t.getId(),
+                        t.getLabel(),
+                        group.getId(),
+                        scope
+                ));
+            }
+        }
+        return new EventFeedbackGroupDto(group.getId(), group.getName(), scope, tags);
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/EventFeedbackTagService.java
+++ b/BES/src/main/java/com/example/BES/services/EventFeedbackTagService.java
@@ -1,5 +1,6 @@
 package com.example.BES.services;
 
+import com.example.BES.dtos.admin.FeedbackTagOverrideDto;
 import com.example.BES.dtos.event.EventFeedbackGroupDto;
 import com.example.BES.dtos.event.EventFeedbackTagDto;
 import com.example.BES.models.Event;
@@ -14,8 +15,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 @Service
@@ -52,6 +55,40 @@ public class EventFeedbackTagService {
             byName.put(g.getName().toLowerCase(), toDto(g, SCOPE_EVENT));
         }
         return new ArrayList<>(byName.values());
+    }
+
+    /**
+     * For each global group whose name is also used by at least one event-scoped group,
+     * returns the global group id + name + list of event names that override it.
+     * Informational only — used by AdminPage to show an "Overridden in N event(s)" chip.
+     */
+    public List<FeedbackTagOverrideDto> getOverrides() {
+        List<FeedbackTagGroup> globalGroups = tagGroupRepo.findByEventIsNull();
+        Map<String, FeedbackTagGroup> globalByName = new HashMap<>();
+        for (FeedbackTagGroup g : globalGroups) {
+            globalByName.put(g.getName().toLowerCase(Locale.ROOT), g);
+        }
+
+        // Map: global group id → set of event names that override it.
+        Map<Long, List<String>> overridesByGlobalId = new LinkedHashMap<>();
+        for (FeedbackTagGroup scoped : tagGroupRepo.findAll()) {
+            if (scoped.getEvent() == null) continue;
+            FeedbackTagGroup match = globalByName.get(scoped.getName().toLowerCase(Locale.ROOT));
+            if (match == null) continue;
+            overridesByGlobalId
+                    .computeIfAbsent(match.getId(), k -> new ArrayList<>())
+                    .add(scoped.getEvent().getEventName());
+        }
+
+        List<FeedbackTagOverrideDto> result = new ArrayList<>();
+        for (Map.Entry<Long, List<String>> entry : overridesByGlobalId.entrySet()) {
+            FeedbackTagGroup global = globalGroups.stream()
+                    .filter(g -> g.getId().equals(entry.getKey()))
+                    .findFirst().orElse(null);
+            if (global == null) continue;
+            result.add(new FeedbackTagOverrideDto(global.getId(), global.getName(), entry.getValue()));
+        }
+        return result;
     }
 
     public List<EventFeedbackGroupDto> addEventScopedGroup(String eventName, String name) {

--- a/BES/src/main/resources/db/migration/V44__add_event_scope_to_feedback_taxonomy.sql
+++ b/BES/src/main/resources/db/migration/V44__add_event_scope_to_feedback_taxonomy.sql
@@ -1,0 +1,13 @@
+-- V44__add_event_scope_to_feedback_taxonomy.sql
+-- Adds optional event scoping to the feedback taxonomy (#157, Task 1).
+-- event_id IS NULL  → global tag/group (managed on /admin, current behaviour)
+-- event_id NOT NULL → event-scoped (managed on EventDetails, future Task 4)
+
+ALTER TABLE feedback_tag_group
+    ADD COLUMN event_id BIGINT NULL REFERENCES event(event_id) ON DELETE CASCADE;
+
+ALTER TABLE feedback_tag
+    ADD COLUMN event_id BIGINT NULL REFERENCES event(event_id) ON DELETE CASCADE;
+
+CREATE INDEX idx_feedback_tag_group_event_id ON feedback_tag_group(event_id);
+CREATE INDEX idx_feedback_tag_event_id       ON feedback_tag(event_id);

--- a/BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/AuditionFeedbackServiceTest.java
@@ -47,7 +47,7 @@ class AuditionFeedbackServiceTest {
         tag.setLabel("High");
         tag.setGroup(group);
         group.setTags(List.of(tag));
-        when(tagGroupRepo.findAll()).thenReturn(List.of(group));
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of(group));
 
         List<GetFeedbackGroupDto> result = service.getAllFeedbackGroups();
 
@@ -62,7 +62,7 @@ class AuditionFeedbackServiceTest {
         group.setId(1L);
         group.setName("Energy");
         group.setTags(new ArrayList<>());
-        when(tagGroupRepo.findAll()).thenReturn(List.of(group));
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of(group));
 
         service.addFeedbackGroup("Energy");
 
@@ -78,7 +78,7 @@ class AuditionFeedbackServiceTest {
     @Test
     void addFeedbackTag_returnsAllGroupsWhenGroupNotFound() {
         when(tagGroupRepo.findById(99L)).thenReturn(Optional.empty());
-        when(tagGroupRepo.findAll()).thenReturn(List.of());
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of());
 
         List<GetFeedbackGroupDto> result = service.addFeedbackTag(99L, "label");
 

--- a/BES/src/test/java/com/example/BES/services/EventFeedbackTagServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/EventFeedbackTagServiceTest.java
@@ -1,0 +1,183 @@
+package com.example.BES.services;
+
+import com.example.BES.dtos.event.EventFeedbackGroupDto;
+import com.example.BES.models.Event;
+import com.example.BES.models.FeedbackTag;
+import com.example.BES.models.FeedbackTagGroup;
+import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.FeedbackTagGroupRepository;
+import com.example.BES.respositories.FeedbackTagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventFeedbackTagServiceTest {
+
+    @Mock EventRepo eventRepo;
+    @Mock FeedbackTagGroupRepository tagGroupRepo;
+    @Mock FeedbackTagRepository tagRepo;
+    @InjectMocks EventFeedbackTagService service;
+
+    private Event event;
+
+    @BeforeEach
+    void setUp() {
+        event = new Event();
+        event.setEventId(7L);
+        event.setEventName("Fest");
+    }
+
+    private FeedbackTagGroup group(Long id, String name, Event owner, FeedbackTag... tags) {
+        FeedbackTagGroup g = new FeedbackTagGroup();
+        g.setId(id);
+        g.setName(name);
+        g.setEvent(owner);
+        g.setTags(new ArrayList<>(List.of(tags)));
+        return g;
+    }
+
+    private FeedbackTag tag(Long id, String label, FeedbackTagGroup g, Event owner) {
+        FeedbackTag t = new FeedbackTag();
+        t.setId(id);
+        t.setLabel(label);
+        t.setGroup(g);
+        t.setEvent(owner);
+        return t;
+    }
+
+    @Test
+    void getResolvedGroups_returnsGlobalOnlyWhenNoEventScoped() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        FeedbackTagGroup global = group(1L, "Strengths", null);
+        global.setTags(List.of(tag(10L, "Sharp", global, null)));
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of(global));
+        when(tagGroupRepo.findByEventEventId(7L)).thenReturn(List.of());
+
+        List<EventFeedbackGroupDto> result = service.getResolvedGroups("Fest");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Strengths");
+        assertThat(result.get(0).getScope()).isEqualTo("GLOBAL");
+        assertThat(result.get(0).getTags().get(0).getScope()).isEqualTo("GLOBAL");
+    }
+
+    @Test
+    void getResolvedGroups_eventScopedOverridesGlobalByName() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        FeedbackTagGroup global = group(1L, "Strengths", null);
+        global.setTags(List.of(tag(10L, "Sharp", global, null)));
+        FeedbackTagGroup scoped = group(2L, "Strengths", event);
+        scoped.setTags(List.of(tag(20L, "Power moves", scoped, event)));
+
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of(global));
+        when(tagGroupRepo.findByEventEventId(7L)).thenReturn(List.of(scoped));
+
+        List<EventFeedbackGroupDto> result = service.getResolvedGroups("Fest");
+
+        // event-scoped wins by name — exactly one group, scoped, with scoped tag only
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(2L);
+        assertThat(result.get(0).getScope()).isEqualTo("EVENT");
+        assertThat(result.get(0).getTags()).hasSize(1);
+        assertThat(result.get(0).getTags().get(0).getLabel()).isEqualTo("Power moves");
+    }
+
+    @Test
+    void getResolvedGroups_unionsDistinctNames() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        FeedbackTagGroup global = group(1L, "Strengths", null);
+        FeedbackTagGroup scoped = group(2L, "Hip-hop only", event);
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of(global));
+        when(tagGroupRepo.findByEventEventId(7L)).thenReturn(List.of(scoped));
+
+        List<EventFeedbackGroupDto> result = service.getResolvedGroups("Fest");
+
+        assertThat(result).extracting(EventFeedbackGroupDto::getName)
+                .containsExactlyInAnyOrder("Strengths", "Hip-hop only");
+    }
+
+    @Test
+    void getResolvedGroups_throws404WhenEventMissing() {
+        when(eventRepo.findByEventName("Nope")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getResolvedGroups("Nope"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Event not found");
+    }
+
+    @Test
+    void addEventScopedGroup_savesWithEventOwner() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of());
+        when(tagGroupRepo.findByEventEventId(7L)).thenReturn(List.of());
+
+        service.addEventScopedGroup("Fest", "Locking-specific");
+
+        verify(tagGroupRepo).save(argThat(g ->
+                "Locking-specific".equals(g.getName()) && event.equals(g.getEvent())
+        ));
+    }
+
+    @Test
+    void addEventScopedTag_rejectsGlobalGroup() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        FeedbackTagGroup global = group(1L, "Strengths", null);
+        when(tagGroupRepo.findById(1L)).thenReturn(Optional.of(global));
+
+        assertThatThrownBy(() -> service.addEventScopedTag("Fest", 1L, "should fail"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("event-scoped");
+        verify(tagRepo, never()).save(any());
+    }
+
+    @Test
+    void updateEventScopedTag_rejectsGlobalTag() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        FeedbackTag globalTag = tag(10L, "Sharp", null, null);
+        when(tagRepo.findById(10L)).thenReturn(Optional.of(globalTag));
+
+        assertThatThrownBy(() -> service.updateEventScopedTag("Fest", 10L, "renamed"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("global tag");
+        verify(tagRepo, never()).save(any());
+    }
+
+    @Test
+    void deleteEventScopedTag_rejectsTagFromDifferentEvent() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        Event other = new Event();
+        other.setEventId(99L);
+        FeedbackTag otherTag = tag(10L, "Sharp", null, other);
+        when(tagRepo.findById(10L)).thenReturn(Optional.of(otherTag));
+
+        assertThatThrownBy(() -> service.deleteEventScopedTag("Fest", 10L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("different event");
+        verify(tagRepo, never()).delete(any());
+    }
+
+    @Test
+    void deleteEventScopedGroup_deletesWhenOwned() {
+        when(eventRepo.findByEventName("Fest")).thenReturn(Optional.of(event));
+        FeedbackTagGroup scoped = group(2L, "Hip-hop only", event);
+        when(tagGroupRepo.findById(2L)).thenReturn(Optional.of(scoped));
+        when(tagGroupRepo.findByEventIsNull()).thenReturn(List.of());
+        when(tagGroupRepo.findByEventEventId(7L)).thenReturn(List.of());
+
+        service.deleteEventScopedGroup("Fest", 2L);
+
+        verify(tagGroupRepo).delete(scoped);
+    }
+}


### PR DESCRIPTION
Closes #157.

Implements per-event feedback groups and tags so each event can extend (or override) the global taxonomy without affecting other events.

## Summary

- **DB**: V44 adds nullable `event_id` (FK to `event`, `ON DELETE CASCADE`, indexed) to `feedback_tag_group` and `feedback_tag`. `event_id IS NULL` = global (managed in `/admin`), `event_id NOT NULL` = event-scoped (managed in EventDetails).
- **Backend**: new `EventFeedbackTagService` merges global + scoped — when both share a (case-insensitive) group name, event-scoped wins and fully replaces global for that name. New endpoints under `/api/v1/event/{name}/feedback-tags` (GET, POST groups/tags, PUT/DELETE tags, DELETE groups). All mutations reject attempts to modify global rows with `409 Conflict`.
- **Admin protection**: `AuditionFeedbackService.getAllFeedbackGroups()` now reads only `WHERE event_id IS NULL` so event-scoped tags don't leak into the `/admin` tab.
- **Judge UI**: `FeedbackPopout` reads via the new event endpoint and shows a small `EVENT` badge on event-scoped chips. Events with no scoped tags look identical to before.
- **Organiser UI**: new **Feedback Tags** sub-tab on EventDetails Setup (next to Categories, Judges, Share Links) with inline add-group / add-tag / edit / delete; inherited global rows are read-only with `manage in /admin`.
- **Admin UI**: `/admin` Feedback Tags tab now shows an `OVERRIDDEN IN N EVENT(S)` chip on global groups that are overridden by at least one event-scoped group of the same name (tooltip lists the event names).

Task 6 (event-delete dialog warning) is deferred — there is no delete-event flow today; the V44 `ON DELETE CASCADE` already handles data integrity when one is built. See issue #157.

## Test plan

- [ ] Backend: \`mvn test\` (224 tests green, +9 new in \`EventFeedbackTagServiceTest\`)
- [ ] Frontend: \`npm test\` (123 tests pass) and \`npm run build\` clean
- [ ] Flyway V44 applies cleanly on Postgres on container boot
- [ ] As Organiser, add an event-scoped group on EventDetails Setup → Feedback Tags tab → tag shows up in FeedbackPopout for judges of that event with an EVENT badge, and does NOT appear on other events
- [ ] As Admin, override a global group from one event → the matching global row on \`/admin\` shows the OVERRIDDEN chip with the event listed
- [ ] As Judge on an event with zero event-scoped tags, FeedbackPopout looks identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)