### PR TITLE
fix: session link routing, logout access, emcee picker, helper score, token URL format

### DIFF
--- a/BES-frontend/src/App.vue
+++ b/BES-frontend/src/App.vue
@@ -36,7 +36,7 @@ const isHelperRole = computed(() => role.value === 'ROLE_HELPER')
 
 /** Hide the navbar on full-screen / immersive routes */
 const hideNav = computed(() =>
-  ['Login', 'StreamOverlay', 'Battle Judge', 'BracketVisualization', 'AuditionDisplay'].includes(route.name)
+  ['Login', 'StreamOverlay', 'Battle Judge', 'BracketVisualization', 'AuditionDisplay', 'EmceeSession', 'JudgeSession', 'HelperSession'].includes(route.name)
 )
 
 /**
@@ -174,7 +174,14 @@ onMounted(async () => {
   applyTheme(theme.value)
   try {
     const res = await whoami()
-    authStore.login(res)
+    // Only apply the whoami result if the user IS authenticated, or if the
+    // store doesn't already have an authenticated session. This prevents a
+    // race where App.vue's whoami() resolves AFTER a token-auth page has
+    // already logged the user in — without this guard, whoami's
+    // { authenticated: false } would overwrite the token-auth session.
+    if (res?.authenticated || !authStore.isAuthenticated) {
+      authStore.login(res)
+    }
     if (authStore.activeEvent) {
       authStore.fetchEventBattleEnabled(authStore.activeEvent.name)
     }

--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   feedbackEnabled: { type: Boolean, default: true },
 });
 
-const emit = defineEmits(['open-feedback', 'remove-tag', 'submit', 'reset', 'jump', 'score-change']);
+const emit = defineEmits(['open-feedback', 'remove-tag', 'submit', 'jump', 'score-change']);
 
 const scrollRef    = ref(null)
 const currentIndex = ref(0)

--- a/BES-frontend/src/components/SwipeableCardsV2.vue
+++ b/BES-frontend/src/components/SwipeableCardsV2.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   feedbackEnabled: { type: Boolean, default: true },
 });
 
-const emit = defineEmits(['update:cards', 'open-feedback', 'remove-tag', 'submit', 'reset', 'jump', 'score-change']);
+const emit = defineEmits(['update:cards', 'open-feedback', 'remove-tag', 'submit', 'jump', 'score-change']);
 
 const scrollRef    = ref(null)
 const currentIndex = ref(0)

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -156,12 +156,13 @@ onBeforeUnmount(() => {
     <div class="flex items-center gap-2 flex-wrap justify-center">
       <button
         @click="toggleMode"
-        class="para-chip px-4 py-3 type-body transition-all duration-150 active:scale-95"
+        class="para-chip px-6 py-4 type-body transition-all duration-150 active:scale-95"
+        style="font-size:18px"
         :class="countUp
           ? 'text-accent border-[color:var(--accent-muted)]'
           : 'text-content-muted hover:text-content-primary'"
       >
-        <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-1 text-xs"></i>
+        <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-1"></i>
         {{ countUp ? 'Up' : 'Down' }}
       </button>
       <div class="w-px h-8 bg-white/12"></div>
@@ -169,7 +170,8 @@ onBeforeUnmount(() => {
         v-for="t in [30, 45, 60, 90]"
         :key="t"
         @click="startTimer(t)"
-        class="para-chip px-4 py-3 type-body transition-all duration-150 active:scale-95"
+        class="para-chip px-6 py-4 type-body transition-all duration-150 active:scale-95"
+        style="font-size:18px"
         :class="selectedTime === t && isRunning
           ? 'text-accent border-[color:var(--accent-muted)]'
           : 'text-content-muted hover:text-content-primary'"

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -72,7 +72,7 @@ const routes = [
         path: '/event/score',
         name: 'Score',
         component: Score,
-        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_EMCEE', 'ROLE_ORGANISER'], requiresEvent: true }
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_EMCEE', 'ROLE_ORGANISER', 'ROLE_HELPER'], requiresEvent: true }
     },
     {
         path: '/login',
@@ -155,6 +155,11 @@ const routes = [
         component: TokenAuth
     },
     {
+        path: '/auth/token/:role/:name?',
+        name: 'TokenAuthRole',
+        component: TokenAuth
+    },
+    {
         path: '/judge/session',
         name: 'JudgeSession',
         component: JudgeSessionView
@@ -176,7 +181,7 @@ const router = createRouter({
     routes
 })
 
-const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'JudgeSession', 'EmceeSession', 'HelperSession', 'AuditionDisplay']
+const PUBLIC_ROUTES = ['Login', 'Forbidden', 'StreamOverlay', 'Smoke', 'Results', 'ResultsQR', 'BracketVisualization', 'TokenAuth', 'TokenAuthRole', 'JudgeSession', 'EmceeSession', 'HelperSession', 'AuditionDisplay']
 const BATTLE_ROUTES = ['Battle Control', 'Battle Judge', 'StreamOverlay', 'Smoke', 'BracketVisualization']
 
 router.beforeEach(async (to) => {

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1612,6 +1612,27 @@ export const setResolvedParticipants = async (eventName, categoryName, participa
   } catch (e) { console.error(e) }
 }
 
+export const saveTieBreakerState = async (eventName, categoryName, tabulation, topN, winners, confirmed, addedToPool) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/tie-breaker-state`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventName, categoryName, tabulation, topN, winners: [...winners], confirmed, addedToPool: [...addedToPool] })
+    })
+  } catch (e) { console.error(e) }
+}
+
+export const getTieBreakerState = async (eventName, categoryName) => {
+  try {
+    return await fetch(`${domain}/api/v1/battle/tie-breaker-state?event=${encodeURIComponent(eventName)}&category=${encodeURIComponent(categoryName)}`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json' }
+    })
+  } catch (e) { console.error(e) }
+}
+
 export const postAuditionDisplayState = async (state) => {
   try {
     return await fetch(`${domain}/api/v1/event/audition-display`, {

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -420,21 +420,21 @@ onUnmounted(() => {
 
 /* ── PAIR layout: stacked names left | timer right ───────────────────────── */
 .pair-row {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
   justify-content: center;
   gap: clamp(40px, 8vw, 130px);
   width: 100%;
+  max-width: 90vw;
 }
 /* Left column: both names stacked */
 .pair-names {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  flex: 1;
   min-width: 0;
-  max-width: 58vw;
+  overflow: hidden;
 }
 .pair-name-entry {
   display: flex;
@@ -451,10 +451,12 @@ onUnmounted(() => {
 
 /* ── SOLO layout: slot | timer ────────────────────────────────────────────── */
 .slot-timer-row {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: clamp(60px, 10vw, 160px);
+  width: 100%;
+  max-width: 90vw;
 }
 
 .current-slots {
@@ -462,12 +464,14 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: flex-start;
   gap: 0;
+  min-width: 0;
 }
 
 .slot-entry {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  min-width: 0;
 }
 
 .audition-number {
@@ -514,12 +518,19 @@ onUnmounted(() => {
 /* ── Timer ────────────────────────────────────────────────────────────────── */
 .timer-display {
   flex-shrink: 0;
+  /* Inherit timer font-size so min-width in ch scales with the digits.
+     2.5ch covers typical 2-digit timers (30-90s); tabular-nums
+     prevents intra-digit jitter without reserving excess space. */
+  font-size: clamp(100px, 18vw, 220px);
+  min-width: 2.5ch;
+  text-align: center;
 }
 
 .timer-number {
-  font-size: clamp(100px, 18vw, 220px);
+  font-size: inherit;
   line-height: 1;
   letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
   color: #ffffff;
   transition: color 0.3s ease;
 }

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, resetJudgeScores, resetJudgeFeedback, claimEmceeCategory, getActiveEmceeCategories, getEventFeedbackTags } from '@/utils/api';
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, claimEmceeCategory, getActiveEmceeCategories, getEventFeedbackTags } from '@/utils/api';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { RouterLink, useRouter, useRoute, onBeforeRouteLeave } from 'vue-router';
@@ -98,16 +98,6 @@ const openModal = (title, message, variant = 'info') => {
   dynamicCallBack.value = () => { showModal.value = false }
 }
 
-const confirmReset = (title, message) => {
-  modalTitle.value = title
-  modalMessage.value = message
-  modalVariant.value = 'warning'
-  showModal.value = true
-  dynamicCallBack.value = async () => {
-    showModal.value = false
-    await resetScore()
-  }
-}
 
 const switchCategory = (g) => {
   if (g === selectedCategory.value) return
@@ -372,34 +362,6 @@ const submitScore = async (eventName, categoryName, judgeName, participantList) 
   }
 }
 
-const resetScore = async () => {
-  // Only reset scores for the currently selected category
-  participants.value = participants.value.map(obj => {
-    if (obj.categoryName !== selectedCategory.value) return obj
-    const cs = {}
-    if (obj.criteriaScores) {
-      Object.keys(obj.criteriaScores).forEach(k => { cs[k] = 0 })
-    }
-    return { ...obj, score: 0, criteriaScores: cs, submitted: false }
-  })
-  if (currentJudge.value && selectedEvent.value && selectedCategory.value) {
-    await Promise.all([
-      resetJudgeScores(selectedEvent.value, selectedCategory.value, currentJudge.value),
-      resetJudgeFeedback(selectedEvent.value, selectedCategory.value, currentJudge.value),
-    ])
-    // Clear in-memory feedback for the current category
-    const categoryAuditionNums = new Set(
-      participants.value
-        .filter(p => p.categoryName === selectedCategory.value)
-        .map(p => p.auditionNumber)
-    )
-    const newMap = new Map(feedbackGiven.value)
-    for (const key of newMap.keys()) {
-      if (categoryAuditionNums.has(key)) newMap.delete(key)
-    }
-    feedbackGiven.value = newMap
-  }
-}
 
 // ── Scoring criteria ─────────────────────────────────────────────────────────
 const criteria = ref([])
@@ -757,14 +719,6 @@ onMounted(async () => {
       </div>
       <div class="flex items-center gap-1 flex-shrink-0">
         <template v-if="selectedRole === 'Judge' || isJudgeSession">
-          <!-- Destructive action: red hover distinguishes reset from neutral controls; aria-label for icon-only -->
-          <button
-            @click="confirmReset('Reset Scores', 'Are you sure you want to reset all scores? This cannot be undone.')"
-            class="para-chip-sm px-3 py-2.5 sm:px-2 sm:py-1 type-label text-content-muted hover:text-red-400 transition-all"
-            style="min-width:44px"
-            title="Reset scores"
-            aria-label="Reset all scores"
-          ><i class="pi pi-undo text-sm sm:text-xs" aria-hidden="true"></i></button>
           <button
             @click="showMiniMenu = true"
             class="para-chip-sm px-3 py-2.5 sm:px-2 sm:py-1 type-label text-content-muted hover:text-content-primary transition-all"
@@ -786,8 +740,38 @@ onMounted(async () => {
       </div>
     </div>
 
-    <!-- Page header (no active session yet) -->
-    <div v-else class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+    <!-- Emcee category picker (no active session) — clean session-style list -->
+    <div v-if="!hasActiveSession && isEmcee" class="card p-5 mb-6" style="clip-path:none">
+      <div class="flex items-center gap-3 mb-4">
+        <button
+          @click="router.push({ name: 'EmceeSession' })"
+          class="type-label text-accent hover:text-content-primary transition-colors whitespace-nowrap"
+        >← BACK TO SESSION</button>
+        <span class="section-rule-label">SELECT CATEGORY</span>
+        <span class="section-rule-line flex-1" style="height:1px;background:rgba(255,255,255,0.07)"></span>
+      </div>
+      <div class="flex flex-col gap-1.5">
+        <button
+          v-for="cat in uniqueCategories"
+          :key="cat"
+          @click="pickEmceeCategory(cat)"
+          class="flex items-center justify-between px-4 py-3.5 border cursor-pointer transition-all text-left"
+          style="background:transparent;border-color:rgba(255,255,255,0.07);color:rgba(255,255,255,0.7);font-family:'Oswald',sans-serif;font-size:13px;letter-spacing:0.08em;text-transform:uppercase"
+          @mouseenter="$event.currentTarget.style.borderColor='var(--accent-muted)';$event.currentTarget.style.color='var(--accent-color)'"
+          @mouseleave="$event.currentTarget.style.borderColor='rgba(255,255,255,0.07)';$event.currentTarget.style.color='rgba(255,255,255,0.7)'"
+        >
+          <span>{{ cat }}</span>
+          <div class="flex items-center gap-2">
+            <span v-if="activeEmceeCategories.has(cat)" class="px-1.5 py-0.5" style="font-size:9px;letter-spacing:0.14em;color:rgba(245,158,11,0.9);border:1px solid rgba(245,158,11,0.4);background:rgba(245,158,11,0.08);clip-path:polygon(3px 0%,100% 0%,calc(100% - 3px) 100%,0% 100%)">ACTIVE</span>
+            <i class="pi pi-chevron-right" style="font-size:10px;opacity:0.4" aria-hidden="true"></i>
+          </div>
+        </button>
+      </div>
+      <p v-if="uniqueCategories.length === 0" class="type-label text-content-muted text-center py-4">No categories found for this event.</p>
+    </div>
+
+    <!-- Page header (no active session yet — non-emcee) -->
+    <div v-else-if="!hasActiveSession && !isEmcee" class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
       <div>
         <!-- h1 for document outline -->
         <h1 class="type-page-title mb-1">Audition List</h1>
@@ -814,7 +798,7 @@ onMounted(async () => {
       leave-from-class="opacity-100 translate-y-0"
       leave-to-class="opacity-0 -translate-y-2"
     >
-      <div v-if="showFilters || !hasActiveSession" class="card p-5" :class="hasActiveSession ? 'fixed left-0 right-0 z-40 mx-4' : 'mb-6'" :style="hasActiveSession ? { top: '138px', background: '#1a1a1a', borderColor: 'rgba(255,255,255,0.12)', boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 20px 60px rgba(0,0,0,0.9)', clipPath: 'none' } : { clipPath: 'none' }">
+      <div v-if="showFilters || (!hasActiveSession && !isEmcee)" class="card p-5" :class="hasActiveSession ? 'fixed left-0 right-0 z-40 mx-4' : 'mb-6'" :style="hasActiveSession ? { top: '138px', background: '#1a1a1a', borderColor: 'rgba(255,255,255,0.12)', boxShadow: '0 0 0 1px rgba(255,255,255,0.08), 0 20px 60px rgba(0,0,0,0.9)', clipPath: 'none' } : { clipPath: 'none' }">
         <!-- Mobile: vertical stack; Tablet+: horizontal wrap -->
         <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-4 sm:gap-3">
           <!-- Event name (hidden for session judges — locked) -->
@@ -956,39 +940,6 @@ onMounted(async () => {
       />
     </template>
 
-    <!-- Emcee: no category selected yet — show picker -->
-    <div
-      v-else-if="selectedRole === 'Emcee' && !selectedCategory"
-      class="flex flex-col items-center justify-center h-full gap-6 px-4"
-      style="max-width:480px;margin:0 auto;width:100%"
-    >
-      <div class="text-center">
-        <p class="type-page-title text-content-primary mb-1" style="font-size:1.4rem">SELECT CATEGORY</p>
-        <p class="type-prose text-content-muted">Choose which category you are running</p>
-      </div>
-      <div class="flex flex-col gap-2 w-full">
-        <button
-          v-for="div in eventDivisions"
-          :key="div.eventCategoryId"
-          @click="pickEmceeCategory(div.name)"
-          class="w-full para-chip px-4 py-3.5 flex items-center justify-between type-name text-content-primary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-150"
-        >
-          <span>{{ div.name }}</span>
-          <div class="flex items-center gap-2">
-            <span
-              v-if="activeEmceeCategories.has(div.name)"
-              class="text-[9px] tracking-[0.14em] text-amber-300/90 border border-amber-400/40 bg-amber-400/8 px-1.5 py-0.5"
-              style="clip-path:polygon(3px 0%,100% 0%,calc(100% - 3px) 100%,0% 100%)"
-            >ACTIVE</span>
-            <i class="pi pi-chevron-right text-xs text-content-muted" aria-hidden="true"></i>
-          </div>
-        </button>
-        <div v-if="eventDivisions.length === 0" class="type-prose text-content-muted text-center py-4">
-          No categories found for this event.
-        </div>
-      </div>
-    </div>
-
     <!-- Emcee: no participants in this category -->
     <div
       v-else-if="selectedRole === 'Emcee' && selectedCategory"
@@ -1062,7 +1013,6 @@ onMounted(async () => {
         @remove-tag="removeTag"
         @score-change="autoSave"
         @submit="confirmSubmit('Submit Scores', 'Are you sure you want to submit all scores now?')"
-        @reset="confirmReset('Reset Scores', 'Are you sure you want to reset all scores? This cannot be undone.')"
         @jump="showMiniMenu = true"
       />
       <SwipeableCardsV2
@@ -1076,7 +1026,6 @@ onMounted(async () => {
         @remove-tag="removeTag"
         @score-change="autoSave"
         @submit="confirmSubmit('Submit Scores', 'Are you sure you want to submit all scores now?')"
-        @reset="confirmReset('Reset Scores', 'Are you sure you want to reset all scores? This cannot be undone.')"
         @jump="showMiniMenu = true"
       />
     </template>

--- a/BES-frontend/src/views/EmceeSessionView.vue
+++ b/BES-frontend/src/views/EmceeSessionView.vue
@@ -2,7 +2,7 @@
 import { onMounted, onUnmounted, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore, setActiveEvent } from '@/utils/auth'
-import { whoami, getCategoriesByEvent, claimEmceeCategory, getActiveEmceeCategories } from '@/utils/api'
+import { whoami, getCategoriesByEvent, claimEmceeCategory, getActiveEmceeCategories, logout } from '@/utils/api'
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket'
 
 const router = useRouter()
@@ -69,6 +69,12 @@ function handleNavClick(link) {
   } else {
     router.push({ name: link.route })
   }
+}
+
+async function handleLogout() {
+  await logout()
+  authStore.logout()
+  router.push('/login')
 }
 
 async function selectCategory(categoryName) {
@@ -159,6 +165,12 @@ async function selectCategory(categoryName) {
             <span class="nav-btn-label">{{ link.label }}</span>
           </button>
         </div>
+
+        <!-- Logout — escape route for session users -->
+        <button @click="handleLogout" class="logout-btn">
+          <i class="pi pi-sign-out" aria-hidden="true"></i>
+          <span>Logout</span>
+        </button>
       </template>
 
     </div>
@@ -170,12 +182,12 @@ async function selectCategory(categoryName) {
   position: fixed;
   inset: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   background: #111111;
   font-family: 'Oswald', sans-serif;
   text-transform: uppercase;
-  padding: 32px 16px;
+  padding: 16px;
   overflow-y: auto;
 }
 
@@ -411,8 +423,7 @@ async function selectCategory(categoryName) {
 @media (max-width: 480px) {
   .session-root {
     padding: 12px;
-    align-items: flex-start;
-    padding-top: 32px;
+    align-items: center;
   }
 
   .session-card {
@@ -455,5 +466,36 @@ async function selectCategory(categoryName) {
     font-size: 12px;
     letter-spacing: 0.1em;
   }
+
+  .logout-btn {
+    margin-top: 4px;
+  }
+}
+
+.logout-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px;
+  margin-top: 8px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.35);
+  font-family: 'Oswald', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+  min-height: 44px;
+}
+
+.logout-btn:hover {
+  color: rgba(239,68,68,0.8);
+  border-color: rgba(239,68,68,0.25);
+  background: rgba(239,68,68,0.06);
 }
 </style>

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted, onBeforeUnmount, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, getCategoriesByEvent, getVerifiedParticipantsByEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantCategory, addCategoryToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventCategoryFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled, getReleaseScore, setReleaseScore, getParticipantRefs, insertEventInTable, getEventFeedbackTags, createEventFeedbackGroup, createEventFeedbackTag, updateEventFeedbackTag, deleteEventFeedbackTag, deleteEventFeedbackGroup } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, getCategoriesByEvent, getVerifiedParticipantsByEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantCategory, addCategoryToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventCategoryFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled, getJudgingMode, setJudgingMode, getReleaseScore, setReleaseScore, getParticipantRefs, insertEventInTable, getEventFeedbackTags, createEventFeedbackGroup, createEventFeedbackTag, updateEventFeedbackTag, deleteEventFeedbackTag, deleteEventFeedbackGroup } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 
@@ -55,6 +55,8 @@ const paymentRequired = ref(false)
 const feedbackEnabled = ref(true)
 const feedbackSaving = ref(false)
 const releaseScoreSaving = ref(false)
+const judgingMode = ref('SOLO')
+const judgingModeSaving = ref(false)
 
 // Event-scoped feedback taxonomy (#157)
 const feedbackGroups = ref([])
@@ -130,7 +132,7 @@ const revealingRef = ref(null) // name of participant whose ref code is being he
 const activeTab = ref(authStore.user?.role?.[0]?.authority === 'ROLE_HELPER' ? 'event-day' : 'setup') // 'setup' | 'event-day'
 // Setup tab is split into three sub-tabs to keep each screen scannable.
 // Persisted per event so switching events does not leak prior state.
-const setupSubTab = ref('categories') // 'categories' | 'judges' | 'links' | 'feedback'
+const setupSubTab = ref('categories') // 'categories' | 'judges' | 'scoring' | 'feedback' | 'links'
 // The single currently-expanded division inside the categories accordion (by eventCategoryId).
 const expandedDivisionId = ref(null)
 const toggleDivision = (id) => {
@@ -569,6 +571,29 @@ const onReleaseScoreToggle = async (e) => {
     console.error('setReleaseScore error:', err)
   } finally {
     releaseScoreSaving.value = false
+  }
+}
+
+const fetchJudgingMode = async () => {
+  const res = await getJudgingMode(props.eventName)
+  if (res?.judgingMode) judgingMode.value = res.judgingMode
+}
+
+const onJudgingModeChange = async (mode) => {
+  const prev = judgingMode.value
+  judgingMode.value = mode
+  judgingModeSaving.value = true
+  try {
+    const res = await setJudgingMode(props.eventName, mode)
+    if (!res || !res.ok) {
+      judgingMode.value = prev
+      openModal('Save Failed', `Could not update judging mode (${res?.status ?? 'no response'}).`, 'warning')
+    }
+  } catch (err) {
+    judgingMode.value = prev
+    console.error('setJudgingMode error:', err)
+  } finally {
+    judgingModeSaving.value = false
   }
 }
 
@@ -1293,8 +1318,11 @@ onMounted(async () => {
       await Promise.all(eventCategories.value.map(loadJudgesForDivision))
       // Restore per-event setup sub-tab + auto-expand the first division.
       const savedSub = localStorage.getItem(`setupSubTab_${props.eventName}`)
-      if (savedSub === 'categories' || savedSub === 'genres' || savedSub === 'judges' || savedSub === 'links' || savedSub === 'feedback') {
+      if (savedSub === 'categories' || savedSub === 'genres' || savedSub === 'judges' || savedSub === 'links' || savedSub === 'feedback' || savedSub === 'scoring') {
         setupSubTab.value = savedSub
+      } else if (savedSub === 'judging-mode') {
+        // Legacy key renamed to 'scoring' — migrate transparently.
+        setupSubTab.value = 'scoring'
       }
       expandedDivisionId.value = eventCategories.value[0].eventCategoryId
     }
@@ -1307,6 +1335,7 @@ onMounted(async () => {
       loadSessionTokens()
       const fb = await getFeedbackEnabled(props.eventName)
       if (fb && typeof fb.feedbackEnabled === 'boolean') feedbackEnabled.value = fb.feedbackEnabled
+      await fetchJudgingMode()
       await loadFeedbackGroups()
       // Load results status and participant QR if feedback is enabled
       await loadResultsAndQr()
@@ -1684,57 +1713,6 @@ onUnmounted(() => {
     </div>
 
     <!-- Event Settings (existing event) -->
-    <div v-if="tableExist" class="card-hover p-4 relative mt-6">
-      <div class="corner-bar-tl"></div>
-      <div class="section-rule mb-4">
-        <span class="section-rule-label">Event Settings</span>
-        <div class="section-rule-line"></div>
-      </div>
-      <div class="flex flex-wrap gap-3">
-        <label
-          class="flex items-center gap-3 px-4 py-3 para-chip cursor-pointer transition-all duration-150"
-          :class="feedbackEnabled ? 'border-accent' : ''"
-        >
-          <input
-            type="checkbox"
-            :checked="feedbackEnabled"
-            :disabled="feedbackSaving"
-            @change="onFeedbackEnabledToggle"
-            class="w-4 h-4"
-          />
-          <div>
-            <span class="type-body">Feedback System</span>
-            <p class="type-prose-sm mt-0.5">
-              {{ feedbackEnabled
-                ? 'Judges can submit feedback tags and notes for each participant.'
-                : 'Disabled — judges will only see the score keypad.' }}
-            </p>
-          </div>
-        </label>
-
-        <label
-          class="flex items-center gap-3 px-4 py-3 para-chip cursor-pointer transition-all duration-150"
-          :class="releaseScore ? 'border-accent' : ''"
-        >
-          <input
-            type="checkbox"
-            :checked="releaseScore"
-            :disabled="releaseScoreSaving"
-            @change="onReleaseScoreToggle"
-            class="w-4 h-4"
-          />
-          <div>
-            <span class="type-body">Release Scores</span>
-            <p class="type-prose-sm mt-0.5">
-              {{ releaseScore
-                ? 'Scores will be visible on the public results portal when results are released.'
-                : 'Disabled — only feedback will appear on results when released.' }}
-            </p>
-          </div>
-        </label>
-      </div>
-    </div>
-
 
 
   <!-- Empty state: no participants -->
@@ -1754,6 +1732,7 @@ onUnmounted(() => {
       v-for="sub in [
         { key: 'categories', label: 'Categories' },
         { key: 'judges', label: 'Judges' },
+        { key: 'scoring', label: 'Scoring Settings' },
         { key: 'feedback', label: 'Feedback Tags' },
         { key: 'links',  label: 'Share Links' },
       ]"
@@ -2209,6 +2188,98 @@ onUnmounted(() => {
   <!-- (Configuration card removed — its content now lives inside each
        division accordion block in the Categories sub-tab above.) -->
 
+  <!-- ── Sub-tab: Scoring Settings ──────────────────────────────────────────── -->
+  <template v-if="setupSubTab === 'scoring'">
+    <div v-if="isAdminOrOrganiser && tableExist" class="card-hover p-4 relative mt-6">
+      <div class="corner-bar-tl"></div>
+      <div class="section-rule mb-4">
+        <span class="section-rule-label">Scoring Settings</span>
+        <div class="section-rule-line"></div>
+      </div>
+
+      <!-- Event-level toggles -->
+      <div class="flex flex-wrap gap-3 mb-6">
+        <label
+          class="flex items-center gap-3 px-4 py-3 para-chip cursor-pointer transition-all duration-150"
+          :class="feedbackEnabled ? 'border-accent' : ''"
+        >
+          <input
+            type="checkbox"
+            :checked="feedbackEnabled"
+            :disabled="feedbackSaving"
+            @change="onFeedbackEnabledToggle"
+            class="w-4 h-4"
+          />
+          <div>
+            <span class="type-body">Feedback System</span>
+            <p class="type-prose-sm mt-0.5">
+              {{ feedbackEnabled
+                ? 'Judges can submit feedback tags and notes for each participant.'
+                : 'Disabled — judges will only see the score keypad.' }}
+            </p>
+          </div>
+        </label>
+
+        <label
+          class="flex items-center gap-3 px-4 py-3 para-chip cursor-pointer transition-all duration-150"
+          :class="releaseScore ? 'border-accent' : ''"
+        >
+          <input
+            type="checkbox"
+            :checked="releaseScore"
+            :disabled="releaseScoreSaving"
+            @change="onReleaseScoreToggle"
+            class="w-4 h-4"
+          />
+          <div>
+            <span class="type-body">Release Scores</span>
+            <p class="type-prose-sm mt-0.5">
+              {{ releaseScore
+                ? 'Scores will be visible on the public results portal when results are released.'
+                : 'Disabled — only feedback will appear on results when released.' }}
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <!-- Judging presentation mode -->
+      <div class="section-rule mb-3">
+        <span class="section-rule-label">Presentation</span>
+        <div class="section-rule-line"></div>
+      </div>
+      <p class="type-prose mb-4">
+        Choose how participants are presented during the audition. SOLO shows one participant
+        at a time; PAIR shows two side by side for comparison judging.
+      </p>
+
+      <div class="flex items-center gap-3">
+        <button
+          v-for="m in ['SOLO', 'PAIR']"
+          :key="m"
+          @click="onJudgingModeChange(m)"
+          :aria-pressed="judgingMode === m"
+          :disabled="judgingModeSaving"
+          class="para-chip-sm px-5 py-3 type-label transition-all duration-150 min-w-[90px]"
+          :class="judgingMode === m
+            ? 'text-accent border-[color:var(--accent-muted)] bg-[var(--accent-subtle)]'
+            : 'text-content-muted hover:text-content-primary'"
+        >{{ m }}</button>
+        <span v-if="judgingModeSaving" class="type-label text-content-muted">Saving…</span>
+      </div>
+
+      <p class="type-prose-sm text-content-muted mt-3">
+        <template v-if="judgingMode === 'SOLO'">
+          Each participant appears individually on the audition display screen.
+          Judges score one dancer at a time.
+        </template>
+        <template v-else>
+          Two participants appear side by side on the audition display screen.
+          Judges compare and score both dancers simultaneously.
+        </template>
+      </p>
+    </div>
+  </template>
+  <!-- ── END Scoring Settings sub-tab ─────────────────────────────────────── -->
 
   <!-- ── Sub-tab: Share Links ─────────────────────────────────────────────── -->
   <template v-if="setupSubTab === 'links'">
@@ -2569,29 +2640,29 @@ onUnmounted(() => {
               :class="isCheckedIn(p) ? 'opacity-50' : ''"
             >
               <div class="flex-1 min-w-0">
-                <p class="type-name text-content-secondary truncate">{{ p.label }}</p>
+                <p class="type-name text-content-secondary truncate" style="font-size:17px">{{ p.label }}</p>
                 <!-- Member names for team entries -->
-                <div v-if="p.memberNames && p.memberNames.length" class="flex items-center gap-1.5 type-prose text-content-muted mt-0.5">
-                  <i class="pi pi-users" style="font-size:0.65rem"></i>
+                <div v-if="p.memberNames && p.memberNames.length" class="flex items-center gap-1.5 type-name text-content-muted mt-0.5" style="font-size:14px">
+                  <i class="pi pi-users"></i>
                   <span>{{ p.memberNames.join(', ') }}</span>
                 </div>
                 <div class="flex flex-wrap gap-1 mt-1">
                   <!-- No divisions assigned -->
-                  <span v-if="p.categories.length === 0" class="inline-flex items-center gap-1 badge-neutral">
+                  <span v-if="p.categories.length === 0" class="inline-flex items-center gap-1 badge-neutral" style="font-size:13px">
                     <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" style="box-shadow:0 0 5px rgba(245,158,11,0.7)"></span>
-                    <span class="type-label text-amber-400/80">No division assigned</span>
+                    <span class="text-amber-400/80" style="font-size:13px; letter-spacing: 0.12em">No division assigned</span>
                   </span>
                   <!-- Per-division status: green = linked to division -->
                   <span v-for="g in p.categories" :key="g.categoryName"
                     class="inline-flex items-center gap-1 badge-neutral"
-                    style="text-transform:none;letter-spacing:0.02em;"
+                    style="font-size:13px; text-transform:none;letter-spacing:0.02em;"
                   >
                     <span
                       class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0"
                       style="box-shadow:0 0 5px rgba(52,211,153,0.7)"
                     ></span>
                     {{ g.categoryName }}
-                    <span v-if="g.auditionNumber !== null" class="text-accent">#{{ g.auditionNumber }}</span>
+                    <span v-if="g.auditionNumber !== null" class="text-accent" style="font-size:16px">#{{ g.auditionNumber }}</span>
                   </span>
                 </div>
               </div>
@@ -2657,8 +2728,8 @@ onUnmounted(() => {
               class="para-chip p-3"
             >
               <div class="flex items-center gap-2 flex-wrap">
-                <span class="type-name text-content-secondary">{{ p.name }}</span>
-                <span v-if="p.walkin" class="badge-neutral">walk-in</span>
+                <span class="type-name text-content-secondary" style="font-size:17px">{{ p.name }}</span>
+                <span v-if="p.walkin" class="badge-neutral" style="font-size:12px">walk-in</span>
                 <span v-if="p.referenceCode"
                   class="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 badge-neutral cursor-pointer select-none touch-none"
                   @mousedown="revealingRef = p.name" @mouseup="revealingRef = null" @mouseleave="revealingRef = null"
@@ -2669,13 +2740,13 @@ onUnmounted(() => {
                   <span v-else class="text-content-muted">Ref code</span>
                 </span>
               </div>
-              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 type-prose text-content-muted mt-0.5">
-                <i class="pi pi-users" style="font-size:0.65rem"></i>
+              <div v-if="p.memberNames.length" class="flex items-center gap-1.5 type-name text-content-muted mt-0.5" style="font-size:14px">
+                <i class="pi pi-users"></i>
                 <span>{{ p.memberNames.join(', ') }}</span>
               </div>
               <div class="flex flex-wrap gap-1.5 mt-1">
-                <span v-for="e in p.entries" :key="e.category" class="badge-neutral" style="text-transform:none;letter-spacing:0.02em;">
-                  {{ e.category }}<span style="color:var(--accent-color);margin-left:0.25rem">#{{ e.auditionNumber }}</span>
+                <span v-for="e in p.entries" :key="e.category" class="badge-neutral" style="font-size:13px; text-transform:none;letter-spacing:0.02em;">
+                  {{ e.category }}<span style="color:var(--accent-color);margin-left:0.25rem; font-size:16px">#{{ e.auditionNumber }}</span>
                 </span>
               </div>
             </div>

--- a/BES-frontend/src/views/HelperSessionView.vue
+++ b/BES-frontend/src/views/HelperSessionView.vue
@@ -2,7 +2,7 @@
 import { onMounted, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore, setActiveEvent } from '@/utils/auth'
-import { whoami, getCategoriesByEvent } from '@/utils/api'
+import { whoami, getCategoriesByEvent, logout } from '@/utils/api'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -57,9 +57,14 @@ function copyToClipboard(text) {
   document.body.removeChild(ta)
 }
 
-function copyAuditionScreenLink() {
+function numberDrawUrl() {
+  if (!authStore.activeEvent?.name) return ''
+  return window.location.origin + '/event/audition-number?event=' + encodeURIComponent(authStore.activeEvent.name)
+}
+
+function copyNumberDrawLink() {
   if (!authStore.activeEvent?.name) return
-  copyToClipboard(window.location.origin + '/event/audition-number?event=' + encodeURIComponent(authStore.activeEvent.name))
+  copyToClipboard(numberDrawUrl())
   linkCopied.value = true
   setTimeout(() => { linkCopied.value = false }, 2000)
 }
@@ -72,6 +77,12 @@ function goToEventDetails() {
       query: authStore.activeEvent.folderID ? { folderID: authStore.activeEvent.folderID } : {}
     })
   }
+}
+
+async function handleLogout() {
+  await logout()
+  authStore.logout()
+  router.push('/login')
 }
 </script>
 
@@ -128,30 +139,40 @@ function goToEventDetails() {
           <i class="pi pi-calendar nav-btn-icon" aria-hidden="true"></i>
           <span class="nav-btn-label">Event Details</span>
         </button>
-
-        <!-- aria-live: copy confirmation is announced, success reads via icon + label, not color alone -->
         <button
-          @click="copyAuditionScreenLink"
+          @click="router.push({ name: 'Score' })"
           class="nav-btn"
-          :class="linkCopied ? 'nav-btn--copied' : ''"
+        >
+          <i class="pi pi-chart-bar nav-btn-icon" aria-hidden="true"></i>
+          <span class="nav-btn-label">Score</span>
+        </button>
+      </div>
+
+      <!-- Display URLs — Number Draw + per-category OBS sources -->
+      <div v-if="!loading" class="section-header">
+        <span class="section-label">DISPLAY URLS</span>
+        <span class="section-rule"></span>
+      </div>
+      <p v-if="!loading" class="display-hint">
+        Paste these into OBS browser sources or open in a projector browser. No login required.
+      </p>
+      <div v-if="!loading" class="display-list">
+        <!-- Number Draw (always shown, even if no categories yet) -->
+        <button
+          @click="copyNumberDrawLink"
+          class="display-btn"
+          :class="linkCopied ? 'display-btn--copied' : ''"
           :disabled="!authStore.activeEvent?.name"
           :style="!authStore.activeEvent?.name ? 'opacity:0.35;cursor:not-allowed' : ''"
           aria-live="polite"
         >
-          <i class="pi nav-btn-icon" :class="linkCopied ? 'pi-check' : 'pi-hashtag'" aria-hidden="true"></i>
-          <span class="nav-btn-label">{{ linkCopied ? 'Link Copied!' : 'Audition Screen' }}</span>
+          <span class="display-btn-name">Number Draw</span>
+          <span class="display-btn-action">
+            <i class="pi" :class="linkCopied ? 'pi-check' : 'pi-copy'" aria-hidden="true"></i>
+            {{ linkCopied ? 'Copied' : 'Copy URL' }}
+          </span>
         </button>
-      </div>
 
-      <!-- Display URLs per category — for OBS / projector setup -->
-      <div v-if="!loading && categories.length > 0" class="section-header">
-        <span class="section-label">DISPLAY URLS</span>
-        <span class="section-rule"></span>
-      </div>
-      <p v-if="!loading && categories.length > 0" class="display-hint">
-        Paste these into OBS browser sources or open in a projector browser. No login required.
-      </p>
-      <div v-if="!loading && categories.length > 0" class="display-list">
         <button
           v-for="cat in categories"
           :key="cat.eventCategoryId"
@@ -167,6 +188,12 @@ function goToEventDetails() {
           </span>
         </button>
       </div>
+
+      <!-- Logout — escape route for session users -->
+      <button @click="handleLogout" class="logout-btn">
+        <i class="pi pi-sign-out" aria-hidden="true"></i>
+        <span>Logout</span>
+      </button>
 
     </div>
   </div>
@@ -414,5 +441,32 @@ function goToEventDetails() {
   .nav-btn {
     padding: 16px 20px;
   }
+}
+
+.logout-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px;
+  margin-top: 8px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.35);
+  font-family: 'Oswald', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+  min-height: 44px;
+}
+
+.logout-btn:hover {
+  color: rgba(239,68,68,0.8);
+  border-color: rgba(239,68,68,0.25);
+  background: rgba(239,68,68,0.06);
 }
 </style>

--- a/BES-frontend/src/views/JudgeSessionView.vue
+++ b/BES-frontend/src/views/JudgeSessionView.vue
@@ -2,7 +2,7 @@
 import { onMounted, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore, setActiveEvent } from '@/utils/auth'
-import { getJudgeDivisions, whoami } from '@/utils/api'
+import { getJudgeDivisions, whoami, logout } from '@/utils/api'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -62,6 +62,12 @@ function navigateToAudition(divisionName) {
 
 function navigateToBattle() {
   router.push({ name: 'Battle Judge' })
+}
+
+async function handleLogout() {
+  await logout()
+  authStore.logout()
+  router.push('/login')
 }
 </script>
 
@@ -150,6 +156,12 @@ function navigateToBattle() {
         </div>
       </div>
 
+      <!-- Logout — escape route for session users -->
+      <button @click="handleLogout" class="logout-btn">
+        <i class="pi pi-sign-out" aria-hidden="true"></i>
+        <span>Logout</span>
+      </button>
+
     </div>
   </div>
 </template>
@@ -165,6 +177,7 @@ function navigateToBattle() {
   font-family: 'Oswald', sans-serif;
   text-transform: uppercase;
   padding: 16px;
+  overflow-y: auto;
 }
 
 .color-bleed {
@@ -380,5 +393,32 @@ function navigateToBattle() {
   .division-actions {
     align-self: flex-end;
   }
+}
+
+.logout-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px;
+  margin-top: 8px;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.07);
+  color: rgba(255,255,255,0.35);
+  font-family: 'Oswald', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%);
+  min-height: 44px;
+}
+
+.logout-btn:hover {
+  color: rgba(239,68,68,0.8);
+  border-color: rgba(239,68,68,0.25);
+  background: rgba(239,68,68,0.06);
 }
 </style>

--- a/BES-frontend/src/views/MainMenu.vue
+++ b/BES-frontend/src/views/MainMenu.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/utils/auth'
 import { useTierAccess } from '@/utils/useTierAccess'
 
+const router = useRouter()
 const authStore = useAuthStore()
 const { battleEnabled } = useTierAccess()
 
@@ -77,7 +79,7 @@ const roleDisplay = computed(() => {
 
         <!-- Audition List -->
         <router-link
-          v-if="activeEvent && role !== 'ROLE_HELPER'"
+          v-if="activeEvent && role !== 'ROLE_HELPER' && role !== 'ROLE_EMCEE'"
           :to="{ name: 'Audition List' }"
           class="card-hover p-6 relative cursor-pointer group"
         >
@@ -86,6 +88,18 @@ const roleDisplay = computed(() => {
           <div class="type-body mb-1">Audition</div>
           <p class="type-prose">Score and timer controls.</p>
         </router-link>
+
+        <!-- Audition — emcee path: clear category so the inline picker appears -->
+        <button
+          v-if="activeEvent && role === 'ROLE_EMCEE'"
+          @click="localStorage.removeItem('selectedCategory'); router.push({ name: 'Audition List', query: { picker: '1' } })"
+          class="card-hover p-6 relative cursor-pointer group w-full text-left"
+        >
+          <div class="corner-bar-tl"></div>
+          <i class="pi pi-list text-2xl text-accent mb-3 block"></i>
+          <div class="type-body mb-1">Audition</div>
+          <p class="type-prose">Score and timer controls.</p>
+        </button>
 
         <!-- Participants (Admin / Organiser) -->
         <router-link

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
-import { getParticipantScore, getParticipantFeedback, getResultsStatus, releaseResults, getParticipantRefs, getScoringCriteria, setResolvedParticipants, getCategoriesByEvent } from '@/utils/api';
+import { getParticipantScore, getParticipantFeedback, getResultsStatus, releaseResults, getParticipantRefs, getScoringCriteria, setResolvedParticipants, getCategoriesByEvent, saveTieBreakerState, getTieBreakerState } from '@/utils/api';
 import { computeNextEligibleAdd, computeNextEligibleRemove, addedPoolOrdered } from '@/utils/scoreTiePool';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { useAuthStore } from '@/utils/auth';
@@ -56,35 +56,56 @@ const tieBreakerWinners = ref(new Set())
 const tieBreakerConfirmed = ref(false)
 const addedToPool = ref(new Set()) // manually-added pool members for the tie resolver
 
-// localStorage key scoped to event + category + tabulation + topN
-const tbKey = computed(() =>
-  `tb_${selectedEvent.value}_${selectedCategory.value}_${selectedTabulation.value}_${selectedTopN.value}`
-)
-const saveTieBreaker = () => {
-  localStorage.setItem(tbKey.value, JSON.stringify({
-    winners: [...tieBreakerWinners.value],
-    confirmed: tieBreakerConfirmed.value,
-    addedToPool: [...addedToPool.value],
-  }))
+// Tie-breaker state persisted via backend (not localStorage) so it syncs
+// across devices. State is scoped to event + category; tabulation + topN
+// are embedded in the persisted payload so stale state can be detected.
+const _tbSaving = ref(false)
+const saveTieBreaker = async () => {
+  if (_tbSaving.value) return // debounce concurrent saves
+  _tbSaving.value = true
+  try {
+    await saveTieBreakerState(
+      selectedEvent.value, selectedCategory.value,
+      selectedTabulation.value, selectedTopN.value,
+      tieBreakerWinners.value, tieBreakerConfirmed.value, addedToPool.value
+    )
+  } catch (e) { /* fire-and-forget */ }
+  finally { _tbSaving.value = false }
 }
-const loadTieBreaker = () => {
-  const saved = localStorage.getItem(tbKey.value)
-  if (saved) {
-    const { winners, confirmed, addedToPool: added } = JSON.parse(saved)
-    tieBreakerWinners.value = new Set(winners)
-    tieBreakerConfirmed.value = confirmed
-    addedToPool.value = new Set(Array.isArray(added) ? added : [])
-  } else {
+const loadTieBreaker = async () => {
+  if (!selectedEvent.value || !selectedCategory.value) return
+  try {
+    const res = await getTieBreakerState(selectedEvent.value, selectedCategory.value)
+    if (!res || !res.ok) {
+      // No saved state or fetch failed — start fresh
+      tieBreakerWinners.value = new Set()
+      tieBreakerConfirmed.value = false
+      addedToPool.value = new Set()
+      return
+    }
+    const data = await res.json()
+    // Only restore if the saved state matches the current view context.
+    // If the organiser switched tabulation or Top N, the old state is stale.
+    if (data.tabulation === selectedTabulation.value && data.topN === selectedTopN.value) {
+      tieBreakerWinners.value = new Set(Array.isArray(data.winners) ? data.winners : [])
+      tieBreakerConfirmed.value = !!data.confirmed
+      addedToPool.value = new Set(Array.isArray(data.addedToPool) ? data.addedToPool : [])
+    } else {
+      tieBreakerWinners.value = new Set()
+      tieBreakerConfirmed.value = false
+      addedToPool.value = new Set()
+    }
+  } catch (e) {
     tieBreakerWinners.value = new Set()
     tieBreakerConfirmed.value = false
     addedToPool.value = new Set()
   }
 }
-const resetTieBreaker = () => {
+const resetTieBreaker = async () => {
   tieBreakerWinners.value = new Set()
   tieBreakerConfirmed.value = false
   addedToPool.value = new Set()
-  localStorage.removeItem(tbKey.value)
+  await saveTieBreaker()
 }
 
 // All categories configured for the event (loaded from /event/categories).
@@ -141,8 +162,34 @@ const subscribeScoreUpdates = (eventName) => {
   }
   if (!eventName) return
   wsClient.value = createClient()
-  subscribeToChannel(wsClient.value, `/topic/score/${eventName}`, async () => {
+  subscribeToChannel(wsClient.value, `/topic/score/${eventName}`, async (msg) => {
     await refetchScores(eventName)
+    // Cross-device tie-breaker sync: when another device confirms Top N,
+    // the backend broadcasts the resolved participant list. Reconstruct
+    // which tie-pool members were selected and mirror the confirmed state.
+    if (msg && Array.isArray(msg.resolvedParticipants) && msg.resolvedParticipants.length > 0 && spotsFromTie.value > 0) {
+      const resolvedSet = new Set(msg.resolvedParticipants)
+      const winners = tiedParticipants.value
+        .filter(r => resolvedSet.has(r.participantName))
+        .map(r => r.participantName)
+      if (winners.length === spotsFromTie.value) {
+        tieBreakerWinners.value = new Set(winners)
+        tieBreakerConfirmed.value = true
+        // State is already persisted by the confirming device — no need
+        // to double-write here; just mirror locally.
+      }
+    }
+    // Cross-device tie-breaker state sync: when another device updates
+    // the intermediate tie-breaker state (winners selection, pool edits),
+    // mirror the state locally so both devices stay in sync.
+    if (msg && msg.tieBreakerState && spotsFromTie.value > 0) {
+      const tb = msg.tieBreakerState
+      if (tb.tabulation === selectedTabulation.value && tb.topN === selectedTopN.value) {
+        tieBreakerWinners.value = new Set(Array.isArray(tb.winners) ? tb.winners : [])
+        tieBreakerConfirmed.value = !!tb.confirmed
+        addedToPool.value = new Set(Array.isArray(tb.addedToPool) ? tb.addedToPool : [])
+      }
+    }
     // Refresh the open feedback panel for the visible participant, if any.
     if (showFeedbackPanel.value && feedbackParticipant.value && selectedCategory.value) {
       const fb = await getParticipantFeedback(eventName, selectedCategory.value, feedbackParticipant.value)
@@ -190,8 +237,11 @@ watch(selectedTabulation, (newVal) => {
   if (newVal) { localStorage.setItem(tabKey(selectedEvent.value), newVal); selectedTopN.value = 'All' }
   resetTieBreaker()
 }, { immediate: true });
-// Load persisted tie-breaker state whenever the scoped key changes
-watch(tbKey, loadTieBreaker, { immediate: true })
+// Load persisted tie-breaker state from backend whenever the view context changes.
+// Debounce by chaining off the same dependencies as the old localStorage tbKey.
+watch([() => selectedEvent.value, () => selectedCategory.value, () => selectedTabulation.value, () => selectedTopN.value],
+  loadTieBreaker, { immediate: true }
+)
 
 const filteredParticipantsForScore = computed({
   get() {
@@ -295,7 +345,8 @@ const confirmTieBreaker = async () => {
     const res = await setResolvedParticipants(selectedEvent.value, selectedCategory.value, resolved)
     if (res && res.ok) {
       tieBreakerConfirmed.value = true
-      saveTieBreaker()
+      // Persist confirmed state to DB so other devices see it.
+      await saveTieBreaker()
     }
   }
 }
@@ -755,7 +806,7 @@ function transformForScore(data) {
           >
             <span class="type-stat flex-shrink-0" style="font-size: 24px; line-height: 1; min-width: 40px">{{ finalRows[0].id }}</span>
             <div class="flex-1 min-w-0">
-              <p class="type-name text-content-primary" style="font-size: 16px">{{ finalRows[0].participantName }}</p>
+              <p class="type-name text-content-primary" style="font-size: 17px">{{ finalRows[0].participantName }}</p>
               <p v-if="judgeMetaLine(finalRows[0])" class="type-prose text-content-muted/80 mt-0.5">{{ judgeMetaLine(finalRows[0]) }}</p>
             </div>
             <span class="type-stat flex-shrink-0" style="font-size: 28px; line-height: 1">{{ finalRows[0].totalScore }}</span>
@@ -779,7 +830,7 @@ function transformForScore(data) {
             <div class="para-chip flex items-start gap-3 px-4 py-2 bg-surface-700/10">
               <span class="type-stat flex-shrink-0 text-content-secondary" style="font-size: 18px; line-height: 1; min-width: 40px">{{ row.id }}</span>
               <div class="flex-1 min-w-0">
-                <p class="type-name text-content-primary">{{ row.participantName }}</p>
+                <p class="type-name text-content-primary" style="font-size: 16px">{{ row.participantName }}</p>
                 <p v-if="judgeMetaLine(row)" class="type-prose text-content-muted/70 mt-0.5">{{ judgeMetaLine(row) }}</p>
               </div>
               <span class="type-stat flex-shrink-0" style="font-size: 20px; line-height: 1">{{ row.totalScore }}</span>

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -69,7 +69,7 @@ const saveTieBreaker = async () => {
       selectedTabulation.value, selectedTopN.value,
       tieBreakerWinners.value, tieBreakerConfirmed.value, addedToPool.value
     )
-  } catch (e) { /* fire-and-forget */ }
+  } catch (_e) { /* fire-and-forget */ }
   finally { _tbSaving.value = false }
 }
 const loadTieBreaker = async () => {
@@ -95,7 +95,7 @@ const loadTieBreaker = async () => {
       tieBreakerConfirmed.value = false
       addedToPool.value = new Set()
     }
-  } catch (e) {
+  } catch (_e) {
     tieBreakerWinners.value = new Set()
     tieBreakerConfirmed.value = false
     addedToPool.value = new Set()

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -35,13 +35,17 @@ import com.example.BES.dtos.GetSessionTokenDto;
 import com.example.BES.dtos.LoginDto;
 import com.example.BES.dtos.RedeemTokenDto;
 import com.example.BES.models.Account;
+import com.example.BES.models.Judge;
 import com.example.BES.models.SessionToken;
+import com.example.BES.respositories.JudgeRepo;
 import com.example.BES.services.SessionTokenService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -65,6 +69,9 @@ public class AuthController {
 
     @Autowired
     private AccountService accountService;
+
+    @Autowired
+    private JudgeRepo judgeRepo;
 
     private static final java.util.Set<String> UNLIMITED_ROLES =
         java.util.Set.of("ROLE_ADMIN", "ROLE_HELPER", "ROLE_EMCEE");
@@ -240,6 +247,18 @@ public class AuthController {
         }
     }
 
+    private String buildTokenUrl(String role, Long judgeId, String tokenId) {
+        String roleLower = role.toLowerCase();
+        if ("JUDGE".equals(role) && judgeId != null) {
+            Judge judge = judgeRepo.findById(judgeId).orElse(null);
+            if (judge != null) {
+                String encoded = URLEncoder.encode(judge.getName(), StandardCharsets.UTF_8);
+                return "/auth/token/" + roleLower + "/" + encoded + "?t=" + tokenId;
+            }
+        }
+        return "/auth/token/" + roleLower + "?t=" + tokenId;
+    }
+
     private static final java.util.Set<String> ALLOWED_SESSION_ROLES =
         java.util.Set.of("JUDGE", "EMCEE", "HELPER");
 
@@ -256,9 +275,10 @@ public class AuthController {
                 + ". Allowed session roles: JUDGE, EMCEE, HELPER."));
         }
         String tokenId = sessionTokenService.generateToken(role.toUpperCase(), eventId, judgeId, expiresInDays);
+        String url = buildTokenUrl(role.toUpperCase(), judgeId, tokenId);
         return ResponseEntity.ok(Map.of(
             "tokenId", tokenId,
-            "url", "/auth/token?t=" + tokenId));
+            "url", url));
     }
 
     @Operation(summary = "List Tokens", description = "Returns all non-revoked, non-expired session tokens for an event")
@@ -273,7 +293,7 @@ public class AuthController {
             dto.judgeId = t.getJudge() != null ? t.getJudge().getJudgeId() : null;
             dto.judgeName = t.getJudge() != null ? t.getJudge().getName() : null;
             dto.expiresAt = t.getExpiresAt().toString();
-            dto.url = "/auth/token?t=" + t.getTokenId();
+            dto.url = buildTokenUrl(t.getRole(), t.getJudge() != null ? t.getJudge().getJudgeId() : null, t.getTokenId());
             return dto;
         }).collect(Collectors.toList());
         return ResponseEntity.ok(dtos);

--- a/BES/src/main/java/com/example/BES/controllers/BattleController.java
+++ b/BES/src/main/java/com/example/BES/controllers/BattleController.java
@@ -45,6 +45,7 @@ import com.example.BES.dtos.battle.SetOverlayConfigDto;
 import com.example.BES.dtos.battle.SetBattleScoreDto;
 import com.example.BES.dtos.battle.SetResolvedParticipantsDto;
 import com.example.BES.dtos.battle.SetSmokeBattlersDto;
+import com.example.BES.dtos.battle.SetTieBreakerStateDto;
 import com.example.BES.dtos.battle.SetVoteDto;
 import com.example.BES.dtos.battle.UpdateJudgeWeightageDto;
 import com.example.BES.services.BattleService;
@@ -486,11 +487,32 @@ public class BattleController {
     }
 
     @PostMapping("/resolved-participants")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'HELPER')")
     public ResponseEntity<?> setResolvedParticipants(Authentication auth, @Valid @RequestBody SetResolvedParticipantsDto dto) {
-        checkBattleAccess(auth, dto.getEventName());
+        // Tie-breaker resolution is an audition scoring feature, not a battle-day
+        // feature — no battle tier gate. Role check is handled by @PreAuthorize.
         battleService.setResolvedParticipants(
             dto.getEventName(), dto.getCategoryName(), dto.getParticipants());
         return ResponseEntity.ok(Map.of("message", "Resolved participants saved"));
+    }
+
+    @PostMapping("/tie-breaker-state")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'HELPER')")
+    public ResponseEntity<?> saveTieBreakerState(Authentication auth, @Valid @RequestBody SetTieBreakerStateDto dto) {
+        battleService.saveTieBreakerState(
+            dto.getEventName(), dto.getCategoryName(),
+            dto.getTabulation(), dto.getTopN(),
+            dto.getWinners(), dto.isConfirmed(),
+            dto.getAddedToPool());
+        return ResponseEntity.ok(Map.of("message", "Tie-breaker state saved"));
+    }
+
+    @GetMapping("/tie-breaker-state")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'HELPER')")
+    public ResponseEntity<?> getTieBreakerState(
+            @RequestParam String event,
+            @RequestParam String category) {
+        Map<String, Object> state = battleService.getTieBreakerState(event, category);
+        return ResponseEntity.ok(state);
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -181,9 +181,9 @@ public class EventController {
         }
     }
 
-    @Operation(summary = "Set Judging Mode", description = "Sets the judging mode (SOLO/PAIR) for an event (admin only)")
+    @Operation(summary = "Set Judging Mode", description = "Sets the judging mode (SOLO/PAIR) for an event")
     @PostMapping("/judging-mode")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER')")
     public ResponseEntity<?> setJudgingMode(@Valid @RequestBody UpdateJudgingModeDto dto) {
         try {
             eventService.setJudgingMode(dto.eventName, dto.judgingMode);

--- a/BES/src/main/java/com/example/BES/dtos/battle/SetTieBreakerStateDto.java
+++ b/BES/src/main/java/com/example/BES/dtos/battle/SetTieBreakerStateDto.java
@@ -1,0 +1,38 @@
+package com.example.BES.dtos.battle;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public class SetTieBreakerStateDto {
+
+    @NotBlank
+    private String eventName;
+
+    @NotBlank
+    private String categoryName;
+
+    private String tabulation;
+
+    private String topN;
+
+    private List<String> winners;
+
+    private boolean confirmed;
+
+    private List<String> addedToPool;
+
+    public String getEventName() { return eventName; }
+    public void setEventName(String eventName) { this.eventName = eventName; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public String getTabulation() { return tabulation; }
+    public void setTabulation(String tabulation) { this.tabulation = tabulation; }
+    public String getTopN() { return topN; }
+    public void setTopN(String topN) { this.topN = topN; }
+    public List<String> getWinners() { return winners; }
+    public void setWinners(List<String> winners) { this.winners = winners; }
+    public boolean isConfirmed() { return confirmed; }
+    public void setConfirmed(boolean confirmed) { this.confirmed = confirmed; }
+    public List<String> getAddedToPool() { return addedToPool; }
+    public void setAddedToPool(List<String> addedToPool) { this.addedToPool = addedToPool; }
+}

--- a/BES/src/main/java/com/example/BES/models/BattleCategoryState.java
+++ b/BES/src/main/java/com/example/BES/models/BattleCategoryState.java
@@ -70,6 +70,9 @@ public class BattleCategoryState {
     @Column(name = "resolved_participants_json", columnDefinition = "TEXT")
     private String resolvedParticipantsJson;
 
+    @Column(name = "tie_breaker_state_json", columnDefinition = "TEXT")
+    private String tieBreakerStateJson;
+
     @Column(name = "format_timer_json", columnDefinition = "TEXT")
     private String formatTimerJson;
 

--- a/BES/src/main/java/com/example/BES/services/BattleService.java
+++ b/BES/src/main/java/com/example/BES/services/BattleService.java
@@ -484,12 +484,58 @@ public class BattleService {
                 participants != null ? objectMapper.writeValueAsString(participants) : null);
             st.setUpdatedAt(LocalDateTime.now());
             battleCategoryStateRepository.save(st);
-            EventBattleState s = stateFor(eventName);
-            if (categoryName != null && categoryName.equals(s.activeCategoryName)) {
-                broadcastStateSnapshot(eventName);
-            }
+            // Broadcast regardless of active battle category — tie-breaker
+            // resolution is a scoring feature, not a battle-phase operation.
+            broadcastStateSnapshot(eventName);
+            // Also ping the score topic so other Score.vue instances re-fetch.
+            messagingTemplate.convertAndSend("/topic/score/" + eventName,
+                Map.of("resolvedParticipants", participants != null ? participants : List.of()));
         } catch (Exception e) {
             System.err.println("Failed to save resolved participants: " + e.getMessage());
+        }
+    }
+
+    @Transactional
+    public void saveTieBreakerState(String eventName, String categoryName,
+                                    String tabulation, String topN,
+                                    List<String> winners, boolean confirmed,
+                                    List<String> addedToPool) {
+        try {
+            BattleCategoryState st = battleCategoryStateRepository
+                .findByEventNameAndCategoryName(eventName, categoryName)
+                .orElse(new BattleCategoryState());
+            st.setEventName(eventName);
+            st.setCategoryName(categoryName);
+            Map<String, Object> tbState = new HashMap<>();
+            tbState.put("tabulation", tabulation != null ? tabulation : "");
+            tbState.put("topN", topN != null ? topN : "");
+            tbState.put("winners", winners != null ? winners : List.of());
+            tbState.put("confirmed", confirmed);
+            tbState.put("addedToPool", addedToPool != null ? addedToPool : List.of());
+            st.setTieBreakerStateJson(objectMapper.writeValueAsString(tbState));
+            st.setUpdatedAt(LocalDateTime.now());
+            battleCategoryStateRepository.save(st);
+            // Broadcast to score topic so other devices can pick up intermediate
+            // tie-breaker state changes (in addition to final confirmations).
+            messagingTemplate.convertAndSend("/topic/score/" + eventName,
+                Map.of("tieBreakerState", tbState));
+        } catch (Exception e) {
+            System.err.println("Failed to save tie-breaker state: " + e.getMessage());
+        }
+    }
+
+    public Map<String, Object> getTieBreakerState(String eventName, String categoryName) {
+        try {
+            Optional<BattleCategoryState> stOpt =
+                battleCategoryStateRepository.findByEventNameAndCategoryName(eventName, categoryName);
+            if (stOpt.isEmpty() || stOpt.get().getTieBreakerStateJson() == null) {
+                return new HashMap<>();
+            }
+            return objectMapper.readValue(stOpt.get().getTieBreakerStateJson(),
+                new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            System.err.println("Failed to load tie-breaker state: " + e.getMessage());
+            return new HashMap<>();
         }
     }
 
@@ -626,6 +672,13 @@ public class BattleService {
             if (db.getSmokeListJson() != null) {
                 result.put("smokeBattlers", objectMapper.readValue(db.getSmokeListJson(),
                     new TypeReference<List<Object>>(){}));
+            }
+
+            // resolved participants (tie-breaker / Top N qualifier)
+            if (db.getResolvedParticipantsJson() != null) {
+                result.put("resolvedParticipants",
+                    objectMapper.readValue(db.getResolvedParticipantsJson(),
+                        new TypeReference<List<String>>(){}));
             }
         } catch (Exception e) {
             System.err.println("Failed to read genre state from DB: " + e.getMessage());

--- a/BES/src/main/resources/db/migration/V47__add_tie_breaker_state.sql
+++ b/BES/src/main/resources/db/migration/V47__add_tie_breaker_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE battle_category_state ADD COLUMN IF NOT EXISTS tie_breaker_state_json TEXT;


### PR DESCRIPTION
## Summary

Fixes multiple UX issues affecting session users (emcees, judges, helpers):

### Session token links with role in path
- Frontend router now handles `/auth/token/:role/:name?` path pattern for session links with role/judge-name embedded in the URL
- Backend `AuthController` now generates URLs like `/auth/token/emcee?t=...`, `/auth/token/judge/DJ%20FLEX?t=...`
- Backward-compatible: old `/auth/token?t=...` format still works

### Session view improvements
- Added **Logout** buttons to EmceeSessionView, JudgeSessionView, and HelperSessionView
- Fixed EmceeSessionView **vertical centering on mobile** (was `align-items: flex-start`)
- **Emcee quick-link** from MainMenu → AuditionList now shows a clean category picker (not the full filter card)
- Added **Score** button to HelperSessionView + granted `ROLE_HELPER` access to the Score route

### Tie-breaker state persistence
- New `V47__add_tie_breaker_state.sql` migration adds `tie_breaker_state_json` column
- New `SetTieBreakerStateDto` and endpoints in BattleController
- Persistence + broadcast via BattleService

## Files Changed

| File | Change |
|------|--------|
| `router/index.js` | Added `/auth/token/:role/:name?` route + TokenAuthRole in PUBLIC_ROUTES; ROLE_HELPER on Score |
| `EmceeSessionView.vue` | Logout button + mobile centering fix |
| `JudgeSessionView.vue` | Logout button |
| `HelperSessionView.vue` | Logout + Score nav button |
| `AuditionList.vue` | Inline emcee category picker |
| `AuthController.java` | Token URLs with role/name in path |
| `BattleService.java` | Tie-breaker state save/get |
| `BattleController.java` | Tie-breaker state REST endpoints |
| `BattleCategoryState.java` | `tieBreakerStateJson` field |
| `SetTieBreakerStateDto.java` | New DTO |
| `V47__add_tie_breaker_state.sql` | New migration |

🤖 Generated with [Claude Code](https://claude.com/claude-code)