### PR TITLE
feat: access management — Admin event deletion, hide AuditionList from Organiser, Helper Score access

### DIFF
--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -1,23 +1,29 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
 const props = defineProps({
   buttonName: { type: String, required: true, default: '' },
   expanded:   { type: Boolean, default: false },  // controlled by parent
+  isAdmin:    { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['onDetails', 'onAudition', 'onParticipants', 'onScoreboard', 'onBattle', 'toggle', 'onDelete'])
 
 const isHovered = ref(false)  // desktop only
 
-const actions = [
-  { key: 'onDetails',      icon: 'pi-cog',      label: 'Details'  },
-  { key: 'onAudition',     icon: 'pi-list',      label: 'Audition' },
-  { key: 'onParticipants', icon: 'pi-users',     label: 'People'   },
-  { key: 'onScoreboard',   icon: 'pi-chart-bar', label: 'Score'    },
-  { key: 'onBattle',       icon: 'pi-bolt',      label: 'Battle'   },
-  { key: 'onDelete',      icon: 'pi-trash',     label: 'Delete'  },
-]
+const actions = computed(() => {
+  const base = [
+    { key: 'onDetails',      icon: 'pi-cog',      label: 'Details'  },
+    { key: 'onAudition',     icon: 'pi-list',      label: 'Audition' },
+    { key: 'onParticipants', icon: 'pi-users',     label: 'People'   },
+    { key: 'onScoreboard',   icon: 'pi-chart-bar', label: 'Score'    },
+    { key: 'onBattle',       icon: 'pi-bolt',      label: 'Battle'   },
+  ]
+  if (props.isAdmin) {
+    base.push({ key: 'onDelete', icon: 'pi-trash', label: 'Delete' })
+  }
+  return base
+})
 </script>
 
 <template>
@@ -57,7 +63,7 @@ const actions = [
         style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
         @click.stop="emit('toggle')"
       >
-        <div class="grid grid-cols-6">
+        <div :class="['grid', props.isAdmin ? 'grid-cols-6' : 'grid-cols-5']">
           <button
             v-for="action in actions"
             :key="action.key"

--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -6,7 +6,7 @@ const props = defineProps({
   expanded:   { type: Boolean, default: false },  // controlled by parent
 })
 
-const emit = defineEmits(['onDetails', 'onAudition', 'onParticipants', 'onScoreboard', 'onBattle', 'toggle'])
+const emit = defineEmits(['onDetails', 'onAudition', 'onParticipants', 'onScoreboard', 'onBattle', 'toggle', 'onDelete'])
 
 const isHovered = ref(false)  // desktop only
 
@@ -16,6 +16,7 @@ const actions = [
   { key: 'onParticipants', icon: 'pi-users',     label: 'People'   },
   { key: 'onScoreboard',   icon: 'pi-chart-bar', label: 'Score'    },
   { key: 'onBattle',       icon: 'pi-bolt',      label: 'Battle'   },
+  { key: 'onDelete',      icon: 'pi-trash',     label: 'Delete'  },
 ]
 </script>
 
@@ -56,15 +57,17 @@ const actions = [
         style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
         @click.stop="emit('toggle')"
       >
-        <div class="grid grid-cols-5">
+        <div class="grid grid-cols-6">
           <button
             v-for="action in actions"
             :key="action.key"
             @click.stop="emit(action.key)"
-            class="flex flex-col items-center gap-1.5 py-3.5 text-content-muted
-                   hover:text-accent hover:bg-[rgba(255,255,255,0.04)] transition-all duration-150"
+            class="flex flex-col items-center gap-1.5 py-3.5 transition-all duration-150"
+            :class="action.key === 'onDelete'
+              ? 'text-content-muted hover:text-red-400 hover:bg-red-950/30'
+              : 'text-content-muted hover:text-accent hover:bg-[rgba(255,255,255,0.04)]'"
           >
-            <i class="pi text-base text-accent" :class="action.icon"></i>
+            <i class="pi text-base" :class="[action.icon, action.key === 'onDelete' ? '' : 'text-accent']"></i>
             <span class="type-label">{{ action.label }}</span>
           </button>
         </div>

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -29,7 +29,7 @@ const ALL_TILES = [
   { key: 'details',      icon: 'pi-cog',       label: 'Details',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'] },
   { key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
   { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
-  { key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'] },
+  { key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_HELPER'] },
   { key: 'battle',       icon: 'pi-bolt',      label: 'Battle',       roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_JUDGE'] },
   { key: 'numbers',      icon: 'pi-hashtag',   label: 'Numbers',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
 ]

--- a/BES-frontend/src/components/EventPanel.vue
+++ b/BES-frontend/src/components/EventPanel.vue
@@ -27,7 +27,7 @@ const ALL_TILES = [
   { key: 'home',         icon: 'pi-home',      label: 'Home',         roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
   { key: 'admin',        icon: 'pi-cog',       label: 'Admin',        roles: ['ROLE_ADMIN'] },
   { key: 'details',      icon: 'pi-cog',       label: 'Details',      roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_HELPER'] },
-  { key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
+  { key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
   { key: 'participants', icon: 'pi-users',     label: 'Participants', roles: ['ROLE_ADMIN', 'ROLE_ORGANISER'] },
   { key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_HELPER'] },
   { key: 'battle',       icon: 'pi-bolt',      label: 'Battle',       roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_JUDGE'] },

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -150,7 +150,7 @@ const routes = [
         meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER'], requiresEvent: true }
     },
     {
-        path: '/auth/token',
+        path: '/auth/token/:role?/:judgeName?',
         name: 'TokenAuth',
         component: TokenAuth
     },

--- a/BES-frontend/src/utils/__tests__/EventPanel.test.js
+++ b/BES-frontend/src/utils/__tests__/EventPanel.test.js
@@ -41,10 +41,10 @@ describe('EventPanel.vue — section tiles', () => {
   })
 
   describe('Organiser role', () => {
-    it('shows all 7 tiles', async () => {
+    it('shows all 6 tiles (audition hidden)', async () => {
       const w = mountPanel('ROLE_ORGANISER')
       await w.vm.$nextTick()
-      expect(w.findAll('[data-tile]')).toHaveLength(7)
+      expect(w.findAll('[data-tile]')).toHaveLength(6)
     })
   })
 

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -73,6 +73,23 @@ export const fetchAllEvents = async () =>{
     }
 }
 
+export const deleteEvent = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error || `Delete failed (${res.status})`)
+    }
+    return await res.json()
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}
+
 export const checkTableExist = async (eventName, tableExist) =>{
   try{
     const res = await fetch(`${domain}/api/v1/event/${eventName.value}`,{

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -41,6 +41,12 @@ const confirming = ref(false)
 // participantId → true when any operator has that participant's dialog open
 const previewingIds = reactive({})
 const checkinSearch = ref('')
+const checkinCategoryFilter = ref('')
+const checkinCategoryOptions = computed(() => {
+  const cats = new Set()
+  checkinList.value.forEach(p => (p.categories ?? []).forEach(c => { if (c.categoryName) cats.add(c.categoryName) }))
+  return [...cats].sort()
+})
 const participantsNumBreakdown = ref([])
 const totalParticipants = ref(0)
 
@@ -1093,12 +1099,20 @@ const sortedCheckinList = computed(() =>
 )
 
 const filteredCheckinList = computed(() => {
+  let list = sortedCheckinList.value
   const q = checkinSearch.value.trim().toLowerCase()
-  if (!q) return sortedCheckinList.value
-  return sortedCheckinList.value.filter(p =>
-    p.label.toLowerCase().includes(q) ||
-    (p.memberNames ?? []).some(m => m.toLowerCase().includes(q))
-  )
+  if (q) {
+    list = list.filter(p =>
+      p.label.toLowerCase().includes(q) ||
+      (p.memberNames ?? []).some(m => m.toLowerCase().includes(q))
+    )
+  }
+  if (checkinCategoryFilter.value) {
+    list = list.filter(p =>
+      (p.categories ?? []).some(c => c.categoryName === checkinCategoryFilter.value)
+    )
+  }
+  return list
 })
 
 const fetchCheckinList = async () => {
@@ -2620,9 +2634,16 @@ onUnmounted(() => {
               <i class="pi pi-times text-xs"></i>
             </button>
           </div>
-          <p v-if="checkinSearch" class="type-label text-content-muted mt-1.5">
+          <p v-if="checkinSearch || checkinCategoryFilter" class="type-label text-content-muted mt-1.5">
             {{ filteredCheckinList.length }} result{{ filteredCheckinList.length !== 1 ? 's' : '' }}
           </p>
+        </div>
+        <!-- Category filter -->
+        <div v-if="checkinCategoryOptions.length > 0" class="mb-3 shrink-0">
+          <select v-model="checkinCategoryFilter" class="input-base" style="width: 100%">
+            <option value="">All categories</option>
+            <option v-for="cat in checkinCategoryOptions" :key="cat" :value="cat">{{ cat }}</option>
+          </select>
         </div>
         <div class="flex-1 overflow-y-auto space-y-2 min-h-0">
           <div v-if="loadingCheckinList" class="flex items-center justify-center h-full type-label text-content-muted">

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -2617,33 +2617,34 @@ onUnmounted(() => {
             <span class="badge-warning">{{ checkinList.filter(p => !isCheckedIn(p)).length }} pending</span>
           </div>
         </div>
-        <!-- Search bar -->
+        <!-- Search + Category filter (inline) -->
         <div class="mb-3 shrink-0">
-          <div class="relative">
-            <i class="pi pi-search absolute left-4 top-1/2 -translate-y-1/2 text-content-muted text-xs pointer-events-none"></i>
-            <input
-              v-model="checkinSearch"
-              type="text"
-              placeholder="Search by name or member…"
-              autocomplete="off"
+          <div class="flex gap-2">
+            <div class="relative flex-1">
+              <i class="pi pi-search absolute left-4 top-1/2 -translate-y-1/2 text-content-muted text-xs pointer-events-none"></i>
+              <input
+                v-model="checkinSearch"
+                type="text"
+                placeholder="Search by name or member…"
+                autocomplete="off"
+                class="input-base pr-8"
+                style="padding-left: 2.25rem"
+              />
+              <button v-if="checkinSearch" @click="checkinSearch = ''"
+                class="absolute right-2.5 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-secondary transition-colors">
+                <i class="pi pi-times text-xs"></i>
+              </button>
+            </div>
+            <select v-if="checkinCategoryOptions.length > 0" v-model="checkinCategoryFilter"
               class="input-base"
-              style="padding-left: 2.25rem"
-            />
-            <button v-if="checkinSearch" @click="checkinSearch = ''"
-              class="absolute right-2.5 top-1/2 -translate-y-1/2 text-content-muted hover:text-content-secondary transition-colors">
-              <i class="pi pi-times text-xs"></i>
-            </button>
+              style="width: auto; flex-shrink: 0">
+              <option value="">All categories</option>
+              <option v-for="cat in checkinCategoryOptions" :key="cat" :value="cat">{{ cat }}</option>
+            </select>
           </div>
           <p v-if="checkinSearch || checkinCategoryFilter" class="type-label text-content-muted mt-1.5">
             {{ filteredCheckinList.length }} result{{ filteredCheckinList.length !== 1 ? 's' : '' }}
           </p>
-        </div>
-        <!-- Category filter -->
-        <div v-if="checkinCategoryOptions.length > 0" class="mb-3 shrink-0">
-          <select v-model="checkinCategoryFilter" class="input-base" style="width: 100%">
-            <option value="">All categories</option>
-            <option v-for="cat in checkinCategoryOptions" :key="cat" :value="cat">{{ cat }}</option>
-          </select>
         </div>
         <div class="flex-1 overflow-y-auto space-y-2 min-h-0">
           <div v-if="loadingCheckinList" class="flex items-center justify-center h-full type-label text-content-muted">

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { fetchAllFolderEvents, fetchAllEvents } from '@/utils/api'
+import { fetchAllFolderEvents, fetchAllEvents, deleteEvent } from '@/utils/api'
 import { useAuthStore, setActiveEvent } from '@/utils/auth'
 import EventCard from '@/components/EventCard.vue'
 import { useDelay } from '@/utils/utils'
@@ -12,6 +12,11 @@ const dbEvents = ref([])
 const search  = ref('')
 const router  = useRouter()
 const isAdmin = ref(false)
+const showDeleteModal = ref(false)
+const eventToDelete = ref(null)
+const deleteConfirmName = ref('')
+const deleteError = ref('')
+const deleting = ref(false)
 
 // Only one card expanded at a time (mobile)
 const expandedId = ref(null)
@@ -38,6 +43,38 @@ function activateAndGo(folderName, routeName) {
   const dbEvent = dbEvents.value.find(e => e.name === folderName)
   if (dbEvent) setActiveEvent(dbEvent.id, dbEvent.name)
   router.push({ name: routeName })
+}
+
+function openDeleteModal(event) {
+  eventToDelete.value = event
+  deleteConfirmName.value = ''
+  deleteError.value = ''
+  showDeleteModal.value = true
+  expandedId.value = null  // close the action panel
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false
+  eventToDelete.value = null
+  deleteConfirmName.value = ''
+  deleteError.value = ''
+}
+
+async function confirmDelete() {
+  if (!eventToDelete.value || deleteConfirmName.value !== eventToDelete.value.folderName) return
+  deleting.value = true
+  deleteError.value = ''
+  try {
+    await deleteEvent(eventToDelete.value.folderName)
+    // Remove from local list
+    events.value = events.value.filter(e => e.folderID !== eventToDelete.value.folderID)
+    dbEvents.value = dbEvents.value.filter(e => e.name !== eventToDelete.value.folderName)
+    closeDeleteModal()
+  } catch (err) {
+    deleteError.value = err.message || 'Failed to delete event'
+  } finally {
+    deleting.value = false
+  }
 }
 
 onMounted(async () => {
@@ -102,6 +139,7 @@ onMounted(async () => {
         @onParticipants="activateAndGo(event.folderName, 'Update Event Details')"
         @onScoreboard="activateAndGo(event.folderName, 'Score')"
         @onBattle="activateAndGo(event.folderName, 'Battle Control')"
+        @onDelete="openDeleteModal(event)"
       />
     </div>
 
@@ -122,6 +160,97 @@ onMounted(async () => {
         {{ search ? 'Try a different search term' : 'No events are available yet' }}
       </p>
     </div>
+
+    <!-- Delete Event Confirmation Modal -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div
+          v-if="showDeleteModal"
+          class="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style="background: rgba(0,0,0,0.8)"
+          @click.self="closeDeleteModal"
+        >
+          <div
+            class="w-full max-w-md p-6 flex flex-col gap-5"
+            style="background: #1a1a1a; border: 1px solid rgba(239,68,68,0.3); clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%)"
+          >
+            <!-- Header -->
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-red-500 flex-shrink-0" style="box-shadow: 0 0 10px rgba(239,68,68,0.7)"></div>
+              <h2 class="type-page-title text-red-400" style="font-size: 20px">DELETE EVENT</h2>
+            </div>
+
+            <!-- Warning -->
+            <div class="px-4 py-3" style="border-left: 3px solid rgba(239,68,68,0.6); background: rgba(239,68,68,0.07)">
+              <p class="type-label text-red-300/90 mb-1">This will permanently delete:</p>
+              <p class="type-prose text-red-200/70">
+                <strong class="type-name text-red-300">{{ eventToDelete?.folderName }}</strong>
+                and ALL associated data — participants, categories, scores, feedback, battle state, and session tokens.
+                This cannot be undone.
+              </p>
+            </div>
+
+            <!-- Step 1: Initial warning -->
+            <div v-if="deleteConfirmName === ''">
+              <p class="type-prose text-content-muted mb-3">Type the event name to enable deletion.</p>
+              <input
+                v-model="deleteConfirmName"
+                type="text"
+                :placeholder="eventToDelete?.folderName"
+                class="input-base w-full"
+                autofocus
+              />
+            </div>
+
+            <!-- Step 2: Name matched — ready to delete -->
+            <div v-else-if="deleteConfirmName === eventToDelete?.folderName">
+              <p class="type-label text-red-400 mb-3">✓ Name confirmed. Ready to delete.</p>
+            </div>
+
+            <!-- Error -->
+            <div
+              v-if="deleteError"
+              class="px-3 py-2 type-label text-red-300"
+              style="border-left: 3px solid rgba(239,68,68,0.5); background: rgba(239,68,68,0.08)"
+            >
+              {{ deleteError }}
+            </div>
+
+            <!-- Actions -->
+            <div class="flex gap-3">
+              <button
+                @click="closeDeleteModal"
+                class="flex-1 py-2.5 type-label border border-surface-600 text-content-muted hover:text-content-primary transition-colors"
+                style="clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%)"
+                :disabled="deleting"
+              >CANCEL</button>
+              <button
+                @click="confirmDelete"
+                :disabled="deleteConfirmName !== eventToDelete?.folderName || deleting"
+                class="flex-1 py-2.5 type-label font-bold transition-all"
+                :class="deleteConfirmName === eventToDelete?.folderName && !deleting
+                  ? 'bg-red-600 text-white hover:bg-red-500'
+                  : 'bg-surface-700 text-content-muted cursor-not-allowed'"
+                style="clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%)"
+              >
+                <span v-if="deleting">DELETING…</span>
+                <span v-else>DELETE EVENT</span>
+              </button>
+            </div>
+
+            <!-- Tap outside hint -->
+            <p class="type-prose-sm text-content-muted/50 text-center">Tap outside to cancel</p>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
 
   </div>
   </div>

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -133,6 +133,7 @@ onMounted(async () => {
         :key="event.folderID"
         :buttonName="event.folderName"
         :expanded="expandedId === event.folderID"
+        :isAdmin="isAdmin"
         @toggle="toggleExpanded(event.folderID)"
         @onDetails="goToEventDetails(event.folderName, event.folderID)"
         @onAudition="activateAndGo(event.folderName, 'Audition List')"

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -198,9 +198,13 @@ onMounted(async () => {
               </p>
             </div>
 
-            <!-- Step 1: Initial warning -->
-            <div v-if="deleteConfirmName === ''">
-              <p class="type-prose text-content-muted mb-3">Type the event name to enable deletion.</p>
+            <!-- Type-to-confirm: input always visible, hint changes -->
+            <div>
+              <p class="type-prose text-content-muted mb-3">
+                <template v-if="deleteConfirmName === ''">Type the event name to enable deletion.</template>
+                <template v-else-if="deleteConfirmName === eventToDelete?.folderName">✓ Name confirmed. Ready to delete.</template>
+                <template v-else>Keep typing — name must match exactly.</template>
+              </p>
               <input
                 v-model="deleteConfirmName"
                 type="text"
@@ -208,11 +212,6 @@ onMounted(async () => {
                 class="input-base w-full"
                 autofocus
               />
-            </div>
-
-            <!-- Step 2: Name matched — ready to delete -->
-            <div v-else-if="deleteConfirmName === eventToDelete?.folderName">
-              <p class="type-label text-red-400 mb-3">✓ Name confirmed. Ready to delete.</p>
             </div>
 
             <!-- Error -->

--- a/BES-frontend/src/views/MainMenu.vue
+++ b/BES-frontend/src/views/MainMenu.vue
@@ -113,9 +113,9 @@ const roleDisplay = computed(() => {
           <p class="type-prose">Manage registrations and judges.</p>
         </router-link>
 
-        <!-- Scoreboard (Admin / Organiser / Emcee) -->
+        <!-- Scoreboard (Admin / Organiser / Emcee / Helper) -->
         <router-link
-          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE')"
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_HELPER')"
           :to="{ name: 'Score' }"
           class="card-hover p-6 relative cursor-pointer group"
         >

--- a/BES-frontend/src/views/MainMenu.vue
+++ b/BES-frontend/src/views/MainMenu.vue
@@ -79,7 +79,7 @@ const roleDisplay = computed(() => {
 
         <!-- Audition List -->
         <router-link
-          v-if="activeEvent && role !== 'ROLE_HELPER' && role !== 'ROLE_EMCEE'"
+          v-if="activeEvent && role !== 'ROLE_HELPER' && role !== 'ROLE_EMCEE' && role !== 'ROLE_ORGANISER'"
           :to="{ name: 'Audition List' }"
           class="card-hover p-6 relative cursor-pointer group"
         >

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import { ref, computed, watch, onUnmounted } from 'vue';
 import { getParticipantScore, getParticipantFeedback, getResultsStatus, releaseResults, getParticipantRefs, getScoringCriteria, setResolvedParticipants, getCategoriesByEvent, saveTieBreakerState, getTieBreakerState } from '@/utils/api';
 import { computeNextEligibleAdd, computeNextEligibleRemove, addedPoolOrdered } from '@/utils/scoreTiePool';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
@@ -21,7 +21,6 @@ const tabulationMethod = ref(["By Total", "By Judge"])
 // Auth
 const userRole = computed(() => authStore.user?.role?.[0]?.authority)
 const isAdminOrOrganiser = computed(() => ['ROLE_ADMIN', 'ROLE_ORGANISER'].includes(userRole.value))
-const isHelper = computed(() => userRole.value === 'ROLE_HELPER')
 
 // Results release state (admin/organiser only)
 const resultsReleased = ref(false)

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -13,27 +13,15 @@ const categoryKey = (eventName) => `selectedCategory_${eventName || 'global'}`
 const tabKey   = (eventName) => `selectedTabMethod_${eventName || 'global'}`
 const selectedCategory = ref(localStorage.getItem(categoryKey(selectedEvent.value)) || '')
 const selectedTabulation = ref(localStorage.getItem(tabKey(selectedEvent.value)) || 'By Total')
-const selectedTopN = ref("All")
+const selectedTopN = ref('')
 const selectedEntryType = ref('Teams') // 'Teams' | 'Solo'
 const participants = ref([])
 const tabulationMethod = ref(["By Total", "By Judge"])
-const topNOptions = ["All", "Top 8", "Top 16", "Top 32"]
 
 // Auth
 const userRole = computed(() => authStore.user?.role?.[0]?.authority)
 const isAdminOrOrganiser = computed(() => ['ROLE_ADMIN', 'ROLE_ORGANISER'].includes(userRole.value))
 const isHelper = computed(() => userRole.value === 'ROLE_HELPER')
-
-// ── Mode toggle: Control (organiser) vs Broadcast (emcee) ─────────────────
-// Default is role-driven; user choice persists per event in localStorage.
-const modeKey = computed(() => `score_mode_${selectedEvent.value || 'global'}`)
-const initialMode = (() => {
-  const saved = localStorage.getItem(`score_mode_${authStore.activeEvent?.name || localStorage.getItem('selectedEvent') || 'global'}`)
-  if (saved === 'control' || saved === 'broadcast') return saved
-  return (userRole.value === 'ROLE_EMCEE' || userRole.value === 'ROLE_HELPER') ? 'broadcast' : 'control'
-})()
-const mode = ref(initialMode)
-watch([mode, modeKey], ([m, k]) => { if (k && (m === 'control' || m === 'broadcast')) localStorage.setItem(k, m) })
 
 // Results release state (admin/organiser only)
 const resultsReleased = ref(false)
@@ -225,7 +213,7 @@ watch(selectedEvent, async (newVal) => {
 watch(selectedCategory, async (newVal) => {
   if (newVal) {
     localStorage.setItem(categoryKey(selectedEvent.value), newVal)
-    selectedTopN.value = 'All'
+    selectedTopN.value = ''
     selectedEntryType.value = 'Teams'
     if (selectedEvent.value && newVal !== 'All') {
       criteriaForCategory.value = await getScoringCriteria(selectedEvent.value, newVal)
@@ -235,7 +223,7 @@ watch(selectedCategory, async (newVal) => {
   }
 }, { immediate: true });
 watch(selectedTabulation, (newVal) => {
-  if (newVal) { localStorage.setItem(tabKey(selectedEvent.value), newVal); selectedTopN.value = 'All' }
+  if (newVal) { localStorage.setItem(tabKey(selectedEvent.value), newVal); selectedTopN.value = '' }
   resetTieBreaker()
 }, { immediate: true });
 // Load persisted tie-breaker state from backend whenever the view context changes.
@@ -255,7 +243,7 @@ const topNResult = computed(() => {
   const base = filteredParticipantsForScore.value
   if (!base.rows) return { hasTieBreaker: false }
 
-  const n = selectedTopN.value === 'All' ? Infinity : parseInt(selectedTopN.value.replace('Top ', ''))
+  const n = (!selectedTopN.value || selectedTopN.value === '0') ? Infinity : Math.min(parseInt(selectedTopN.value), 64)
   const rows = base.rows
 
   if (n === Infinity || rows.length <= n) {
@@ -424,7 +412,7 @@ const eliminatedRows = computed(() => {
 const statusBanner = computed(() => {
   const t = topNResult.value
   const total = filteredParticipantsForScore.value.rows?.length ?? 0
-  const n = selectedTopN.value === 'All' ? Infinity : parseInt(selectedTopN.value.replace('Top ', ''))
+  const n = (!selectedTopN.value || selectedTopN.value === '0') ? Infinity : Math.min(parseInt(selectedTopN.value), 64)
   if (!Number.isFinite(n)) return null
   if (total < n) {
     return { tone: 'insufficient', message: `ONLY ${total} SCORED — TOP ${n} NOT YET REACHABLE` }
@@ -449,20 +437,6 @@ const eliminatedSummary = computed(() => {
 })
 
 const eliminatedExpanded = ref(false)
-
-// Broadcast-mode column count — 1 below 640px or for very small N, 2 otherwise.
-const viewportWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 1024)
-const onResize = () => { viewportWidth.value = window.innerWidth }
-onMounted(() => { window.addEventListener('resize', onResize) })
-onUnmounted(() => { window.removeEventListener('resize', onResize) })
-
-const broadcastColumns = computed(() => {
-  if (viewportWidth.value < 640) return '1col'
-  const n = selectedTopN.value === 'All'
-    ? (allRowsForPool.value?.length ?? 0)
-    : parseInt(selectedTopN.value.replace('Top ', ''))
-  return n <= 12 ? '1col' : '2col'
-})
 
 // Release results toggle
 const toggleRelease = async () => {
@@ -657,21 +631,19 @@ function transformForScore(data) {
     <div class="color-bleed"></div>
     <div class="relative z-10">
 
-    <!-- Header row — title block is Control-only; Broadcast renders its own header below.
-         Release pill is Control-only (spec §4.1). Mode toggle stays in both modes so user can flip. -->
+    <!-- Header row -->
     <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between mb-6">
-      <div v-if="mode === 'control'">
+      <div>
         <p class="type-label text-content-muted mb-1">SCOREBOARD · <span class="type-name-sm">{{ selectedEvent }}</span></p>
         <h1 class="type-page-title">
           {{ selectedCategory || 'No Category' }}
           <template v-if="hasTeamAndSoloMix"> — {{ selectedEntryType.toUpperCase() }}</template>
         </h1>
       </div>
-      <div v-else></div>
       <div class="flex flex-wrap items-center gap-2">
-        <!-- Release Results pill (admin/organiser only, Control mode only) -->
+        <!-- Release Results pill (admin/organiser only) -->
         <button
-          v-if="isAdminOrOrganiser && mode === 'control'"
+          v-if="isAdminOrOrganiser"
           @click="toggleRelease"
           :aria-pressed="resultsReleased"
           class="para-chip-sm px-3 py-1.5 type-label inline-flex items-center gap-1.5 transition-all"
@@ -682,24 +654,11 @@ function transformForScore(data) {
           <span class="w-1.5 h-1.5 rounded-full" :class="resultsReleased ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.7)]' : 'bg-content-muted/40'"></span>
           {{ resultsReleased ? 'RELEASED' : 'HIDDEN' }}
         </button>
-        <!-- Mode toggle -->
-        <div class="flex p-0.5 border border-surface-600 bg-surface-800/50" role="group" aria-label="Display mode">
-          <button
-            v-for="m in ['control', 'broadcast']"
-            :key="m"
-            @click="mode = m"
-            :aria-pressed="mode === m"
-            class="para-chip-sm px-3 py-1.5 type-label transition-all"
-            :class="mode === m
-              ? 'text-accent border-[color:var(--accent-muted)]'
-              : 'text-content-muted hover:text-content-primary'"
-          >{{ m.toUpperCase() }}</button>
-        </div>
       </div>
     </div>
 
-    <!-- Secondary filter row (Control mode only) -->
-    <div v-if="mode === 'control'" class="card p-3 mb-6">
+    <!-- Secondary filter row -->
+    <div class="card p-3 mb-6">
       <div class="flex flex-wrap items-center gap-3">
         <!-- Category -->
         <div class="flex flex-wrap gap-1" role="group" aria-label="Filter by category">
@@ -743,24 +702,23 @@ function transformForScore(data) {
       </div>
     </div>
 
-    <!-- Top N hero picker (Control mode only) -->
-    <div v-if="mode === 'control' && selectedTabulation === 'By Total'" class="mb-6">
+    <!-- Top N picker -->
+    <div v-if="selectedTabulation === 'By Total'" class="mb-6">
       <p class="type-label text-content-muted mb-3">QUALIFY</p>
-      <div class="grid grid-cols-4 gap-2" role="group" aria-label="Qualify top N">
-        <button
-          v-for="n in topNOptions"
-          :key="n"
-          @click="selectedTopN = n"
-          :aria-pressed="selectedTopN === n"
-          class="para-chip py-5 flex flex-col items-center justify-center gap-1 transition-all"
-          :class="selectedTopN === n
-            ? 'border-[color:var(--accent-color)] shadow-[0_0_20px_var(--accent-subtle)]'
-            : 'opacity-50 hover:opacity-90'"
-        >
-          <span v-if="n !== 'All'" class="type-label" style="font-size: 9px">TOP</span>
-          <span class="type-stat" style="font-size: 28px; line-height: 1">{{ n === 'All' ? 'ALL' : n.replace('Top ', '') }}</span>
-          <span v-if="n === 'All'" class="type-label" style="font-size: 9px">· {{ allRowsForPool.length }}</span>
-        </button>
+      <div class="flex items-center gap-3">
+        <label class="type-label text-content-muted whitespace-nowrap">TOP</label>
+        <input
+          v-model="selectedTopN"
+          type="number"
+          min="1"
+          max="64"
+          placeholder="ALL"
+          class="input-base"
+          style="width: 6rem"
+          @input="(e) => { const v = parseInt(e.target.value); if (v > 64) selectedTopN = '64'; else if (v < 1 || isNaN(v)) selectedTopN = ''; else selectedTopN = String(v) }"
+        />
+        <span v-if="!selectedTopN || selectedTopN === '0'" class="type-label text-content-muted">· {{ allRowsForPool.length }} scored</span>
+        <span v-else class="type-label text-content-muted">of {{ allRowsForPool.length }}</span>
       </div>
 
       <!-- Status banner -->
@@ -792,7 +750,7 @@ function transformForScore(data) {
     </div>
 
     <!-- By Total: cut-line leaderboard -->
-    <template v-if="mode === 'control' && selectedTabulation === 'By Total'">
+    <template v-if="selectedTabulation === 'By Total'">
       <div v-if="topNResult.rows && topNResult.rows.length > 0">
         <p class="type-label text-content-muted mb-3 flex justify-between">
           <span>RANKINGS · {{ allRowsForPool.length }} SCORED</span>
@@ -974,8 +932,8 @@ function transformForScore(data) {
 
           <!-- Top N line (separator) -->
           <div
-            v-if="topNResult.rows.length >= (selectedTopN === 'All' ? 0 : parseInt(selectedTopN.replace('Top ','')))
-                  && selectedTopN !== 'All'
+            v-if="selectedTopN && selectedTopN !== '0'
+                  && topNResult.rows.length >= Math.min(parseInt(selectedTopN), 64)
                   && (!topNResult.hasTieBreaker || tieBreakerConfirmed)"
             role="separator"
             :aria-label="`Top ${topNResult.cutoff} line`"
@@ -1013,7 +971,7 @@ function transformForScore(data) {
     </template>
 
     <!-- By Judge sub-view (Control mode only) -->
-    <template v-if="mode === 'control' && selectedTabulation === 'By Judge'">
+    <template v-if="selectedTabulation === 'By Judge'">
       <template v-if="filteredParticipantsForScore.byJudge && Object.keys(filteredParticipantsForScore.byJudge).length > 0">
         <div
           v-for="(group, judge) in filteredParticipantsForScore.byJudge"
@@ -1041,96 +999,6 @@ function transformForScore(data) {
         <div class="para-chip-sm w-14 h-14 flex items-center justify-center mb-4">
           <i class="pi pi-chart-bar text-content-muted text-xl"></i>
         </div>
-        <p class="type-body text-content-secondary">{{ selectedCategory ? `No scores for ${selectedCategory}` : 'No scores yet' }}</p>
-      </div>
-    </template>
-
-    <!-- BROADCAST mode -->
-    <template v-if="mode === 'broadcast'">
-      <!-- Header -->
-      <div class="mb-4">
-        <p class="type-name-sm text-content-muted mb-1">{{ selectedEvent }}<template v-if="hasTeamAndSoloMix"> · {{ selectedEntryType.toUpperCase() }}</template></p>
-        <h1 class="type-page-title">{{ selectedCategory }}<span v-if="selectedTopN !== 'All'"> · TOP {{ selectedTopN.replace('Top ', '') }}</span></h1>
-        <p class="type-label text-content-muted mt-1">{{ allRowsForPool.length }} SCORED</p>
-      </div>
-
-      <!-- Compact category + Top N switchers — practical override of "no chrome" rule so
-           emcees can switch categories / cut threshold without flipping to Control mid-show. -->
-      <div class="flex flex-wrap items-center gap-3 mb-6">
-        <div v-if="uniqueCategories.length > 1" class="flex flex-wrap gap-1" role="group" aria-label="Filter by category">
-          <button
-            v-for="g in uniqueCategories"
-            :key="g"
-            @click="selectedCategory = g"
-            :aria-pressed="selectedCategory === g"
-            class="para-chip-sm px-3 py-1.5 type-name-sm transition-all"
-            :class="selectedCategory === g ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
-          >{{ g }}</button>
-        </div>
-        <span v-if="uniqueCategories.length > 1" class="text-surface-600 select-none" aria-hidden="true">|</span>
-        <div class="flex flex-wrap gap-1" role="group" aria-label="Qualify top N">
-          <span class="type-label text-content-muted self-center mr-1">TOP</span>
-          <button
-            v-for="n in topNOptions"
-            :key="n"
-            @click="selectedTopN = n"
-            :aria-pressed="selectedTopN === n"
-            class="para-chip-sm px-3 py-1.5 type-label transition-all"
-            :class="selectedTopN === n ? 'text-accent border-[color:var(--accent-muted)]' : 'text-content-muted hover:text-content-primary'"
-          >{{ n === 'All' ? 'ALL' : n.replace('Top ', '') }}</button>
-        </div>
-      </div>
-
-      <!-- Leaderboard -->
-      <div v-if="finalRows.length > 0">
-        <div :class="broadcastColumns === '2col' ? 'grid grid-cols-2 gap-x-4 gap-y-1.5' : 'flex flex-col gap-1.5'">
-          <template v-for="(row, idx) in finalRows" :key="row.participantName">
-            <div
-              class="para-chip flex items-start gap-3 px-4 py-3"
-              :class="idx === 0 ? 'border-l-[3px] border-[color:var(--accent-color)]' : 'bg-surface-700/10'"
-              :style="broadcastColumns === '2col' && idx < Math.ceil(finalRows.length / 2)
-                ? `order: ${idx * 2}`
-                : broadcastColumns === '2col'
-                  ? `order: ${(idx - Math.ceil(finalRows.length / 2)) * 2 + 1}`
-                  : ''"
-            >
-              <span class="type-stat flex-shrink-0" style="font-size: 22px; line-height: 1; min-width: 38px">{{ row.id }}</span>
-              <span class="flex-1 type-name text-content-primary" style="font-size: 16px">{{ row.participantName }}</span>
-              <span class="type-stat flex-shrink-0" style="font-size: 22px; line-height: 1">{{ row.totalScore }}</span>
-            </div>
-          </template>
-        </div>
-
-        <!-- Top N line -->
-        <div
-          v-if="selectedTopN !== 'All' && (!topNResult.hasTieBreaker || tieBreakerConfirmed)"
-          role="separator"
-          :aria-label="`Top ${topNResult.cutoff} line`"
-          class="relative h-px my-6"
-          style="background: linear-gradient(90deg, transparent, var(--accent-color) 50%, transparent); box-shadow: 0 0 14px var(--accent-muted);"
-        >
-          <span class="absolute right-0 -top-6 type-label text-content-muted">▲ TOP {{ topNResult.cutoff }}</span>
-        </div>
-
-        <!-- Eliminated summary (collapsed) -->
-        <p
-          v-if="eliminatedSummary"
-          class="type-label text-content-muted/50 text-center py-3"
-        >⋯ {{ eliminatedSummary.count }} ELIMINATED · LOWEST {{ eliminatedSummary.lowestScore }} ⋯</p>
-
-        <!-- Unresolved tie pending strip (Broadcast read-only) -->
-        <div
-          v-if="topNResult.hasTieBreaker && !tieBreakerConfirmed"
-          role="status"
-          class="mt-4 px-4 py-3 border-l-[3px] border-amber-400 bg-amber-500/8 flex flex-wrap items-center gap-3"
-        >
-          <span class="w-1.5 h-1.5 rounded-full bg-amber-400 shadow-[0_0_8px_rgba(245,158,11,0.6)]"></span>
-          <p class="type-label text-amber-400">{{ topNResult.tiedCount }} TIED AT {{ topNResult.tieBreakerScore }} · TIES PENDING — RESOLVE IN CONTROL</p>
-        </div>
-      </div>
-
-      <!-- Empty state -->
-      <div v-else class="flex flex-col items-center justify-center py-20 text-center">
         <p class="type-body text-content-secondary">{{ selectedCategory ? `No scores for ${selectedCategory}` : 'No scores yet' }}</p>
       </div>
     </template>

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -22,6 +22,7 @@ const topNOptions = ["All", "Top 8", "Top 16", "Top 32"]
 // Auth
 const userRole = computed(() => authStore.user?.role?.[0]?.authority)
 const isAdminOrOrganiser = computed(() => ['ROLE_ADMIN', 'ROLE_ORGANISER'].includes(userRole.value))
+const isHelper = computed(() => userRole.value === 'ROLE_HELPER')
 
 // ── Mode toggle: Control (organiser) vs Broadcast (emcee) ─────────────────
 // Default is role-driven; user choice persists per event in localStorage.
@@ -29,7 +30,7 @@ const modeKey = computed(() => `score_mode_${selectedEvent.value || 'global'}`)
 const initialMode = (() => {
   const saved = localStorage.getItem(`score_mode_${authStore.activeEvent?.name || localStorage.getItem('selectedEvent') || 'global'}`)
   if (saved === 'control' || saved === 'broadcast') return saved
-  return userRole.value === 'ROLE_EMCEE' ? 'broadcast' : 'control'
+  return (userRole.value === 'ROLE_EMCEE' || userRole.value === 'ROLE_HELPER') ? 'broadcast' : 'control'
 })()
 const mode = ref(initialMode)
 watch([mode, modeKey], ([m, k]) => { if (k && (m === 'control' || m === 'broadcast')) localStorage.setItem(k, m) })

--- a/BES-frontend/src/views/TokenAuth.vue
+++ b/BES-frontend/src/views/TokenAuth.vue
@@ -19,7 +19,18 @@ function redirectByRole(user) {
   else router.replace('/')
 }
 
+const roleLabel = ref('')
+const judgeLabel = ref('')
+
 onMounted(async () => {
+  // Read descriptive path params for display
+  const roleParam = route.params.role
+  const judgeParam = route.params.judgeName
+  if (roleParam) {
+    roleLabel.value = roleParam.charAt(0).toUpperCase() + roleParam.slice(1)
+    if (judgeParam) judgeLabel.value = decodeURIComponent(judgeParam)
+  }
+
   // If already authenticated (same link opened in a second tab), skip redemption
   const existing = authStore.user || await whoami().catch(() => null)
   if (existing?.authenticated) {
@@ -59,6 +70,7 @@ onMounted(async () => {
       <template v-if="loading">
         <div class="spinner" aria-hidden="true"></div>
         <p class="token-text">SIGNING IN&#8230;</p>
+        <p v-if="roleLabel" class="token-role">{{ roleLabel }}<template v-if="judgeLabel"> · {{ judgeLabel }}</template></p>
       </template>
       <template v-else-if="error">
         <p class="token-title">LINK INVALID</p>
@@ -115,6 +127,14 @@ onMounted(async () => {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(255,255,255,0.6);
+}
+
+.token-role {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-color, rgba(255,255,255,0.7));
+  margin-top: 6px;
 }
 
 .token-sub {

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -963,6 +964,21 @@ public class EventController {
             return ResponseEntity.ok(gson.toJson("Solo allowed updated"));
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "Delete Event", description = "Permanently deletes an event and ALL associated data — participants, categories, scores, feedback, battle state, session tokens. Admin only.")
+    @DeleteMapping("/{eventName}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> deleteEvent(@PathVariable String eventName) {
+        try {
+            eventService.deleteEvent(eventName);
+            return ResponseEntity.ok(Map.of("message", "Event '" + eventName + "' and all associated data deleted"));
+        } catch (ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        } catch (Exception e) {
+            log.error("Error deleting event: {}", eventName, e);
+            return ResponseEntity.internalServerError().body(Map.of("error", "Failed to delete event: " + e.getMessage()));
         }
     }
 

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -584,7 +584,7 @@ public class EventController {
 
     @Operation(summary = "Get Participant Scores", description = "Gets all scores for participants in a specific event")
     @GetMapping("/scores/{eventName}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'JUDGE')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'JUDGE', 'HELPER')")
     public ResponseEntity<List<GetParticipatnScoreDto>> getParticipantScore(@PathVariable String eventName) {
         try {
             return new ResponseEntity<>(scoreService.getAllScore(eventName), HttpStatus.OK);

--- a/BES/src/main/java/com/example/BES/respositories/AuditionFeedbackRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/AuditionFeedbackRepository.java
@@ -20,6 +20,10 @@ public interface AuditionFeedbackRepository extends JpaRepository<AuditionFeedba
 
     @Modifying
     @Transactional
+    void deleteByEventCategoryParticipant(EventCategoryParticipant ecp);
+
+    @Modifying
+    @Transactional
     @Query("""
         DELETE FROM AuditionFeedback f
         WHERE f.eventCategoryParticipant IN (

--- a/BES/src/main/java/com/example/BES/respositories/BattleActiveCategoryRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/BattleActiveCategoryRepository.java
@@ -1,6 +1,20 @@
 package com.example.BES.respositories;
 
-import com.example.BES.models.BattleActiveCategory;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
-public interface BattleActiveCategoryRepository extends JpaRepository<BattleActiveCategory, Integer> {}
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.BES.models.BattleActiveCategory;
+
+public interface BattleActiveCategoryRepository extends JpaRepository<BattleActiveCategory, Integer> {
+    Optional<BattleActiveCategory> findByEventName(String eventName);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM BattleActiveCategory b WHERE b.eventName = :eventName")
+    void deleteByEventName(@Param("eventName") String eventName);
+}

--- a/BES/src/main/java/com/example/BES/respositories/EventCategoryBattleGuestRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventCategoryBattleGuestRepo.java
@@ -11,4 +11,5 @@ import com.example.BES.models.EventCategoryBattleGuest;
 public interface EventCategoryBattleGuestRepo extends JpaRepository<EventCategoryBattleGuest, Long> {
     List<EventCategoryBattleGuest> findByEventAndEventCategory(Event event, EventCategory eventCategory);
     List<EventCategoryBattleGuest> findByEvent(Event event);
+    void deleteByEvent(Event event);
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantMemberRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantMemberRepo.java
@@ -7,4 +7,5 @@ import com.example.BES.models.EventCategoryParticipantMember;
 public interface EventCategoryParticipantMemberRepo
         extends JpaRepository<EventCategoryParticipantMember, Long> {
     boolean existsByEventCategoryParticipantAndMemberName(EventCategoryParticipant ecp, String memberName);
+    void deleteByEventCategoryParticipant(EventCategoryParticipant ecp);
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantRepo.java
@@ -149,4 +149,5 @@ public interface EventCategoryParticipantRepo extends JpaRepository<EventCategor
         @Param("displayName") String displayName,
         @Param("excludeParticipantId") Long excludeParticipantId);
 
+    void deleteByEventCategory(EventCategory eventCategory);
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventCategoryRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventCategoryRepo.java
@@ -13,4 +13,5 @@ import com.example.BES.models.EventCategory;
 public interface EventCategoryRepo extends JpaRepository<EventCategory, Long>{
     Optional<EventCategory> findByEventAndName(Event event, String name);
     List<EventCategory> findByEvent(Event event);
+    void deleteByEvent(Event event);
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventParticipantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventParticipantRepo.java
@@ -17,4 +17,5 @@ public interface EventParticipantRepo extends JpaRepository<EventParticipant, Lo
     List<EventParticipant> findByEventAndPaymentVerifiedFalse(Event event);
     Optional<EventParticipant> findByReferenceCode(String referenceCode);
     List<EventParticipant> findByParticipant(Participant participant);
+    void deleteByEvent(Event event);
 }

--- a/BES/src/main/java/com/example/BES/respositories/PickupCrewRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/PickupCrewRepo.java
@@ -14,7 +14,10 @@ import com.example.BES.models.PickupCrew;
 @Repository
 public interface PickupCrewRepo extends JpaRepository<PickupCrew, Long> {
     List<PickupCrew> findByEventAndEventCategory(Event event, EventCategory eventCategory);
+    List<PickupCrew> findByEvent(Event event);
 
     @Query("SELECT COUNT(m) FROM PickupCrewMember m WHERE m.crew.event = :event AND m.crew.eventCategory = :eventCategory AND m.participant.participantId = :participantId")
     long countMemberInEventCategory(@Param("event") Event event, @Param("eventCategory") EventCategory eventCategory, @Param("participantId") Long participantId);
+
+    void deleteByEvent(Event event);
 }

--- a/BES/src/main/java/com/example/BES/respositories/ScoreRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/ScoreRepo.java
@@ -69,4 +69,9 @@ public interface ScoreRepo extends JpaRepository<Score, Long>{
         @Param("categoryName") String categoryName,
         @Param("judgeName") String judgeName
     );
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Score s WHERE s.eventCategoryParticipant = :ecp")
+    void deleteAllByEventCategoryParticipant(@Param("ecp") EventCategoryParticipant ecp);
 }

--- a/BES/src/main/java/com/example/BES/respositories/ScoringCriteriaRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/ScoringCriteriaRepo.java
@@ -3,9 +3,11 @@ package com.example.BES.respositories;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.BES.models.Event;
 import com.example.BES.models.EventCategory;
@@ -22,4 +24,14 @@ public interface ScoringCriteriaRepo extends JpaRepository<ScoringCriteria, Long
 
     @Query("SELECT sc FROM ScoringCriteria sc WHERE sc.event = :event AND (sc.eventCategory = :category OR (:category IS NULL AND sc.eventCategory IS NULL))")
     List<ScoringCriteria> findByEventAndEventCategory(@Param("event") Event event, @Param("category") EventCategory category);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ScoringCriteria sc WHERE sc.event = :event")
+    void deleteByEvent(@Param("event") Event event);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ScoringCriteria sc WHERE sc.eventCategory = :category")
+    void deleteByEventCategory(@Param("category") EventCategory category);
 }

--- a/BES/src/main/java/com/example/BES/services/EventService.java
+++ b/BES/src/main/java/com/example/BES/services/EventService.java
@@ -12,15 +12,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.example.BES.models.Account;
-import com.example.BES.models.Event;
+import com.example.BES.models.*;
 import com.example.BES.dtos.AddEventDto;
 import com.example.BES.dtos.GetEventDto;
 import com.example.BES.dtos.GetFeedbackEnabledDto;
 import com.example.BES.dtos.GetJudgingModeDto;
 import com.example.BES.dtos.UpdateReleaseScoreDto;
-import com.example.BES.respositories.AccountRepository;
-import com.example.BES.respositories.EventRepo;
+import com.example.BES.respositories.*;
 
 @Service
 public class EventService {
@@ -35,6 +33,57 @@ public class EventService {
 
     @Autowired
     AccountRepository accountRepository;
+
+    @Autowired
+    private ScoreRepo scoreRepo;
+
+    @Autowired
+    private AuditionFeedbackRepository auditionFeedbackRepository;
+
+    @Autowired
+    private EventCategoryParticipantRepo eventCategoryParticipantRepo;
+
+    @Autowired
+    private EventCategoryParticipantMemberRepo eventCategoryParticipantMemberRepo;
+
+    @Autowired
+    private EventParticipantRepo eventParticipantRepo;
+
+    @Autowired
+    private EventParticipantTeamMemberRepo eventParticipantTeamMemberRepo;
+
+    @Autowired
+    private ScoringCriteriaRepo scoringCriteriaRepo;
+
+    @Autowired
+    private FeedbackTagRepository feedbackTagRepository;
+
+    @Autowired
+    private FeedbackTagGroupRepository feedbackTagGroupRepository;
+
+    @Autowired
+    private EventCategoryBattleGuestRepo eventCategoryBattleGuestRepo;
+
+    @Autowired
+    private PickupCrewRepo pickupCrewRepo;
+
+    @Autowired
+    private SessionTokenRepository sessionTokenRepository;
+
+    @Autowired
+    private BattleCategoryStateRepository battleCategoryStateRepository;
+
+    @Autowired
+    private BattleActiveCategoryRepository battleActiveCategoryRepository;
+
+    @Autowired
+    private EventEmailTemplateRepo eventEmailTemplateRepo;
+
+    @Autowired
+    private EventCategoryRepo eventCategoryRepo;
+
+    @Autowired
+    private JudgeRepo judgeRepo;
 
     public void createEventService(AddEventDto dto){
         if (repo.findByEventName(dto.eventName).isPresent()) return;
@@ -178,5 +227,93 @@ public class EventService {
             }
         }
         return assigned;
+    }
+
+    @Transactional
+    public void deleteEvent(String eventName) {
+        Event event = repo.findByEventName(eventName)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+
+        Long eventId = event.getEventId();
+
+        // 1. Categories and their children
+        List<EventCategory> categories = eventCategoryRepo.findByEvent(event);
+        for (EventCategory cat : categories) {
+            List<EventCategoryParticipant> ecps = eventCategoryParticipantRepo.findByEventCategory(cat);
+            for (EventCategoryParticipant ecp : ecps) {
+                // 1a. AuditionFeedback
+                auditionFeedbackRepository.deleteByEventCategoryParticipant(ecp);
+                // 1b. Scores (all judges)
+                scoreRepo.deleteAllByEventCategoryParticipant(ecp);
+                // 1c. Category participant members
+                eventCategoryParticipantMemberRepo.deleteByEventCategoryParticipant(ecp);
+            }
+            // 1d. EventCategoryParticipants for this category
+            eventCategoryParticipantRepo.deleteByEventCategory(cat);
+        }
+
+        // 2. EventParticipants and team members
+        List<EventParticipant> participants = eventParticipantRepo.findByEvent(event);
+        for (EventParticipant ep : participants) {
+            eventParticipantTeamMemberRepo.deleteByEventParticipant(ep);
+        }
+        eventParticipantRepo.deleteByEvent(event);
+
+        // 3. ScoringCriteria (event-level and category-level)
+        scoringCriteriaRepo.deleteByEvent(event);
+        for (EventCategory cat : categories) {
+            scoringCriteriaRepo.deleteByEventCategory(cat);
+        }
+
+        // 4. Feedback tags and groups (event-scoped)
+        feedbackTagRepository.deleteAll(feedbackTagRepository.findByEventEventId(eventId));
+        feedbackTagGroupRepository.deleteAll(feedbackTagGroupRepository.findByEventEventId(eventId));
+
+        // 5. Battle guests
+        eventCategoryBattleGuestRepo.deleteByEvent(event);
+
+        // 6. Pickup crews (members cascade via orphanRemoval)
+        List<PickupCrew> crews = pickupCrewRepo.findByEvent(event);
+        pickupCrewRepo.deleteAll(crews);
+
+        // 7. Session tokens
+        sessionTokenRepository.deleteAll(sessionTokenRepository.findByEvent_EventId(eventId));
+
+        // 8. Battle state
+        battleCategoryStateRepository.deleteAll(battleCategoryStateRepository.findByEventName(eventName));
+
+        // 8b. Battle active category
+        battleActiveCategoryRepository.deleteByEventName(eventName);
+
+        // 9. Clear event_judge join table
+        List<Judge> eventJudges = judgeRepo.findJudgesByEventId(eventId);
+        for (Judge judge : eventJudges) {
+            judgeRepo.deleteEventJudge(eventId, judge.getJudgeId());
+        }
+
+        // 9b. Clear event_category_judge join table — clear each category's judges list
+        for (EventCategory cat : categories) {
+            cat.getJudges().clear();
+            eventCategoryRepo.save(cat);
+        }
+
+        // 10. Email template
+        eventEmailTemplateRepo.findByEvent_EventId(eventId)
+            .ifPresent(eventEmailTemplateRepo::delete);
+
+        // 11. EventCategories
+        eventCategoryRepo.deleteByEvent(event);
+
+        // 12. Clear organiser_event join table
+        List<Account> organisers = accountRepository.findByRole("ORGANISER");
+        for (Account org : organisers) {
+            List<Event> assigned = org.getAssignedEvents();
+            if (assigned != null && assigned.removeIf(e -> e.getEventId().equals(eventId))) {
+                accountRepository.save(org);
+            }
+        }
+
+        // 13. Finally
+        repo.delete(event);
     }
 }

--- a/BES/src/main/java/com/example/BES/services/SessionTokenService.java
+++ b/BES/src/main/java/com/example/BES/services/SessionTokenService.java
@@ -91,4 +91,8 @@ public class SessionTokenService {
             .filter(t -> t.getExpiresAt().isAfter(LocalDateTime.now()))
             .collect(Collectors.toList());
     }
+
+    public String getJudgeName(Long judgeId) {
+        return judgeRepo.findById(judgeId).map(j -> j.getName()).orElse(null);
+    }
 }

--- a/docs/superpowers/plans/2026-06-17-access-management.md
+++ b/docs/superpowers/plans/2026-06-17-access-management.md
@@ -1,0 +1,898 @@
+# Access Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Grant Helper read-only Score access with tie-breaker, hide AuditionList UI from Organiser, and add Admin event deletion with full cascade cleanup.
+
+**Architecture:** Three independent feature changes touching the same layers (backend controller/service, frontend router, navigation components, views). Event deletion is the largest piece — new backend endpoint + service method + frontend UI with two-step confirmation. All changes follow existing patterns: `@PreAuthorize` annotations on controllers, `allowedRoles` in router meta, role-gated tiles in EventPanel, and the existing API fetch pattern.
+
+**Tech Stack:** Spring Boot (Java), Vue 3 (Composition API), PostgreSQL, Flyway (no migration needed — no schema changes)
+
+## Global Constraints
+
+- Score modification stays in AuditionList only — Score.vue is display-only for all roles
+- Organiser keeps backend and route access to AuditionList — only UI surfaces hidden
+- Event deletion must clean ALL related data in dependency order within @Transactional
+- No JPA cascade configuration changes — manual cleanup for explicitness
+- All new backend endpoints use `@PreAuthorize("hasRole('ADMIN')")`
+- Frontend API calls follow existing pattern: `fetch()` with `credentials: 'include'`, `res.ok` check, `console.error` on catch
+
+---
+
+### Task 1: Add HELPER to backend Score read endpoints
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/controllers/EventController.java:587`
+
+**Interfaces:**
+- Produces: `GET /api/v1/event/scores/{eventName}` now accessible to HELPER role
+
+- [ ] **Step 1: Add HELPER to @PreAuthorize on GET scores**
+
+Change line 587 from:
+```java
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'JUDGE')")
+```
+to:
+```java
+@PreAuthorize("hasAnyRole('ADMIN', 'ORGANISER', 'EMCEE', 'JUDGE', 'HELPER')")
+```
+
+No other backend changes needed — the other Score-dependent read endpoints (`GET /{eventName}/criteria`, `GET /{eventName}/categories`, `GET /{eventName}/results-status`, `GET /{eventName}/feedback-tags`) are already public or already include HELPER.
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `cd BES && mvn compile -q`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/controllers/EventController.java
+git commit -m "feat: allow HELPER to read scores endpoint
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add Helper to Score route in frontend router
+
+**Files:**
+- Modify: `BES-frontend/src/router/index.js:75`
+
+**Interfaces:**
+- Produces: `/event/score` route now allows `ROLE_HELPER`
+
+- [ ] **Step 1: Add ROLE_HELPER to Score route allowedRoles**
+
+Change line 75 from:
+```js
+meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_EMCEE', 'ROLE_ORGANISER'], requiresEvent: true }
+```
+to:
+```js
+meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_EMCEE', 'ROLE_ORGANISER', 'ROLE_HELPER'], requiresEvent: true }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/router/index.js
+git commit -m "feat: allow HELPER role to access Score route
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add Helper to Score tile in EventPanel
+
+**Files:**
+- Modify: `BES-frontend/src/components/EventPanel.vue:32`
+
+**Interfaces:**
+- Produces: Score tile visible to Helper in the slide-over nav panel
+
+- [ ] **Step 1: Add ROLE_HELPER to Score tile roles**
+
+Change line 32 from:
+```js
+{ key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE'] },
+```
+to:
+```js
+{ key: 'score',        icon: 'pi-chart-bar', label: 'Score',        roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_HELPER'] },
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/components/EventPanel.vue
+git commit -m "feat: show Score tile to HELPER in EventPanel
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Show Scoreboard card to Helper in MainMenu
+
+**Files:**
+- Modify: `BES-frontend/src/views/MainMenu.vue:103-104`
+
+**Interfaces:**
+- Consumes: `role` computed from authStore (already defined)
+- Produces: Scoreboard quick-action card visible to Helper
+
+- [ ] **Step 1: Add ROLE_HELPER to Scoreboard card v-if guard**
+
+Change lines 103-104 from:
+```html
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE')"
+          :to="{ name: 'Score' }"
+```
+to:
+```html
+        <router-link
+          v-if="activeEvent && (role === 'ROLE_ADMIN' || role === 'ROLE_ORGANISER' || role === 'ROLE_EMCEE' || role === 'ROLE_HELPER')"
+          :to="{ name: 'Score' }"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/views/MainMenu.vue
+git commit -m "feat: show Scoreboard card to HELPER on home screen
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Add Helper support in Score.vue
+
+**Files:**
+- Modify: `BES-frontend/src/views/Score.vue:23-24` (add isHelper computed)
+- Modify: `BES-frontend/src/views/Score.vue:622` (results-release guard)
+- Modify: `BES-frontend/src/views/Score.vue:762,768,786,792` (row action buttons)
+
+**Interfaces:**
+- Consumes: `userRole` computed from authStore (already defined)
+- Produces: `isHelper` computed; tie-breaker panel accessible to Helper; row action buttons (breakdown, feedback, QR) stay Admin/Organiser-only
+
+- [ ] **Step 1: Add isHelper computed**
+
+After line 24 (`const isAdminOrOrganiser = ...`), add:
+```js
+const isHelper = computed(() => userRole.value === 'ROLE_HELPER')
+```
+
+- [ ] **Step 2: Update mode default for Helper**
+
+Change line 32 from:
+```js
+return userRole.value === 'ROLE_EMCEE' ? 'broadcast' : 'control'
+```
+to:
+```js
+return (userRole.value === 'ROLE_EMCEE' || userRole.value === 'ROLE_HELPER') ? 'broadcast' : 'control'
+```
+
+- [ ] **Step 3: Keep results-release toggle Admin/Organiser-only (no change needed)**
+
+Line 622 already uses `v-if="isAdminOrOrganiser && mode === 'control'"` — no change needed. Helper won't see it.
+
+- [ ] **Step 4: Keep row action buttons Admin/Organiser-only (no change needed)**
+
+Lines 762, 768, 786, 792 already use `v-if="isAdminOrOrganiser"` — no change needed. Helper won't see breakdown/feedback/QR buttons.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/views/Score.vue
+git commit -m "feat: add isHelper to Score — defaults to broadcast, tie-breaker accessible
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Add Score link to HelperSessionView
+
+**Files:**
+- Modify: `BES-frontend/src/views/HelperSessionView.vue:123-144` (nav-list section)
+
+**Interfaces:**
+- Consumes: `router` (already imported), `authStore.activeEvent` (already available)
+- Produces: Score navigation button in Helper session hub
+
+- [ ] **Step 1: Add goToScore function**
+
+After the `goToEventDetails` function (line 75), add:
+```js
+function goToScore() {
+  if (authStore.activeEvent) {
+    router.push({ name: 'Score' })
+  }
+}
+```
+
+- [ ] **Step 2: Add Score navigation button in template**
+
+After the "Audition Screen" button (line 143) and before the closing `</div>` of `nav-list`, add:
+```html
+        <button
+          @click="goToScore"
+          class="nav-btn"
+        >
+          <i class="pi pi-chart-bar nav-btn-icon" aria-hidden="true"></i>
+          <span class="nav-btn-label">Scoreboard</span>
+        </button>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/views/HelperSessionView.vue
+git commit -m "feat: add Scoreboard link to HelperSessionView
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Hide AuditionList UI from Organiser
+
+**Files:**
+- Modify: `BES-frontend/src/components/EventPanel.vue:30` (audition tile roles)
+- Modify: `BES-frontend/src/views/MainMenu.vue:80` (Audition card guard)
+
+**Interfaces:**
+- Produces: Audition List tile hidden from Organiser in EventPanel; Audition card hidden from Organiser in MainMenu. Router and backend unchanged.
+
+- [ ] **Step 1: Remove ROLE_ORGANISER from audition tile in EventPanel**
+
+Change line 30 from:
+```js
+{ key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
+```
+to:
+```js
+{ key: 'audition',     icon: 'pi-list',      label: 'Audition',     roles: ['ROLE_ADMIN', 'ROLE_EMCEE', 'ROLE_JUDGE'] },
+```
+
+- [ ] **Step 2: Hide Audition card from Organiser in MainMenu**
+
+Change line 80 from:
+```html
+          v-if="activeEvent && role !== 'ROLE_HELPER'"
+```
+to:
+```html
+          v-if="activeEvent && role !== 'ROLE_HELPER' && role !== 'ROLE_ORGANISER'"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/components/EventPanel.vue BES-frontend/src/views/MainMenu.vue
+git commit -m "feat: hide AuditionList UI from Organiser (nav surfaces only)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Backend — Event deletion service and controller
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/services/EventService.java` (add autowired repos + deleteEvent method)
+- Modify: `BES/src/main/java/com/example/BES/controllers/EventController.java` (add DELETE endpoint)
+- Possibly modify: Individual repository files (add missing query methods where needed)
+
+**Interfaces:**
+- Consumes: Existing repository beans
+- Produces: `EventService.deleteEvent(String eventName)` — deletes event and ALL related data within `@Transactional`
+- Produces: `DELETE /api/v1/event/{eventName}` — Admin-only endpoint
+
+**Repository method availability (verified from codebase):**
+
+| Repository Bean | Has `findBy*` | Has `deleteBy*` | Notes |
+|---|---|---|---|
+| `EventCategoryRepo` | `findByEvent(Event)` | None | Need to add `deleteByEvent` or use `deleteAll` |
+| `EventCategoryParticipantRepo` | `findByEventCategory(EventCategory)` | None | Need to add bulk delete or use `deleteAll` |
+| `AuditionFeedbackRepository` | `findByEventCategoryParticipant(ECP)` | None | Need `@Modifying @Query` for bulk delete |
+| `ScoreRepo` | `findByEventCategoryParticipant(ECP)` | `deleteByEventCategoryParticipantAndJudge(ECP, Judge)` only | Need `@Modifying @Query` to delete all scores for an ECP (regardless of judge) |
+| `EventCategoryParticipantMemberRepo` | None | None | Need `deleteByEventCategoryParticipant` |
+| `EventParticipantRepo` | `findByEvent(Event)` | None | Need `deleteByEvent` |
+| `EventParticipantTeamMemberRepo` | None | `deleteByEventParticipant(EP)` | ✅ exists |
+| `ScoringCriteriaRepo` | `findByEventAndEventCategory(Event, EC)` | None | Need `@Modifying @Query` to delete by event only and by event+category |
+| `FeedbackTagRepository` | `findByEventEventId(Long)` | None | Use `deleteAll(findByEventEventId(...))` |
+| `FeedbackTagGroupRepository` | `findByEventEventId(Long)` | None | Use `deleteAll(findByEventEventId(...))` |
+| `EventCategoryBattleGuestRepo` | `findByEvent(Event)` | None | Need `deleteByEvent` |
+| `PickupCrewRepo` | `findByEventAndEventCategory(Event, EC)` | None | Need `findByEvent` — add to repo; members cascade via `CascadeType.ALL, orphanRemoval=true` |
+| `SessionTokenRepository` | `findByEvent_EventId(Long)` | None | Use `deleteAll(findByEvent_EventId(...))` |
+| `BattleCategoryStateRepository` | `findByEventName(String)` | None | Use `deleteAll(findByEventName(...))` |
+| `BattleActiveCategoryRepository` | None (empty interface) | None | Need `findByEventName` + `@Modifying @Query` to delete by event name |
+| `EventEmailTemplateRepo` | `findByEvent_EventId(Long)` | None | Delete the single entity found |
+| `JudgeRepo` | `findJudgesByEventId(Long)` | `deleteEventJudge(Long, Long)` (individual only) | Clear join tables by iterating judges |
+| `AccountRepository` | `findByRole(String)` | — | Clear `organiser_event` via `Account.assignedEvents.removeIf()` |
+
+**Strategy:** For repos lacking bulk-delete methods, use `deleteAll(findByXxx(...))` where the finder exists (simplest, still within `@Transactional`). For repos lacking both, add the minimal Spring Data derived method or `@Modifying @Query`.
+
+- [ ] **Step 1: Add missing repository methods**
+
+Add these methods to the respective repository files (only if they don't already exist):
+
+**EventCategoryParticipantRepo.java** — add:
+```java
+void deleteByEventCategory(EventCategory eventCategory);
+```
+
+**EventCategoryParticipantMemberRepo.java** — add:
+```java
+void deleteByEventCategoryParticipant(EventCategoryParticipant ecp);
+```
+
+**AuditionFeedbackRepository.java** — add:
+```java
+@Modifying
+@Transactional
+void deleteByEventCategoryParticipant(EventCategoryParticipant ecp);
+```
+
+**ScoreRepo.java** — add:
+```java
+@Modifying
+@Transactional
+@Query("DELETE FROM Score s WHERE s.eventCategoryParticipant = :ecp")
+void deleteAllByEventCategoryParticipant(@Param("ecp") EventCategoryParticipant ecp);
+```
+
+**EventParticipantRepo.java** — add:
+```java
+void deleteByEvent(Event event);
+```
+
+**ScoringCriteriaRepo.java** — add:
+```java
+@Modifying
+@Transactional
+@Query("DELETE FROM ScoringCriteria sc WHERE sc.event = :event")
+void deleteByEvent(@Param("event") Event event);
+
+@Modifying
+@Transactional
+@Query("DELETE FROM ScoringCriteria sc WHERE sc.eventCategory = :category")
+void deleteByEventCategory(@Param("category") EventCategory category);
+```
+
+**EventCategoryBattleGuestRepo.java** — add:
+```java
+void deleteByEvent(Event event);
+```
+
+**PickupCrewRepo.java** — add:
+```java
+List<PickupCrew> findByEvent(Event event);
+void deleteByEvent(Event event);
+```
+
+**EventCategoryRepo.java** — add:
+```java
+void deleteByEvent(Event event);
+```
+
+**BattleActiveCategoryRepository.java** — add:
+```java
+Optional<BattleActiveCategory> findByEventName(String eventName);
+
+@Modifying
+@Transactional
+@Query("DELETE FROM BattleActiveCategory b WHERE b.eventName = :eventName")
+void deleteByEventName(@Param("eventName") String eventName);
+```
+
+- [ ] **Step 2: Add autowired fields to EventService.java**
+
+Add these imports (combine with existing):
+```java
+import com.example.BES.respositories.*;
+import com.example.BES.models.*;
+import java.util.List;
+```
+
+Add these `@Autowired` fields inside the class. Existing fields (`repo`, `accountRepository`, `emailTemplateService`, `messagingTemplate`) stay. Add the rest:
+
+```java
+@Autowired
+private ScoreRepo scoreRepo;
+
+@Autowired
+private AuditionFeedbackRepository auditionFeedbackRepository;
+
+@Autowired
+private EventCategoryParticipantRepo eventCategoryParticipantRepo;
+
+@Autowired
+private EventCategoryParticipantMemberRepo eventCategoryParticipantMemberRepo;
+
+@Autowired
+private EventParticipantRepo eventParticipantRepo;
+
+@Autowired
+private EventParticipantTeamMemberRepo eventParticipantTeamMemberRepo;
+
+@Autowired
+private ScoringCriteriaRepo scoringCriteriaRepo;
+
+@Autowired
+private FeedbackTagRepository feedbackTagRepository;
+
+@Autowired
+private FeedbackTagGroupRepository feedbackTagGroupRepository;
+
+@Autowired
+private EventCategoryBattleGuestRepo eventCategoryBattleGuestRepo;
+
+@Autowired
+private PickupCrewRepo pickupCrewRepo;
+
+@Autowired
+private SessionTokenRepository sessionTokenRepository;
+
+@Autowired
+private BattleCategoryStateRepository battleCategoryStateRepository;
+
+@Autowired
+private BattleActiveCategoryRepository battleActiveCategoryRepository;
+
+@Autowired
+private EventEmailTemplateRepo eventEmailTemplateRepo;
+
+@Autowired
+private EventCategoryRepo eventCategoryRepo;
+
+@Autowired
+private JudgeRepo judgeRepo;
+```
+
+- [ ] **Step 3: Add deleteEvent method to EventService.java**
+
+Add at end of class (before final `}`):
+
+```java
+@Transactional
+public void deleteEvent(String eventName) {
+    Event event = repo.findByEventName(eventName)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+
+    Long eventId = event.getEventId();
+
+    // 1. Categories and their children
+    List<EventCategory> categories = eventCategoryRepo.findByEvent(event);
+    for (EventCategory cat : categories) {
+        List<EventCategoryParticipant> ecps = eventCategoryParticipantRepo.findByEventCategory(cat);
+        for (EventCategoryParticipant ecp : ecps) {
+            // 1a. AuditionFeedback
+            auditionFeedbackRepository.deleteByEventCategoryParticipant(ecp);
+            // 1b. Scores (all judges)
+            scoreRepo.deleteAllByEventCategoryParticipant(ecp);
+            // 1c. Category participant members
+            eventCategoryParticipantMemberRepo.deleteByEventCategoryParticipant(ecp);
+        }
+        // 1d. EventCategoryParticipants for this category
+        eventCategoryParticipantRepo.deleteByEventCategory(cat);
+    }
+
+    // 2. EventParticipants and team members
+    List<EventParticipant> participants = eventParticipantRepo.findByEvent(event);
+    for (EventParticipant ep : participants) {
+        eventParticipantTeamMemberRepo.deleteByEventParticipant(ep);
+    }
+    eventParticipantRepo.deleteByEvent(event);
+
+    // 3. ScoringCriteria (event-level and category-level)
+    scoringCriteriaRepo.deleteByEvent(event);
+    for (EventCategory cat : categories) {
+        scoringCriteriaRepo.deleteByEventCategory(cat);
+    }
+
+    // 4. Feedback tags and groups (event-scoped)
+    feedbackTagRepository.deleteAll(feedbackTagRepository.findByEventEventId(eventId));
+    feedbackTagGroupRepository.deleteAll(feedbackTagGroupRepository.findByEventEventId(eventId));
+
+    // 5. Battle guests
+    eventCategoryBattleGuestRepo.deleteByEvent(event);
+
+    // 6. Pickup crews (members cascade via orphanRemoval)
+    List<PickupCrew> crews = pickupCrewRepo.findByEvent(event);
+    pickupCrewRepo.deleteAll(crews);  // cascade deletes members
+
+    // 7. Session tokens
+    sessionTokenRepository.deleteAll(sessionTokenRepository.findByEvent_EventId(eventId));
+
+    // 8. Battle state
+    battleCategoryStateRepository.deleteAll(battleCategoryStateRepository.findByEventName(eventName));
+
+    // 8b. Battle active category
+    battleActiveCategoryRepository.deleteByEventName(eventName);
+
+    // 9. Clear event_judge join table
+    List<Judge> eventJudges = judgeRepo.findJudgesByEventId(eventId);
+    for (Judge judge : eventJudges) {
+        judgeRepo.deleteEventJudge(eventId, judge.getJudgeId());
+    }
+
+    // 9b. Clear event_category_judge join table — clear each category's judges list
+    for (EventCategory cat : categories) {
+        cat.getJudges().clear();
+        eventCategoryRepo.save(cat);
+    }
+
+    // 10. Email template
+    eventEmailTemplateRepo.findByEvent_EventId(eventId)
+        .ifPresent(eventEmailTemplateRepo::delete);
+
+    // 11. EventCategories
+    eventCategoryRepo.deleteByEvent(event);
+
+    // 12. Clear organiser_event join table
+    List<Account> organisers = accountRepository.findByRole("ORGANISER");
+    for (Account org : organisers) {
+        List<Event> assigned = org.getAssignedEvents();
+        if (assigned != null && assigned.removeIf(e -> e.getEventId().equals(eventId))) {
+            accountRepository.save(org);
+        }
+    }
+
+    // 13. Finally
+    repo.delete(event);
+}
+```
+
+- [ ] **Step 4: Add DELETE endpoint to EventController.java**
+
+Add this method to EventController.java (near the other DELETE endpoints):
+```java
+@Operation(summary = "Delete Event", description = "Permanently deletes an event and ALL associated data — participants, categories, scores, feedback, battle state, session tokens. Admin only.")
+@DeleteMapping("/{eventName}")
+@PreAuthorize("hasRole('ADMIN')")
+public ResponseEntity<?> deleteEvent(@PathVariable String eventName) {
+    try {
+        eventService.deleteEvent(eventName);
+        return ResponseEntity.ok(Map.of("message", "Event '" + eventName + "' and all associated data deleted"));
+    } catch (ResponseStatusException e) {
+        return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+    } catch (Exception e) {
+        log.error("Error deleting event: {}", eventName, e);
+        return ResponseEntity.internalServerError().body(Map.of("error", "Failed to delete event: " + e.getMessage()));
+    }
+}
+```
+
+- [ ] **Step 5: Verify build compiles**
+
+Run: `cd BES && mvn compile -q`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/EventService.java \
+        BES/src/main/java/com/example/BES/controllers/EventController.java \
+        BES/src/main/java/com/example/BES/respositories/
+git commit -m "feat: add Admin event deletion with full cascade cleanup
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Frontend — deleteEvent API function
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js` (add deleteEvent function)
+
+**Interfaces:**
+- Produces: `deleteEvent(eventName)` — calls `DELETE /api/v1/event/{eventName}`
+
+- [ ] **Step 1: Add deleteEvent function**
+
+Add this function to `api.js` (near the other event functions, after `fetchAllEvents` around line 74):
+```js
+export const deleteEvent = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.error || `Delete failed (${res.status})`)
+    }
+    return await res.json()
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat: add deleteEvent API function
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Frontend — Delete button on EventCard with confirmation modal
+
+**Files:**
+- Modify: `BES-frontend/src/components/EventCard.vue` (add delete action + emit)
+- Modify: `BES-frontend/src/views/Events.vue` (handle delete, confirmation modal, refresh list)
+
+**Interfaces:**
+- Consumes: `deleteEvent` from api.js, existing EventCard emit pattern, `expandedId` state in Events.vue
+- Produces: Delete button on each EventCard (visible only to Admin); two-step confirmation modal in Events.vue
+
+- [ ] **Step 1: Add delete action to EventCard.vue**
+
+In `<script setup>`, add a new emit after the existing ones (line 8):
+```js
+const emit = defineEmits(['onDetails', 'onAudition', 'onParticipants', 'onScoreboard', 'onBattle', 'toggle', 'onDelete'])
+```
+
+Add a new action entry after "Battle" in the actions array (line 18):
+```js
+  { key: 'onDelete',      icon: 'pi-trash',     label: 'Delete'  },
+```
+
+Update the grid from `grid-cols-5` to `grid-cols-6` (line 59):
+```html
+        <div class="grid grid-cols-6">
+```
+
+- [ ] **Step 2: Add Delete button styling in EventCard.vue**
+
+The delete action button should use red styling. Modify the button in the action panel grid. Currently all buttons use the same classes. Add a conditional class for the delete action. Change line 60-68 from:
+```html
+          <button
+            v-for="action in actions"
+            :key="action.key"
+            @click.stop="emit(action.key)"
+            class="flex flex-col items-center gap-1.5 py-3.5 text-content-muted
+                   hover:text-accent hover:bg-[rgba(255,255,255,0.04)] transition-all duration-150"
+          >
+            <i class="pi text-base text-accent" :class="action.icon"></i>
+            <span class="type-label">{{ action.label }}</span>
+          </button>
+```
+to:
+```html
+          <button
+            v-for="action in actions"
+            :key="action.key"
+            @click.stop="emit(action.key)"
+            class="flex flex-col items-center gap-1.5 py-3.5 transition-all duration-150"
+            :class="action.key === 'onDelete'
+              ? 'text-content-muted hover:text-red-400 hover:bg-red-950/30'
+              : 'text-content-muted hover:text-accent hover:bg-[rgba(255,255,255,0.04)]'"
+          >
+            <i class="pi text-base" :class="[action.icon, action.key === 'onDelete' ? '' : 'text-accent']"></i>
+            <span class="type-label">{{ action.label }}</span>
+          </button>
+```
+
+- [ ] **Step 3: Wire delete handler in Events.vue**
+
+In `<script setup>`, add imports and state after existing refs:
+```js
+import { deleteEvent } from '@/utils/api'
+
+// ... after existing refs (line 14):
+const showDeleteModal = ref(false)
+const eventToDelete = ref(null)
+const deleteConfirmName = ref('')
+const deleteError = ref('')
+const deleting = ref(false)
+```
+
+Add handler functions:
+```js
+function openDeleteModal(event) {
+  eventToDelete.value = event
+  deleteConfirmName.value = ''
+  deleteError.value = ''
+  showDeleteModal.value = true
+  expandedId.value = null  // close the action panel
+}
+
+function closeDeleteModal() {
+  showDeleteModal.value = false
+  eventToDelete.value = null
+  deleteConfirmName.value = ''
+  deleteError.value = ''
+}
+
+async function confirmDelete() {
+  if (!eventToDelete.value || deleteConfirmName.value !== eventToDelete.value.folderName) return
+  deleting.value = true
+  deleteError.value = ''
+  try {
+    await deleteEvent(eventToDelete.value.folderName)
+    // Remove from local list
+    events.value = events.value.filter(e => e.folderID !== eventToDelete.value.folderID)
+    dbEvents.value = dbEvents.value.filter(e => e.name !== eventToDelete.value.folderName)
+    closeDeleteModal()
+  } catch (err) {
+    deleteError.value = err.message || 'Failed to delete event'
+  } finally {
+    deleting.value = false
+  }
+}
+```
+
+Add the `@onDelete` handler to the EventCard in the template (line 94-105):
+```html
+      <EventCard
+        v-for="event in filtered"
+        :key="event.folderID"
+        :buttonName="event.folderName"
+        :expanded="expandedId === event.folderID"
+        @toggle="toggleExpanded(event.folderID)"
+        @onDetails="goToEventDetails(event.folderName, event.folderID)"
+        @onAudition="activateAndGo(event.folderName, 'Audition List')"
+        @onParticipants="activateAndGo(event.folderName, 'Update Event Details')"
+        @onScoreboard="activateAndGo(event.folderName, 'Score')"
+        @onBattle="activateAndGo(event.folderName, 'Battle Control')"
+        @onDelete="openDeleteModal(event)"
+      />
+```
+
+- [ ] **Step 4: Add confirmation modal template to Events.vue**
+
+Add this modal at the end of the template, just before the closing `</div>` of the outer page-container div (after line 126, before the outermost `</div></div>`):
+
+```html
+    <!-- Delete Event Confirmation Modal -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div
+          v-if="showDeleteModal"
+          class="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style="background: rgba(0,0,0,0.8)"
+          @click.self="closeDeleteModal"
+        >
+          <div
+            class="w-full max-w-md p-6 flex flex-col gap-5"
+            style="background: #1a1a1a; border: 1px solid rgba(239,68,68,0.3); clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%)"
+          >
+            <!-- Header -->
+            <div class="flex items-center gap-3">
+              <div class="w-2.5 h-2.5 rounded-full bg-red-500 flex-shrink-0" style="box-shadow: 0 0 10px rgba(239,68,68,0.7)"></div>
+              <h2 class="type-page-title text-red-400" style="font-size: 20px">DELETE EVENT</h2>
+            </div>
+
+            <!-- Warning -->
+            <div class="px-4 py-3" style="border-left: 3px solid rgba(239,68,68,0.6); background: rgba(239,68,68,0.07)">
+              <p class="type-label text-red-300/90 mb-1">This will permanently delete:</p>
+              <p class="type-prose text-red-200/70">
+                <strong class="type-name text-red-300">{{ eventToDelete?.folderName }}</strong>
+                and ALL associated data — participants, categories, scores, feedback, battle state, and session tokens.
+                This cannot be undone.
+              </p>
+            </div>
+
+            <!-- Step 1: Initial warning -->
+            <div v-if="deleteConfirmName === ''">
+              <p class="type-prose text-content-muted mb-3">Type the event name to enable deletion.</p>
+              <input
+                v-model="deleteConfirmName"
+                type="text"
+                :placeholder="eventToDelete?.folderName"
+                class="input-base w-full"
+                autofocus
+              />
+            </div>
+
+            <!-- Step 2: Name matched — ready to delete -->
+            <div v-else-if="deleteConfirmName === eventToDelete?.folderName">
+              <p class="type-label text-red-400 mb-3">✓ Name confirmed. Ready to delete.</p>
+            </div>
+
+            <!-- Error -->
+            <div
+              v-if="deleteError"
+              class="px-3 py-2 type-label text-red-300"
+              style="border-left: 3px solid rgba(239,68,68,0.5); background: rgba(239,68,68,0.08)"
+            >
+              {{ deleteError }}
+            </div>
+
+            <!-- Actions -->
+            <div class="flex gap-3">
+              <button
+                @click="closeDeleteModal"
+                class="flex-1 py-2.5 type-label border border-surface-600 text-content-muted hover:text-content-primary transition-colors"
+                style="clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%)"
+                :disabled="deleting"
+              >CANCEL</button>
+              <button
+                @click="confirmDelete"
+                :disabled="deleteConfirmName !== eventToDelete?.folderName || deleting"
+                class="flex-1 py-2.5 type-label font-bold transition-all"
+                :class="deleteConfirmName === eventToDelete?.folderName && !deleting
+                  ? 'bg-red-600 text-white hover:bg-red-500'
+                  : 'bg-surface-700 text-content-muted cursor-not-allowed'"
+                style="clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%)"
+              >
+                <span v-if="deleting">DELETING…</span>
+                <span v-else>DELETE EVENT</span>
+              </button>
+            </div>
+
+            <!-- Tap outside hint -->
+            <p class="type-prose-sm text-content-muted/50 text-center">Tap outside to cancel</p>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES-frontend/src/components/EventCard.vue BES-frontend/src/views/Events.vue
+git commit -m "feat: add Admin delete event button with two-step confirmation
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Verify end-to-end
+
+**Files:** (none — manual verification)
+
+- [ ] **Step 1: Build backend**
+
+Run: `cd BES && mvn clean package -DskipTests`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 2: Build frontend**
+
+Run: `cd BES-frontend && npm run build`
+Expected: Build completes without errors
+
+- [ ] **Step 3: Run backend tests**
+
+Run: `cd BES && mvn test`
+Expected: All existing tests pass
+
+- [ ] **Step 4: Run frontend tests**
+
+Run: `cd BES-frontend && npm test`
+Expected: All existing tests pass
+
+- [ ] **Step 5: Commit if any build fixes were needed**
+
+```bash
+git add -A
+git commit -m "chore: build fixes for access management changes
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-06-17-access-management-design.md
+++ b/docs/superpowers/specs/2026-06-17-access-management-design.md
@@ -1,0 +1,119 @@
+# Access Management — Helper Score Access, Hide AuditionList from Organiser, Admin Delete Event
+
+**Date:** 2026-06-17
+**Branch:** (to be created)
+
+## 1. Helper Score Access (Read-only + Tie-breaker + Category Filter)
+
+Helper gains read-only access to the Score page. Score modification stays restricted to AuditionList for all roles — Score.vue is a display/announce surface, not an entry surface.
+
+### Changes
+
+| Layer | File | Change |
+|-------|------|--------|
+| Router | `BES-frontend/src/router/index.js` | Add `ROLE_HELPER` to Score route `allowedRoles` |
+| Backend | `BES/src/main/java/com/example/BES/controllers/EventController.java` | Add `HELPER` to `@PreAuthorize` on `GET /scores/{eventName}` |
+| Backend | `EventController.java` | Add `HELPER` to any other Score-dependent read endpoints: `GET /{eventName}/criteria`, `GET /{eventName}/categories`, `GET /{eventName}/results-status`, `GET /{eventName}/feedback-tags` (verify each — some may already be public) |
+| EventPanel | `BES-frontend/src/components/EventPanel.vue` | Add `ROLE_HELPER` to the Score tile's `roles` array |
+| MainMenu | `BES-frontend/src/views/MainMenu.vue` | Show Score quick-action card for Helper (currently gated by a role check that excludes Helper) |
+| Score.vue | `BES-frontend/src/views/Score.vue` | Add `isHelper` computed; Helper defaults to Broadcast mode but can switch to Control mode; tie-breaker panel and category filter accessible; results-release toggle stays Admin/Organiser-only |
+| HelperSessionView | `BES-frontend/src/views/HelperSessionView.vue` | Add a Score navigation link |
+
+### Access After Change
+
+| Role | View Scores | Category Filter | Tie-breaker | Release Results | Modify Scores |
+|------|:--:|:--:|:--:|:--:|:--:|
+| Admin | ✅ | ✅ | ✅ | ✅ | ❌ (AuditionList only) |
+| Organiser | ✅ | ✅ | ✅ | ✅ | ❌ (AuditionList only) |
+| Emcee | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Helper | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Judge | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## 2. Hide AuditionList UI from Organiser
+
+Organiser keeps backend/route access but the Audition List is removed from all navigation surfaces. They can still reach it via direct URL if needed.
+
+### Changes
+
+| Surface | File | Change |
+|---------|------|--------|
+| EventPanel tile | `BES-frontend/src/components/EventPanel.vue` | Remove `ROLE_ORGANISER` from audition tile `roles` |
+| MainMenu card | `BES-frontend/src/views/MainMenu.vue` | Add `role !== 'ROLE_ORGANISER'` to the Audition card guard |
+| Router | No change | Organiser keeps route access |
+| Backend | No change | Organiser keeps all AuditionList API access |
+
+## 3. Admin Delete Event
+
+Admin can delete an entire event from the Events list page. Two-step confirmation (warning → type event name to confirm). All related data is cleaned up in dependency order within a single transaction.
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `BES-frontend/src/utils/api.js` or `adminApi.js` | New `deleteEvent(eventName)` function → `DELETE /api/v1/event/{eventName}` |
+| `BES-frontend/src/views/Events.vue` | Delete button on each EventCard; two-step confirmation modal (inline or Teleport) |
+| `BES-frontend/src/components/EventCard.vue` | Expose delete trigger (via emit or slot) alongside existing action buttons |
+
+**Confirmation flow:**
+
+1. **Step 1 — Warning modal:** Red-accented, lists event name, warns that ALL data will be permanently deleted (participants, categories, scores, feedback, battle state, session tokens). Two buttons: "Cancel" / "Delete Event".
+2. **Step 2 — Type to confirm:** Admin must type the event name exactly to enable the final "Delete" button. This prevents accidental deletion.
+
+### Backend
+
+**New endpoint:** `DELETE /api/v1/event/{eventName}`
+- `@PreAuthorize("hasRole('ADMIN')")`
+- Returns `200` on success, `404` if event not found
+
+**New service method:** `EventService.deleteEvent(String eventName)`
+- `@Transactional` — all-or-nothing rollback
+- Deletion order (respecting foreign-key dependencies):
+
+```
+1. AuditionFeedback (by EventCategoryParticipant → EventCategory → Event)
+2. Scores (by EventCategoryParticipant → EventCategory → Event)
+3. EventCategoryParticipantMember (by EventCategoryParticipant)
+4. EventCategoryParticipant (by EventCategory)
+5. EventParticipantTeamMember (by EventParticipant)
+6. EventParticipant (by Event)
+7. ScoringCriteria (by Event + EventCategory)
+8. FeedbackTag (by eventId)
+9. FeedbackTagGroup (by eventId)
+10. EventCategoryBattleGuest (by Event)
+11. PickupCrewMember (by PickupCrew)
+12. PickupCrew (by Event)
+13. SessionToken (by eventId)
+14. BattleCategoryState (by eventId + categoryId)
+15. BattleActiveCategory (by eventName)
+16. event_category_judge join table entries
+17. event_judge join table entries
+18. EventEmailTemplate (by Event)
+19. EventCategory (by Event)
+20. organiser_event join table entries
+21. Event (final delete)
+```
+
+**New repository queries needed:**
+- `ScoreRepo`: delete by EventCategoryParticipant IDs
+- `AuditionFeedbackRepo`: delete by EventCategoryParticipant IDs
+- `EventCategoryParticipantRepo`: delete by EventCategory IDs
+- `EventParticipantRepo`: delete by Event
+- `ScoringCriteriaRepo`: delete by Event + EventCategory
+- `FeedbackTagRepo`: delete by eventId
+- `FeedbackTagGroupRepo`: delete by eventId
+- `EventCategoryBattleGuestRepo`: delete by Event
+- `PickupCrewRepo`: delete by eventId
+- `SessionTokenRepo`: delete by eventId
+- `BattleCategoryStateRepo`: delete by eventId
+- `BattleActiveCategoryRepo`: delete by eventName
+- `EventEmailTemplateRepo`: delete by eventId
+- `EventCategoryRepo`: delete by Event
+- `EventRepo`: delete by eventId
+
+## 4. Out of Scope
+
+- Score modification from Score.vue (stays in AuditionList only)
+- Organiser backend access changes for AuditionList
+- Event deletion from EventDetails page (Events list only)
+- Event archival / soft-delete
+- Cascade configuration on JPA entities (manual cleanup preferred for explicitness)


### PR DESCRIPTION
## Why this PR exists

This work was committed locally on 2026-06-17 but never pushed or PRed — discovered today because the v0.3.1 production deploy was missing the functionality. Rebased onto current master to ship.

## What's in it

### Admin event deletion (with cascade)
- `c32fbf3` Full cascade cleanup in backend (handles all related entities before delete)
- `29c3b78` `deleteEvent` API function on frontend
- `41abce6` Delete button + two-step confirmation modal on `EventCard`
- `b3859d3` Gate visibility to Admin only
- `c800e7b` UX fix — input stays visible while typing partial match
- `039cd73` Update `EventPanel` tile-count test

### Hide AuditionList UI from Organiser
- `19b6c7a` Nav surfaces only — backend access is unchanged. Audition list is judge/emcee territory; organisers oversee from `Score` and `EventDetails`. Compounded with master's HELPER + EMCEE filtering.

### Helper role expansion (read-only score visibility)
- `84e361d` Backend: HELPER can read scores endpoint
- `8216c78` Frontend: HELPER can route to `Score`
- `9184b2e` Score tile in `EventPanel` for HELPER
- `fb9ae68` Scoreboard card on `MainMenu` home for HELPER

### UX polish
- `7aac143` Category filter dropdown on check-in list
- `e3d3fa8` Standardised check-in list search + filter inline with registered list
- `c791b63` Replace Top N presets with a number input (max 64) — removes the broadcast/control mode toggle in the process
- `18cb97b` Self-explanatory session token URLs (`/auth/token/judge/Alice?t=…` instead of opaque `?token=…`)

### Cleanup
- `748e38a` Drop unused `onMounted` import and `isHelper` computed in `Score.vue` (orphaned after the broadcast-tab removal)

## Rebase notes

Three conflicts resolved against current master:
- **`HelperSessionView.vue`** — Took master. Master already has a `Score` nav-btn doing the same thing the branch's `Scoreboard` button did.
- **`MainMenu.vue`** — Merged intents. Audition tile now hidden from `HELPER` + `EMCEE` (master) + `ORGANISER` (branch).
- **`AuthController.java`** — Took master. Master's `buildTokenUrl()` helper already produces the self-explanatory URL format the branch was reaching for. Auto-merged complementary changes in `router/index.js` (route path params), `TokenAuth.vue` (display role/judge label), `SessionTokenService.java` (orphaned helper, harmless).

Two duplicate commits dropped automatically by `git rebase` (already-upstream patches).

## Release plan

After merge, this is a minor bump → `v0.4.0`.