### PR TITLE
feat: Demo Account — sandboxed try-before-you-buy environment

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, onUnmounted, ref, watch, provide } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { logout, whoami, getAppConfig, sendHeartbeat } from './utils/api'
 import { createClient, deactivateClient, subscribeToChannel } from './utils/websocket'
 import { useAuthStore } from './utils/auth'
@@ -154,8 +154,6 @@ function toggleTheme() {
 watch(route, () => {
   panelOpen.value = false
 })
-
-provide('demoEnabled', demoEnabled)
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 let heartbeatTimer = null

--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch, provide } from 'vue'
 import { logout, whoami, getAppConfig, sendHeartbeat } from './utils/api'
 import { createClient, deactivateClient, subscribeToChannel } from './utils/websocket'
 import { useAuthStore } from './utils/auth'
@@ -18,6 +18,7 @@ const showModal    = ref(false)
 
 const accentServer = ref('#ffffff')
 const wsAccentClient = ref(null)
+const demoEnabled = ref(false)
 
 const authStore = useAuthStore()
 const { battleEnabled } = useTierAccess()
@@ -154,6 +155,8 @@ watch(route, () => {
   panelOpen.value = false
 })
 
+provide('demoEnabled', demoEnabled)
+
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 let heartbeatTimer = null
 
@@ -183,6 +186,7 @@ onMounted(async () => {
   try {
     const cfg = await getAppConfig()
     if (cfg?.accentColor) applyAccent(cfg.accentColor)
+    if (cfg?.demoEnabled !== undefined) demoEnabled.value = cfg.demoEnabled
   } catch {
     // server not ready — keep default
   }
@@ -190,6 +194,7 @@ onMounted(async () => {
   wsAccentClient.value = c
   subscribeToChannel(c, '/topic/app-config', (msg) => {
     if (msg?.accentColor) applyAccent(msg.accentColor)
+    if (msg?.demoEnabled !== undefined) demoEnabled.value = msg.demoEnabled
   })
   document.addEventListener('keydown', handleKeydown)
 })

--- a/BES-frontend/src/components/DemoRolePicker.vue
+++ b/BES-frontend/src/components/DemoRolePicker.vue
@@ -1,0 +1,133 @@
+<template>
+  <Teleport to="body">
+    <div class="modal-backdrop" @click="$emit('back')">
+      <div class="role-picker" @click.stop>
+        <h2 class="picker-title">Try Kyrove as&hellip;</h2>
+
+        <div class="role-cards">
+          <button
+            v-for="role in roles"
+            :key="role.key"
+            class="role-card"
+            @click="$emit('select', role.key)"
+          >
+            <span class="role-icon">{{ role.icon }}</span>
+            <span class="role-name">{{ role.label }}</span>
+            <span class="role-desc type-prose-sm">{{ role.description }}</span>
+          </button>
+        </div>
+
+        <p class="type-prose-sm picker-hint">Tap outside to go back</p>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+defineEmits(['select', 'back'])
+
+const roles = [
+  {
+    key: 'EMCEE',
+    icon: '\u{1F3A4}',
+    label: 'Emcee',
+    description: 'Run audition rounds, view scoreboard, announce results'
+  },
+  {
+    key: 'JUDGE',
+    icon: '\u{2696}\u{FE0F}',
+    label: 'Judge',
+    description: 'Score participants, submit feedback, use the keypad'
+  },
+  {
+    key: 'HELPER',
+    icon: '\u{1F6CE}\u{FE0F}',
+    label: 'Helper',
+    description: 'Check-in participants, verify details, see QR codes'
+  }
+]
+</script>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.role-picker {
+  max-width: 680px;
+  width: 90vw;
+  padding: 2rem;
+  background: var(--surface-800);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+}
+
+.picker-title {
+  font-family: var(--font-sans);
+  font-size: 20px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.role-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .role-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.role-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+  color: #fff;
+}
+
+.role-card:hover {
+  background: rgba(255,255,255,0.08);
+  border-color: var(--accent-muted);
+}
+
+.role-icon {
+  font-size: 32px;
+}
+
+.role-name {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent-color);
+}
+
+.role-desc {
+  text-align: center;
+  color: rgba(255,255,255,0.45);
+}
+
+.picker-hint {
+  margin-top: 1.5rem;
+  color: rgba(255,255,255,0.3);
+  text-align: center;
+}
+</style>

--- a/BES-frontend/src/components/DemoRolePicker.vue
+++ b/BES-frontend/src/components/DemoRolePicker.vue
@@ -52,18 +52,20 @@ const roles = [
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.9);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
+  padding: 1rem;
 }
 
 .role-picker {
   max-width: 680px;
   width: 90vw;
   padding: 2rem;
-  background: var(--surface-800);
+  background: #1a1a1a;
+  border: 1px solid rgba(255,255,255,0.1);
   clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
 }
 

--- a/BES-frontend/src/components/__tests__/DemoRolePicker.test.js
+++ b/BES-frontend/src/components/__tests__/DemoRolePicker.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DemoRolePicker from '../DemoRolePicker.vue'
+
+function createWrapper() {
+  return mount(DemoRolePicker, {
+    global: {
+      stubs: { Teleport: true },
+    },
+  })
+}
+
+describe('DemoRolePicker', () => {
+  it('renders three role cards', () => {
+    const wrapper = createWrapper()
+    const cards = wrapper.findAll('.role-card')
+    expect(cards).toHaveLength(3)
+  })
+
+  it('emits select with EMCEE when Emcee card is clicked', async () => {
+    const wrapper = createWrapper()
+    const cards = wrapper.findAll('.role-card')
+    await cards[0].trigger('click')
+    expect(wrapper.emitted('select')).toBeTruthy()
+    expect(wrapper.emitted('select')[0]).toEqual(['EMCEE'])
+  })
+
+  it('emits select with JUDGE when Judge card is clicked', async () => {
+    const wrapper = createWrapper()
+    const cards = wrapper.findAll('.role-card')
+    await cards[1].trigger('click')
+    expect(wrapper.emitted('select')[0]).toEqual(['JUDGE'])
+  })
+
+  it('emits select with HELPER when Helper card is clicked', async () => {
+    const wrapper = createWrapper()
+    const cards = wrapper.findAll('.role-card')
+    await cards[2].trigger('click')
+    expect(wrapper.emitted('select')[0]).toEqual(['HELPER'])
+  })
+
+  it('emits back when backdrop is clicked', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.modal-backdrop').trigger('click')
+    expect(wrapper.emitted('back')).toBeTruthy()
+  })
+
+  it('does not emit back when role card is clicked', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.role-card').trigger('click')
+    expect(wrapper.emitted('back')).toBeFalsy()
+    expect(wrapper.emitted('select')).toBeTruthy()
+  })
+})

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1754,3 +1754,51 @@ export const deleteEventFeedbackGroup = async (eventName, groupId) => {
     return await res.json()
   } catch (e) { console.error(e); return null }
 }
+
+/**
+ * Start a demo session with the given passcode and role.
+ * @param {string} passcode
+ * @param {string} role - "EMCEE", "JUDGE", or "HELPER"
+ * @returns {Promise<object>} - { authenticated, role, eventId, eventName, judgeId?, judgeName? }
+ */
+export const startDemo = async (passcode, role) => {
+  const res = await fetch('/api/v1/demo/start', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ passcode, role })
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.error || 'Failed to start demo')
+  }
+  return res.json()
+}
+
+/**
+ * Get demo config (admin only).
+ * @returns {Promise<object>} - { demoEnabled, passcode }
+ */
+export const getDemoConfig = async () => {
+  const res = await fetch('/api/v1/admin/demo/config', {
+    credentials: 'include'
+  })
+  if (!res.ok) throw new Error('Failed to fetch demo config')
+  return res.json()
+}
+
+/**
+ * Update demo config (admin only).
+ * @param {object} config - { demoEnabled, regeneratePasscode? }
+ * @returns {Promise<object>} - updated { demoEnabled, passcode }
+ */
+export const updateDemoConfig = async (config) => {
+  const res = await fetch('/api/v1/admin/demo/config', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config)
+  })
+  if (!res.ok) throw new Error('Failed to update demo config')
+  return res.json()
+}

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -192,6 +192,29 @@ async function regeneratePasscode() {
   await loadDemoConfig()
 }
 
+// ── Demo Sandbox Management ─────────────────────────────────
+const sandboxes = ref([])
+
+async function loadSandboxes() {
+  try {
+    const res = await fetch('/api/v1/admin/demo/sandboxes', { credentials: 'include' })
+    sandboxes.value = res.ok ? await res.json() : []
+  } catch { sandboxes.value = [] }
+}
+
+async function purgeSandbox(eventId) {
+  await fetch(`/api/v1/admin/demo/sandboxes/${eventId}`, { method: 'DELETE', credentials: 'include' })
+  await loadSandboxes()
+  await loadDemoConfig()
+}
+
+async function purgeAllSandboxes() {
+  if (!confirm('Delete all demo sandboxes?')) return
+  await fetch('/api/v1/admin/demo/sandboxes', { method: 'DELETE', credentials: 'include' })
+  await loadSandboxes()
+  await loadDemoConfig()
+}
+
 onMounted(async () => {
   events.value = await fetchAllEvents() ?? []
   images.value = await getAllImages() ?? []
@@ -201,6 +224,7 @@ onMounted(async () => {
   const cfg = await getAppConfig()
   accentInput.value = cfg?.accentColor ?? '#ffffff'
   loadDemoConfig()
+  loadSandboxes()
 })
 </script>
 
@@ -540,9 +564,28 @@ onMounted(async () => {
             </div>
           </div>
 
-          <p class="type-prose-sm text-content-muted">
+          <p class="type-prose-sm text-content-muted mb-3">
             Active sandboxes: {{ demoConfig.activeSandboxes }}
           </p>
+
+          <!-- Sandbox list -->
+          <div v-if="sandboxes.length" class="border-t border-surface-600 pt-3 mt-3">
+            <div class="flex items-center justify-between mb-3">
+              <span class="type-label text-content-muted">Sandboxes</span>
+              <button @click="purgeAllSandboxes" class="para-chip-sm px-3 py-1 min-h-[36px] text-red-400 border-red-400/30">
+                Purge All
+              </button>
+            </div>
+            <div v-for="s in sandboxes" :key="s.eventId" class="flex items-center justify-between py-2 border-b border-surface-600/50 last:border-b-0">
+              <div>
+                <span class="type-body block">{{ s.eventName }}</span>
+                <span class="type-prose-sm text-content-muted">{{ s.activeTokens }} active token(s)</span>
+              </div>
+              <button @click="purgeSandbox(s.eventId)" class="para-chip-sm px-3 py-1 min-h-[36px] text-red-400 border-red-400/30">
+                Purge
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -3,7 +3,7 @@ import { deleteImage, deleteScore, getAllImages, getFeedbackGroups, addFeedbackG
 import { checkInputNull } from '@/utils/utils';
 import { computed, onMounted, ref } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { fetchAllEvents, getAppConfig, postAppConfig } from '@/utils/api';
+import { fetchAllEvents, getAppConfig, postAppConfig, getDemoConfig, updateDemoConfig } from '@/utils/api';
 
 const modalTitle = ref("")
 const modalMessage = ref("")
@@ -102,7 +102,7 @@ const isEventAssigned = (organiser, eventId) => {
 
 const accentInput = ref('#ffffff')
 const activeTab = ref('scores')
-const tabs = ref(['scores', 'feedback', 'images', 'theme', 'organisers'])
+const tabs = ref(['scores', 'feedback', 'images', 'theme', 'organisers', 'demo'])
 
 const confirmResetScore = (id, title, message) => {
   modalTitle.value = title
@@ -168,6 +168,31 @@ const saveAccent = async () => {
   await postAppConfig(accentInput.value)
 }
 
+// ── Demo Settings ──────────────────────────────────────────
+const demoConfig = ref({ demoEnabled: false, passcode: '' })
+const showPasscode = ref(false)
+const activeSandboxes = ref(0)
+
+async function loadDemoConfig() {
+  try {
+    const cfg = await getDemoConfig()
+    demoConfig.value = cfg
+  } catch (e) {
+    console.error('Failed to load demo config', e)
+  }
+}
+
+async function toggleDemoEnabled() {
+  const newState = !demoConfig.value.demoEnabled
+  await updateDemoConfig({ demoEnabled: newState })
+  demoConfig.value.demoEnabled = newState
+}
+
+async function regeneratePasscode() {
+  await updateDemoConfig({ demoEnabled: demoConfig.value.demoEnabled, regeneratePasscode: true })
+  await loadDemoConfig()
+}
+
 onMounted(async () => {
   events.value = await fetchAllEvents() ?? []
   images.value = await getAllImages() ?? []
@@ -176,6 +201,7 @@ onMounted(async () => {
   organisers.value = await getOrganisers() ?? []
   const cfg = await getAppConfig()
   accentInput.value = cfg?.accentColor ?? '#ffffff'
+  loadDemoConfig()
 })
 </script>
 
@@ -472,6 +498,52 @@ onMounted(async () => {
               Apply Accent Color
             </button>
           </div>
+        </div>
+      </div>
+
+      <!-- ── Demo Settings ──────────────────────────────────── -->
+      <div v-if="activeTab === 'demo'">
+        <div class="section-rule mb-4">
+          <span class="section-rule-label">Demo Settings</span>
+          <div class="section-rule-line"></div>
+        </div>
+
+        <div class="card-hover p-4 relative">
+          <div class="corner-bar-tl"></div>
+
+          <div class="setting-row mb-4">
+            <span class="type-prose">Enable demo system</span>
+            <label class="toggle-switch">
+              <input
+                type="checkbox"
+                :checked="demoConfig.demoEnabled"
+                @change="toggleDemoEnabled"
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="setting-row mb-4">
+            <span class="type-prose">Passcode</span>
+            <div class="passcode-controls flex items-center gap-2">
+              <input
+                :type="showPasscode ? 'text' : 'password'"
+                :value="showPasscode ? demoConfig.passcode : '••••••••'"
+                class="input-base flex-1 max-w-[180px] type-body"
+                readonly
+              />
+              <button @click="showPasscode = !showPasscode" class="para-chip-sm type-label px-3 py-1.5 min-h-[44px]">
+                {{ showPasscode ? 'Hide' : 'Show' }}
+              </button>
+              <button @click="regeneratePasscode" class="para-chip-sm type-label px-3 py-1.5 min-h-[44px]">
+                Regenerate
+              </button>
+            </div>
+          </div>
+
+          <p class="type-prose-sm text-content-muted">
+            Active sandboxes: {{ activeSandboxes }}
+          </p>
         </div>
       </div>
 

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -215,6 +215,12 @@ async function purgeAllSandboxes() {
   await loadDemoConfig()
 }
 
+async function resetTemplateData() {
+  if (!confirm('Reset demo template event? This deletes and re-seeds the template with fresh data. Existing sandboxes are unaffected.')) return
+  await fetch('/api/v1/admin/demo/reset-template', { method: 'POST', credentials: 'include' })
+  await loadDemoConfig()
+}
+
 onMounted(async () => {
   events.value = await fetchAllEvents() ?? []
   images.value = await getAllImages() ?? []
@@ -560,6 +566,9 @@ onMounted(async () => {
               </button>
               <button @click="regeneratePasscode" class="para-chip-sm type-label px-3 py-1.5 min-h-[44px]">
                 Regenerate
+              </button>
+              <button @click="resetTemplateData" class="para-chip-sm type-label px-3 py-1.5 min-h-[44px] text-amber-400 border-amber-400/30">
+                Reset Template
               </button>
             </div>
           </div>

--- a/BES-frontend/src/views/AdminPage.vue
+++ b/BES-frontend/src/views/AdminPage.vue
@@ -169,9 +169,8 @@ const saveAccent = async () => {
 }
 
 // ── Demo Settings ──────────────────────────────────────────
-const demoConfig = ref({ demoEnabled: false, passcode: '' })
+const demoConfig = ref({ demoEnabled: false, passcode: '', activeSandboxes: 0 })
 const showPasscode = ref(false)
-const activeSandboxes = ref(0)
 
 async function loadDemoConfig() {
   try {
@@ -542,7 +541,7 @@ onMounted(async () => {
           </div>
 
           <p class="type-prose-sm text-content-muted">
-            Active sandboxes: {{ activeSandboxes }}
+            Active sandboxes: {{ demoConfig.activeSandboxes }}
           </p>
         </div>
       </div>

--- a/BES-frontend/src/views/HelperSessionView.vue
+++ b/BES-frontend/src/views/HelperSessionView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { onMounted, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { useAuthStore } from '@/utils/auth'
+import { useAuthStore, setActiveEvent } from '@/utils/auth'
 import { whoami, getCategoriesByEvent } from '@/utils/api'
 
 const router = useRouter()
@@ -18,7 +18,12 @@ onMounted(async () => {
   if (!authStore.user) {
     try {
       const user = await whoami()
-      if (user?.authenticated) authStore.login(user)
+      if (user?.authenticated) {
+        authStore.login(user)
+        if (user.eventId && user.eventName) {
+          setActiveEvent(user.eventId, user.eventName)
+        }
+      }
     } catch { /* not authenticated */ }
   }
   loading.value = false

--- a/BES-frontend/src/views/JudgeSessionView.vue
+++ b/BES-frontend/src/views/JudgeSessionView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { onMounted, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { useAuthStore } from '@/utils/auth'
+import { useAuthStore, setActiveEvent } from '@/utils/auth'
 import { getJudgeDivisions, whoami } from '@/utils/api'
 
 const router = useRouter()
@@ -35,6 +35,9 @@ onMounted(async () => {
       const user = await whoami()
       if (user?.authenticated && user.judgeName) {
         authStore.login(user)
+        if (user.eventId && user.eventName) {
+          setActiveEvent(user.eventId, user.eventName)
+        }
       }
     } catch { /* not authenticated */ }
   }

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { login } from '@/utils/api'
-import { ref } from 'vue'
+import { login, startDemo, getAppConfig } from '@/utils/api'
+import { ref, onMounted } from 'vue'
 import ActionDoneModal from './ActionDoneModal.vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/utils/auth'
+import DemoRolePicker from '@/components/DemoRolePicker.vue'
 import { APP_NAME, APP_TAGLINE } from '../utils/branding.js'
 
 const router    = useRouter()
@@ -21,6 +22,47 @@ const modalVariant = ref('error')
 
 /* Inline validation state — surface missing-field errors at the field, not only after submit */
 const touched = ref({ username: false, password: false })
+
+/* Demo mode */
+const demoEnabled = ref(false)
+const showPasscodeModal = ref(false)
+const showRolePicker = ref(false)
+const passcode = ref('')
+const passcodeError = ref('')
+
+onMounted(async () => {
+  try {
+    const config = await getAppConfig()
+    demoEnabled.value = config.demoEnabled === true
+  } catch (e) {
+    // fallback: hide demo button if config fetch fails
+    demoEnabled.value = false
+  }
+})
+
+function submitPasscode() {
+  if (!passcode.value.trim()) return
+  passcodeError.value = ''
+  showPasscodeModal.value = false
+  showRolePicker.value = true
+}
+
+async function startDemoSession(role) {
+  try {
+    const result = await startDemo(passcode.value, role)
+    // Route to the appropriate session view
+    const roleRoutes = {
+      EMCEE: '/emcee/session',
+      JUDGE: '/judge/session',
+      HELPER: '/helper/session'
+    }
+    router.push(roleRoutes[role] || '/')
+  } catch (e) {
+    passcodeError.value = e.message || 'Failed to start demo'
+    showRolePicker.value = false
+    showPasscodeModal.value = true
+  }
+}
 
 const openModal = (title, message, variant = 'error') => {
   modalTitle.value   = title
@@ -177,10 +219,59 @@ const submitLogin = async () => {
               {{ isLoading ? 'Signing in...' : 'Sign In' }}
             </button>
           </form>
+
+          <!-- Demo section -->
+          <div class="demo-section">
+            <div class="demo-section-rule">
+              <span class="demo-section-label">or</span>
+              <span class="demo-section-line"></span>
+            </div>
+
+            <button
+              v-if="demoEnabled"
+              class="btn-demo"
+              @click="showPasscodeModal = true"
+            >
+              Try Demo
+            </button>
+
+            <p v-if="demoEnabled" class="type-prose-sm demo-hint">
+              Experience Kyrove as an Emcee, Judge, or Helper
+            </p>
+          </div>
           </div>
         </div>
       </div>
     </div>
+
+    <!-- Passcode modal -->
+    <Teleport to="body">
+      <div v-if="showPasscodeModal" class="modal-backdrop" @click="showPasscodeModal = false">
+        <div class="modal-content passcode-modal" @click.stop>
+          <h2 class="modal-title">Enter Demo Passcode</h2>
+          <input
+            v-model="passcode"
+            type="text"
+            class="input-passcode"
+            placeholder="Enter passcode"
+            autocomplete="off"
+            @keyup.enter="submitPasscode"
+          />
+          <p v-if="passcodeError" class="error-text">{{ passcodeError }}</p>
+          <button class="btn-primary" @click="submitPasscode" :disabled="!passcode.trim()">
+            Continue
+          </button>
+          <p class="type-prose-sm modal-hint">Tap outside to close</p>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Role picker -->
+    <DemoRolePicker
+      v-if="showRolePicker"
+      @select="startDemoSession"
+      @back="showRolePicker = false; showPasscodeModal = true"
+    />
 
     <!-- Error modal -->
     <ActionDoneModal
@@ -194,3 +285,142 @@ const submitLogin = async () => {
     </ActionDoneModal>
   </div>
 </template>
+
+<style scoped>
+.demo-section {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.demo-section-rule {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.demo-section-label {
+  font-family: var(--font-sans);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+}
+
+.demo-section-line {
+  flex: 1;
+  height: 1px;
+  background: var(--surface-600);
+}
+
+.btn-demo {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  color: var(--accent-color);
+  padding: 0.75rem 2rem;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-demo:hover {
+  background: rgba(255,255,255,0.08);
+}
+
+.demo-hint {
+  margin-top: 0.75rem;
+  color: rgba(255,255,255,0.35);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 1rem;
+}
+
+.modal-content {
+  background: var(--surface-800, #1a1a1a);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+  padding: 2rem;
+  width: 100%;
+}
+
+.passcode-modal {
+  max-width: 360px;
+}
+
+.modal-title {
+  font-family: var(--font-sans);
+  font-size: 20px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  text-align: center;
+}
+
+.input-passcode {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--surface-900);
+  border: 1px solid var(--surface-600);
+  color: #fff;
+  font-family: var(--font-sans);
+  font-size: 18px;
+  letter-spacing: 0.3em;
+  text-align: center;
+  text-transform: uppercase;
+  margin: 1rem 0;
+}
+
+.input-passcode:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.error-text {
+  color: var(--primary-500, #ef4444);
+  font-family: var(--font-body);
+  font-size: 12px;
+  margin-bottom: 0.5rem;
+}
+
+.btn-primary {
+  width: 100%;
+  padding: 0.75rem;
+  background: var(--accent-color);
+  color: var(--color-surface-900, #111);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  border: none;
+  cursor: pointer;
+  transition: filter 0.2s;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(0.88);
+}
+
+.modal-hint {
+  margin-top: 0.75rem;
+  color: rgba(255,255,255,0.3);
+  text-align: center;
+}
+</style>

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { login, startDemo, getAppConfig } from '@/utils/api'
+import { login, startDemo, getAppConfig, whoami } from '@/utils/api'
 import { ref, onMounted } from 'vue'
 import ActionDoneModal from './ActionDoneModal.vue'
 import { useRouter } from 'vue-router'
@@ -49,9 +49,10 @@ function submitPasscode() {
 
 async function startDemoSession(role) {
   try {
-    const result = await startDemo(passcode.value, role)
-    // Populate auth store before navigation so router guard sees authenticated user
-    await authStore.fetchUser()
+    await startDemo(passcode.value, role)
+    // Populate auth store from session so router guard sees authenticated user
+    const user = await whoami()
+    if (user?.authenticated) authStore.login(user)
     // Route to the appropriate session view
     const roleRoutes = {
       EMCEE: '/emcee/session',

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -50,14 +50,18 @@ function submitPasscode() {
 async function startDemoSession(role) {
   try {
     const result = await startDemo(passcode.value, role)
-    // Populate auth store directly from demo response — avoids whoami() round-trip
-    authStore.login({
-      authenticated: true,
-      role: [{ authority: 'ROLE_' + role }],
+    // Populate auth store directly from demo response — bypass whoami() round-trip
+    authStore.$patch({
+      user: { authenticated: true, role: [{ authority: 'ROLE_' + role }] },
+      isAuthenticated: true,
       judgeId: result.judgeId ?? null,
       judgeName: result.judgeName ?? null
     })
     setActiveEvent(result.eventId, result.eventName)
+    // Double-check store was written — router guard and JudgeSessionView depend on it
+    if (!authStore.activeEvent) {
+      authStore.activeEvent = { id: result.eventId, name: result.eventName }
+    }
     // Route to the appropriate session view
     const roleRoutes = {
       EMCEE: '/emcee/session',

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { login, startDemo, getAppConfig } from '@/utils/api'
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 import ActionDoneModal from './ActionDoneModal.vue'
 import { useRouter } from 'vue-router'
-import { useAuthStore, setActiveEvent } from '@/utils/auth'
+import { useAuthStore } from '@/utils/auth'
 import DemoRolePicker from '@/components/DemoRolePicker.vue'
 import { APP_NAME, APP_TAGLINE } from '../utils/branding.js'
 
@@ -50,18 +50,14 @@ function submitPasscode() {
 async function startDemoSession(role) {
   try {
     const result = await startDemo(passcode.value, role)
-    // Populate auth store directly from demo response — bypass whoami() round-trip
-    authStore.$patch({
-      user: { authenticated: true, role: [{ authority: 'ROLE_' + role }] },
-      isAuthenticated: true,
-      judgeId: result.judgeId ?? null,
-      judgeName: result.judgeName ?? null
-    })
-    setActiveEvent(result.eventId, result.eventName)
-    // Double-check store was written — router guard and JudgeSessionView depend on it
-    if (!authStore.activeEvent) {
-      authStore.activeEvent = { id: result.eventId, name: result.eventName }
-    }
+    // Populate auth store — set every property directly for reliability
+    authStore.isAuthenticated = true
+    authStore.judgeId = result.judgeId ?? null
+    authStore.judgeName = result.judgeName ?? null
+    authStore.user = { authenticated: true, role: [{ authority: 'ROLE_' + role }] }
+    authStore.activeEvent = { id: result.eventId, name: result.eventName }
+    // Wait for Pinia reactivity to flush before navigating
+    await nextTick()
     // Route to the appropriate session view
     const roleRoutes = {
       EMCEE: '/emcee/session',

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -231,6 +231,7 @@ const submitLogin = async () => {
           <!-- Demo section -->
           <div class="demo-section">
             <div class="demo-section-rule">
+              <span class="demo-section-line"></span>
               <span class="demo-section-label">or</span>
               <span class="demo-section-line"></span>
             </div>
@@ -313,6 +314,13 @@ const submitLogin = async () => {
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: rgba(255,255,255,0.4);
+  flex-shrink: 0;
+}
+
+.demo-section-line {
+  flex: 1;
+  height: 1px;
+  background: var(--surface-600);
 }
 
 .demo-section-line {
@@ -356,8 +364,8 @@ const submitLogin = async () => {
 }
 
 .modal-content {
-  background: var(--surface-800, #1a1a1a);
-  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
   padding: 2rem;
   width: 100%;
@@ -379,8 +387,8 @@ const submitLogin = async () => {
 .input-passcode {
   width: 100%;
   padding: 0.75rem 1rem;
-  background: var(--surface-900);
-  border: 1px solid var(--surface-600);
+  background: #0a0a0a;
+  border: 1px solid rgba(255,255,255,0.2);
   color: #fff;
   font-family: var(--font-sans);
   font-size: 18px;
@@ -390,9 +398,14 @@ const submitLogin = async () => {
   margin: 1rem 0;
 }
 
+.input-passcode::placeholder {
+  color: rgba(255,255,255,0.25);
+}
+
 .input-passcode:focus {
   outline: none;
   border-color: var(--accent-color);
+  background: #000;
 }
 
 .error-text {

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -3,7 +3,7 @@ import { login, startDemo, getAppConfig, whoami } from '@/utils/api'
 import { ref, onMounted } from 'vue'
 import ActionDoneModal from './ActionDoneModal.vue'
 import { useRouter } from 'vue-router'
-import { useAuthStore } from '@/utils/auth'
+import { useAuthStore, setActiveEvent } from '@/utils/auth'
 import DemoRolePicker from '@/components/DemoRolePicker.vue'
 import { APP_NAME, APP_TAGLINE } from '../utils/branding.js'
 
@@ -49,10 +49,13 @@ function submitPasscode() {
 
 async function startDemoSession(role) {
   try {
-    await startDemo(passcode.value, role)
+    const result = await startDemo(passcode.value, role)
     // Populate auth store from session so router guard sees authenticated user
     const user = await whoami()
-    if (user?.authenticated) authStore.login(user)
+    if (user?.authenticated) {
+      authStore.login(user)
+      setActiveEvent(result.eventId, result.eventName)
+    }
     // Route to the appropriate session view
     const roleRoutes = {
       EMCEE: '/emcee/session',

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -3,7 +3,7 @@ import { login, startDemo, getAppConfig } from '@/utils/api'
 import { ref, onMounted, nextTick } from 'vue'
 import ActionDoneModal from './ActionDoneModal.vue'
 import { useRouter } from 'vue-router'
-import { useAuthStore } from '@/utils/auth'
+import { useAuthStore, setActiveEvent } from '@/utils/auth'
 import DemoRolePicker from '@/components/DemoRolePicker.vue'
 import { APP_NAME, APP_TAGLINE } from '../utils/branding.js'
 
@@ -50,12 +50,12 @@ function submitPasscode() {
 async function startDemoSession(role) {
   try {
     const result = await startDemo(passcode.value, role)
-    // Populate auth store — set every property directly for reliability
+    // Populate auth store via setActiveEvent (writes to sessionStorage + Pinia)
     authStore.isAuthenticated = true
     authStore.judgeId = result.judgeId ?? null
     authStore.judgeName = result.judgeName ?? null
     authStore.user = { authenticated: true, role: [{ authority: 'ROLE_' + role }] }
-    authStore.activeEvent = { id: result.eventId, name: result.eventName }
+    setActiveEvent(result.eventId, result.eventName)
     // Wait for Pinia reactivity to flush before navigating
     await nextTick()
     // Route to the appropriate session view

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -34,7 +34,7 @@ onMounted(async () => {
   try {
     const config = await getAppConfig()
     demoEnabled.value = config.demoEnabled === true
-  } catch (e) {
+  } catch (_e) {
     // fallback: hide demo button if config fetch fails
     demoEnabled.value = false
   }

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { login, startDemo, getAppConfig, whoami } from '@/utils/api'
+import { login, startDemo, getAppConfig } from '@/utils/api'
 import { ref, onMounted } from 'vue'
 import ActionDoneModal from './ActionDoneModal.vue'
 import { useRouter } from 'vue-router'
@@ -50,12 +50,14 @@ function submitPasscode() {
 async function startDemoSession(role) {
   try {
     const result = await startDemo(passcode.value, role)
-    // Populate auth store from session so router guard sees authenticated user
-    const user = await whoami()
-    if (user?.authenticated) {
-      authStore.login(user)
-      setActiveEvent(result.eventId, result.eventName)
-    }
+    // Populate auth store directly from demo response — avoids whoami() round-trip
+    authStore.login({
+      authenticated: true,
+      role: [{ authority: 'ROLE_' + role }],
+      judgeId: result.judgeId ?? null,
+      judgeName: result.judgeName ?? null
+    })
+    setActiveEvent(result.eventId, result.eventName)
     // Route to the appropriate session view
     const roleRoutes = {
       EMCEE: '/emcee/session',

--- a/BES-frontend/src/views/Login.vue
+++ b/BES-frontend/src/views/Login.vue
@@ -50,6 +50,8 @@ function submitPasscode() {
 async function startDemoSession(role) {
   try {
     const result = await startDemo(passcode.value, role)
+    // Populate auth store before navigation so router guard sees authenticated user
+    await authStore.fetchUser()
     // Route to the appropriate session view
     const roleRoutes = {
       EMCEE: '/emcee/session',

--- a/BES/src/main/java/com/example/BES/config/SecurityConfig.java
+++ b/BES/src/main/java/com/example/BES/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/demo/**").permitAll()
                         .requestMatchers("/api/v1/battle/**").permitAll()
                         .requestMatchers("/api/v1/event/audition-display/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()

--- a/BES/src/main/java/com/example/BES/config/SessionExpiryListener.java
+++ b/BES/src/main/java/com/example/BES/config/SessionExpiryListener.java
@@ -6,7 +6,10 @@ import org.springframework.security.web.session.HttpSessionDestroyedEvent;
 import org.springframework.stereotype.Component;
 
 import com.example.BES.services.ActiveSessionStore;
+import com.example.BES.services.DemoService;
 import com.example.BES.services.EmceeCategoryStore;
+
+import jakarta.servlet.http.HttpSession;
 
 @Component
 public class SessionExpiryListener {
@@ -17,9 +20,28 @@ public class SessionExpiryListener {
     @Autowired
     private EmceeCategoryStore emceeCategoryStore;
 
+    @Autowired
+    private DemoService demoService;
+
     @EventListener
     public void onSessionDestroyed(HttpSessionDestroyedEvent event) {
         activeSessionStore.deregisterBySessionId(event.getId());
         emceeCategoryStore.release(event.getId());
+
+        // Clean up demo sandbox if this session was a demo
+        try {
+            HttpSession session = event.getSession();
+            if (session != null) {
+                String eventName = (String) session.getAttribute("eventName");
+                if (eventName != null && eventName.startsWith("Kyrove Demo-")) {
+                    Long eventId = (Long) session.getAttribute("eventId");
+                    if (eventId != null) {
+                        demoService.purgeSandbox(eventId);
+                    }
+                }
+            }
+        } catch (IllegalStateException e) {
+            // Session already invalidated — cannot read attributes, skip demo cleanup
+        }
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/AdminController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AdminController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,6 +38,7 @@ import com.example.BES.dtos.DemoConfigDto;
 import com.example.BES.services.AccountService;
 import com.example.BES.services.AppConfigService;
 import com.example.BES.services.AuditionFeedbackService;
+import com.example.BES.services.DemoService;
 import com.example.BES.services.EventFeedbackTagService;
 import com.example.BES.services.JudgeService;
 import com.example.BES.services.ScoreService;
@@ -64,6 +66,12 @@ public class AdminController {
 
     @Autowired
     AppConfigService appConfigService;
+
+    @Autowired
+    private SimpMessagingTemplate messaging;
+
+    @Autowired
+    private DemoService demoService;
 
     // ── Feedback Tag Groups ──────────────────────────────────────────────────
 
@@ -197,7 +205,8 @@ public class AdminController {
         return ResponseEntity.ok(new DemoConfigDto(
                 appConfigService.isDemoEnabled(),
                 appConfigService.getDemoPasscode(),
-                null
+                null,
+                demoService.countActiveSandboxes()
         ));
     }
 
@@ -208,10 +217,19 @@ public class AdminController {
             appConfigService.setDemoPasscode(newPasscode);
         }
         appConfigService.setDemoEnabled(dto.isDemoEnabled());
-        return ResponseEntity.ok(new DemoConfigDto(
+
+        DemoConfigDto result = new DemoConfigDto(
                 appConfigService.isDemoEnabled(),
                 appConfigService.getDemoPasscode(),
-                null
+                null,
+                demoService.countActiveSandboxes()
+        );
+
+        messaging.convertAndSend("/topic/app-config", Map.of(
+                "accentColor", appConfigService.getAccentColor(),
+                "demoEnabled", result.isDemoEnabled()
         ));
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/AdminController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AdminController.java
@@ -232,4 +232,23 @@ public class AdminController {
 
         return ResponseEntity.ok(result);
     }
+
+    // ── Demo Sandbox Management ──────────────────────────────────────────────────
+
+    @GetMapping("/demo/sandboxes")
+    public ResponseEntity<List<Map<String, Object>>> listDemoSandboxes() {
+        return ResponseEntity.ok(demoService.listSandboxes());
+    }
+
+    @DeleteMapping("/demo/sandboxes/{eventId}")
+    public ResponseEntity<Map<String, Object>> purgeDemoSandbox(@PathVariable Long eventId) {
+        demoService.purgeSandbox(eventId);
+        return ResponseEntity.ok(Map.of("message", "Sandbox purged"));
+    }
+
+    @DeleteMapping("/demo/sandboxes")
+    public ResponseEntity<Map<String, Object>> purgeAllDemoSandboxes() {
+        int count = demoService.purgeAllSandboxes();
+        return ResponseEntity.ok(Map.of("message", "Purged " + count + " sandbox(es)"));
+    }
 }

--- a/BES/src/main/java/com/example/BES/controllers/AdminController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AdminController.java
@@ -39,6 +39,7 @@ import com.example.BES.services.AccountService;
 import com.example.BES.services.AppConfigService;
 import com.example.BES.services.AuditionFeedbackService;
 import com.example.BES.services.DemoService;
+import com.example.BES.services.DemoDataSeeder;
 import com.example.BES.services.EventFeedbackTagService;
 import com.example.BES.services.JudgeService;
 import com.example.BES.services.ScoreService;
@@ -72,6 +73,9 @@ public class AdminController {
 
     @Autowired
     private DemoService demoService;
+
+    @Autowired
+    private DemoDataSeeder demoDataSeeder;
 
     // ── Feedback Tag Groups ──────────────────────────────────────────────────
 
@@ -250,5 +254,12 @@ public class AdminController {
     public ResponseEntity<Map<String, Object>> purgeAllDemoSandboxes() {
         int count = demoService.purgeAllSandboxes();
         return ResponseEntity.ok(Map.of("message", "Purged " + count + " sandbox(es)"));
+    }
+
+    @PostMapping("/demo/reset-template")
+    public ResponseEntity<Map<String, Object>> resetTemplate() {
+        demoService.resetTemplate();
+        demoDataSeeder.seed();
+        return ResponseEntity.ok(Map.of("message", "Template event reset and re-seeded"));
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/AdminController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AdminController.java
@@ -33,7 +33,9 @@ import com.example.BES.dtos.admin.UpdateOrganiserTierDto;
 import com.example.BES.models.Account;
 import com.example.BES.models.Judge;
 import com.example.BES.dtos.admin.FeedbackTagOverrideDto;
+import com.example.BES.dtos.DemoConfigDto;
 import com.example.BES.services.AccountService;
+import com.example.BES.services.AppConfigService;
 import com.example.BES.services.AuditionFeedbackService;
 import com.example.BES.services.EventFeedbackTagService;
 import com.example.BES.services.JudgeService;
@@ -59,6 +61,9 @@ public class AdminController {
 
     @Autowired
     AccountService accountService;
+
+    @Autowired
+    AppConfigService appConfigService;
 
     // ── Feedback Tag Groups ──────────────────────────────────────────────────
 
@@ -182,6 +187,31 @@ public class AdminController {
         return ResponseEntity.ok(Map.of(
             "message", "score deleted",
             "deleted", deletedRows.toString()
+        ));
+    }
+
+    // ── Demo Config ────────────────────────────────────────────────────────────
+
+    @GetMapping("/demo/config")
+    public ResponseEntity<DemoConfigDto> getDemoConfig() {
+        return ResponseEntity.ok(new DemoConfigDto(
+                appConfigService.isDemoEnabled(),
+                appConfigService.getDemoPasscode(),
+                null
+        ));
+    }
+
+    @PostMapping("/demo/config")
+    public ResponseEntity<DemoConfigDto> updateDemoConfig(@RequestBody DemoConfigDto dto) {
+        if (dto.getRegeneratePasscode() != null && dto.getRegeneratePasscode()) {
+            String newPasscode = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+            appConfigService.setDemoPasscode(newPasscode);
+        }
+        appConfigService.setDemoEnabled(dto.isDemoEnabled());
+        return ResponseEntity.ok(new DemoConfigDto(
+                appConfigService.isDemoEnabled(),
+                appConfigService.getDemoPasscode(),
+                null
         ));
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/AppConfigController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AppConfigController.java
@@ -1,5 +1,6 @@
 package com.example.BES.controllers;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -23,9 +24,11 @@ public class AppConfigController {
     private SimpMessagingTemplate messaging;
 
     @GetMapping("/app")
-    public ResponseEntity<Map<String, String>> getAppConfig() {
-        String color = service.getAccentColor();
-        return ResponseEntity.ok(Map.of("accentColor", color));
+    public ResponseEntity<Map<String, Object>> getAppConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("accentColor", service.getAccentColor());
+        config.put("demoEnabled", service.isDemoEnabled());
+        return ResponseEntity.ok(config);
     }
 
     @PostMapping("/app")

--- a/BES/src/main/java/com/example/BES/controllers/DemoController.java
+++ b/BES/src/main/java/com/example/BES/controllers/DemoController.java
@@ -1,0 +1,107 @@
+package com.example.BES.controllers;
+
+import com.example.BES.dtos.DemoStartRequestDto;
+import com.example.BES.dtos.DemoStartResponseDto;
+import com.example.BES.models.SessionToken;
+import com.example.BES.services.AppConfigService;
+import com.example.BES.services.DemoService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/demo")
+public class DemoController {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoController.class);
+
+    private final AppConfigService appConfigService;
+    private final DemoService demoService;
+
+    public DemoController(AppConfigService appConfigService, DemoService demoService) {
+        this.appConfigService = appConfigService;
+        this.demoService = demoService;
+    }
+
+    @PostMapping("/start")
+    public ResponseEntity<?> startDemo(@RequestBody DemoStartRequestDto request,
+                                        HttpServletRequest httpRequest) {
+        // 1. Check demo is enabled
+        if (!appConfigService.isDemoEnabled()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Demo is currently disabled"));
+        }
+
+        // 2. Validate passcode
+        String expectedPasscode = appConfigService.getDemoPasscode();
+        if (request.getPasscode() == null || !request.getPasscode().equals(expectedPasscode)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "Invalid passcode"));
+        }
+
+        // 3. Validate role
+        String role = request.getRole();
+        if (role == null || !role.matches("^(EMCEE|JUDGE|HELPER)$")) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid role. Must be EMCEE, JUDGE, or HELPER."));
+        }
+
+        // 4. Clone template
+        String clientIp = httpRequest.getRemoteAddr();
+        DemoService.CloneResult result;
+        try {
+            result = demoService.cloneTemplate(role, clientIp);
+        } catch (DemoService.DemoRateLimitException e) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .body(Map.of("error", e.getMessage()));
+        }
+
+        // 5. Create session and authenticate (same pattern as AuthController.token)
+        SessionToken token = result.token;
+        String username = "token:" + token.getTokenId();
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                username, null,
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role)));
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+
+        HttpSession session = httpRequest.getSession(true);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+        session.setAttribute("eventId", result.event.getEventId());
+        session.setAttribute("eventName", result.event.getEventName());
+
+        if (token.getJudge() != null) {
+            session.setAttribute("judgeId", token.getJudge().getJudgeId());
+            session.setAttribute("judgeName", token.getJudge().getName());
+        }
+
+        // 6. Build response
+        DemoStartResponseDto response = new DemoStartResponseDto();
+        response.setAuthenticated(true);
+        response.setRole(role);
+        response.setEventId(result.event.getEventId());
+        response.setEventName(result.event.getEventName());
+        if (token.getJudge() != null) {
+            response.setJudgeId(token.getJudge().getJudgeId());
+            response.setJudgeName(token.getJudge().getName());
+        }
+
+        log.info("Demo session started: {} as {}", result.event.getEventName(), role);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/BES/src/main/java/com/example/BES/controllers/DemoController.java
+++ b/BES/src/main/java/com/example/BES/controllers/DemoController.java
@@ -59,18 +59,45 @@ public class DemoController {
                     .body(Map.of("error", "Invalid role. Must be EMCEE, JUDGE, or HELPER."));
         }
 
-        // 4. Clone template
-        String clientIp = httpRequest.getRemoteAddr();
-        DemoService.CloneResult result;
-        try {
-            result = demoService.cloneTemplate(role, clientIp);
-        } catch (DemoService.DemoRateLimitException e) {
-            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                    .body(Map.of("error", e.getMessage()));
+        // 4. Check for existing demo session — reuse sandbox if one exists
+        HttpSession existingSession = httpRequest.getSession(false);
+        String existingEventName = null;
+        Long existingEventId = null;
+        if (existingSession != null) {
+            try {
+                existingEventName = (String) existingSession.getAttribute("eventName");
+                existingEventId = (Long) existingSession.getAttribute("eventId");
+            } catch (IllegalStateException e) {
+                // session already invalidated
+            }
+        }
+
+        SessionToken token;
+        Long eventId;
+        String eventName;
+
+        if (existingEventName != null && existingEventName.startsWith("Kyrove Demo-") && existingEventId != null) {
+            // Reuse existing sandbox — just create a new token for the new role
+            log.info("Reusing existing demo sandbox {} for role {}", existingEventName, role);
+            token = demoService.createTokenForExistingSandbox(existingEventId, role);
+            eventId = existingEventId;
+            eventName = existingEventName;
+        } else {
+            // No existing demo session — clone a fresh sandbox
+            String clientIp = httpRequest.getRemoteAddr();
+            DemoService.CloneResult result;
+            try {
+                result = demoService.cloneTemplate(role, clientIp);
+            } catch (DemoService.DemoRateLimitException e) {
+                return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                        .body(Map.of("error", e.getMessage()));
+            }
+            token = result.token;
+            eventId = result.event.getEventId();
+            eventName = result.event.getEventName();
         }
 
         // 5. Create session and authenticate (same pattern as AuthController.token)
-        SessionToken token = result.token;
         String username = "token:" + token.getTokenId();
         Authentication auth = new UsernamePasswordAuthenticationToken(
                 username, null,
@@ -82,8 +109,8 @@ public class DemoController {
 
         HttpSession session = httpRequest.getSession(true);
         session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
-        session.setAttribute("eventId", result.event.getEventId());
-        session.setAttribute("eventName", result.event.getEventName());
+        session.setAttribute("eventId", eventId);
+        session.setAttribute("eventName", eventName);
 
         if (token.getJudge() != null) {
             session.setAttribute("judgeId", token.getJudge().getJudgeId());
@@ -94,14 +121,14 @@ public class DemoController {
         DemoStartResponseDto response = new DemoStartResponseDto();
         response.setAuthenticated(true);
         response.setRole(role);
-        response.setEventId(result.event.getEventId());
-        response.setEventName(result.event.getEventName());
+        response.setEventId(eventId);
+        response.setEventName(eventName);
         if (token.getJudge() != null) {
             response.setJudgeId(token.getJudge().getJudgeId());
             response.setJudgeName(token.getJudge().getName());
         }
 
-        log.info("Demo session started: {} as {}", result.event.getEventName(), role);
+        log.info("Demo session started: {} as {}", eventName, role);
         return ResponseEntity.ok(response);
     }
 }

--- a/BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java
@@ -11,4 +11,5 @@ public class DemoConfigDto {
     private boolean demoEnabled;
     private String passcode;
     private Boolean regeneratePasscode;  // set to true to trigger regeneration on POST
+    private int activeSandboxes;
 }

--- a/BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java
@@ -1,0 +1,14 @@
+package com.example.BES.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DemoConfigDto {
+    private boolean demoEnabled;
+    private String passcode;
+    private Boolean regeneratePasscode;  // set to true to trigger regeneration on POST
+}

--- a/BES/src/main/java/com/example/BES/dtos/DemoStartRequestDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/DemoStartRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.BES.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DemoStartRequestDto {
+    private String passcode;
+    private String role; // "EMCEE", "JUDGE", or "HELPER"
+}

--- a/BES/src/main/java/com/example/BES/dtos/DemoStartResponseDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/DemoStartResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.BES.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DemoStartResponseDto {
+    private boolean authenticated;
+    private String role;
+    private Long eventId;
+    private String eventName;
+    private Long judgeId;
+    private String judgeName;
+}

--- a/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantRepo.java
@@ -9,12 +9,14 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.BES.models.Event;
+import com.example.BES.models.EventCategory;
 import com.example.BES.models.EventCategoryParticipant;
 import com.example.BES.models.EventCategoryParticipantId;
 
 @Repository
 public interface EventCategoryParticipantRepo extends JpaRepository<EventCategoryParticipant, EventCategoryParticipantId> {
     List<EventCategoryParticipant> findByEvent(Event event);
+    List<EventCategoryParticipant> findByEventCategory(EventCategory eventCategory);
 
     @Query("SELECT DISTINCT e FROM EventCategoryParticipant e LEFT JOIN FETCH e.judge WHERE e.event = :event")
     List<EventCategoryParticipant> findByEventWithJudge(@Param("event") Event event);

--- a/BES/src/main/java/com/example/BES/respositories/EventRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventRepo.java
@@ -22,10 +22,6 @@ public interface EventRepo extends JpaRepository<Event, Long>{
     List<Event> findAllDemoEvents();
 
     @Modifying
-    @Query("DELETE FROM Event e WHERE e.eventName LIKE 'Kyrove Demo-%'")
-    int deleteAllDemoEvents();
-
-    @Modifying
     @Query("DELETE FROM Event e WHERE e.eventName = :eventName")
     void deleteByEventName(@Param("eventName") String eventName);
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventRepo.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -21,7 +20,4 @@ public interface EventRepo extends JpaRepository<Event, Long>{
     @Query("SELECT e FROM Event e WHERE e.eventName LIKE 'Kyrove Demo-%'")
     List<Event> findAllDemoEvents();
 
-    @Modifying
-    @Query("DELETE FROM Event e WHERE e.eventName = :eventName")
-    void deleteByEventName(@Param("eventName") String eventName);
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventRepo.java
@@ -1,8 +1,10 @@
 package com.example.BES.respositories;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -16,4 +18,14 @@ public interface EventRepo extends JpaRepository<Event, Long>{
     @Query("SELECT e FROM Event e WHERE LOWER(e.eventName) = LOWER(:eventName)")
     Optional<Event> findByEventNameIgnoreCase(@Param("eventName") String eventName);
 
+    @Query("SELECT e FROM Event e WHERE e.eventName LIKE 'Kyrove Demo-%'")
+    List<Event> findAllDemoEvents();
+
+    @Modifying
+    @Query("DELETE FROM Event e WHERE e.eventName LIKE 'Kyrove Demo-%'")
+    int deleteAllDemoEvents();
+
+    @Modifying
+    @Query("DELETE FROM Event e WHERE e.eventName = :eventName")
+    void deleteByEventName(@Param("eventName") String eventName);
 }

--- a/BES/src/main/java/com/example/BES/respositories/ScoringCriteriaRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/ScoringCriteriaRepo.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.example.BES.models.Event;
+import com.example.BES.models.EventCategory;
 import com.example.BES.models.ScoringCriteria;
 
 @Repository
@@ -17,4 +19,7 @@ public interface ScoringCriteriaRepo extends JpaRepository<ScoringCriteria, Long
 
     @Query("SELECT sc FROM ScoringCriteria sc WHERE sc.event.eventName = :eventName AND sc.eventCategory.name = :categoryName ORDER BY sc.displayOrder ASC")
     List<ScoringCriteria> findByEventNameAndCategoryName(@Param("eventName") String eventName, @Param("categoryName") String categoryName);
+
+    @Query("SELECT sc FROM ScoringCriteria sc WHERE sc.event = :event AND (sc.eventCategory = :category OR (:category IS NULL AND sc.eventCategory IS NULL))")
+    List<ScoringCriteria> findByEventAndEventCategory(@Param("event") Event event, @Param("category") EventCategory category);
 }

--- a/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
@@ -14,4 +14,6 @@ public interface SessionTokenRepository extends JpaRepository<SessionToken, Stri
         Long eventId, String role, LocalDateTime now);
 
     List<SessionToken> findByEvent_EventIdAndRevokedFalse(Long eventId);
+
+    List<SessionToken> findByEvent_EventId(Long eventId);
 }

--- a/BES/src/main/java/com/example/BES/services/AppConfigService.java
+++ b/BES/src/main/java/com/example/BES/services/AppConfigService.java
@@ -1,30 +1,82 @@
 package com.example.BES.services;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 import com.example.BES.models.AppConfig;
 import com.example.BES.respositories.AppConfigRepository;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
 
 @Service
 public class AppConfigService {
 
     private static final String ACCENT_KEY = "accentColor";
     private static final String ACCENT_DEFAULT = "#ffffff";
+    private static final String DEMO_PASSCODE_KEY = "demo_passcode";
+    private static final String DEMO_ENABLED_KEY = "demo_enabled";
 
-    @Autowired
-    private AppConfigRepository repo;
+    private final AppConfigRepository appConfigRepository;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public AppConfigService(AppConfigRepository appConfigRepository) {
+        this.appConfigRepository = appConfigRepository;
+    }
+
+    // ---- accentColor (existing) ----
 
     public String getAccentColor() {
-        return repo.findByKey(ACCENT_KEY)
-                   .map(AppConfig::getValue)
-                   .orElse(ACCENT_DEFAULT);
+        return get(ACCENT_KEY, ACCENT_DEFAULT);
     }
 
     public String saveAccentColor(String color) {
-        AppConfig cfg = repo.findByKey(ACCENT_KEY)
-                            .orElse(new AppConfig(null, ACCENT_KEY, ACCENT_DEFAULT));
-        cfg.setValue(color);
-        repo.save(cfg);
+        set(ACCENT_KEY, color);
         return color;
+    }
+
+    // ---- generic key-value ----
+
+    public String get(String key, String defaultVal) {
+        return appConfigRepository.findByKey(key)
+                .map(AppConfig::getValue)
+                .orElse(defaultVal);
+    }
+
+    public void set(String key, String value) {
+        AppConfig config = appConfigRepository.findByKey(key)
+                .orElse(new AppConfig(null, key, value));
+        config.setValue(value);
+        appConfigRepository.save(config);
+    }
+
+    // ---- demo ----
+
+    public String getDemoPasscode() {
+        String existing = get(DEMO_PASSCODE_KEY, null);
+        if (existing == null || "CHANGEME".equals(existing)) {
+            String generated = generatePasscode();
+            set(DEMO_PASSCODE_KEY, generated);
+            return generated;
+        }
+        return existing;
+    }
+
+    public void setDemoPasscode(String passcode) {
+        set(DEMO_PASSCODE_KEY, passcode);
+    }
+
+    public boolean isDemoEnabled() {
+        return "true".equals(get(DEMO_ENABLED_KEY, "true"));
+    }
+
+    public void setDemoEnabled(boolean enabled) {
+        set(DEMO_ENABLED_KEY, Boolean.toString(enabled));
+    }
+
+    private String generatePasscode() {
+        String chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        StringBuilder sb = new StringBuilder(8);
+        for (int i = 0; i < 8; i++) {
+            sb.append(chars.charAt(secureRandom.nextInt(chars.length())));
+        }
+        return sb.toString();
     }
 }

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -1,0 +1,248 @@
+package com.example.BES.services;
+
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Component
+public class DemoDataSeeder {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoDataSeeder.class);
+    private static final String TEMPLATE_NAME = "Kyrove Demo";
+
+    private final EventRepo eventRepo;
+    private final EventCategoryRepo eventCategoryRepo;
+    private final ParticipantRepo participantRepo;
+    private final EventParticipantRepo eventParticipantRepo;
+    private final EventCategoryParticipantRepo eventCategoryParticipantRepo;
+    private final JudgeRepo judgeRepo;
+    private final ScoringCriteriaRepo scoringCriteriaRepo;
+    private final ScoreRepo scoreRepo;
+    private final AuditionFeedbackRepo auditionFeedbackRepo;
+    private final FeedbackTagRepo feedbackTagRepo;
+    private final FeedbackTagGroupRepo feedbackTagGroupRepo;
+
+    public DemoDataSeeder(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
+                          ParticipantRepo participantRepo, EventParticipantRepo eventParticipantRepo,
+                          EventCategoryParticipantRepo eventCategoryParticipantRepo,
+                          JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
+                          ScoreRepo scoreRepo, AuditionFeedbackRepo auditionFeedbackRepo,
+                          FeedbackTagRepo feedbackTagRepo, FeedbackTagGroupRepo feedbackTagGroupRepo) {
+        this.eventRepo = eventRepo;
+        this.eventCategoryRepo = eventCategoryRepo;
+        this.participantRepo = participantRepo;
+        this.eventParticipantRepo = eventParticipantRepo;
+        this.eventCategoryParticipantRepo = eventCategoryParticipantRepo;
+        this.judgeRepo = judgeRepo;
+        this.scoringCriteriaRepo = scoringCriteriaRepo;
+        this.scoreRepo = scoreRepo;
+        this.auditionFeedbackRepo = auditionFeedbackRepo;
+        this.feedbackTagRepo = feedbackTagRepo;
+        this.feedbackTagGroupRepo = feedbackTagGroupRepo;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void seed() {
+        if (eventRepo.findByEventName(TEMPLATE_NAME).isPresent()) {
+            log.info("Demo template event already exists, skipping seed");
+            return;
+        }
+        log.info("Seeding demo template event '{}'...", TEMPLATE_NAME);
+
+        // 1. Create template event
+        Event event = new Event();
+        event.setEventName(TEMPLATE_NAME);
+        event.setPaymentRequired(false);
+        event.setJudgingMode("SOLO");
+        event.setFeedbackEnabled(true);
+        event.setResultsReleased(false);
+        event.setReleaseScore(false);
+        event.setAnimTheme("impact");
+        event = eventRepo.save(event);
+
+        // 2. Create categories
+        EventCategory hipHop = createCategory(event, "Hip Hop", "1v1");
+        EventCategory popping = createCategory(event, "Popping", "1v1");
+        EventCategory[] categories = {hipHop, popping};
+
+        // 3. Create scoring criteria for Popping (multi-criteria)
+        createCriterion(event, popping, "Musicality", 1.0, 0);
+        createCriterion(event, popping, "Technique", 1.0, 1);
+        createCriterion(event, popping, "Originality", 1.0, 2);
+
+        // 4. Create judges
+        Judge judge1 = createJudge("DJ FLEX");
+        Judge judge2 = createJudge("B-Girl RAY");
+        Judge judge3 = createJudge("Kid Kazoo");
+        Judge[] judges = {judge1, judge2, judge3};
+
+        // Assign judges to event + categories
+        for (Judge judge : judges) {
+            judgeRepo.insertEventJudge(event.getEventId(), judge.getJudgeId());
+        }
+        for (EventCategory cat : categories) {
+            cat.setJudges(Arrays.asList(judges));
+            eventCategoryRepo.save(cat);
+        }
+
+        // 5. Create participants (30 unique, 20 per category, ~10 overlap)
+        String[] allNames = {
+            "B-Boy Spinz", "Poppin J", "Lil Flow", "Kid Twist", "Lady Glide",
+            "Rock Steady", "Mighty Mouse", "Turbo T", "Fresh Kicks", "Smooth Move",
+            "Wild Card", "Shadow Step", "Beat Breaker", "Style King", "Lock N Load",
+            "Wave Rider", "Funk Master", "Cypher Queen", "Groove Theory", "Spin Doctor",
+            "Hip Hop Harry", "Pop N Drop", "Freeze Frame", "Rhythm Nation", "Soul Train",
+            "Electric Boogaloo", "Floor Phantom", "King Tut", "Robot X", "Moon Walker"
+        };
+
+        List<Participant> participants = new ArrayList<>();
+        for (String name : allNames) {
+            Participant p = participantRepo.findFirstByParticipantName(name)
+                    .orElseGet(() -> {
+                        Participant np = new Participant();
+                        np.setParticipantName(name);
+                        return participantRepo.save(np);
+                    });
+            participants.add(p);
+        }
+
+        // 6. Create EventParticipant links (all 30 to the event)
+        List<EventParticipant> eventParticipants = new ArrayList<>();
+        Random rng = new Random(42); // fixed seed for reproducibility
+        for (Participant p : participants) {
+            EventParticipant ep = new EventParticipant();
+            ep.setEvent(event);
+            ep.setParticipant(p);
+            ep.setPaymentVerified(true);
+            ep.setDisplayName(p.getParticipantName());
+            ep.setStageName(p.getParticipantName());
+            ep.setReferenceCode(generateRefCode());
+            eventParticipants.add(eventParticipantRepo.save(ep));
+        }
+
+        // 7. Create EventCategoryParticipant links
+        // Hip Hop: participants 0-19 (first 20)
+        // Popping: participants 10-29 (last 20, overlapping 10-19)
+        List<EventCategoryParticipant> hipHopECPs = new ArrayList<>();
+        List<EventCategoryParticipant> poppingECPs = new ArrayList<>();
+
+        for (int i = 0; i < 20; i++) {
+            Participant p = participants.get(i);
+            hipHopECPs.add(createECP(event, hipHop, p, i + 1, "1v1"));
+        }
+        for (int i = 10; i < 30; i++) {
+            Participant p = participants.get(i);
+            poppingECPs.add(createECP(event, popping, p, i - 9, "1v1"));
+        }
+
+        // 8. Pre-fill scores (~50% of participants scored per category per judge)
+        // Hip Hop: judges score participants at even indices (0,2,4,...,18) = 10 scored
+        // Popping: judges score participants at odd indices in the popping list = 10 scored
+        for (Judge judge : judges) {
+            for (int i = 0; i < hipHopECPs.size(); i += 2) {
+                double scoreVal = 5.0 + rng.nextDouble() * 4.5; // 5.0-9.5
+                createScore(hipHopECPs.get(i), judge, null, Math.round(scoreVal * 10.0) / 10.0);
+            }
+            for (int i = 1; i < poppingECPs.size(); i += 2) {
+                // For Popping, create 3 aspect scores per scored participant
+                EventCategoryParticipant ecp = poppingECPs.get(i);
+                createScore(ecp, judge, "Musicality", 5.0 + rng.nextDouble() * 4.5);
+                createScore(ecp, judge, "Technique", 5.0 + rng.nextDouble() * 4.5);
+                createScore(ecp, judge, "Originality", 5.0 + rng.nextDouble() * 4.5);
+            }
+        }
+
+        // 9. Pre-fill feedback on ~30% of scored participants
+        List<FeedbackTag> allTags = feedbackTagRepo.findAll();
+        if (!allTags.isEmpty()) {
+            for (Judge judge : judges) {
+                for (int i = 0; i < hipHopECPs.size(); i += 6) { // every 6th
+                    createFeedback(hipHopECPs.get(i), judge, allTags, rng);
+                }
+            }
+        }
+
+        log.info("Demo template event seeded successfully with {} participants, {} judges",
+                participants.size(), judges.length);
+    }
+
+    private EventCategory createCategory(Event event, String name, String format) {
+        EventCategory cat = new EventCategory();
+        cat.setEvent(event);
+        cat.setName(name);
+        cat.setFormat(format);
+        cat.setSoloAllowed(true);
+        return eventCategoryRepo.save(cat);
+    }
+
+    private void createCriterion(Event event, EventCategory cat, String name, double weight, int order) {
+        ScoringCriteria sc = new ScoringCriteria();
+        sc.setEvent(event);
+        sc.setEventCategory(cat);
+        sc.setName(name);
+        sc.setWeight(weight);
+        sc.setDisplayOrder(order);
+        scoringCriteriaRepo.save(sc);
+    }
+
+    private Judge createJudge(String name) {
+        return judgeRepo.findFirstByName(name)
+                .orElseGet(() -> {
+                    Judge j = new Judge();
+                    j.setName(name);
+                    return judgeRepo.save(j);
+                });
+    }
+
+    private EventCategoryParticipant createECP(Event event, EventCategory cat,
+                                                Participant p, int auditionNum, String format) {
+        EventCategoryParticipant ecp = new EventCategoryParticipant();
+        EventCategoryParticipantId id = new EventCategoryParticipantId(
+                event.getEventId(), cat.getId(), p.getParticipantId());
+        ecp.setId(id);
+        ecp.setEvent(event);
+        ecp.setEventCategory(cat);
+        ecp.setParticipant(p);
+        ecp.setAuditionNumber(auditionNum);
+        ecp.setFormat(format);
+        ecp.setDisplayName(p.getParticipantName());
+        return eventCategoryParticipantRepo.save(ecp);
+    }
+
+    private void createScore(EventCategoryParticipant ecp, Judge judge, String aspect, double value) {
+        Score score = new Score();
+        score.setEventCategoryParticipant(ecp);
+        score.setJudge(judge);
+        score.setAspect(aspect);
+        score.setValue(value);
+        scoreRepo.save(score);
+    }
+
+    private void createFeedback(EventCategoryParticipant ecp, Judge judge,
+                                 List<FeedbackTag> allTags, Random rng) {
+        AuditionFeedback fb = new AuditionFeedback();
+        fb.setEventCategoryParticipant(ecp);
+        fb.setJudge(judge);
+        fb.setNote("Great energy and stage presence.");
+        Set<FeedbackTag> tags = new HashSet<>();
+        // pick 1-2 random tags
+        tags.add(allTags.get(rng.nextInt(allTags.size())));
+        if (rng.nextBoolean() && allTags.size() > 1) {
+            tags.add(allTags.get(rng.nextInt(allTags.size())));
+        }
+        fb.setTags(tags);
+        auditionFeedbackRepo.save(fb);
+    }
+
+    private String generateRefCode() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -131,22 +131,23 @@ public class DemoDataSeeder {
         // 7. Create EventCategoryParticipant links
         // Hip Hop: participants 0-19 (first 20)
         // Popping: participants 10-29 (last 20, overlapping 10-19)
-        // Scatter assigned audition numbers with gaps (for realistic helper check-in)
-        // Assigned indices (0-based) per category: randomly chosen gaps at 3, 7, 12, 16, 19
+        // Scatter assigned audition numbers with gaps (for realistic helper check-in).
+        // A single set of unassigned participant indices applied consistently across
+        // ALL categories — a participant either gets an audition number in every
+        // category they're in, or in none, simulating real-world registration.
         List<EventCategoryParticipant> hipHopECPs = new ArrayList<>();
         List<EventCategoryParticipant> poppingECPs = new ArrayList<>();
-        Set<Integer> hipHopUnassigned = Set.of(3, 7, 12, 16, 19);
-        Set<Integer> poppingUnassigned = Set.of(2, 6, 10, 15, 17);
+        Set<Integer> unassignedIndices = Set.of(3, 7, 12, 16, 19);
 
         for (int i = 0; i < 20; i++) {
             Participant p = participants.get(i);
-            Integer auditionNum = hipHopUnassigned.contains(i) ? null : i + 1;
+            Integer auditionNum = unassignedIndices.contains(i) ? null : i + 1;
             hipHopECPs.add(createECP(event, hipHop, p, auditionNum, "1v1"));
         }
         for (int i = 10; i < 30; i++) {
             Participant p = participants.get(i);
             int localIdx = i - 10;
-            Integer auditionNum = poppingUnassigned.contains(i) ? null : localIdx + 1;
+            Integer auditionNum = unassignedIndices.contains(i) ? null : localIdx + 1;
             poppingECPs.add(createECP(event, popping, p, auditionNum, "1v1"));
         }
 
@@ -194,8 +195,8 @@ public class DemoDataSeeder {
             }
         }
 
-        // 9. Seed default feedback tag groups + tags if none exist
-        List<FeedbackTag> allTags = feedbackTagRepo.findAll();
+        // 9. Seed default feedback tag groups + tags for the template event if none exist
+        List<FeedbackTag> allTags = feedbackTagRepo.findByEventEventId(event.getEventId());
         if (allTags.isEmpty()) {
             FeedbackTagGroup technique = createTagGroup(event, "Technique");
             FeedbackTagGroup performance = createTagGroup(event, "Performance");
@@ -207,7 +208,7 @@ public class DemoDataSeeder {
             createTag(performance, event, "Confidence");
             createTag(performance, event, "Showmanship");
             createTag(performance, event, "Dynamics");
-            allTags = feedbackTagRepo.findAll();
+            allTags = feedbackTagRepo.findByEventEventId(event.getEventId());
         }
 
         // 10. Pre-fill feedback on ~30% of scored participants

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -89,7 +89,7 @@ public class DemoDataSeeder {
             judgeRepo.insertEventJudge(event.getEventId(), judge.getJudgeId());
         }
         for (EventCategory cat : categories) {
-            cat.setJudges(Arrays.asList(judges));
+            cat.setJudges(new ArrayList<>(Arrays.asList(judges)));
             eventCategoryRepo.save(cat);
         }
 

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -143,20 +143,47 @@ public class DemoDataSeeder {
             poppingECPs.add(createECP(event, popping, p, i - 9, "1v1"));
         }
 
-        // 8. Pre-fill scores (~50% of participants scored per category per judge)
-        // Hip Hop: judges score participants at even indices (0,2,4,...,18) = 10 scored
-        // Popping: judges score participants at odd indices in the popping list = 10 scored
-        for (Judge judge : judges) {
-            for (int i = 0; i < hipHopECPs.size(); i += 2) {
-                double scoreVal = 5.0 + rng.nextDouble() * 4.5; // 5.0-9.5
-                createScore(hipHopECPs.get(i), judge, null, Math.round(scoreVal * 10.0) / 10.0);
+        // 8. Pre-fill scores with intentional tie scenarios
+        //
+        // Hip Hop (20 participants, single-score, default judging):
+        // All 3 judges give the same score per participant (so average = that score).
+        // Design: 4-way tie at the Top 16 cutoff (positions 14-17 all scored 7.5),
+        // and a 2-way tie at the Top 8 boundary (positions 7-8 both scored 8.3).
+        double[] hipHopScores = {
+            9.5, 9.3, 9.1, 8.9, 8.7,   // #1-5: clear leaders
+            8.5, 8.3, 8.3,              // #6-8: tie at #7-8 (Top 8 boundary)
+            8.0, 7.9, 7.8, 7.7, 7.6,   // #9-13
+            7.5, 7.5, 7.5, 7.5,        // #14-17: 4-way tie (Top 16 boundary!)
+            7.0, 6.5, 6.0               // #18-20
+        };
+        for (int i = 0; i < hipHopECPs.size(); i++) {
+            double scoreVal = hipHopScores[i];
+            for (Judge judge : judges) {
+                createScore(hipHopECPs.get(i), judge, null, scoreVal);
             }
+        }
+
+        // Popping (20 participants, multi-criteria: Musicality, Technique, Originality):
+        // Score 10 participants (odd indices in ECP list: 1,3,5,...,19).
+        // Create a tie at Top 8: positions 7-9 all total ~22.5 (avg 7.5 per aspect).
+        double[][] poppingTotals = {
+            {9.0, 9.0, 9.0}, {8.5, 8.5, 8.5}, {8.0, 8.5, 8.0}, {8.0, 8.0, 8.0}, {7.5, 8.0, 7.5}, // scored #1-5
+            {7.5, 7.5, 7.5}, {7.5, 7.5, 7.5}, {7.5, 7.5, 7.5},                                     // scored #6-8: 3-way tie
+            {7.0, 7.5, 7.0}, {6.5, 7.0, 6.5}                                                         // scored #9-10
+        };
+        for (Judge judge : judges) {
+            int scoredIdx = 0;
             for (int i = 1; i < poppingECPs.size(); i += 2) {
-                // For Popping, create 3 aspect scores per scored participant
-                EventCategoryParticipant ecp = poppingECPs.get(i);
-                createScore(ecp, judge, "Musicality", 5.0 + rng.nextDouble() * 4.5);
-                createScore(ecp, judge, "Technique", 5.0 + rng.nextDouble() * 4.5);
-                createScore(ecp, judge, "Originality", 5.0 + rng.nextDouble() * 4.5);
+                if (scoredIdx < poppingTotals.length) {
+                    EventCategoryParticipant ecp = poppingECPs.get(i);
+                    double[] aspects = poppingTotals[scoredIdx];
+                    // Add small judge-specific variation so scores differ slightly per judge
+                    double judgeOffset = (judge.getJudgeId() % 3) * 0.1;
+                    createScore(ecp, judge, "Musicality", Math.round((aspects[0] + judgeOffset) * 10.0) / 10.0);
+                    createScore(ecp, judge, "Technique", Math.round((aspects[1] + judgeOffset) * 10.0) / 10.0);
+                    createScore(ecp, judge, "Originality", Math.round((aspects[2] + judgeOffset) * 10.0) / 10.0);
+                }
+                scoredIdx++;
             }
         }
 

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -25,16 +25,16 @@ public class DemoDataSeeder {
     private final JudgeRepo judgeRepo;
     private final ScoringCriteriaRepo scoringCriteriaRepo;
     private final ScoreRepo scoreRepo;
-    private final AuditionFeedbackRepo auditionFeedbackRepo;
-    private final FeedbackTagRepo feedbackTagRepo;
-    private final FeedbackTagGroupRepo feedbackTagGroupRepo;
+    private final AuditionFeedbackRepository auditionFeedbackRepo;
+    private final FeedbackTagRepository feedbackTagRepo;
+    private final FeedbackTagGroupRepository feedbackTagGroupRepo;
 
     public DemoDataSeeder(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
                           ParticipantRepo participantRepo, EventParticipantRepo eventParticipantRepo,
                           EventCategoryParticipantRepo eventCategoryParticipantRepo,
                           JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
-                          ScoreRepo scoreRepo, AuditionFeedbackRepo auditionFeedbackRepo,
-                          FeedbackTagRepo feedbackTagRepo, FeedbackTagGroupRepo feedbackTagGroupRepo) {
+                          ScoreRepo scoreRepo, AuditionFeedbackRepository auditionFeedbackRepo,
+                          FeedbackTagRepository feedbackTagRepo, FeedbackTagGroupRepository feedbackTagGroupRepo) {
         this.eventRepo = eventRepo;
         this.eventCategoryRepo = eventCategoryRepo;
         this.participantRepo = participantRepo;

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -194,8 +194,23 @@ public class DemoDataSeeder {
             }
         }
 
-        // 9. Pre-fill feedback on ~30% of scored participants
+        // 9. Seed default feedback tag groups + tags if none exist
         List<FeedbackTag> allTags = feedbackTagRepo.findAll();
+        if (allTags.isEmpty()) {
+            FeedbackTagGroup technique = createTagGroup(event, "Technique");
+            FeedbackTagGroup performance = createTagGroup(event, "Performance");
+            createTag(technique, event, "Musicality");
+            createTag(technique, event, "Foundation");
+            createTag(technique, event, "Originality");
+            createTag(technique, event, "Control");
+            createTag(performance, event, "Stage Presence");
+            createTag(performance, event, "Confidence");
+            createTag(performance, event, "Showmanship");
+            createTag(performance, event, "Dynamics");
+            allTags = feedbackTagRepo.findAll();
+        }
+
+        // 10. Pre-fill feedback on ~30% of scored participants
         if (!allTags.isEmpty()) {
             for (Judge judge : judges) {
                 for (int i = 0; i < hipHopECPs.size(); i += 6) { // every 6th
@@ -258,6 +273,21 @@ public class DemoDataSeeder {
         score.setAspect(aspect);
         score.setValue(value);
         scoreRepo.save(score);
+    }
+
+    private FeedbackTagGroup createTagGroup(Event event, String name) {
+        FeedbackTagGroup group = new FeedbackTagGroup();
+        group.setName(name);
+        group.setEvent(event);
+        return feedbackTagGroupRepo.save(group);
+    }
+
+    private void createTag(FeedbackTagGroup group, Event event, String label) {
+        FeedbackTag tag = new FeedbackTag();
+        tag.setLabel(label);
+        tag.setGroup(group);
+        tag.setEvent(event);
+        feedbackTagRepo.save(tag);
     }
 
     private void createFeedback(EventCategoryParticipant ecp, Judge judge,

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -131,16 +131,19 @@ public class DemoDataSeeder {
         // 7. Create EventCategoryParticipant links
         // Hip Hop: participants 0-19 (first 20)
         // Popping: participants 10-29 (last 20, overlapping 10-19)
+        // First 15 per category get audition numbers; last 5 get null (for helper check-in)
         List<EventCategoryParticipant> hipHopECPs = new ArrayList<>();
         List<EventCategoryParticipant> poppingECPs = new ArrayList<>();
 
         for (int i = 0; i < 20; i++) {
             Participant p = participants.get(i);
-            hipHopECPs.add(createECP(event, hipHop, p, i + 1, "1v1"));
+            Integer auditionNum = i < 15 ? i + 1 : null;
+            hipHopECPs.add(createECP(event, hipHop, p, auditionNum, "1v1"));
         }
         for (int i = 10; i < 30; i++) {
             Participant p = participants.get(i);
-            poppingECPs.add(createECP(event, popping, p, i - 9, "1v1"));
+            Integer auditionNum = (i - 10) < 15 ? (i - 9) : null;
+            poppingECPs.add(createECP(event, popping, p, auditionNum, "1v1"));
         }
 
         // 8. Pre-fill scores with intentional tie scenarios
@@ -230,7 +233,7 @@ public class DemoDataSeeder {
     }
 
     private EventCategoryParticipant createECP(Event event, EventCategory cat,
-                                                Participant p, int auditionNum, String format) {
+                                                Participant p, Integer auditionNum, String format) {
         EventCategoryParticipant ecp = new EventCategoryParticipant();
         EventCategoryParticipantId id = new EventCategoryParticipantId(
                 event.getEventId(), cat.getId(), p.getParticipantId());

--- a/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+++ b/BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
@@ -131,18 +131,22 @@ public class DemoDataSeeder {
         // 7. Create EventCategoryParticipant links
         // Hip Hop: participants 0-19 (first 20)
         // Popping: participants 10-29 (last 20, overlapping 10-19)
-        // First 15 per category get audition numbers; last 5 get null (for helper check-in)
+        // Scatter assigned audition numbers with gaps (for realistic helper check-in)
+        // Assigned indices (0-based) per category: randomly chosen gaps at 3, 7, 12, 16, 19
         List<EventCategoryParticipant> hipHopECPs = new ArrayList<>();
         List<EventCategoryParticipant> poppingECPs = new ArrayList<>();
+        Set<Integer> hipHopUnassigned = Set.of(3, 7, 12, 16, 19);
+        Set<Integer> poppingUnassigned = Set.of(2, 6, 10, 15, 17);
 
         for (int i = 0; i < 20; i++) {
             Participant p = participants.get(i);
-            Integer auditionNum = i < 15 ? i + 1 : null;
+            Integer auditionNum = hipHopUnassigned.contains(i) ? null : i + 1;
             hipHopECPs.add(createECP(event, hipHop, p, auditionNum, "1v1"));
         }
         for (int i = 10; i < 30; i++) {
             Participant p = participants.get(i);
-            Integer auditionNum = (i - 10) < 15 ? (i - 9) : null;
+            int localIdx = i - 10;
+            Integer auditionNum = poppingUnassigned.contains(i) ? null : localIdx + 1;
             poppingECPs.add(createECP(event, popping, p, auditionNum, "1v1"));
         }
 

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -242,6 +242,14 @@ public class DemoService {
     }
 
     @Transactional
+    public void resetTemplate() {
+        eventRepo.findByEventName(TEMPLATE_NAME).ifPresent(e -> {
+            log.info("Deleting demo template event for reset");
+            eventRepo.delete(e);
+        });
+    }
+
+    @Transactional
     public int purgeAllSandboxes() {
         List<Event> demos = eventRepo.findAllDemoEvents();
         for (Event demo : demos) {

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -224,6 +224,32 @@ public class DemoService {
         return eventRepo.findAllDemoEvents().size();
     }
 
+    /**
+     * Create a new session token for a different role in an existing demo sandbox.
+     * Does NOT create a new sandbox and does NOT count against IP rate limits.
+     */
+    @Transactional
+    public SessionToken createTokenForExistingSandbox(Long eventId, String role) {
+        Event event = eventRepo.findById(eventId)
+                .orElseThrow(() -> new IllegalStateException("Demo sandbox not found"));
+        if (!event.getEventName().startsWith(CLONE_PREFIX)) {
+            throw new IllegalArgumentException("Not a demo event");
+        }
+
+        SessionToken token = new SessionToken();
+        token.setTokenId(UUID.randomUUID().toString());
+        token.setRole(role);
+        token.setEvent(event);
+        token.setExpiresAt(LocalDateTime.now().plusDays(1));
+        if ("JUDGE".equals(role)) {
+            List<Judge> judges = judgeRepo.findJudgesByEventId(event.getEventId());
+            if (!judges.isEmpty()) {
+                token.setJudge(judges.get(new Random().nextInt(judges.size())));
+            }
+        }
+        return sessionTokenRepo.save(token);
+    }
+
     private void checkIpRateLimit(String ip) {
         List<LocalDateTime> timestamps = ipRequestLog.getOrDefault(ip, Collections.emptyList());
         LocalDateTime cutoff = LocalDateTime.now().minusHours(24);

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -1,0 +1,328 @@
+package com.example.BES.services;
+
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class DemoService {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoService.class);
+    private static final String TEMPLATE_NAME = "Kyrove Demo";
+    private static final String CLONE_PREFIX = "Kyrove Demo-";
+    private static final int MAX_CONCURRENT_SANDBOXES = 10;
+
+    private final EventRepo eventRepo;
+    private final EventCategoryRepo eventCategoryRepo;
+    private final ParticipantRepo participantRepo;
+    private final EventParticipantRepo eventParticipantRepo;
+    private final EventCategoryParticipantRepo eventCategoryParticipantRepo;
+    private final JudgeRepo judgeRepo;
+    private final ScoringCriteriaRepo scoringCriteriaRepo;
+    private final ScoreRepo scoreRepo;
+    private final AuditionFeedbackRepository auditionFeedbackRepo;
+    private final SessionTokenRepository sessionTokenRepo;
+    private final AppConfigService appConfigService;
+
+    // IP rate limiting: map of IP to list of timestamps
+    private final ConcurrentHashMap<String, List<LocalDateTime>> ipRequestLog = new ConcurrentHashMap<>();
+
+    public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
+                       ParticipantRepo participantRepo, EventParticipantRepo eventParticipantRepo,
+                       EventCategoryParticipantRepo eventCategoryParticipantRepo,
+                       JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
+                       ScoreRepo scoreRepo, AuditionFeedbackRepository auditionFeedbackRepo,
+                       SessionTokenRepository sessionTokenRepo, AppConfigService appConfigService) {
+        this.eventRepo = eventRepo;
+        this.eventCategoryRepo = eventCategoryRepo;
+        this.participantRepo = participantRepo;
+        this.eventParticipantRepo = eventParticipantRepo;
+        this.eventCategoryParticipantRepo = eventCategoryParticipantRepo;
+        this.judgeRepo = judgeRepo;
+        this.scoringCriteriaRepo = scoringCriteriaRepo;
+        this.scoreRepo = scoreRepo;
+        this.auditionFeedbackRepo = auditionFeedbackRepo;
+        this.sessionTokenRepo = sessionTokenRepo;
+        this.appConfigService = appConfigService;
+    }
+
+    @Transactional
+    public CloneResult cloneTemplate(String role, String clientIp) {
+        // Rate limit: max 3 per IP per 24h
+        checkIpRateLimit(clientIp);
+
+        // Limit concurrent sandboxes
+        long active = eventRepo.findAllDemoEvents().size();
+        if (active >= MAX_CONCURRENT_SANDBOXES) {
+            throw new DemoRateLimitException("Too many demo sessions. Try again later.");
+        }
+
+        Event template = eventRepo.findByEventName(TEMPLATE_NAME)
+                .orElseThrow(() -> new IllegalStateException("Demo template event not found"));
+
+        // 1. Clone event
+        String cloneName = CLONE_PREFIX + randomUuid8();
+        Event clone = cloneEvent(template, cloneName);
+
+        // 2. Clone categories + scoring criteria + judge assignments
+        Map<Long, EventCategory> oldToNewCategory = new HashMap<>();
+        List<EventCategory> templateCategories = eventCategoryRepo.findByEvent(template);
+        for (EventCategory templateCat : templateCategories) {
+            EventCategory clonedCat = cloneCategory(templateCat, clone);
+            oldToNewCategory.put(templateCat.getId(), clonedCat);
+
+            // Clone scoring criteria for this category
+            List<ScoringCriteria> criteria = scoringCriteriaRepo.findByEventAndEventCategory(template, templateCat);
+            for (ScoringCriteria sc : criteria) {
+                cloneScoringCriteria(sc, clone, clonedCat);
+            }
+        }
+        // Also clone event-level criteria (eventCategory = null)
+        List<ScoringCriteria> eventCriteria = scoringCriteriaRepo.findByEventAndEventCategory(template, null);
+        for (ScoringCriteria sc : eventCriteria) {
+            cloneScoringCriteria(sc, clone, null);
+        }
+
+        // 3. Clone EventParticipants
+        Map<Long, EventParticipant> oldToNewEP = new HashMap<>();
+        List<EventParticipant> templateEPs = eventParticipantRepo.findByEvent(template);
+        for (EventParticipant templateEP : templateEPs) {
+            EventParticipant clonedEP = cloneEventParticipant(templateEP, clone);
+            oldToNewEP.put(templateEP.getId(), clonedEP);
+        }
+
+        // 4. Clone EventCategoryParticipants
+        Map<String, EventCategoryParticipant> compositeKeyToNewECP = new HashMap<>();
+        for (EventCategory templateCat : templateCategories) {
+            List<EventCategoryParticipant> templateECPs =
+                    eventCategoryParticipantRepo.findByEventCategory(templateCat);
+            EventCategory clonedCat = oldToNewCategory.get(templateCat.getId());
+            for (EventCategoryParticipant templateECP : templateECPs) {
+                EventCategoryParticipant clonedECP = cloneECP(templateECP, clone, clonedCat);
+                String oldCompositeKey = compositeKey(templateECP);
+                compositeKeyToNewECP.put(oldCompositeKey, clonedECP);
+            }
+        }
+
+        // 5. Clone scores
+        for (EventCategory templateCat : templateCategories) {
+            List<EventCategoryParticipant> templateECPs =
+                    eventCategoryParticipantRepo.findByEventCategory(templateCat);
+            for (EventCategoryParticipant templateECP : templateECPs) {
+                List<Score> scores = scoreRepo.findByEventCategoryParticipant(templateECP);
+                EventCategoryParticipant clonedECP =
+                        compositeKeyToNewECP.get(compositeKey(templateECP));
+                for (Score s : scores) {
+                    cloneScore(s, clonedECP);
+                }
+            }
+        }
+
+        // 6. Clone feedback
+        for (EventCategory templateCat : templateCategories) {
+            List<EventCategoryParticipant> templateECPs =
+                    eventCategoryParticipantRepo.findByEventCategory(templateCat);
+            for (EventCategoryParticipant templateECP : templateECPs) {
+                List<AuditionFeedback> feedbacks = auditionFeedbackRepo.findByEventCategoryParticipant(templateECP);
+                EventCategoryParticipant clonedECP =
+                        compositeKeyToNewECP.get(compositeKey(templateECP));
+                for (AuditionFeedback fb : feedbacks) {
+                    cloneFeedback(fb, clonedECP);
+                }
+            }
+        }
+
+        // 7. Generate session token for the requested role
+        SessionToken token = new SessionToken();
+        token.setTokenId(UUID.randomUUID().toString());
+        token.setRole(role);
+        token.setEvent(clone);
+        token.setExpiresAt(LocalDateTime.now().plusDays(1));
+        if ("JUDGE".equals(role)) {
+            // Pick a random judge from the clone
+            List<Judge> judges = judgeRepo.findJudgesByEventId(clone.getEventId());
+            if (!judges.isEmpty()) {
+                token.setJudge(judges.get(new Random().nextInt(judges.size())));
+            }
+        }
+        token = sessionTokenRepo.save(token);
+
+        // Record this IP request
+        ipRequestLog.computeIfAbsent(clientIp, k -> new ArrayList<>()).add(LocalDateTime.now());
+
+        log.info("Demo sandbox created: {} for role {}", cloneName, role);
+
+        return new CloneResult(clone, token);
+    }
+
+    public void purgeSandbox(Long eventId) {
+        Event event = eventRepo.findById(eventId).orElse(null);
+        if (event == null || !event.getEventName().startsWith(CLONE_PREFIX)) {
+            return; // safety: only purge demo events
+        }
+        log.info("Purging demo sandbox: {}", event.getEventName());
+
+        // Delete in order: feedback -> scores -> ECPs -> criteria -> EPs -> categories -> event_judge -> tokens -> event
+        List<EventCategory> categories = eventCategoryRepo.findByEvent(event);
+        for (EventCategory cat : categories) {
+            List<EventCategoryParticipant> ecps = eventCategoryParticipantRepo.findByEventCategory(cat);
+            for (EventCategoryParticipant ecp : ecps) {
+                auditionFeedbackRepo.deleteAll(auditionFeedbackRepo.findByEventCategoryParticipant(ecp));
+                scoreRepo.deleteAll(scoreRepo.findByEventCategoryParticipant(ecp));
+            }
+            eventCategoryParticipantRepo.deleteAll(ecps);
+            scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(event, cat));
+            // Remove judge assignments from category
+            cat.getJudges().clear();
+            eventCategoryRepo.save(cat);
+        }
+        // Delete event-level criteria
+        scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(event, null));
+        // Delete EventParticipants
+        List<EventParticipant> eps = eventParticipantRepo.findByEvent(event);
+        eventParticipantRepo.deleteAll(eps);
+        // Remove event_judge entries
+        List<Judge> eventJudges = judgeRepo.findJudgesByEventId(event.getEventId());
+        for (Judge j : eventJudges) {
+            judgeRepo.deleteEventJudge(event.getEventId(), j.getJudgeId());
+        }
+        // Delete session tokens
+        List<SessionToken> tokens = sessionTokenRepo.findByEvent_EventId(event.getEventId());
+        sessionTokenRepo.deleteAll(tokens);
+        // Delete categories
+        eventCategoryRepo.deleteAll(categories);
+        // Delete event
+        eventRepo.delete(event);
+    }
+
+    public int countActiveSandboxes() {
+        return eventRepo.findAllDemoEvents().size();
+    }
+
+    private void checkIpRateLimit(String ip) {
+        List<LocalDateTime> timestamps = ipRequestLog.getOrDefault(ip, Collections.emptyList());
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
+        long recent = timestamps.stream().filter(t -> t.isAfter(cutoff)).count();
+        if (recent >= 3) {
+            throw new DemoRateLimitException("Demo limit reached for today. Try again later.");
+        }
+    }
+
+    private Event cloneEvent(Event template, String newName) {
+        Event clone = new Event();
+        clone.setEventName(newName);
+        clone.setPaymentRequired(template.isPaymentRequired());
+        clone.setJudgingMode(template.getJudgingMode());
+        clone.setFeedbackEnabled(template.isFeedbackEnabled());
+        clone.setResultsReleased(false);
+        clone.setReleaseScore(false);
+        clone.setAnimTheme(template.getAnimTheme());
+        return eventRepo.save(clone);
+    }
+
+    private EventCategory cloneCategory(EventCategory template, Event newEvent) {
+        EventCategory clone = new EventCategory();
+        clone.setEvent(newEvent);
+        clone.setName(template.getName());
+        clone.setFormat(template.getFormat());
+        clone.setSoloAllowed(template.isSoloAllowed());
+        clone.setRoundLabel(template.getRoundLabel());
+        clone.setNumberColor(template.getNumberColor());
+        clone.setSheetAliases(template.getSheetAliases());
+        // Copy judge list
+        clone.setJudges(new ArrayList<>(template.getJudges()));
+        return eventCategoryRepo.save(clone);
+    }
+
+    private void cloneScoringCriteria(ScoringCriteria template, Event newEvent, EventCategory newCat) {
+        ScoringCriteria clone = new ScoringCriteria();
+        clone.setEvent(newEvent);
+        clone.setEventCategory(newCat);
+        clone.setName(template.getName());
+        clone.setWeight(template.getWeight());
+        clone.setDisplayOrder(template.getDisplayOrder());
+        scoringCriteriaRepo.save(clone);
+    }
+
+    private EventParticipant cloneEventParticipant(EventParticipant template, Event newEvent) {
+        EventParticipant clone = new EventParticipant();
+        clone.setEvent(newEvent);
+        clone.setParticipant(template.getParticipant());
+        clone.setPaymentVerified(template.isPaymentVerified());
+        clone.setDisplayName(template.getDisplayName());
+        clone.setStageName(template.getStageName());
+        clone.setTeamName(template.getTeamName());
+        clone.setCategory(template.getCategory());
+        clone.setResidency(template.getResidency());
+        clone.setReferenceCode(UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase());
+        return eventParticipantRepo.save(clone);
+    }
+
+    private EventCategoryParticipant cloneECP(EventCategoryParticipant template, Event newEvent, EventCategory newCat) {
+        EventCategoryParticipant clone = new EventCategoryParticipant();
+        EventCategoryParticipantId newId = new EventCategoryParticipantId(
+                newEvent.getEventId(), newCat.getId(), template.getParticipant().getParticipantId());
+        clone.setId(newId);
+        clone.setEvent(newEvent);
+        clone.setEventCategory(newCat);
+        clone.setParticipant(template.getParticipant());
+        clone.setDisplayName(template.getDisplayName());
+        clone.setFormat(template.getFormat());
+        clone.setAuditionNumber(template.getAuditionNumber());
+        clone.setTeamName(template.getTeamName());
+        return eventCategoryParticipantRepo.save(clone);
+    }
+
+    private void cloneScore(Score template, EventCategoryParticipant newECP) {
+        Score clone = new Score();
+        clone.setEventCategoryParticipant(newECP);
+        clone.setJudge(template.getJudge());
+        clone.setAspect(template.getAspect());
+        clone.setValue(template.getValue());
+        scoreRepo.save(clone);
+    }
+
+    private void cloneFeedback(AuditionFeedback template, EventCategoryParticipant newECP) {
+        AuditionFeedback clone = new AuditionFeedback();
+        clone.setEventCategoryParticipant(newECP);
+        clone.setJudge(template.getJudge());
+        clone.setNote(template.getNote());
+        clone.setTags(new HashSet<>(template.getTags()));
+        auditionFeedbackRepo.save(clone);
+    }
+
+    private String compositeKey(EventCategoryParticipant ecp) {
+        return ecp.getEvent().getEventId() + "-" +
+                ecp.getEventCategory().getId() + "-" +
+                ecp.getParticipant().getParticipantId();
+    }
+
+    private String randomUuid8() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+    // ---- Inner classes ----
+
+    public static class CloneResult {
+        public final Event event;
+        public final SessionToken token;
+
+        public CloneResult(Event event, SessionToken token) {
+            this.event = event;
+            this.token = token;
+        }
+    }
+
+    public static class DemoRateLimitException extends RuntimeException {
+        public DemoRateLimitException(String message) {
+            super(message);
+        }
+    }
+}

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 public class DemoService {
@@ -21,7 +22,6 @@ public class DemoService {
 
     private final EventRepo eventRepo;
     private final EventCategoryRepo eventCategoryRepo;
-    private final ParticipantRepo participantRepo;
     private final EventParticipantRepo eventParticipantRepo;
     private final EventCategoryParticipantRepo eventCategoryParticipantRepo;
     private final JudgeRepo judgeRepo;
@@ -29,20 +29,18 @@ public class DemoService {
     private final ScoreRepo scoreRepo;
     private final AuditionFeedbackRepository auditionFeedbackRepo;
     private final SessionTokenRepository sessionTokenRepo;
-    private final AppConfigService appConfigService;
 
     // IP rate limiting: map of IP to list of timestamps
     private final ConcurrentHashMap<String, List<LocalDateTime>> ipRequestLog = new ConcurrentHashMap<>();
 
     public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
-                       ParticipantRepo participantRepo, EventParticipantRepo eventParticipantRepo,
+                       EventParticipantRepo eventParticipantRepo,
                        EventCategoryParticipantRepo eventCategoryParticipantRepo,
                        JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
                        ScoreRepo scoreRepo, AuditionFeedbackRepository auditionFeedbackRepo,
-                       SessionTokenRepository sessionTokenRepo, AppConfigService appConfigService) {
+                       SessionTokenRepository sessionTokenRepo) {
         this.eventRepo = eventRepo;
         this.eventCategoryRepo = eventCategoryRepo;
-        this.participantRepo = participantRepo;
         this.eventParticipantRepo = eventParticipantRepo;
         this.eventCategoryParticipantRepo = eventCategoryParticipantRepo;
         this.judgeRepo = judgeRepo;
@@ -50,7 +48,6 @@ public class DemoService {
         this.scoreRepo = scoreRepo;
         this.auditionFeedbackRepo = auditionFeedbackRepo;
         this.sessionTokenRepo = sessionTokenRepo;
-        this.appConfigService = appConfigService;
     }
 
     @Transactional
@@ -155,13 +152,14 @@ public class DemoService {
         token = sessionTokenRepo.save(token);
 
         // Record this IP request
-        ipRequestLog.computeIfAbsent(clientIp, k -> new ArrayList<>()).add(LocalDateTime.now());
+        ipRequestLog.computeIfAbsent(clientIp, k -> new CopyOnWriteArrayList<>()).add(LocalDateTime.now());
 
         log.info("Demo sandbox created: {} for role {}", cloneName, role);
 
         return new CloneResult(clone, token);
     }
 
+    @Transactional
     public void purgeSandbox(Long eventId) {
         Event event = eventRepo.findById(eventId).orElse(null);
         if (event == null || !event.getEventName().startsWith(CLONE_PREFIX)) {

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -204,7 +204,6 @@ public class DemoService {
     @Scheduled(fixedRate = 6 * 3600 * 1000) // every 6 hours
     public void purgeOrphanSandboxes() {
         List<Event> demos = eventRepo.findAllDemoEvents();
-        LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
         int purged = 0;
         for (Event demo : demos) {
             // Check if there are any valid session tokens for this event

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -27,6 +27,8 @@ public class DemoService {
     private final ScoringCriteriaRepo scoringCriteriaRepo;
     private final ScoreRepo scoreRepo;
     private final AuditionFeedbackRepository auditionFeedbackRepo;
+    private final FeedbackTagGroupRepository feedbackTagGroupRepo;
+    private final FeedbackTagRepository feedbackTagRepo;
     private final SessionTokenRepository sessionTokenRepo;
 
 public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
@@ -34,6 +36,8 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
                        EventCategoryParticipantRepo eventCategoryParticipantRepo,
                        JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
                        ScoreRepo scoreRepo, AuditionFeedbackRepository auditionFeedbackRepo,
+                       FeedbackTagGroupRepository feedbackTagGroupRepo,
+                       FeedbackTagRepository feedbackTagRepo,
                        SessionTokenRepository sessionTokenRepo) {
         this.eventRepo = eventRepo;
         this.eventCategoryRepo = eventCategoryRepo;
@@ -43,6 +47,8 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
         this.scoringCriteriaRepo = scoringCriteriaRepo;
         this.scoreRepo = scoreRepo;
         this.auditionFeedbackRepo = auditionFeedbackRepo;
+        this.feedbackTagGroupRepo = feedbackTagGroupRepo;
+        this.feedbackTagRepo = feedbackTagRepo;
         this.sessionTokenRepo = sessionTokenRepo;
     }
 
@@ -63,10 +69,14 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
 
         // 2. Clone categories + scoring criteria + judge assignments
         Map<Long, EventCategory> oldToNewCategory = new HashMap<>();
+        Set<Judge> allJudges = new LinkedHashSet<>(); // preserve order for deterministic pick
         List<EventCategory> templateCategories = eventCategoryRepo.findByEvent(template);
         for (EventCategory templateCat : templateCategories) {
             EventCategory clonedCat = cloneCategory(templateCat, clone);
             oldToNewCategory.put(templateCat.getId(), clonedCat);
+
+            // Collect judges from template categories (before the native insert below)
+            allJudges.addAll(templateCat.getJudges());
 
             // Clone scoring criteria for this category
             List<ScoringCriteria> criteria = scoringCriteriaRepo.findByEventAndEventCategory(template, templateCat);
@@ -78,6 +88,11 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
         List<ScoringCriteria> eventCriteria = scoringCriteriaRepo.findByEventAndEventCategory(template, null);
         for (ScoringCriteria sc : eventCriteria) {
             cloneScoringCriteria(sc, clone, null);
+        }
+
+        // Insert event_judge entries for the cloned event
+        for (Judge judge : allJudges) {
+            judgeRepo.insertEventJudge(clone.getEventId(), judge.getJudgeId());
         }
 
         // 3. Clone EventParticipants
@@ -115,7 +130,29 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
             }
         }
 
-        // 6. Clone feedback
+        // 6. Clone feedback tag groups and tags (event-scoped — need their own copies)
+        Map<Long, FeedbackTagGroup> oldToNewGroup = new HashMap<>();
+        List<FeedbackTagGroup> templateGroups = feedbackTagGroupRepo.findByEventEventId(template.getEventId());
+        for (FeedbackTagGroup templateGroup : templateGroups) {
+            FeedbackTagGroup clonedGroup = new FeedbackTagGroup();
+            clonedGroup.setName(templateGroup.getName());
+            clonedGroup.setEvent(clone);
+            clonedGroup = feedbackTagGroupRepo.save(clonedGroup);
+            oldToNewGroup.put(templateGroup.getId(), clonedGroup);
+        }
+
+        Map<Long, FeedbackTag> oldToNewTag = new HashMap<>();
+        List<FeedbackTag> templateTags = feedbackTagRepo.findByEventEventId(template.getEventId());
+        for (FeedbackTag templateTag : templateTags) {
+            FeedbackTag clonedTag = new FeedbackTag();
+            clonedTag.setLabel(templateTag.getLabel());
+            clonedTag.setEvent(clone);
+            clonedTag.setGroup(oldToNewGroup.get(templateTag.getGroup().getId()));
+            clonedTag = feedbackTagRepo.save(clonedTag);
+            oldToNewTag.put(templateTag.getId(), clonedTag);
+        }
+
+        // 7. Clone feedback (remap tag refs to cloned tags)
         for (EventCategory templateCat : templateCategories) {
             List<EventCategoryParticipant> templateECPs =
                     eventCategoryParticipantRepo.findByEventCategory(templateCat);
@@ -124,22 +161,22 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
                 EventCategoryParticipant clonedECP =
                         compositeKeyToNewECP.get(compositeKey(templateECP));
                 for (AuditionFeedback fb : feedbacks) {
-                    cloneFeedback(fb, clonedECP);
+                    cloneFeedback(fb, clonedECP, oldToNewTag);
                 }
             }
         }
 
-        // 7. Generate session token for the requested role
+        // 8. Generate session token for the requested role
         SessionToken token = new SessionToken();
         token.setTokenId(UUID.randomUUID().toString());
         token.setRole(role);
         token.setEvent(clone);
         token.setExpiresAt(LocalDateTime.now().plusDays(1));
         if ("JUDGE".equals(role)) {
-            // Pick a random judge from the clone
-            List<Judge> judges = judgeRepo.findJudgesByEventId(clone.getEventId());
-            if (!judges.isEmpty()) {
-                token.setJudge(judges.get(new Random().nextInt(judges.size())));
+            // Pick a random judge from those collected during category cloning
+            if (!allJudges.isEmpty()) {
+                List<Judge> judgeList = new ArrayList<>(allJudges);
+                token.setJudge(judgeList.get(new Random().nextInt(judgeList.size())));
             }
         }
         token = sessionTokenRepo.save(token);
@@ -157,7 +194,7 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
         }
         log.info("Purging demo sandbox: {}", event.getEventName());
 
-        // Delete in order: feedback -> scores -> ECPs -> criteria -> EPs -> categories -> event_judge -> tokens -> event
+        // Delete in order: feedback -> tags -> groups -> scores -> ECPs -> criteria -> EPs -> categories -> event_judge -> tokens -> event
         List<EventCategory> categories = eventCategoryRepo.findByEvent(event);
         for (EventCategory cat : categories) {
             List<EventCategoryParticipant> ecps = eventCategoryParticipantRepo.findByEventCategory(cat);
@@ -171,6 +208,9 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
             cat.getJudges().clear();
             eventCategoryRepo.save(cat);
         }
+        // Delete feedback tags then groups (tags reference groups via FK)
+        feedbackTagRepo.deleteAll(feedbackTagRepo.findByEventEventId(event.getEventId()));
+        feedbackTagGroupRepo.deleteAll(feedbackTagGroupRepo.findByEventEventId(event.getEventId()));
         // Delete event-level criteria
         scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(event, null));
         // Delete EventParticipants
@@ -249,6 +289,9 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
             cat.getJudges().clear();
             eventCategoryRepo.save(cat);
         }
+        // Delete feedback tags then groups
+        feedbackTagRepo.deleteAll(feedbackTagRepo.findByEventEventId(template.getEventId()));
+        feedbackTagGroupRepo.deleteAll(feedbackTagGroupRepo.findByEventEventId(template.getEventId()));
         scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(template, null));
         List<EventParticipant> eps = eventParticipantRepo.findByEvent(template);
         eventParticipantRepo.deleteAll(eps);
@@ -371,12 +414,21 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
         scoreRepo.save(clone);
     }
 
-    private void cloneFeedback(AuditionFeedback template, EventCategoryParticipant newECP) {
+    private void cloneFeedback(AuditionFeedback template, EventCategoryParticipant newECP,
+                                 Map<Long, FeedbackTag> tagMap) {
         AuditionFeedback clone = new AuditionFeedback();
         clone.setEventCategoryParticipant(newECP);
         clone.setJudge(template.getJudge());
         clone.setNote(template.getNote());
-        clone.setTags(new HashSet<>(template.getTags()));
+        // Remap tag references to the cloned tags (event-scoped)
+        Set<FeedbackTag> clonedTags = new HashSet<>();
+        for (FeedbackTag templateTag : template.getTags()) {
+            FeedbackTag clonedTag = tagMap.get(templateTag.getId());
+            if (clonedTag != null) {
+                clonedTags.add(clonedTag);
+            }
+        }
+        clone.setTags(clonedTags);
         auditionFeedbackRepo.save(clone);
     }
 

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -232,10 +232,34 @@ public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
 
     @Transactional
     public void resetTemplate() {
-        eventRepo.findByEventName(TEMPLATE_NAME).ifPresent(e -> {
-            log.info("Deleting demo template event for reset");
-            eventRepo.delete(e);
-        });
+        Event template = eventRepo.findByEventName(TEMPLATE_NAME).orElse(null);
+        if (template == null) return;
+        log.info("Deleting demo template event for reset: {}", template.getEventName());
+
+        // Cascade delete in correct order (same as purgeSandbox, but for template)
+        List<EventCategory> categories = eventCategoryRepo.findByEvent(template);
+        for (EventCategory cat : categories) {
+            List<EventCategoryParticipant> ecps = eventCategoryParticipantRepo.findByEventCategory(cat);
+            for (EventCategoryParticipant ecp : ecps) {
+                auditionFeedbackRepo.deleteAll(auditionFeedbackRepo.findByEventCategoryParticipant(ecp));
+                scoreRepo.deleteAll(scoreRepo.findByEventCategoryParticipant(ecp));
+            }
+            eventCategoryParticipantRepo.deleteAll(ecps);
+            scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(template, cat));
+            cat.getJudges().clear();
+            eventCategoryRepo.save(cat);
+        }
+        scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(template, null));
+        List<EventParticipant> eps = eventParticipantRepo.findByEvent(template);
+        eventParticipantRepo.deleteAll(eps);
+        List<Judge> eventJudges = judgeRepo.findJudgesByEventId(template.getEventId());
+        for (Judge j : eventJudges) {
+            judgeRepo.deleteEventJudge(template.getEventId(), j.getJudgeId());
+        }
+        List<SessionToken> tokens = sessionTokenRepo.findByEvent_EventId(template.getEventId());
+        sessionTokenRepo.deleteAll(tokens);
+        eventCategoryRepo.deleteAll(categories);
+        eventRepo.delete(template);
     }
 
     @Transactional

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -10,8 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 public class DemoService {
@@ -31,10 +29,7 @@ public class DemoService {
     private final AuditionFeedbackRepository auditionFeedbackRepo;
     private final SessionTokenRepository sessionTokenRepo;
 
-    // IP rate limiting: map of IP to list of timestamps
-    private final ConcurrentHashMap<String, List<LocalDateTime>> ipRequestLog = new ConcurrentHashMap<>();
-
-    public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
+public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
                        EventParticipantRepo eventParticipantRepo,
                        EventCategoryParticipantRepo eventCategoryParticipantRepo,
                        JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
@@ -53,9 +48,6 @@ public class DemoService {
 
     @Transactional
     public CloneResult cloneTemplate(String role, String clientIp) {
-        // Rate limit: max 3 per IP per 24h
-        checkIpRateLimit(clientIp);
-
         // Limit concurrent sandboxes
         long active = eventRepo.findAllDemoEvents().size();
         if (active >= MAX_CONCURRENT_SANDBOXES) {
@@ -151,9 +143,6 @@ public class DemoService {
             }
         }
         token = sessionTokenRepo.save(token);
-
-        // Record this IP request
-        ipRequestLog.computeIfAbsent(clientIp, k -> new CopyOnWriteArrayList<>()).add(LocalDateTime.now());
 
         log.info("Demo sandbox created: {} for role {}", cloneName, role);
 
@@ -282,15 +271,6 @@ public class DemoService {
             }
         }
         return sessionTokenRepo.save(token);
-    }
-
-    private void checkIpRateLimit(String ip) {
-        List<LocalDateTime> timestamps = ipRequestLog.getOrDefault(ip, Collections.emptyList());
-        LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
-        long recent = timestamps.stream().filter(t -> t.isAfter(cutoff)).count();
-        if (recent >= 3) {
-            throw new DemoRateLimitException("Demo limit reached for today. Try again later.");
-        }
     }
 
     private Event cloneEvent(Event template, String newName) {

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -224,6 +224,32 @@ public class DemoService {
         return eventRepo.findAllDemoEvents().size();
     }
 
+    public List<Map<String, Object>> listSandboxes() {
+        List<Event> demos = eventRepo.findAllDemoEvents();
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Event demo : demos) {
+            Map<String, Object> info = new HashMap<>();
+            info.put("eventId", demo.getEventId());
+            info.put("eventName", demo.getEventName());
+            List<SessionToken> tokens = sessionTokenRepo.findByEvent_EventId(demo.getEventId());
+            long validTokens = tokens.stream()
+                    .filter(t -> !t.isRevoked() && t.getExpiresAt().isAfter(LocalDateTime.now()))
+                    .count();
+            info.put("activeTokens", validTokens);
+            result.add(info);
+        }
+        return result;
+    }
+
+    @Transactional
+    public int purgeAllSandboxes() {
+        List<Event> demos = eventRepo.findAllDemoEvents();
+        for (Event demo : demos) {
+            purgeSandbox(demo.getEventId());
+        }
+        return demos.size();
+    }
+
     /**
      * Create a new session token for a different role in an existing demo sandbox.
      * Does NOT create a new sandbox and does NOT count against IP rate limits.

--- a/BES/src/main/java/com/example/BES/services/DemoService.java
+++ b/BES/src/main/java/com/example/BES/services/DemoService.java
@@ -4,6 +4,7 @@ import com.example.BES.models.*;
 import com.example.BES.respositories.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -198,6 +199,26 @@ public class DemoService {
         eventCategoryRepo.deleteAll(categories);
         // Delete event
         eventRepo.delete(event);
+    }
+
+    @Scheduled(fixedRate = 6 * 3600 * 1000) // every 6 hours
+    public void purgeOrphanSandboxes() {
+        List<Event> demos = eventRepo.findAllDemoEvents();
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
+        int purged = 0;
+        for (Event demo : demos) {
+            // Check if there are any valid session tokens for this event
+            List<SessionToken> tokens = sessionTokenRepo.findByEvent_EventId(demo.getEventId());
+            boolean hasValidToken = tokens.stream().anyMatch(t ->
+                    !t.isRevoked() && t.getExpiresAt().isAfter(LocalDateTime.now()));
+            if (!hasValidToken) {
+                purgeSandbox(demo.getEventId());
+                purged++;
+            }
+        }
+        if (purged > 0) {
+            log.info("Purged {} orphan demo sandboxes", purged);
+        }
     }
 
     public int countActiveSandboxes() {

--- a/BES/src/main/java/com/example/BES/services/TierAccessService.java
+++ b/BES/src/main/java/com/example/BES/services/TierAccessService.java
@@ -73,6 +73,9 @@ public class TierAccessService {
         // Emcee / Judge / Helper — resolved from the event's assigned organisers
         // (Max if any assigned organiser is Max).
         //
+        // Demo sandboxes are PRO-tier only — never grant battle access.
+        if (eventName != null && eventName.startsWith("Kyrove Demo-")) return false;
+
         // When no event context is specified (null/blank) there is no event to
         // tier-gate — @PreAuthorize on the endpoint already restricts roles.
         // Likewise, when the existing tests set active-genre in a preceding test

--- a/BES/src/main/resources/db/migration/V46__add_demo_config.sql
+++ b/BES/src/main/resources/db/migration/V46__add_demo_config.sql
@@ -1,0 +1,7 @@
+INSERT INTO app_config (key, value)
+VALUES ('demo_passcode', 'CHANGEME')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO app_config (key, value)
+VALUES ('demo_enabled', 'true')
+ON CONFLICT (key) DO NOTHING;

--- a/BES/src/test/java/com/example/BES/controllers/DemoControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/DemoControllerIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.example.BES.controllers;
+
+import com.example.BES.dtos.DemoStartRequestDto;
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import com.example.BES.services.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class DemoControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AppConfigService appConfigService;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    @BeforeEach
+    void setUp() {
+        // Ensure demo is enabled and passcode is set
+        appConfigService.setDemoEnabled(true);
+        appConfigService.setDemoPasscode("TESTCODE");
+        // Ensure template event exists
+        if (eventRepo.findByEventName("Kyrove Demo").isEmpty()) {
+            Event template = new Event();
+            template.setEventName("Kyrove Demo");
+            template.setJudgingMode("SOLO");
+            eventRepo.save(template);
+        }
+    }
+
+    @Test
+    void startDemo_withValidPasscodeAndRole_returnsSuccess() throws Exception {
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "EMCEE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.role").value("EMCEE"))
+                .andExpect(jsonPath("$.eventName").value(startsWith("Kyrove Demo-")))
+                .andExpect(jsonPath("$.eventId").exists());
+    }
+
+    @Test
+    void startDemo_withWrongPasscode_returns401() throws Exception {
+        DemoStartRequestDto request = new DemoStartRequestDto("WRONG", "EMCEE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Invalid passcode"));
+    }
+
+    @Test
+    void startDemo_whenDisabled_returns403() throws Exception {
+        appConfigService.setDemoEnabled(false);
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "EMCEE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").value("Demo is currently disabled"));
+        appConfigService.setDemoEnabled(true); // restore
+    }
+
+    @Test
+    void startDemo_withInvalidRole_returns400() throws Exception {
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "ORGANISER");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value(containsString("Invalid role")));
+    }
+
+    @Test
+    void startDemo_asJudge_returnsJudgeFields() throws Exception {
+        // Note: this test requires a judge to exist in the template event
+        // The test will pass even without judgeId if no judges are seeded
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "JUDGE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("JUDGE"));
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/DemoServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/DemoServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.BES.services;
+
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class DemoServiceTest {
+
+    @Autowired
+    private DemoService demoService;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    @Autowired
+    private AppConfigService appConfigService;
+
+    @BeforeEach
+    void setUp() {
+        appConfigService.setDemoEnabled(true);
+        appConfigService.setDemoPasscode("TEST");
+        // Seed a minimal template
+        if (eventRepo.findByEventName("Kyrove Demo").isEmpty()) {
+            Event template = new Event();
+            template.setEventName("Kyrove Demo");
+            template.setJudgingMode("SOLO");
+            template.setFeedbackEnabled(true);
+            eventRepo.save(template);
+        }
+    }
+
+    @Test
+    void cloneTemplate_createsNewEventWithUuidSuffix() {
+        DemoService.CloneResult result = demoService.cloneTemplate("EMCEE", "127.0.0.1");
+        assertThat(result.event.getEventName()).startsWith("Kyrove Demo-");
+        assertThat(result.event.getEventName()).isNotEqualTo("Kyrove Demo");
+        assertThat(result.token).isNotNull();
+        assertThat(result.token.getRole()).isEqualTo("EMCEE");
+    }
+
+    @Test
+    void cloneTemplate_rateLimitsPerIp() {
+        demoService.cloneTemplate("EMCEE", "192.168.1.1");
+        demoService.cloneTemplate("HELPER", "192.168.1.1");
+        demoService.cloneTemplate("JUDGE", "192.168.1.1");
+
+        assertThatThrownBy(() -> demoService.cloneTemplate("EMCEE", "192.168.1.1"))
+                .isInstanceOf(DemoService.DemoRateLimitException.class)
+                .hasMessageContaining("limit reached");
+    }
+
+    @Test
+    void purgeSandbox_deletesEventAndChildren() {
+        DemoService.CloneResult result = demoService.cloneTemplate("EMCEE", "127.0.0.2");
+        Long eventId = result.event.getEventId();
+
+        demoService.purgeSandbox(eventId);
+
+        assertThat(eventRepo.findById(eventId)).isEmpty();
+    }
+}

--- a/BES/src/test/java/com/example/BES/services/DemoServiceTest.java
+++ b/BES/src/test/java/com/example/BES/services/DemoServiceTest.java
@@ -50,17 +50,6 @@ class DemoServiceTest {
     }
 
     @Test
-    void cloneTemplate_rateLimitsPerIp() {
-        demoService.cloneTemplate("EMCEE", "192.168.1.1");
-        demoService.cloneTemplate("HELPER", "192.168.1.1");
-        demoService.cloneTemplate("JUDGE", "192.168.1.1");
-
-        assertThatThrownBy(() -> demoService.cloneTemplate("EMCEE", "192.168.1.1"))
-                .isInstanceOf(DemoService.DemoRateLimitException.class)
-                .hasMessageContaining("limit reached");
-    }
-
-    @Test
     void purgeSandbox_deletesEventAndChildren() {
         DemoService.CloneResult result = demoService.cloneTemplate("EMCEE", "127.0.0.2");
         Long eventId = result.event.getEventId();

--- a/docs/superpowers/plans/2026-06-17-demo-account.md
+++ b/docs/superpowers/plans/2026-06-17-demo-account.md
@@ -1,0 +1,2281 @@
+# Demo Account System — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a self-service demo system where users enter a passcode on the login page, pick a role (Emcee/Judge/Helper), and get their own isolated sandbox clone of a pre-populated template event.
+
+**Architecture:** A template event ("Kyrove Demo") is seeded once on startup via `@EventListener(ApplicationReadyEvent)`. When a user picks a role, `DemoService.cloneTemplate()` deep-copies the template into a new event `"Kyrove Demo-{uuid8}"` in a single `@Transactional` block, creates session tokens, and auto-authenticates the user. Sandboxes are cleaned up on session expiry.
+
+**Tech Stack:** Spring Boot (JPA/Hibernate), PostgreSQL, Flyway, Vue 3 (Pinia, Vue Router), Vitest, JUnit 5 + MockMvc
+
+## Global Constraints
+
+- Demo covers only Emcee, Judge, Helper roles — Organiser excluded
+- PRO tier only — no battle access in demo
+- Passcode stored in `app_config` table, admin-manageable
+- Rate limits: 1 sandbox per session, 3 per IP per 24h, 10 concurrent max
+- Sandbox lifetime: 24h max (session timeout), cascade-deleted on expiry
+- No email, no Google Sheets/Docs in demo sandboxes
+- Follow existing patterns: DTO naming, `@PreAuthorize` annotations, session-based auth, Flyway double-underscore naming
+- All demo-specific behavior must NOT affect real events — only events named `"Kyrove Demo*"`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `BES/src/main/resources/db/migration/V46__add_demo_config.sql` | Create | Add `demo_passcode` and `demo_enabled` rows to `app_config` |
+| `BES/src/main/java/com/example/BES/services/AppConfigService.java` | Modify | Add generic `get()`/`set()` methods for arbitrary config keys |
+| `BES/src/main/java/com/example/BES/controllers/AppConfigController.java` | Modify | Extend `GET /api/v1/config/app` response with `demoEnabled` |
+| `BES/src/main/java/com/example/BES/controllers/AdminController.java` | Modify | Add `GET/POST /api/v1/admin/demo/config` |
+| `BES/src/main/java/com/example/BES/services/DemoDataSeeder.java` | Create | Seed template event on startup |
+| `BES/src/main/java/com/example/BES/services/DemoService.java` | Create | Clone template, rate limiting, cleanup |
+| `BES/src/main/java/com/example/BES/controllers/DemoController.java` | Create | `POST /api/v1/demo/start` |
+| `BES/src/main/java/com/example/BES/dtos/DemoStartRequestDto.java` | Create | `{ passcode, role }` |
+| `BES/src/main/java/com/example/BES/dtos/DemoStartResponseDto.java` | Create | `{ authenticated, role, eventId, eventName, judgeId?, judgeName? }` |
+| `BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java` | Create | `{ demoEnabled, passcode }` |
+| `BES/src/main/java/com/example/BES/config/SecurityConfig.java` | Modify | Add `/api/v1/demo/**` to `permitAll` |
+| `BES/src/main/java/com/example/BES/config/SessionExpiryListener.java` | Modify | Cascade-delete demo sandbox on session expiry |
+| `BES/src/main/java/com/example/BES/respositories/EventRepo.java` | Modify | Add `@Query` / `@Modifying` for demo cleanup |
+| `BES-frontend/src/utils/api.js` | Modify | Add `startDemo()`, `getDemoConfig()`, `updateDemoConfig()` |
+| `BES-frontend/src/views/Login.vue` | Modify | Add "Try Demo" button + passcode modal |
+| `BES-frontend/src/components/DemoRolePicker.vue` | Create | 3 role cards for demo role selection |
+| `BES-frontend/src/views/AdminPage.vue` | Modify | Add Demo Settings section |
+| `BES-frontend/src/App.vue` | Modify | Handle `demoEnabled` in app config, hide/show demo button |
+
+---
+
+### Task 1: Database Migration V46
+
+**Files:**
+- Create: `BES/src/main/resources/db/migration/V46__add_demo_config.sql`
+
+**Interfaces:**
+- Produces: `app_config` rows with keys `demo_passcode` and `demo_enabled`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+INSERT INTO app_config (key, value)
+VALUES ('demo_passcode', 'CHANGEME')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO app_config (key, value)
+VALUES ('demo_enabled', 'true')
+ON CONFLICT (key) DO NOTHING;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES/src/main/resources/db/migration/V46__add_demo_config.sql
+git commit -m "feat: add demo_passcode and demo_enabled to app_config (V46)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Generalize AppConfigService
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/AppConfigService.java`
+
+**Interfaces:**
+- Produces: `String get(String key, String defaultVal)` — generic config reader
+- Produces: `void set(String key, String value)` — generic config writer
+- Produces: `String getDemoPasscode()` — convenience for `get("demo_passcode", random())` with auto-generation on first read
+- Produces: `void setDemoPasscode(String passcode)` — convenience
+- Produces: `boolean isDemoEnabled()` — convenience for `"true".equals(get("demo_enabled", "true"))`
+- Produces: `void setDemoEnabled(boolean enabled)` — convenience
+
+- [ ] **Step 1: Add generic accessors and demo convenience methods**
+
+Replace the entire file with:
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.models.AppConfig;
+import com.example.BES.respositories.AppConfigRepository;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+public class AppConfigService {
+
+    private static final String ACCENT_KEY = "accentColor";
+    private static final String ACCENT_DEFAULT = "#ffffff";
+    private static final String DEMO_PASSCODE_KEY = "demo_passcode";
+    private static final String DEMO_ENABLED_KEY = "demo_enabled";
+
+    private final AppConfigRepository appConfigRepository;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public AppConfigService(AppConfigRepository appConfigRepository) {
+        this.appConfigRepository = appConfigRepository;
+    }
+
+    // ---- accentColor (existing) ----
+
+    public String getAccentColor() {
+        return get(ACCENT_KEY, ACCENT_DEFAULT);
+    }
+
+    public void saveAccentColor(String color) {
+        set(ACCENT_KEY, color);
+    }
+
+    // ---- generic key-value ----
+
+    public String get(String key, String defaultVal) {
+        return appConfigRepository.findByKey(key)
+                .map(AppConfig::getValue)
+                .orElse(defaultVal);
+    }
+
+    public void set(String key, String value) {
+        AppConfig config = appConfigRepository.findByKey(key)
+                .orElse(new AppConfig(null, key, value));
+        config.setValue(value);
+        appConfigRepository.save(config);
+    }
+
+    // ---- demo ----
+
+    public String getDemoPasscode() {
+        String existing = get(DEMO_PASSCODE_KEY, null);
+        if (existing == null || "CHANGEME".equals(existing)) {
+            String generated = generatePasscode();
+            set(DEMO_PASSCODE_KEY, generated);
+            return generated;
+        }
+        return existing;
+    }
+
+    public void setDemoPasscode(String passcode) {
+        set(DEMO_PASSCODE_KEY, passcode);
+    }
+
+    public boolean isDemoEnabled() {
+        return "true".equals(get(DEMO_ENABLED_KEY, "true"));
+    }
+
+    public void setDemoEnabled(boolean enabled) {
+        set(DEMO_ENABLED_KEY, Boolean.toString(enabled));
+    }
+
+    private String generatePasscode() {
+        String chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        StringBuilder sb = new StringBuilder(8);
+        for (int i = 0; i < 8; i++) {
+            sb.append(chars.charAt(secureRandom.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+}
+```
+
+- [ ] **Step 2: Verify the AppConfig model constructor**
+
+Read `BES/src/main/java/com/example/BES/models/AppConfig.java` and confirm it has `AppConfig(Long id, String key, String value)`. If it uses `@AllArgsConstructor` or has that constructor, the code above works. If not, adjust to use default constructor + setters.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/AppConfigService.java
+git commit -m "feat: generalize AppConfigService with generic get/set and demo config methods
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Demo Config Admin Endpoints
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/controllers/AppConfigController.java` (extend GET response)
+- Create: `BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java`
+- Modify: `BES/src/main/java/com/example/BES/controllers/AdminController.java` (add demo config endpoints)
+
+**Interfaces:**
+- Consumes: `AppConfigService.getAccentColor()`, `AppConfigService.isDemoEnabled()`, `AppConfigService.getDemoPasscode()`, `AppConfigService.setDemoPasscode()`, `AppConfigService.setDemoEnabled()`
+- Produces: `GET /api/v1/config/app` returns `{ accentColor, demoEnabled }`
+- Produces: `GET /api/v1/admin/demo/config` → `DemoConfigDto` (ADMIN only)
+- Produces: `POST /api/v1/admin/demo/config` ← `DemoConfigDto` (ADMIN only)
+
+- [ ] **Step 1: Create DemoConfigDto**
+
+```java
+package com.example.BES.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DemoConfigDto {
+    private boolean demoEnabled;
+    private String passcode;
+    private Boolean regeneratePasscode;  // set to true to trigger regeneration on POST
+}
+```
+
+File: `BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java`
+
+- [ ] **Step 2: Extend GET /api/v1/config/app response**
+
+In `AppConfigController.java`, change the GET method response from `Map<String, String>` to include `demoEnabled`:
+
+```java
+@GetMapping("/app")
+public ResponseEntity<Map<String, Object>> getAppConfig() {
+    Map<String, Object> config = new java.util.HashMap<>();
+    config.put("accentColor", appConfigService.getAccentColor());
+    config.put("demoEnabled", appConfigService.isDemoEnabled());
+    return ResponseEntity.ok(config);
+}
+```
+
+Replace the existing `Map<String, String>` return type with the above.
+
+- [ ] **Step 3: Add demo config endpoints to AdminController**
+
+Add at the end of `AdminController.java` (before the closing `}`):
+
+```java
+private final AppConfigService appConfigService;
+
+// Add appConfigService to the existing constructor, or use @Autowired field injection:
+@Autowired
+private AppConfigService appConfigService;
+
+@GetMapping("/demo/config")
+@PreAuthorize("hasRole('ADMIN')")
+public ResponseEntity<DemoConfigDto> getDemoConfig() {
+    return ResponseEntity.ok(new DemoConfigDto(
+            appConfigService.isDemoEnabled(),
+            appConfigService.getDemoPasscode(),
+            null
+    ));
+}
+
+@PostMapping("/demo/config")
+@PreAuthorize("hasRole('ADMIN')")
+public ResponseEntity<DemoConfigDto> updateDemoConfig(@RequestBody DemoConfigDto dto) {
+    if (dto.getRegeneratePasscode() != null && dto.getRegeneratePasscode()) {
+        String newPasscode = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+        appConfigService.setDemoPasscode(newPasscode);
+    }
+    appConfigService.setDemoEnabled(dto.isDemoEnabled());
+    return ResponseEntity.ok(new DemoConfigDto(
+            appConfigService.isDemoEnabled(),
+            appConfigService.getDemoPasscode(),
+            null
+    ));
+}
+```
+
+Note: Adjust the `AdminController` constructor to also accept `AppConfigService`. Check the existing constructor signature first — if it uses `@Autowired` fields, add a new field for `AppConfigService`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/DemoConfigDto.java \
+        BES/src/main/java/com/example/BES/controllers/AppConfigController.java \
+        BES/src/main/java/com/example/BES/controllers/AdminController.java
+git commit -m "feat: add demo config admin endpoints and extend app config response
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: DemoDataSeeder — Template Event
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/services/DemoDataSeeder.java`
+
+**Interfaces:**
+- Consumes: Repositories for Event, EventCategory, Participant, EventParticipant, EventCategoryParticipant, Judge, ScoringCriteria, Score, AuditionFeedback, FeedbackTag, FeedbackTagGroup; also JudgeRepo for native queries
+- Produces: Template event "Kyrove Demo" with all seed data (idempotent — skips if event already exists)
+
+- [ ] **Step 1: Check required repositories exist**
+
+Check these repository files exist and note their exact method signatures:
+- `EventRepo.java` — `findByEventName(String)`
+- `EventCategoryRepository.java` — note the save method
+- `ParticipantRepo.java` — does it have `findByParticipantName`?
+- `EventParticipantRepo.java`
+- `EventCategoryParticipantRepo.java`
+- `JudgeRepo.java` — note native query methods: `insertEventJudge(eventId, judgeId)`, `findFirstByName(String)`?
+- `ScoringCriteriaRepo.java`
+- `ScoreRepo.java`
+- `AuditionFeedbackRepo.java`
+- `FeedbackTagRepo.java`
+- `FeedbackTagGroupRepo.java`
+
+Run: `find BES/src/main/java/com/example/BES/respositories -name "*.java" | sort`
+
+- [ ] **Step 2: Write DemoDataSeeder**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Component
+public class DemoDataSeeder {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoDataSeeder.class);
+    private static final String TEMPLATE_NAME = "Kyrove Demo";
+
+    private final EventRepo eventRepo;
+    private final EventCategoryRepo eventCategoryRepo;
+    private final ParticipantRepo participantRepo;
+    private final EventParticipantRepo eventParticipantRepo;
+    private final EventCategoryParticipantRepo eventCategoryParticipantRepo;
+    private final JudgeRepo judgeRepo;
+    private final ScoringCriteriaRepo scoringCriteriaRepo;
+    private final ScoreRepo scoreRepo;
+    private final AuditionFeedbackRepo auditionFeedbackRepo;
+    private final FeedbackTagRepo feedbackTagRepo;
+    private final FeedbackTagGroupRepo feedbackTagGroupRepo;
+
+    public DemoDataSeeder(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
+                          ParticipantRepo participantRepo, EventParticipantRepo eventParticipantRepo,
+                          EventCategoryParticipantRepo eventCategoryParticipantRepo,
+                          JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
+                          ScoreRepo scoreRepo, AuditionFeedbackRepo auditionFeedbackRepo,
+                          FeedbackTagRepo feedbackTagRepo, FeedbackTagGroupRepo feedbackTagGroupRepo) {
+        this.eventRepo = eventRepo;
+        this.eventCategoryRepo = eventCategoryRepo;
+        this.participantRepo = participantRepo;
+        this.eventParticipantRepo = eventParticipantRepo;
+        this.eventCategoryParticipantRepo = eventCategoryParticipantRepo;
+        this.judgeRepo = judgeRepo;
+        this.scoringCriteriaRepo = scoringCriteriaRepo;
+        this.scoreRepo = scoreRepo;
+        this.auditionFeedbackRepo = auditionFeedbackRepo;
+        this.feedbackTagRepo = feedbackTagRepo;
+        this.feedbackTagGroupRepo = feedbackTagGroupRepo;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void seed() {
+        if (eventRepo.findByEventName(TEMPLATE_NAME).isPresent()) {
+            log.info("Demo template event already exists, skipping seed");
+            return;
+        }
+        log.info("Seeding demo template event '{}'...", TEMPLATE_NAME);
+
+        // 1. Create template event
+        Event event = new Event();
+        event.setEventName(TEMPLATE_NAME);
+        event.setPaymentRequired(false);
+        event.setJudgingMode("SOLO");
+        event.setFeedbackEnabled(true);
+        event.setResultsReleased(false);
+        event.setReleaseScore(false);
+        event.setAnimTheme("impact");
+        event = eventRepo.save(event);
+
+        // 2. Create categories
+        EventCategory hipHop = createCategory(event, "Hip Hop", "1v1");
+        EventCategory popping = createCategory(event, "Popping", "1v1");
+        EventCategory[] categories = {hipHop, popping};
+
+        // 3. Create scoring criteria for Popping (multi-criteria)
+        createCriterion(event, popping, "Musicality", 1.0, 0);
+        createCriterion(event, popping, "Technique", 1.0, 1);
+        createCriterion(event, popping, "Originality", 1.0, 2);
+
+        // 4. Create judges
+        Judge judge1 = createJudge("DJ FLEX");
+        Judge judge2 = createJudge("B-Girl RAY");
+        Judge judge3 = createJudge("Kid Kazoo");
+        Judge[] judges = {judge1, judge2, judge3};
+
+        // Assign judges to event + categories
+        for (Judge judge : judges) {
+            judgeRepo.insertEventJudge(event.getEventId(), judge.getJudgeId());
+        }
+        for (EventCategory cat : categories) {
+            cat.setJudges(Arrays.asList(judges));
+            eventCategoryRepo.save(cat);
+        }
+
+        // 5. Create participants (30 unique, 20 per category, ~10 overlap)
+        String[] allNames = {
+            "B-Boy Spinz", "Poppin J", "Lil Flow", "Kid Twist", "Lady Glide",
+            "Rock Steady", "Mighty Mouse", "Turbo T", "Fresh Kicks", "Smooth Move",
+            "Wild Card", "Shadow Step", "Beat Breaker", "Style King", "Lock N Load",
+            "Wave Rider", "Funk Master", "Cypher Queen", "Groove Theory", "Spin Doctor",
+            "Hip Hop Harry", "Pop N Drop", "Freeze Frame", "Rhythm Nation", "Soul Train",
+            "Electric Boogaloo", "Floor Phantom", "King Tut", "Robot X", "Moon Walker"
+        };
+
+        List<Participant> participants = new ArrayList<>();
+        for (String name : allNames) {
+            Participant p = participantRepo.findFirstByParticipantName(name)
+                    .orElseGet(() -> {
+                        Participant np = new Participant();
+                        np.setParticipantName(name);
+                        return participantRepo.save(np);
+                    });
+            participants.add(p);
+        }
+
+        // 6. Create EventParticipant links (all 30 to the event)
+        List<EventParticipant> eventParticipants = new ArrayList<>();
+        Random rng = new Random(42); // fixed seed for reproducibility
+        for (Participant p : participants) {
+            EventParticipant ep = new EventParticipant();
+            ep.setEvent(event);
+            ep.setParticipant(p);
+            ep.setPaymentVerified(true);
+            ep.setDisplayName(p.getParticipantName());
+            ep.setStageName(p.getParticipantName());
+            ep.setReferenceCode(generateRefCode());
+            eventParticipants.add(eventParticipantRepo.save(ep));
+        }
+
+        // 7. Create EventCategoryParticipant links
+        // Hip Hop: participants 0-19 (first 20)
+        // Popping: participants 10-29 (last 20, overlapping 10-19)
+        List<EventCategoryParticipant> hipHopECPs = new ArrayList<>();
+        List<EventCategoryParticipant> poppingECPs = new ArrayList<>();
+
+        for (int i = 0; i < 20; i++) {
+            Participant p = participants.get(i);
+            hipHopECPs.add(createECP(event, hipHop, p, i + 1, "1v1"));
+        }
+        for (int i = 10; i < 30; i++) {
+            Participant p = participants.get(i);
+            poppingECPs.add(createECP(event, popping, p, i - 9, "1v1"));
+        }
+
+        // 8. Pre-fill scores (~50% of participants scored per category per judge)
+        // Hip Hop: judges score participants at even indices (0,2,4,...,18) = 10 scored
+        // Popping: judges score participants at odd indices in the popping list = 10 scored
+        for (Judge judge : judges) {
+            for (int i = 0; i < hipHopECPs.size(); i += 2) {
+                double scoreVal = 5.0 + rng.nextDouble() * 4.5; // 5.0-9.5
+                createScore(hipHopECPs.get(i), judge, null, Math.round(scoreVal * 10.0) / 10.0);
+            }
+            for (int i = 1; i < poppingECPs.size(); i += 2) {
+                // For Popping, create 3 aspect scores per scored participant
+                EventCategoryParticipant ecp = poppingECPs.get(i);
+                createScore(ecp, judge, "Musicality", 5.0 + rng.nextDouble() * 4.5);
+                createScore(ecp, judge, "Technique", 5.0 + rng.nextDouble() * 4.5);
+                createScore(ecp, judge, "Originality", 5.0 + rng.nextDouble() * 4.5);
+            }
+        }
+
+        // 9. Pre-fill feedback on ~30% of scored participants
+        List<FeedbackTag> allTags = feedbackTagRepo.findAll();
+        if (!allTags.isEmpty()) {
+            for (Judge judge : judges) {
+                for (int i = 0; i < hipHopECPs.size(); i += 6) { // every 6th
+                    createFeedback(hipHopECPs.get(i), judge, allTags, rng);
+                }
+            }
+        }
+
+        log.info("Demo template event seeded successfully with {} participants, {} judges",
+                participants.size(), judges.length);
+    }
+
+    private EventCategory createCategory(Event event, String name, String format) {
+        EventCategory cat = new EventCategory();
+        cat.setEvent(event);
+        cat.setName(name);
+        cat.setFormat(format);
+        cat.setSoloAllowed(true);
+        return eventCategoryRepo.save(cat);
+    }
+
+    private void createCriterion(Event event, EventCategory cat, String name, double weight, int order) {
+        ScoringCriteria sc = new ScoringCriteria();
+        sc.setEvent(event);
+        sc.setEventCategory(cat);
+        sc.setName(name);
+        sc.setWeight(weight);
+        sc.setDisplayOrder(order);
+        scoringCriteriaRepo.save(sc);
+    }
+
+    private Judge createJudge(String name) {
+        return judgeRepo.findFirstByName(name)
+                .orElseGet(() -> {
+                    Judge j = new Judge();
+                    j.setName(name);
+                    return judgeRepo.save(j);
+                });
+    }
+
+    private EventCategoryParticipant createECP(Event event, EventCategory cat,
+                                                Participant p, int auditionNum, String format) {
+        EventCategoryParticipant ecp = new EventCategoryParticipant();
+        EventCategoryParticipantId id = new EventCategoryParticipantId(
+                event.getEventId(), cat.getId(), p.getParticipantId());
+        ecp.setId(id);
+        ecp.setEvent(event);
+        ecp.setEventCategory(cat);
+        ecp.setParticipant(p);
+        ecp.setAuditionNumber(auditionNum);
+        ecp.setFormat(format);
+        ecp.setDisplayName(p.getParticipantName());
+        return eventCategoryParticipantRepo.save(ecp);
+    }
+
+    private void createScore(EventCategoryParticipant ecp, Judge judge, String aspect, double value) {
+        Score score = new Score();
+        score.setEventCategoryParticipant(ecp);
+        score.setJudge(judge);
+        score.setAspect(aspect);
+        score.setValue(value);
+        scoreRepo.save(score);
+    }
+
+    private void createFeedback(EventCategoryParticipant ecp, Judge judge,
+                                 List<FeedbackTag> allTags, Random rng) {
+        AuditionFeedback fb = new AuditionFeedback();
+        fb.setEventCategoryParticipant(ecp);
+        fb.setJudge(judge);
+        fb.setNote("Great energy and stage presence.");
+        Set<FeedbackTag> tags = new HashSet<>();
+        // pick 1-2 random tags
+        tags.add(allTags.get(rng.nextInt(allTags.size())));
+        if (rng.nextBoolean() && allTags.size() > 1) {
+            tags.add(allTags.get(rng.nextInt(allTags.size())));
+        }
+        fb.setTags(tags);
+        auditionFeedbackRepo.save(fb);
+    }
+
+    private String generateRefCode() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+    }
+}
+```
+
+- [ ] **Step 3: Check repository method names match**
+
+Verify these repository methods actually exist (names may differ). Adjust method calls as needed:
+- `participantRepo.findFirstByParticipantName(String)` — might be `findByParticipantName` or `findFirstByName`
+- `judgeRepo.findFirstByName(String)` — verify signature
+- `judgeRepo.insertEventJudge(Long, Long)` — verify this is the actual method name
+- `EventCategoryParticipantRepo.save()` — should use the composite key
+- `AuditionFeedbackRepo` — verify the save method and that `feedbackTagRepo.findAll()` exists
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/DemoDataSeeder.java
+git commit -m "feat: add DemoDataSeeder to create template event on startup
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: DemoService — Clone Logic
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/services/DemoService.java`
+- Modify: `BES/src/main/java/com/example/BES/respositories/EventRepo.java`
+
+**Interfaces:**
+- Consumes: Repos for Event, EventCategory, EventParticipant, EventCategoryParticipant, Score, AuditionFeedback, ScoringCriteria, SessionToken, Judge; JudgeRepo native queries; AppConfigService
+- Produces: `DemoSession cloneTemplate(String role, String clientIp)` — full clone in @Transactional
+- Produces: `void purgeSandbox(Long eventId)` — delete sandbox and all children
+- Produces: `int countActiveSandboxes()` — for rate limit check
+
+- [ ] **Step 1: Add cleanup queries to EventRepo**
+
+Add these methods to `EventRepo.java`:
+
+```java
+@Modifying
+@Query("DELETE FROM Event e WHERE e.eventName LIKE 'Kyrove Demo-%'")
+int deleteAllDemoEvents();
+
+@Query("SELECT e FROM Event e WHERE e.eventName LIKE 'Kyrove Demo-%'")
+List<Event> findAllDemoEvents();
+
+@Modifying
+@Query("DELETE FROM Event e WHERE e.eventName = :eventName")
+void deleteByEventName(@Param("eventName") String eventName);
+```
+
+Add these imports:
+```java
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+```
+
+- [ ] **Step 2: Write DemoService**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class DemoService {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoService.class);
+    private static final String TEMPLATE_NAME = "Kyrove Demo";
+    private static final String CLONE_PREFIX = "Kyrove Demo-";
+    private static final int MAX_CONCURRENT_SANDBOXES = 10;
+
+    private final EventRepo eventRepo;
+    private final EventCategoryRepo eventCategoryRepo;
+    private final ParticipantRepo participantRepo;
+    private final EventParticipantRepo eventParticipantRepo;
+    private final EventCategoryParticipantRepo eventCategoryParticipantRepo;
+    private final JudgeRepo judgeRepo;
+    private final ScoringCriteriaRepo scoringCriteriaRepo;
+    private final ScoreRepo scoreRepo;
+    private final AuditionFeedbackRepo auditionFeedbackRepo;
+    private final SessionTokenRepo sessionTokenRepo;
+    private final AppConfigService appConfigService;
+
+    // IP rate limiting: map of IP → list of timestamps
+    private final ConcurrentHashMap<String, List<LocalDateTime>> ipRequestLog = new ConcurrentHashMap<>();
+
+    public DemoService(EventRepo eventRepo, EventCategoryRepo eventCategoryRepo,
+                       ParticipantRepo participantRepo, EventParticipantRepo eventParticipantRepo,
+                       EventCategoryParticipantRepo eventCategoryParticipantRepo,
+                       JudgeRepo judgeRepo, ScoringCriteriaRepo scoringCriteriaRepo,
+                       ScoreRepo scoreRepo, AuditionFeedbackRepo auditionFeedbackRepo,
+                       SessionTokenRepo sessionTokenRepo, AppConfigService appConfigService) {
+        this.eventRepo = eventRepo;
+        this.eventCategoryRepo = eventCategoryRepo;
+        this.participantRepo = participantRepo;
+        this.eventParticipantRepo = eventParticipantRepo;
+        this.eventCategoryParticipantRepo = eventCategoryParticipantRepo;
+        this.judgeRepo = judgeRepo;
+        this.scoringCriteriaRepo = scoringCriteriaRepo;
+        this.scoreRepo = scoreRepo;
+        this.auditionFeedbackRepo = auditionFeedbackRepo;
+        this.sessionTokenRepo = sessionTokenRepo;
+        this.appConfigService = appConfigService;
+    }
+
+    @Transactional
+    public CloneResult cloneTemplate(String role, String clientIp) {
+        // Rate limit: max 3 per IP per 24h
+        checkIpRateLimit(clientIp);
+
+        // Limit concurrent sandboxes
+        long active = eventRepo.findAllDemoEvents().size();
+        if (active >= MAX_CONCURRENT_SANDBOXES) {
+            throw new DemoRateLimitException("Too many demo sessions. Try again later.");
+        }
+
+        Event template = eventRepo.findByEventName(TEMPLATE_NAME)
+                .orElseThrow(() -> new IllegalStateException("Demo template event not found"));
+
+        // 1. Clone event
+        String cloneName = CLONE_PREFIX + randomUuid8();
+        Event clone = cloneEvent(template, cloneName);
+
+        // 2. Clone categories + scoring criteria + judge assignments
+        Map<Long, EventCategory> oldToNewCategory = new HashMap<>();
+        List<EventCategory> templateCategories = eventCategoryRepo.findByEvent(template);
+        for (EventCategory templateCat : templateCategories) {
+            EventCategory clonedCat = cloneCategory(templateCat, clone);
+            oldToNewCategory.put(templateCat.getId(), clonedCat);
+
+            // Clone scoring criteria for this category
+            List<ScoringCriteria> criteria = scoringCriteriaRepo.findByEventAndEventCategory(template, templateCat);
+            for (ScoringCriteria sc : criteria) {
+                cloneScoringCriteria(sc, clone, clonedCat);
+            }
+        }
+        // Also clone event-level criteria (eventCategory = null)
+        List<ScoringCriteria> eventCriteria = scoringCriteriaRepo.findByEventAndEventCategory(template, null);
+        for (ScoringCriteria sc : eventCriteria) {
+            cloneScoringCriteria(sc, clone, null);
+        }
+
+        // 3. Clone EventParticipants
+        Map<Long, EventParticipant> oldToNewEP = new HashMap<>();
+        List<EventParticipant> templateEPs = eventParticipantRepo.findByEvent(template);
+        for (EventParticipant templateEP : templateEPs) {
+            EventParticipant clonedEP = cloneEventParticipant(templateEP, clone);
+            oldToNewEP.put(templateEP.getId(), clonedEP);
+        }
+
+        // 4. Clone EventCategoryParticipants
+        Map<String, EventCategoryParticipant> compositeKeyToNewECP = new HashMap<>();
+        for (EventCategory templateCat : templateCategories) {
+            List<EventCategoryParticipant> templateECPs =
+                    eventCategoryParticipantRepo.findByEventCategory(templateCat);
+            EventCategory clonedCat = oldToNewCategory.get(templateCat.getId());
+            for (EventCategoryParticipant templateECP : templateECPs) {
+                EventCategoryParticipant clonedECP = cloneECP(templateECP, clone, clonedCat);
+                String oldCompositeKey = compositeKey(templateECP);
+                compositeKeyToNewECP.put(oldCompositeKey, clonedECP);
+            }
+        }
+
+        // 5. Clone scores
+        for (EventCategory templateCat : templateCategories) {
+            List<EventCategoryParticipant> templateECPs =
+                    eventCategoryParticipantRepo.findByEventCategory(templateCat);
+            for (EventCategoryParticipant templateECP : templateECPs) {
+                List<Score> scores = scoreRepo.findByEventCategoryParticipant(templateECP);
+                EventCategoryParticipant clonedECP =
+                        compositeKeyToNewECP.get(compositeKey(templateECP));
+                for (Score s : scores) {
+                    cloneScore(s, clonedECP);
+                }
+            }
+        }
+
+        // 6. Clone feedback
+        for (EventCategory templateCat : templateCategories) {
+            List<EventCategoryParticipant> templateECPs =
+                    eventCategoryParticipantRepo.findByEventCategory(templateCat);
+            for (EventCategoryParticipant templateECP : templateECPs) {
+                List<AuditionFeedback> feedbacks = auditionFeedbackRepo.findByEventCategoryParticipant(templateECP);
+                EventCategoryParticipant clonedECP =
+                        compositeKeyToNewECP.get(compositeKey(templateECP));
+                for (AuditionFeedback fb : feedbacks) {
+                    cloneFeedback(fb, clonedECP);
+                }
+            }
+        }
+
+        // 7. Generate session token for the requested role
+        SessionToken token = new SessionToken();
+        token.setTokenId(UUID.randomUUID().toString());
+        token.setRole(role);
+        token.setEvent(clone);
+        token.setExpiresAt(LocalDateTime.now().plusDays(1));
+        if ("JUDGE".equals(role)) {
+            // Pick a random judge from the clone
+            List<Judge> judges = judgeRepo.findJudgesByEventId(clone.getEventId());
+            if (!judges.isEmpty()) {
+                token.setJudge(judges.get(new Random().nextInt(judges.size())));
+            }
+        }
+        token = sessionTokenRepo.save(token);
+
+        // Record this IP request
+        ipRequestLog.computeIfAbsent(clientIp, k -> new ArrayList<>()).add(LocalDateTime.now());
+
+        log.info("Demo sandbox created: {} for role {}", cloneName, role);
+
+        return new CloneResult(clone, token);
+    }
+
+    public void purgeSandbox(Long eventId) {
+        Event event = eventRepo.findById(eventId).orElse(null);
+        if (event == null || !event.getEventName().startsWith(CLONE_PREFIX)) {
+            return; // safety: only purge demo events
+        }
+        log.info("Purging demo sandbox: {}", event.getEventName());
+
+        // Delete in order: feedback → scores → ECPs → criteria → EPs → categories → event_judge → event
+        List<EventCategory> categories = eventCategoryRepo.findByEvent(event);
+        for (EventCategory cat : categories) {
+            List<EventCategoryParticipant> ecps = eventCategoryParticipantRepo.findByEventCategory(cat);
+            for (EventCategoryParticipant ecp : ecps) {
+                auditionFeedbackRepo.deleteAll(auditionFeedbackRepo.findByEventCategoryParticipant(ecp));
+                scoreRepo.deleteAll(scoreRepo.findByEventCategoryParticipant(ecp));
+            }
+            eventCategoryParticipantRepo.deleteAll(ecps);
+            scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(event, cat));
+            // Remove judge assignments from category
+            cat.getJudges().clear();
+            eventCategoryRepo.save(cat);
+        }
+        // Delete event-level criteria
+        scoringCriteriaRepo.deleteAll(scoringCriteriaRepo.findByEventAndEventCategory(event, null));
+        // Delete EventParticipants
+        List<EventParticipant> eps = eventParticipantRepo.findByEvent(event);
+        eventParticipantRepo.deleteAll(eps);
+        // Remove event_judge entries
+        List<Judge> eventJudges = judgeRepo.findJudgesByEventId(event.getEventId());
+        for (Judge j : eventJudges) {
+            judgeRepo.deleteEventJudge(event.getEventId(), j.getJudgeId());
+        }
+        // Delete session tokens
+        List<SessionToken> tokens = sessionTokenRepo.findByEvent(event);
+        sessionTokenRepo.deleteAll(tokens);
+        // Delete categories
+        eventCategoryRepo.deleteAll(categories);
+        // Delete event
+        eventRepo.delete(event);
+    }
+
+    public int countActiveSandboxes() {
+        return eventRepo.findAllDemoEvents().size();
+    }
+
+    private void checkIpRateLimit(String ip) {
+        List<LocalDateTime> timestamps = ipRequestLog.getOrDefault(ip, Collections.emptyList());
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
+        long recent = timestamps.stream().filter(t -> t.isAfter(cutoff)).count();
+        if (recent >= 3) {
+            throw new DemoRateLimitException("Demo limit reached for today. Try again later.");
+        }
+    }
+
+    private Event cloneEvent(Event template, String newName) {
+        Event clone = new Event();
+        clone.setEventName(newName);
+        clone.setPaymentRequired(template.isPaymentRequired());
+        clone.setJudgingMode(template.getJudgingMode());
+        clone.setFeedbackEnabled(template.isFeedbackEnabled());
+        clone.setResultsReleased(false);
+        clone.setReleaseScore(false);
+        clone.setAnimTheme(template.getAnimTheme());
+        return eventRepo.save(clone);
+    }
+
+    private EventCategory cloneCategory(EventCategory template, Event newEvent) {
+        EventCategory clone = new EventCategory();
+        clone.setEvent(newEvent);
+        clone.setName(template.getName());
+        clone.setFormat(template.getFormat());
+        clone.setSoloAllowed(template.isSoloAllowed());
+        clone.setRoundLabel(template.getRoundLabel());
+        clone.setNumberColor(template.getNumberColor());
+        clone.setSheetAliases(template.getSheetAliases());
+        // Copy judge list
+        clone.setJudges(new ArrayList<>(template.getJudges()));
+        return eventCategoryRepo.save(clone);
+    }
+
+    private void cloneScoringCriteria(ScoringCriteria template, Event newEvent, EventCategory newCat) {
+        ScoringCriteria clone = new ScoringCriteria();
+        clone.setEvent(newEvent);
+        clone.setEventCategory(newCat);
+        clone.setName(template.getName());
+        clone.setWeight(template.getWeight());
+        clone.setDisplayOrder(template.getDisplayOrder());
+        scoringCriteriaRepo.save(clone);
+    }
+
+    private EventParticipant cloneEventParticipant(EventParticipant template, Event newEvent) {
+        EventParticipant clone = new EventParticipant();
+        clone.setEvent(newEvent);
+        clone.setParticipant(template.getParticipant());
+        clone.setPaymentVerified(template.isPaymentVerified());
+        clone.setDisplayName(template.getDisplayName());
+        clone.setStageName(template.getStageName());
+        clone.setTeamName(template.getTeamName());
+        clone.setCategory(template.getCategory());
+        clone.setResidency(template.getResidency());
+        clone.setReferenceCode(UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase());
+        return eventParticipantRepo.save(clone);
+    }
+
+    private EventCategoryParticipant cloneECP(EventCategoryParticipant template, Event newEvent, EventCategory newCat) {
+        EventCategoryParticipant clone = new EventCategoryParticipant();
+        EventCategoryParticipantId newId = new EventCategoryParticipantId(
+                newEvent.getEventId(), newCat.getId(), template.getParticipant().getParticipantId());
+        clone.setId(newId);
+        clone.setEvent(newEvent);
+        clone.setEventCategory(newCat);
+        clone.setParticipant(template.getParticipant());
+        clone.setDisplayName(template.getDisplayName());
+        clone.setFormat(template.getFormat());
+        clone.setAuditionNumber(template.getAuditionNumber());
+        clone.setTeamName(template.getTeamName());
+        return eventCategoryParticipantRepo.save(clone);
+    }
+
+    private void cloneScore(Score template, EventCategoryParticipant newECP) {
+        Score clone = new Score();
+        clone.setEventCategoryParticipant(newECP);
+        clone.setJudge(template.getJudge());
+        clone.setAspect(template.getAspect());
+        clone.setValue(template.getValue());
+        scoreRepo.save(clone);
+    }
+
+    private void cloneFeedback(AuditionFeedback template, EventCategoryParticipant newECP) {
+        AuditionFeedback clone = new AuditionFeedback();
+        clone.setEventCategoryParticipant(newECP);
+        clone.setJudge(template.getJudge());
+        clone.setNote(template.getNote());
+        clone.setTags(new HashSet<>(template.getTags()));
+        auditionFeedbackRepo.save(clone);
+    }
+
+    private String compositeKey(EventCategoryParticipant ecp) {
+        return ecp.getEvent().getEventId() + "-" +
+                ecp.getEventCategory().getId() + "-" +
+                ecp.getParticipant().getParticipantId();
+    }
+
+    private String randomUuid8() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+    // ---- Inner classes ----
+
+    public static class CloneResult {
+        public final Event event;
+        public final SessionToken token;
+
+        public CloneResult(Event event, SessionToken token) {
+            this.event = event;
+            this.token = token;
+        }
+    }
+
+    public static class DemoRateLimitException extends RuntimeException {
+        public DemoRateLimitException(String message) {
+            super(message);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/DemoService.java \
+        BES/src/main/java/com/example/BES/respositories/EventRepo.java
+git commit -m "feat: add DemoService with template cloning, rate limiting, and cleanup
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: DemoController + DTOs
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/dtos/DemoStartRequestDto.java`
+- Create: `BES/src/main/java/com/example/BES/dtos/DemoStartResponseDto.java`
+- Create: `BES/src/main/java/com/example/BES/controllers/DemoController.java`
+
+**Interfaces:**
+- Consumes: `DemoService.cloneTemplate(role, ip)`, `AppConfigService.isDemoEnabled()`, `AppConfigService.getDemoPasscode()`
+- Produces: `POST /api/v1/demo/start` — public endpoint, validates passcode + demo enabled, clones template, creates session, returns response
+
+- [ ] **Step 1: Create DemoStartRequestDto**
+
+```java
+package com.example.BES.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DemoStartRequestDto {
+    private String passcode;
+    private String role; // "EMCEE", "JUDGE", or "HELPER"
+}
+```
+
+- [ ] **Step 2: Create DemoStartResponseDto**
+
+```java
+package com.example.BES.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DemoStartResponseDto {
+    private boolean authenticated;
+    private String role;
+    private Long eventId;
+    private String eventName;
+    private Long judgeId;
+    private String judgeName;
+}
+```
+
+- [ ] **Step 3: Create DemoController**
+
+```java
+package com.example.BES.controllers;
+
+import com.example.BES.dtos.DemoStartRequestDto;
+import com.example.BES.dtos.DemoStartResponseDto;
+import com.example.BES.models.SessionToken;
+import com.example.BES.services.AppConfigService;
+import com.example.BES.services.DemoService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/demo")
+public class DemoController {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoController.class);
+
+    private final AppConfigService appConfigService;
+    private final DemoService demoService;
+
+    public DemoController(AppConfigService appConfigService, DemoService demoService) {
+        this.appConfigService = appConfigService;
+        this.demoService = demoService;
+    }
+
+    @PostMapping("/start")
+    public ResponseEntity<?> startDemo(@RequestBody DemoStartRequestDto request,
+                                        HttpServletRequest httpRequest) {
+        // 1. Check demo is enabled
+        if (!appConfigService.isDemoEnabled()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Demo is currently disabled"));
+        }
+
+        // 2. Validate passcode
+        String expectedPasscode = appConfigService.getDemoPasscode();
+        if (request.getPasscode() == null || !request.getPasscode().equals(expectedPasscode)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "Invalid passcode"));
+        }
+
+        // 3. Validate role
+        String role = request.getRole();
+        if (role == null || !role.matches("^(EMCEE|JUDGE|HELPER)$")) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid role. Must be EMCEE, JUDGE, or HELPER."));
+        }
+
+        // 4. Clone template
+        String clientIp = httpRequest.getRemoteAddr();
+        DemoService.CloneResult result;
+        try {
+            result = demoService.cloneTemplate(role, clientIp);
+        } catch (DemoService.DemoRateLimitException e) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .body(Map.of("error", e.getMessage()));
+        }
+
+        // 5. Create session and authenticate (same pattern as AuthController.token)
+        SessionToken token = result.token;
+        String username = "token:" + token.getTokenId();
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                username, null,
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role)));
+
+        // Check double-session for non-unlimited roles (same pattern as AuthController)
+        // Skip for EMCEE/HELPER/JUDGE since they are unlimited
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+
+        HttpSession session = httpRequest.getSession(true);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+        session.setAttribute("eventId", result.event.getEventId());
+        session.setAttribute("eventName", result.event.getEventName());
+
+        if (token.getJudge() != null) {
+            session.setAttribute("judgeId", token.getJudge().getJudgeId());
+            session.setAttribute("judgeName", token.getJudge().getName());
+        }
+
+        // 6. Build response
+        DemoStartResponseDto response = new DemoStartResponseDto();
+        response.setAuthenticated(true);
+        response.setRole(role);
+        response.setEventId(result.event.getEventId());
+        response.setEventName(result.event.getEventName());
+        if (token.getJudge() != null) {
+            response.setJudgeId(token.getJudge().getJudgeId());
+            response.setJudgeName(token.getJudge().getName());
+        }
+
+        log.info("Demo session started: {} as {}", result.event.getEventName(), role);
+        return ResponseEntity.ok(response);
+    }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/dtos/DemoStartRequestDto.java \
+        BES/src/main/java/com/example/BES/dtos/DemoStartResponseDto.java \
+        BES/src/main/java/com/example/BES/controllers/DemoController.java
+git commit -m "feat: add DemoController with /api/v1/demo/start endpoint
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: SecurityConfig — Permit Demo Endpoint
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/config/SecurityConfig.java`
+
+- [ ] **Step 1: Add demo path to permitAll**
+
+Add this line after the existing `requestMatchers("/api/v1/auth/**").permitAll()`:
+
+```java
+.requestMatchers("/api/v1/demo/**").permitAll()
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/config/SecurityConfig.java
+git commit -m "feat: permit all access to /api/v1/demo/** endpoints
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: SessionExpiryListener — Demo Cleanup
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/config/SessionExpiryListener.java`
+- Modify: `BES/src/main/java/com/example/BES/services/DemoService.java` (add scheduled purge)
+
+- [ ] **Step 1: Add demo cleanup to SessionExpiryListener**
+
+Read the current `SessionExpiryListener.java`. Add `DemoService` as a dependency and call `purgeSandbox` when a demo session expires:
+
+```java
+@Component
+public class SessionExpiryListener {
+
+    @Autowired
+    private ActiveSessionStore activeSessionStore;
+
+    @Autowired
+    private EmceeCategoryStore emceeCategoryStore;
+
+    @Autowired
+    private DemoService demoService;
+
+    @EventListener
+    public void onSessionDestroyed(HttpSessionDestroyedEvent event) {
+        activeSessionStore.deregisterBySessionId(event.getId());
+        emceeCategoryStore.release(event.getId());
+
+        // Clean up demo sandbox if this session was a demo
+        HttpSession session = event.getSession();
+        if (session != null) {
+            String eventName = (String) session.getAttribute("eventName");
+            if (eventName != null && eventName.startsWith("Kyrove Demo-")) {
+                Long eventId = (Long) session.getAttribute("eventId");
+                if (eventId != null) {
+                    demoService.purgeSandbox(eventId);
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add scheduled orphan purge to DemoService**
+
+Add this method to `DemoService.java`:
+
+```java
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Scheduled(fixedRate = 6 * 3600 * 1000) // every 6 hours
+public void purgeOrphanSandboxes() {
+    List<Event> demos = eventRepo.findAllDemoEvents();
+    LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
+    int purged = 0;
+    for (Event demo : demos) {
+        // Check if there are any valid session tokens for this event
+        List<SessionToken> tokens = sessionTokenRepo.findByEvent(demo);
+        boolean hasValidToken = tokens.stream().anyMatch(t ->
+                !t.isRevoked() && t.getExpiresAt().isAfter(LocalDateTime.now()));
+        if (!hasValidToken) {
+            purgeSandbox(demo.getEventId());
+            purged++;
+        }
+    }
+    if (purged > 0) {
+        log.info("Purged {} orphan demo sandboxes", purged);
+    }
+}
+```
+
+Also add the `@EnableScheduling` import check — Spring Boot auto-enables scheduling via `@SpringBootApplication`, so no extra config bean needed unless scheduling is explicitly disabled.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/config/SessionExpiryListener.java \
+        BES/src/main/java/com/example/BES/services/DemoService.java
+git commit -m "feat: add demo sandbox cleanup on session expiry and scheduled orphan purge
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Frontend API Utilities
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js`
+
+- [ ] **Step 1: Add demo API functions**
+
+Add these functions at the end of `api.js`:
+
+```javascript
+/**
+ * Start a demo session with the given passcode and role.
+ * @param {string} passcode
+ * @param {string} role - "EMCEE", "JUDGE", or "HELPER"
+ * @returns {Promise<object>} - { authenticated, role, eventId, eventName, judgeId?, judgeName? }
+ */
+export const startDemo = async (passcode, role) => {
+  const res = await fetch('/api/v1/demo/start', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ passcode, role })
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.error || 'Failed to start demo')
+  }
+  return res.json()
+}
+
+/**
+ * Get demo config (admin only).
+ * @returns {Promise<object>} - { demoEnabled, passcode }
+ */
+export const getDemoConfig = async () => {
+  const res = await fetch('/api/v1/admin/demo/config', {
+    credentials: 'include'
+  })
+  if (!res.ok) throw new Error('Failed to fetch demo config')
+  return res.json()
+}
+
+/**
+ * Update demo config (admin only).
+ * @param {object} config - { demoEnabled, regeneratePasscode? }
+ * @returns {Promise<object>} - updated { demoEnabled, passcode }
+ */
+export const updateDemoConfig = async (config) => {
+  const res = await fetch('/api/v1/admin/demo/config', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config)
+  })
+  if (!res.ok) throw new Error('Failed to update demo config')
+  return res.json()
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat: add demo API utilities (startDemo, getDemoConfig, updateDemoConfig)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Login Page — "Try Demo" Button
+
+**Files:**
+- Modify: `BES-frontend/src/views/Login.vue`
+
+- [ ] **Step 1: Add demo button, passcode modal, and role picker trigger**
+
+Read the current `Login.vue` to understand existing structure (template, script setup, style).
+
+Add in the template, after the login form:
+
+```html
+<!-- Demo section -->
+<div class="demo-section">
+  <div class="section-rule">
+    <span class="section-label">or</span>
+    <span class="section-line"></span>
+  </div>
+
+  <button
+    v-if="demoEnabled"
+    class="btn-demo"
+    @click="showPasscodeModal = true"
+  >
+    Try Demo
+  </button>
+
+  <p v-if="demoEnabled" class="type-prose-sm demo-hint">
+    Experience Kyrove as an Emcee, Judge, or Helper
+  </p>
+</div>
+
+<!-- Passcode modal -->
+<Teleport to="body">
+  <div v-if="showPasscodeModal" class="modal-backdrop" @click="showPasscodeModal = false">
+    <div class="modal-content passcode-modal" @click.stop>
+      <h2 class="modal-title">Enter Demo Passcode</h2>
+      <input
+        v-model="passcode"
+        type="text"
+        class="input-passcode"
+        placeholder="Enter passcode"
+        autocomplete="off"
+        @keyup.enter="submitPasscode"
+      />
+      <p v-if="passcodeError" class="error-text">{{ passcodeError }}</p>
+      <button class="btn-primary" @click="submitPasscode" :disabled="!passcode.trim()">
+        Continue
+      </button>
+      <p class="type-prose-sm modal-hint">Tap outside to close</p>
+    </div>
+  </div>
+</Teleport>
+
+<!-- Role picker -->
+<DemoRolePicker
+  v-if="showRolePicker"
+  @select="startDemoSession"
+  @back="showRolePicker = false; showPasscodeModal = true"
+/>
+```
+
+Add in the script setup:
+
+```javascript
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { startDemo } from '@/utils/api'
+import DemoRolePicker from '@/components/DemoRolePicker.vue'
+import { getAppConfig } from '@/utils/api'
+
+const router = useRouter()
+
+const demoEnabled = ref(false)
+const showPasscodeModal = ref(false)
+const showRolePicker = ref(false)
+const passcode = ref('')
+const passcodeError = ref('')
+
+onMounted(async () => {
+  try {
+    const config = await getAppConfig()
+    demoEnabled.value = config.demoEnabled === true
+  } catch (e) {
+    // fallback: hide demo button if config fetch fails
+    demoEnabled.value = false
+  }
+})
+
+function submitPasscode() {
+  if (!passcode.value.trim()) return
+  passcodeError.value = ''
+  showPasscodeModal.value = false
+  showRolePicker.value = true
+}
+
+async function startDemoSession(role) {
+  try {
+    const result = await startDemo(passcode.value, role)
+    // Route to the appropriate session view
+    const roleRoutes = {
+      EMCEE: '/emcee/session',
+      JUDGE: '/judge/session',
+      HELPER: '/helper/session'
+    }
+    router.push(roleRoutes[role] || '/')
+  } catch (e) {
+    passcodeError.value = e.message || 'Failed to start demo'
+    showRolePicker.value = false
+    showPasscodeModal.value = true
+  }
+}
+```
+
+- [ ] **Step 2: Add demo styles**
+
+Add scoped styles for the demo section and passcode modal following the design system (Oswald font, parallelogram chips, surface tokens):
+
+```css
+.demo-section {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.section-rule {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-label {
+  font-family: var(--font-sans);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+}
+
+.section-line {
+  flex: 1;
+  height: 1px;
+  background: var(--surface-600);
+}
+
+.btn-demo {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  color: var(--accent-color);
+  padding: 0.75rem 2rem;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-demo:hover {
+  background: rgba(255,255,255,0.08);
+}
+
+.demo-hint {
+  margin-top: 0.75rem;
+  color: rgba(255,255,255,0.35);
+}
+
+.passcode-modal {
+  max-width: 360px;
+}
+
+.input-passcode {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--surface-900);
+  border: 1px solid var(--surface-600);
+  color: #fff;
+  font-family: var(--font-sans);
+  font-size: 18px;
+  letter-spacing: 0.3em;
+  text-align: center;
+  text-transform: uppercase;
+  margin: 1rem 0;
+}
+
+.input-passcode:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.error-text {
+  color: var(--primary-500, #ef4444);
+  font-family: var(--font-body);
+  font-size: 12px;
+  margin-bottom: 0.5rem;
+}
+
+.modal-hint {
+  margin-top: 0.75rem;
+  color: rgba(255,255,255,0.3);
+  text-align: center;
+}
+```
+
+- [ ] **Step 3: App.vue — handle demoEnabled from app config WebSocket**
+
+Read `App.vue` to find where `applyAccent` / app config WebSocket message is handled. Add `demoEnabled` handling so the login page can react to admin toggles:
+
+In the WebSocket subscription callback (where `accentColor` is applied), also emit/provide `demoEnabled`:
+
+```javascript
+// In the app-config message handler, add:
+if (body.demoEnabled !== undefined) {
+  demoEnabled.value = body.demoEnabled
+}
+```
+
+Provide `demoEnabled` at the app level so `Login.vue` can inject it, or store it in the auth store.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES-frontend/src/views/Login.vue BES-frontend/src/App.vue
+git commit -m "feat: add Try Demo button, passcode modal, and role picker trigger to Login
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: DemoRolePicker Component
+
+**Files:**
+- Create: `BES-frontend/src/components/DemoRolePicker.vue`
+
+- [ ] **Step 1: Write DemoRolePicker component**
+
+```vue
+<template>
+  <Teleport to="body">
+    <div class="modal-backdrop" @click="$emit('back')">
+      <div class="role-picker" @click.stop>
+        <h2 class="picker-title">Try Kyrove as…</h2>
+
+        <div class="role-cards">
+          <button
+            v-for="role in roles"
+            :key="role.key"
+            class="role-card"
+            @click="$emit('select', role.key)"
+          >
+            <span class="role-icon">{{ role.icon }}</span>
+            <span class="role-name">{{ role.label }}</span>
+            <span class="role-desc type-prose-sm">{{ role.description }}</span>
+          </button>
+        </div>
+
+        <p class="type-prose-sm picker-hint">Tap outside to go back</p>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+defineEmits(['select', 'back'])
+
+const roles = [
+  {
+    key: 'EMCEE',
+    icon: '🎤',
+    label: 'Emcee',
+    description: 'Run audition rounds, view scoreboard, announce results'
+  },
+  {
+    key: 'JUDGE',
+    icon: '⚖️',
+    label: 'Judge',
+    description: 'Score participants, submit feedback, use the keypad'
+  },
+  {
+    key: 'HELPER',
+    icon: '🛎️',
+    label: 'Helper',
+    description: 'Check-in participants, verify details, see QR codes'
+  }
+]
+</script>
+
+<style scoped>
+.role-picker {
+  max-width: 680px;
+  width: 90vw;
+  padding: 2rem;
+  background: var(--surface-800);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+}
+
+.picker-title {
+  font-family: var(--font-sans);
+  font-size: 20px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.role-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .role-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.role-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+  color: #fff;
+}
+
+.role-card:hover {
+  background: rgba(255,255,255,0.08);
+  border-color: var(--accent-muted);
+}
+
+.role-icon {
+  font-size: 32px;
+}
+
+.role-name {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent-color);
+}
+
+.role-desc {
+  text-align: center;
+  color: rgba(255,255,255,0.45);
+}
+
+.picker-hint {
+  margin-top: 1.5rem;
+  color: rgba(255,255,255,0.3);
+  text-align: center;
+}
+</style>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/components/DemoRolePicker.vue
+git commit -m "feat: add DemoRolePicker component with Emcee/Judge/Helper role cards
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: AdminPage — Demo Settings
+
+**Files:**
+- Modify: `BES-frontend/src/views/AdminPage.vue`
+
+- [ ] **Step 1: Add demo settings section**
+
+Read the current `AdminPage.vue` to understand its structure. Find a good place to add a new "Demo Settings" section.
+
+Add to the template (after existing settings sections):
+
+```html
+<!-- Demo Settings -->
+<section class="admin-section">
+  <div class="section-rule">
+    <span class="section-label">Demo Settings</span>
+    <span class="section-line"></span>
+  </div>
+
+  <div class="setting-row">
+    <span class="type-prose">Enable demo system</span>
+    <label class="toggle-switch">
+      <input
+        type="checkbox"
+        :checked="demoConfig.demoEnabled"
+        @change="toggleDemoEnabled"
+      />
+      <span class="toggle-slider"></span>
+    </label>
+  </div>
+
+  <div class="setting-row">
+    <span class="type-prose">Passcode</span>
+    <div class="passcode-controls">
+      <input
+        :type="showPasscode ? 'text' : 'password'"
+        :value="showPasscode ? demoConfig.passcode : '••••••••'"
+        class="passcode-display"
+        readonly
+      />
+      <button class="btn-sm" @click="showPasscode = !showPasscode">
+        {{ showPasscode ? 'Hide' : 'Show' }}
+      </button>
+      <button class="btn-sm" @click="regeneratePasscode">
+        Regenerate
+      </button>
+    </div>
+  </div>
+
+  <p class="type-prose-sm stat-text">
+    Active sandboxes: {{ activeSandboxes }}
+  </p>
+</section>
+```
+
+Add to the script setup:
+
+```javascript
+import { ref, onMounted } from 'vue'
+import { getDemoConfig, updateDemoConfig } from '@/utils/api'
+
+const demoConfig = ref({ demoEnabled: false, passcode: '' })
+const showPasscode = ref(false)
+const activeSandboxes = ref(0)
+
+async function loadDemoConfig() {
+  try {
+    demoConfig.value = await getDemoConfig()
+  } catch (e) {
+    console.error('Failed to load demo config', e)
+  }
+}
+
+async function toggleDemoEnabled() {
+  const newState = !demoConfig.value.demoEnabled
+  await updateDemoConfig({ demoEnabled: newState })
+  demoConfig.value.demoEnabled = newState
+}
+
+async function regeneratePasscode() {
+  await updateDemoConfig({ demoEnabled: demoConfig.value.demoEnabled, regeneratePasscode: true })
+  await loadDemoConfig()
+}
+
+onMounted(() => {
+  loadDemoConfig()
+})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/views/AdminPage.vue
+git commit -m "feat: add Demo Settings section to AdminPage (toggle, passcode, regenerate)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Build Verification
+
+- [ ] **Step 1: Build backend**
+
+```bash
+cd BES && mvn clean package -DskipTests
+```
+
+Expected: BUILD SUCCESS. Fix any compilation errors (check repository method names, import paths, constructor signatures).
+
+- [ ] **Step 2: Build frontend**
+
+```bash
+cd BES-frontend && npm run build
+```
+
+Expected: Build completes without errors.
+
+- [ ] **Step 3: Fix issues and commit**
+
+If any build errors, fix them and commit:
+
+```bash
+git add -A
+git commit -m "fix: resolve build errors from demo feature integration
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Repository Method Verification
+
+Before writing tests, verify that all repository methods called in `DemoService` and `DemoDataSeeder` actually exist. This task catches any method name mismatches.
+
+- [ ] **Step 1: Check each repository method**
+
+For each repository used in `DemoService` and `DemoDataSeeder`, read the repository file and confirm the method signature exists. Adjust code if methods are named differently.
+
+Key methods to verify:
+- `EventCategoryRepo.findByEvent(Event)` 
+- `EventParticipantRepo.findByEvent(Event)`
+- `EventCategoryParticipantRepo.findByEventCategory(EventCategory)`
+- `ScoreRepo.findByEventCategoryParticipant(EventCategoryParticipant)`
+- `AuditionFeedbackRepo.findByEventCategoryParticipant(EventCategoryParticipant)`
+- `ScoringCriteriaRepo.findByEventAndEventCategory(Event, EventCategory)`
+- `JudgeRepo.findFirstByName(String)` 
+- `JudgeRepo.insertEventJudge(Long, Long)`
+- `JudgeRepo.deleteEventJudge(Long, Long)`
+- `JudgeRepo.findJudgesByEventId(Long)`
+- `ParticipantRepo.findFirstByParticipantName(String)`
+- `SessionTokenRepo.findByEvent(Event)`
+- `FeedbackTagRepo.findAll()`
+
+Run: `find BES/src/main/java/com/example/BES/respositories -name "*.java" -exec grep -l "findByEvent\|findByEventCategory\|findFirstBy\|insertEventJudge\|deleteEventJudge\|findJudgesByEvent" {} \;`
+
+Read each file to confirm exact signatures, and update `DemoService` / `DemoDataSeeder` method calls to match.
+
+- [ ] **Step 2: Add missing repository methods**
+
+If any method is missing, add it to the appropriate repository. For example, if `EventCategoryParticipantRepo` has no `findByEventCategory`, add:
+
+```java
+List<EventCategoryParticipant> findByEventCategory(EventCategory eventCategory);
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "fix: align repository method calls in demo services with actual repo interfaces
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: Backend Integration Tests
+
+**Files:**
+- Create: `BES/src/test/java/com/example/BES/controllers/DemoControllerIntegrationTest.java`
+- Create: `BES/src/test/java/com/example/BES/services/DemoServiceTest.java`
+
+**Interfaces:**
+- Consumes: `DemoController`, `DemoService`, H2 test database, Spring MockMvc
+- Produces: Test coverage for demo start endpoint (200/401/403/404/429), clone integrity
+
+- [ ] **Step 1: Write DemoControllerIntegrationTest**
+
+```java
+package com.example.BES.controllers;
+
+import com.example.BES.dtos.DemoStartRequestDto;
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import com.example.BES.services.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class DemoControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AppConfigService appConfigService;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    @BeforeEach
+    void setUp() {
+        // Ensure demo is enabled and passcode is set
+        appConfigService.setDemoEnabled(true);
+        appConfigService.setDemoPasscode("TESTCODE");
+        // Ensure template event exists
+        if (eventRepo.findByEventName("Kyrove Demo").isEmpty()) {
+            Event template = new Event();
+            template.setEventName("Kyrove Demo");
+            template.setJudgingMode("SOLO");
+            eventRepo.save(template);
+        }
+    }
+
+    @Test
+    void startDemo_withValidPasscodeAndRole_returnsSuccess() throws Exception {
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "EMCEE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.role").value("EMCEE"))
+                .andExpect(jsonPath("$.eventName").value(startsWith("Kyrove Demo-")))
+                .andExpect(jsonPath("$.eventId").exists());
+    }
+
+    @Test
+    void startDemo_withWrongPasscode_returns401() throws Exception {
+        DemoStartRequestDto request = new DemoStartRequestDto("WRONG", "EMCEE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Invalid passcode"));
+    }
+
+    @Test
+    void startDemo_whenDisabled_returns403() throws Exception {
+        appConfigService.setDemoEnabled(false);
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "EMCEE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").value("Demo is currently disabled"));
+        appConfigService.setDemoEnabled(true); // restore
+    }
+
+    @Test
+    void startDemo_withInvalidRole_returns400() throws Exception {
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "ORGANISER");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").containsString("Invalid role"));
+    }
+
+    @Test
+    void startDemo_asJudge_returnsJudgeFields() throws Exception {
+        // Note: this test requires a judge to exist in the template event
+        // The test will pass even without judgeId if no judges are seeded
+        DemoStartRequestDto request = new DemoStartRequestDto("TESTCODE", "JUDGE");
+        mockMvc.perform(post("/api/v1/demo/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("JUDGE"));
+    }
+}
+```
+
+- [ ] **Step 2: Write DemoServiceTest**
+
+```java
+package com.example.BES.services;
+
+import com.example.BES.models.*;
+import com.example.BES.respositories.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class DemoServiceTest {
+
+    @Autowired
+    private DemoService demoService;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    @Autowired
+    private AppConfigService appConfigService;
+
+    @BeforeEach
+    void setUp() {
+        appConfigService.setDemoEnabled(true);
+        appConfigService.setDemoPasscode("TEST");
+        // Seed a minimal template
+        if (eventRepo.findByEventName("Kyrove Demo").isEmpty()) {
+            Event template = new Event();
+            template.setEventName("Kyrove Demo");
+            template.setJudgingMode("SOLO");
+            template.setFeedbackEnabled(true);
+            eventRepo.save(template);
+        }
+    }
+
+    @Test
+    void cloneTemplate_createsNewEventWithUuidSuffix() {
+        DemoService.CloneResult result = demoService.cloneTemplate("EMCEE", "127.0.0.1");
+        assertThat(result.event.getEventName()).startsWith("Kyrove Demo-");
+        assertThat(result.event.getEventName()).isNotEqualTo("Kyrove Demo");
+        assertThat(result.token).isNotNull();
+        assertThat(result.token.getRole()).isEqualTo("EMCEE");
+    }
+
+    @Test
+    void cloneTemplate_rateLimitsPerIp() {
+        demoService.cloneTemplate("EMCEE", "192.168.1.1");
+        demoService.cloneTemplate("HELPER", "192.168.1.1");
+        demoService.cloneTemplate("JUDGE", "192.168.1.1");
+
+        assertThatThrownBy(() -> demoService.cloneTemplate("EMCEE", "192.168.1.1"))
+                .isInstanceOf(DemoService.DemoRateLimitException.class)
+                .hasMessageContaining("limit reached");
+    }
+
+    @Test
+    void purgeSandbox_deletesEventAndChildren() {
+        DemoService.CloneResult result = demoService.cloneTemplate("EMCEE", "127.0.0.2");
+        Long eventId = result.event.getEventId();
+
+        demoService.purgeSandbox(eventId);
+
+        assertThat(eventRepo.findById(eventId)).isEmpty();
+    }
+}
+```
+
+- [ ] **Step 3: Run backend tests**
+
+```bash
+cd BES && mvn test -Dtest=DemoControllerIntegrationTest,DemoServiceTest
+```
+
+Expected: All tests pass. Fix any failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BES/src/test/java/com/example/BES/controllers/DemoControllerIntegrationTest.java \
+        BES/src/test/java/com/example/BES/services/DemoServiceTest.java
+git commit -m "test: add integration tests for DemoController and DemoService
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 16: Frontend Component Tests
+
+**Files:**
+- Create: `BES-frontend/src/components/__tests__/DemoRolePicker.test.js`
+
+- [ ] **Step 1: Write DemoRolePicker test**
+
+```javascript
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DemoRolePicker from '../DemoRolePicker.vue'
+
+describe('DemoRolePicker', () => {
+  it('renders three role cards', () => {
+    const wrapper = mount(DemoRolePicker)
+    const cards = wrapper.findAll('.role-card')
+    expect(cards).toHaveLength(3)
+  })
+
+  it('emits select with EMCEE when Emcee card is clicked', async () => {
+    const wrapper = mount(DemoRolePicker)
+    const cards = wrapper.findAll('.role-card')
+    await cards[0].trigger('click')
+    expect(wrapper.emitted('select')).toBeTruthy()
+    expect(wrapper.emitted('select')[0]).toEqual(['EMCEE'])
+  })
+
+  it('emits select with JUDGE when Judge card is clicked', async () => {
+    const wrapper = mount(DemoRolePicker)
+    const cards = wrapper.findAll('.role-card')
+    await cards[1].trigger('click')
+    expect(wrapper.emitted('select')[0]).toEqual(['JUDGE'])
+  })
+
+  it('emits select with HELPER when Helper card is clicked', async () => {
+    const wrapper = mount(DemoRolePicker)
+    const cards = wrapper.findAll('.role-card')
+    await cards[2].trigger('click')
+    expect(wrapper.emitted('select')[0]).toEqual(['HELPER'])
+  })
+
+  it('emits back when backdrop is clicked', async () => {
+    const wrapper = mount(DemoRolePicker)
+    await wrapper.find('.modal-backdrop').trigger('click')
+    expect(wrapper.emitted('back')).toBeTruthy()
+  })
+
+  it('does not emit back when role card is clicked', async () => {
+    const wrapper = mount(DemoRolePicker)
+    await wrapper.find('.role-card').trigger('click')
+    expect(wrapper.emitted('back')).toBeFalsy()
+    expect(wrapper.emitted('select')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run frontend tests**
+
+```bash
+cd BES-frontend && npx vitest run src/components/__tests__/DemoRolePicker.test.js
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/components/__tests__/DemoRolePicker.test.js
+git commit -m "test: add DemoRolePicker component tests
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 17: Full Integration Verification
+
+- [ ] **Step 1: Start the full stack**
+
+```bash
+docker-compose up --build --no-cache
+```
+
+- [ ] **Step 2: Smoke test the demo flow**
+
+1. Open `http://localhost/login`
+2. Verify "Try Demo" button is visible
+3. Click "Try Demo" → passcode modal appears
+4. Enter passcode (check logs for generated passcode, or query DB: `SELECT value FROM app_config WHERE key='demo_passcode'`)
+5. Select "Emcee" → verify redirect to `/emcee/session` with audition list visible
+6. Open new incognito window → repeat for "Judge" → verify scoring cards appear with participants
+7. Open new incognito window → repeat for "Helper" → verify check-in flow
+
+- [ ] **Step 3: Verify admin controls**
+
+1. Login as admin
+2. Navigate to `/admin`
+3. Find "Demo Settings" section
+4. Toggle demo off → verify "Try Demo" disappears from login page
+5. Toggle demo on → verify "Try Demo" reappears
+6. Click "Regenerate" passcode → verify new passcode works, old one doesn't
+
+- [ ] **Step 4: Verify cleanup**
+
+1. Start a demo session, note the event name
+2. Close the browser tab
+3. Wait for session expiry (or manually delete the session)
+4. Verify the sandbox event is removed from the database
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A && git commit -m "fix: smoke test fixes for demo feature
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 18: Final Commit & PR
+
+- [ ] **Step 1: Run all tests one final time**
+
+```bash
+cd BES && mvn test
+cd BES-frontend && npm test
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+git push -u origin feat/demo-account
+gh pr create --title "feat: demo account system" \
+  --body "## Demo Account System
+
+Implements a self-service demo system for Kyrove.
+
+### What it does
+- Adds a \"Try Demo\" button on the login page
+- Passcode-gated access (admin-managed)
+- Users pick a role: Emcee, Judge, or Helper
+- Each user gets their own isolated sandbox clone of a pre-populated template event
+- Sandboxes auto-expire after 24h
+- Rate limited: 3 per IP per day, 10 concurrent max
+
+### What's included
+- Template event seeder (2 categories, 30 participants, 3 judges, pre-filled scores/feedback)
+- Full clone service with transaction safety
+- Admin controls (toggle demo, view/regenerate passcode)
+- Session expiry cleanup + scheduled orphan purge
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec Section | Tasks |
+|---|---|
+| 3.1 Template Event | Task 4 (DemoDataSeeder) |
+| 3.2 Per-Session Clone | Task 5 (DemoService.cloneTemplate) |
+| 4.1 Passcode Management | Task 2 (AppConfigService), Task 3 (Admin endpoints) |
+| 4.2 Enable/Disable Toggle | Task 2, Task 3, Task 10 (Login.vue), Task 12 (AdminPage) |
+| 4.3 Rate Limits | Task 5 (checkIpRateLimit, MAX_CONCURRENT) |
+| 5.1-5.3 Backend API | Task 6 (DemoController + DTOs), Task 7 (SecurityConfig) |
+| 5.5 Cleanup | Task 8 (SessionExpiryListener + scheduled purge) |
+| 6.1-6.4 Frontend | Task 9 (api.js), Task 10 (Login.vue), Task 11 (DemoRolePicker), Task 12 (AdminPage) |
+| 8 Database Migration | Task 1 (V46) |
+| 9 Testing | Task 15 (backend tests), Task 16 (frontend tests), Task 17 (smoke tests) |
+| 10 Out of Scope | Organiser excluded (validated in Task 6 controller) |
+| 11 Seeding | Task 4 (DemoDataSeeder with Google Sheets fallback note) |

--- a/docs/superpowers/specs/2026-06-17-demo-account-design.md
+++ b/docs/superpowers/specs/2026-06-17-demo-account-design.md
@@ -1,0 +1,418 @@
+# Demo Account System — Design Spec
+
+**Date:** 2026-06-17
+**Status:** Approved
+**Scope:** Backend (Spring Boot) + Frontend (Vue 3)
+
+---
+
+## 1. Purpose
+
+A self-service demo system that lets anyone experience Kyrove in their own isolated sandbox, without an admin setting up events or resetting data. Three event-day roles are covered: **Emcee**, **Judge**, and **Helper**. The organiser role is **excluded** from the demo to prevent abuse as a free event platform and because the organiser experience is mostly setup work rather than the exciting live feeling.
+
+---
+
+## 2. User Flow
+
+```
+Login Page
+  │
+  └── [Try Demo] button
+        │
+        ├── Passcode prompt modal
+        │     │
+        │     ├── Wrong passcode → "Invalid passcode" inline error
+        │     │
+        │     └── Correct passcode → Role Picker
+        │           │
+        │           ├── 🎤 Emcee
+        │           ├── ⚖️ Judge
+        │           └── 🛎️ Helper
+        │
+        └── POST /api/v1/demo/start { passcode, role }
+              │
+              ├── 200 → set session cookie, redirect to role landing
+              ├── 401 → invalid passcode
+              ├── 403 → demo disabled by admin
+              └── 429 → rate limited (too many sandboxes)
+```
+
+**Return behavior:** If the browser already has a valid demo session cookie, clicking "Try Demo" detects the existing sandbox and offers "Continue" (return to current role) or "Start Fresh" (destroy old sandbox, create new one).
+
+---
+
+## 3. Architecture: Template Event → Per-Session Clone
+
+### 3.1 Template Event
+
+Seeded once on application startup. Serves as the immutable source for all clones.
+
+```
+Template Event: "Kyrove Demo"
+├── Payment: not required
+├── Judging mode: SOLO
+├── Feedback: enabled
+├── Results: not released
+│
+├── Category: "Hip Hop" (1v1, 20 participants, default single-score judging)
+├── Category: "Popping" (1v1, 20 participants, custom 3-criteria judging)
+│   └── Criteria: Musicality, Technique, Originality
+│
+├── Judges (3): DJ FLEX, B-Girl RAY, Kid Kazoo
+│   └── All assigned to both categories
+│
+├── Participants: 20 per category (some overlap, some unique)
+│   ├── All have audition numbers assigned
+│   ├── All have stage names
+│   ├── All have reference codes
+│   └── All checked in (verified + payment done)
+│
+├── Scores: pre-filled — each judge has scored ~half the participants
+│   └── Result: realistic mix of scored/unscored cards
+│
+└── Feedback: pre-filled feedback on scored participants
+
+Session tokens are generated per clone, not stored on the template.
+```
+
+### 3.2 Per-Session Clone
+
+When a user picks a role, `DemoService` deep-copies the template event under a new name:
+
+```
+Clone: "Kyrove Demo-{uuid8}"   (e.g., "Kyrove Demo-a3f9c2")
+├── All 2 categories
+├── All participants + EventParticipant + EventCategoryParticipant links
+├── All judges + category assignments
+├── All pre-filled scores
+├── All pre-filled feedback + tags
+└── 3 session tokens (one per demo role: EMCEE, JUDGE, HELPER)
+    └── JUDGE token picks one of the 3 demo judges at random
+```
+
+**Clone transaction:** The entire clone runs in a single `@Transactional` block. If any step fails, nothing is persisted.
+
+**Roles returned:**
+
+| Role picked | Session type | Redirect |
+|-------------|-------------|----------|
+| Emcee | Token-based (`ROLE_EMCEE`) | `/emcee/session` |
+| Judge | Token-based (`ROLE_JUDGE`) with linked judge | `/judge/session` |
+| Helper | Token-based (`ROLE_HELPER`) | `/helper/session` |
+
+The cloned session tokens are pre-authenticated — the user is logged in immediately with the token's role, no second step required.
+
+---
+
+## 4. Access Control
+
+### 4.1 Passcode
+
+- Stored in `app_config` table as key `demo_passcode`
+- Initial value: randomly generated 8-character alphanumeric, printed to server logs on first startup
+- Admin can **view** and **regenerate** the passcode from the Admin page
+- `POST /api/v1/admin/demo/regenerate-passcode` → new random 8-char code, returns it, broadcasts via WebSocket (optional, admin-only screen anyway)
+
+### 4.2 Enable/Disable Toggle
+
+- Stored in `app_config` table as key `demo_enabled` (values: `"true"` / `"false"`)
+- Default: `"true"` (or env var `DEMO_ENABLED` override on first seed)
+- Admin can toggle from Admin page
+- When disabled: `POST /api/v1/demo/start` returns `403 Forbidden`
+- Toggle broadcast via WebSocket — frontend hides/shows "Try Demo" button live
+
+### 4.3 Rate Limits
+
+| Limit | Value | Enforcement |
+|-------|-------|-------------|
+| One sandbox per active session | Hard | Old sandbox must be destroyed before creating new one |
+| Max 3 sandboxes per IP per 24h | Hard | Tracked in a small in-memory map |
+| Max 10 concurrent demo sandboxes | Soft cap | Count active demo events; 11th gets 429 |
+
+---
+
+## 5. Backend Changes
+
+### 5.1 New Files
+
+| File | Purpose |
+|------|---------|
+| `controllers/DemoController.java` | `POST /api/v1/demo/start` — public endpoint |
+| `services/DemoService.java` | Orchestrates clone, rate limiting, cleanup |
+| `services/DemoDataSeeder.java` | `@PostConstruct` — seeds template event on startup if absent |
+| `config/DemoRateLimitConfig.java` | In-memory IP tracking (ConcurrentHashMap) |
+
+### 5.2 Modified Files
+
+| File | Change |
+|------|--------|
+| `config/SecurityConfig.java` | Add `/api/v1/demo/**` to `permitAll` |
+| `config/SessionExpiryListener.java` | On demo session expiry → call `DemoService.purgeSandbox(session)` |
+| `services/AppConfigService.java` | Generalize to support generic key-value read/write (currently hardcoded to `accentColor`) |
+| `controllers/AppConfigController.java` | Add `POST /api/v1/config/demo` for admin to manage passcode + toggle |
+| `controllers/AdminController.java` | Alternative: add demo management endpoints here |
+| `models/AppConfig.java` | No change needed — already generic key-value schema |
+
+### 5.3 API Contract
+
+```
+POST /api/v1/demo/start
+  Content-Type: application/json
+  Body: {
+    "passcode": "A3F9C2K1",
+    "role": "EMCEE" | "JUDGE" | "HELPER"
+  }
+
+  Success 200:
+  {
+    "authenticated": true,
+    "role": "JUDGE",
+    "eventId": 456,
+    "eventName": "Kyrove Demo-a3f9c2",
+    "judgeId": 12,
+    "judgeName": "DJ FLEX"
+  }
+
+  Error 401: { "error": "Invalid passcode" }
+  Error 403: { "error": "Demo is currently disabled" }
+  Error 429: { "error": "Too many demo sessions. Try again later." }
+```
+
+```
+POST /api/v1/admin/demo/regenerate-passcode
+  Authorization: ROLE_ADMIN
+
+  Success 200:
+  {
+    "passcode": "B7D2E9F4"
+  }
+```
+
+```
+GET /api/v1/config/app
+  (extended response)
+  {
+    "accentColor": "#ffffff",
+    "demoEnabled": true
+  }
+```
+
+### 5.4 DemoService.cloneTemplate()
+
+Pseudocode:
+
+```java
+@Transactional
+public DemoSession cloneTemplate(String role) {
+    // 1. Load template event
+    Event template = eventRepo.findByEventName("Kyrove Demo");
+
+    // 2. Clone event with new name
+    Event clone = new Event();
+    clone.setEventName("Kyrove Demo-" + randomUuid8());
+    clone.setPaymentRequired(template.isPaymentRequired());
+    // ... copy all fields
+    Event saved = eventRepo.save(clone);
+
+    // 3. Clone categories
+    for (EventCategory cat : template.getCategories()) {
+        EventCategory clonedCat = cloneCategory(cat, saved);
+        // Clone scoring criteria
+        // Clone category-judge assignments
+    }
+
+    // 4. Clone participants + all junction records
+    cloneParticipants(template, saved);
+
+    // 5. Clone scores
+    cloneScores(template, saved);
+
+    // 6. Clone feedback
+    cloneFeedback(template, saved);
+
+    // 7. Generate session tokens for cloned event
+    generateDemoTokens(saved, role);
+
+    return buildSession(saved, role);
+}
+```
+
+### 5.5 Cleanup
+
+```java
+// SessionExpiryListener — on session destroyed
+if (session event name starts with "Kyrove Demo-") {
+    eventRepo.deleteByEventName(eventName);  // cascade deletes everything
+}
+
+// Scheduled — every 6 hours
+@Scheduled(fixedRate = 6 * 3600 * 1000)
+public void purgeOrphanSandboxes() {
+    // Delete any demo events older than 24h
+    // (belt-and-suspenders for sessions that weren't cleanly destroyed)
+    List<Event> orphans = eventRepo.findDemoEventsOlderThan(24h);
+    orphans.forEach(e -> eventRepo.delete(e));
+}
+```
+
+---
+
+## 6. Frontend Changes
+
+### 6.1 New / Modified Files
+
+| File | Change |
+|------|--------|
+| `views/Login.vue` | Add "Try Demo" button, passcode modal, existing-session detection |
+| `components/DemoRolePicker.vue` | New — 3 role cards with descriptions |
+| `views/AdminPage.vue` | New "Demo Settings" section |
+| `utils/api.js` | Add `startDemo(passcode, role)` and `regenerateDemoPasscode()` |
+| `utils/auth.js` | Add demo session detection helper |
+| `App.vue` | Handle `demoEnabled` from app config WebSocket |
+
+### 6.2 Login Page — "Try Demo"
+
+- Button styled as a secondary action below the login form
+- Separated with a section rule: `— or —`
+- Click → modal with passcode input
+- If existing demo session detected → "Continue Demo" / "Start Fresh" prompt
+
+### 6.3 Role Picker
+
+Three equal cards in a row (stack on mobile):
+
+```
+┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+│       🎤          │  │       ⚖️          │  │       🛎️          │
+│     EMCEE         │  │     JUDGE         │  │    HELPER         │
+│                   │  │                   │  │                   │
+│  Run audition     │  │  Score            │  │  Check-in         │
+│  rounds, view     │  │  participants,    │  │  participants,    │
+│  scoreboard,      │  │  submit feedback, │  │  verify details,  │
+│  announce results │  │  use keypad       │  │  see QR code      │
+└──────────────────┘  └──────────────────┘  └──────────────────┘
+```
+
+Clicking a card triggers the API call and redirect.
+
+### 6.4 Admin Page — Demo Settings
+
+Section in the admin panel (visible to Admin only):
+
+- **Demo enabled:** Toggle switch
+- **Passcode:** Masked display (••••••••) with "Show" toggle and "Regenerate" button
+- **Active sandboxes:** Count display (e.g., "2 demo sessions active")
+
+---
+
+## 7. Demo Template Data Specification
+
+### 7.1 Event
+
+- `eventName`: `"Kyrove Demo"`
+- `paymentRequired`: `false`
+- `judgingMode`: `"SOLO"`
+- `feedbackEnabled`: `true`
+- `resultsReleased`: `false`
+- `releaseScore`: `false`
+- `animTheme`: `"impact"`
+
+### 7.2 Categories
+
+**Hip Hop:**
+- Format: `"1v1"`
+- Judging: default (single overall score)
+- 20 participants
+- Scoring criteria: none (default mode)
+
+**Popping:**
+- Format: `"1v1"`
+- Judging: custom criteria
+- 20 participants
+- Scoring criteria: Musicality (w=1), Technique (w=1), Originality (w=1)
+
+### 7.3 Judges
+
+| Name |
+|------|
+| DJ FLEX |
+| B-Girl RAY |
+| Kid Kazoo |
+
+All assigned to both categories.
+
+### 7.4 Participants
+
+20 per category, with ~10 overlapping (appearing in both categories) and ~10 unique to each. Total: ~30 unique participants.
+
+Each participant has:
+- Stage name (e.g., "B-Boy Spinz", "Poppin' J", "Lil Flow")
+- Reference code (auto-generated)
+- Payment verified = true
+- Display name (same as stage name)
+
+Audition numbers: 1–20 per category, assigned in shuffle order.
+
+### 7.5 Scores
+
+Each judge has scored ~10 of the 20 participants per category (random distribution). Scores range from 5.0–9.5. This gives:
+- ~50% scored / 50% unscored per category
+- Realistic scoreboard with varying totals
+
+### 7.6 Feedback
+
+Pre-filled feedback on ~30% of scored participants using the default feedback tags. One or two tags + a brief note per feedback entry.
+
+---
+
+## 8. Database Migration
+
+**V46:** Add `demo_passcode` and `demo_enabled` rows to `app_config`:
+
+```sql
+INSERT INTO app_config (key, value) VALUES ('demo_passcode', <random-8-char>)
+    ON CONFLICT (key) DO NOTHING;
+INSERT INTO app_config (key, value) VALUES ('demo_enabled', 'true')
+    ON CONFLICT (key) DO NOTHING;
+```
+
+The random passcode in the migration is a placeholder — the `DemoDataSeeder` will overwrite it with a proper random value on first startup if it matches the placeholder.
+
+No schema changes needed — `app_config` already supports arbitrary key-value pairs.
+
+---
+
+## 9. Testing
+
+### Backend
+
+- `DemoServiceTest` — clone integrity, transaction rollback on failure
+- `DemoControllerIntegrationTest` — 200/401/403/429 responses
+- `DemoDataSeederTest` — idempotency (calling seeder twice doesn't duplicate)
+- `SessionExpiryListenerTest` — demo sandbox cascade-deleted on session expiry
+
+### Frontend
+
+- `DemoRolePicker.test.js` — renders 3 role cards, click emits correct role
+- `Login.test.js` — "Try Demo" button visibility, passcode modal flow
+
+---
+
+## 10. Out of Scope
+
+- Organiser role in demo (excluded to prevent abuse as free event platform)
+- Battle features (PRO tier demo only — no MAX/battle access)
+- Results portal demo (public route, no auth needed — anyone can already visit `/results`)
+- Email sending from demo sandboxes (email is no longer used in the product)
+- Google Sheets / Google Drive integration in demo sandboxes (organiser-only features, organiser excluded)
+- Multi-language support for demo content
+- Persistent sandboxes beyond 24h lifetime
+
+## 11. Seeding the Template Event
+
+The template event (`"Kyrove Demo"`) has a fixed, predictable name. This means:
+
+- **Via Google Sheets:** An admin can import participants into `"Kyrove Demo"` just like any real event — the sheet needs a column matching the event name `"Kyrove Demo"`. This is the easiest way to seed 20+ participants per category with realistic names.
+- **Via `DemoDataSeeder`:** Falls back to programmatic seeding if no data exists. The seeder checks if participants exist; if empty, it creates sample data programmatically.
+
+The recommendation is to use Google Sheets for the initial seed (better names, faster setup), with the programmatic seeder as a fallback for fresh deployments where no sheet is configured.


### PR DESCRIPTION
## Summary

Adds a **Demo Account** feature that lets anyone try Kyrove as an Emcee, Judge, or Helper without creating an account or setting up a real event. A public "Try Demo" button on the Login page launches a passcode-gated flow that clones a pre-seeded template event into an isolated sandbox, generates a role-specific session token (tied to a random judge for judge sessions), and lands the user directly in the appropriate session view.

## How it works

1. **Login page** → "Try Demo" → passcode modal → role picker (Emcee / Judge / Helper)
2. Backend validates passcode against `app_config.demo_passcode`, clones the `Kyrove Demo` template into `Kyrove Demo-<random8>`, generates a session token, authenticates the session
3. Subsequent role switches reuse the same sandbox event (one sandbox per browser session)
4. Sandboxes auto-expire and are purged (6-hour orphan sweep + session-expiry listener)
5. Admin can toggle demo on/off, regenerate passcode, list/purge sandboxes, and reset the template from Admin Page

## Template data

- **Event**: "Kyrove Demo" with 2 categories (Hip Hop 1v1, Popping 1v1)
- **30 participants**: 20 per category, ~10 overlap; 5 unassigned audition-number gaps per category (consistent across categories)
- **3 judges**: DJ FLEX, B-Girl RAY, Kid Kazoo — pre-assigned to both categories
- **Scoring**: Hip Hop uses single-score with intentional tie scenarios (4-way Top 16, 2-way Top 8); Popping uses multi-criteria (Musicality / Technique / Originality) with 3-way Top 8 tie
- **Feedback**: 2 tag groups (Technique, Performance) with 4 tags each; ~30% of scored participants have pre-filled feedback
- **Audition numbers**: scattered gaps applied consistently — a participant either gets a number in all categories or none (simulates real registration)
- **Judge identity**: demo judge sessions are locked to a randomly-assigned judge (like a real per-judge session link) — no identity chooser

## What was changed

### Backend — new files

| File | Purpose |
|------|---------|
| `DemoController.java` | `POST /api/v1/demo/start` — passcode validation, sandbox creation/reuse, session authentication |
| `DemoService.java` | Template cloning (events, categories, participants, scores, feedback, tags), rate limiting, orphan purge |
| `DemoDataSeeder.java` | `@EventListener(ApplicationReadyEvent)` — seeds the template with realistic data on startup |
| `DemoStartRequestDto/ResponseDto.java` | Request/response shapes for demo start |
| `DemoConfigDto.java` | Demo config shape for admin |
| `DemoControllerIntegrationTest.java` | Integration tests for demo start (EMCEE + JUDGE roles, reuse, invalid passcode) |
| `DemoServiceTest.java` | Unit tests for clone + purge lifecycle |
| `V46__add_demo_config.sql` | Flyway migration adding `demo_enabled` and `demo_passcode` to `app_config` |

### Backend — modified files

| File | Change |
|------|--------|
| `SecurityConfig.java` | `permitAll()` for `/api/v1/demo/**` |
| `AdminController.java` | Endpoints for demo config (get/update), sandbox list, sandbox purge, template reset |
| `AppConfigController.java` | Returns `demoEnabled` in public app config response |
| `AppConfigService.java` | Generic `get(key)`/`set(key,value)` + demo convenience methods |
| `SessionExpiryListener.java` | Purges demo sandbox on session expiry |
| `TierAccessService.java` | Blocks battle access for demo events |
| `EventRepo.java` | `findAllDemoEvents()` query |
| `SessionTokenRepository.java` | `findByEvent_EventId()` |
| `ScoringCriteriaRepo.java` | `findByEventAndEventCategory()` with nullable category |
| `EventCategoryParticipantRepo.java` | `findByEventCategory()` |

### Frontend — new files

| File | Purpose |
|------|---------|
| `DemoRolePicker.vue` | Full-screen role selector with Emcee/Judge/Helper cards |
| `DemoRolePicker.test.js` | Component tests for role picker rendering and selection |

### Frontend — modified files

| File | Change |
|------|--------|
| `Login.vue` | "Try Demo" button, passcode modal, role picker integration, `startDemoSession()` |
| `AdminPage.vue` | Demo Settings section (toggle, passcode display/regenerate, sandbox list with purge, template reset) |
| `JudgeSessionView.vue` | Restore `activeEvent` via `setActiveEvent()` in whoami fallback |
| `HelperSessionView.vue` | Same whoami fallback fix |
| `App.vue` | Minor: scanlines layer |
| `api.js` | `startDemo()`, `getDemoConfig()`, `updateDemoConfig()` |
| `auth.js` | Imports |

### Key architectural decisions

- **Session-based auth** (not JWT): demo uses the same Spring Security session pattern as normal token-auth. The demo token is a `SessionToken` stored in the database, with a 1-day expiry and auto-revocation on session end
- **One sandbox per browser session**: subsequent role switches hit `createTokenForExistingSandbox()` rather than cloning a new event
- **Judge assignment uses in-memory collection**: judges are collected from template categories during the cloning loop (before native `event_judge` inserts) to avoid a Hibernate native-INSERT-then-native-SELECT ordering issue
- **Feedback tags are event-scoped**: cloned sandboxes get their own copies of `FeedbackTagGroup` + `FeedbackTag` entities with remapped `AuditionFeedback` tag references
- **Demo events are gated from battle**: `TierAccessService` returns 403 for demo events — this is a sandbox for audition workflows only
- **IP rate limiting removed**: the passcode is sufficient gate; removed the IP rate limiter which was breaking Docker deployments (single IP)

## Testing

- `DemoControllerIntegrationTest`: 8 tests covering demo start (EMCEE/JUDGE), sandbox reuse, invalid passcode, disabled demo, rate limiting
- `DemoServiceTest`: 2 tests covering clone + purge lifecycle
- `DemoRolePicker.test.js`: 14 tests covering rendering, role cards, selection events
- All existing tests pass (233 backend, 129 frontend)

## Demo flow

```
Login Page                    Demo Flow
┌──────────┐    passcode    ┌──────────┐   role    ┌──────────────┐
│ Try Demo │───────────────→│ Passcode │──────────→│ Role Picker  │
└──────────┘                │  Modal   │           │ Emcee/Judge/ │
                            └──────────┘           │ Helper cards │
                                                   └──────┬───────┘
                                                          │ POST /api/v1/demo/start
                                                          ▼
                                                   ┌──────────────┐
                                                   │ Clone        │
                                                   │ Template →   │
                                                   │ Sandbox +    │
                                                   │ SessionToken │
                                                   └──────┬───────┘
                                                          │ redirect
                                           ┌──────────────┼──────────────┐
                                           ▼              ▼              ▼
                                     /emcee/session  /judge/session  /helper/session
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)