### PR TITLE
chore: CI guard for migration bugs against real Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,52 @@ jobs:
         run: npm run lint
         working-directory: BES-frontend
 
+  migrations:
+    name: Migrations / Flyway against Postgres
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: besdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard against hash-named constraints
+        run: |
+          # Hibernate-generated FK constraint names (e.g. fk5nearhompurfhv6qrt792v4pj)
+          # differ per database. Migrations must not reference them by name —
+          # use a pg_constraint lookup instead.
+          if grep -rnE 'CONSTRAINT[[:space:]]+fk[a-z0-9]{20,}' \
+               BES/src/main/resources/db/migration/; then
+            echo "::error::Migration references a Hibernate-hash constraint name above."
+            echo "Hash names are database-specific and will fail in prod."
+            echo "Look up the constraint dynamically via pg_constraint instead."
+            exit 1
+          fi
+          echo "✓ No hash-named constraints found in migrations."
+      - name: Run all Flyway migrations
+        run: |
+          docker run --rm --network host \
+            -v "$GITHUB_WORKSPACE/BES/src/main/resources/db/migration:/flyway/sql" \
+            flyway/flyway \
+            -url=jdbc:postgresql://localhost:5432/besdb \
+            -user=postgres \
+            -password=test \
+            -connectRetries=10 \
+            migrate
+
   report:
     name: Report
     runs-on: ubuntu-latest
-    needs: [backend-build, backend-test, frontend-build, frontend-test, analysis]
+    needs: [backend-build, backend-test, frontend-build, frontend-test, analysis, migrations]
     if: always() && github.event_name == 'pull_request'
     permissions:
       pull-requests: write
@@ -126,6 +168,7 @@ jobs:
               'Frontend / Build': '${{ needs.frontend-build.result }}',
               'Frontend / Tests': '${{ needs.frontend-test.result }}',
               'Analysis':         '${{ needs.analysis.result }}',
+              'Migrations':       '${{ needs.migrations.result }}',
             }
 
             const icon = r => r === 'success' ? '✅ Pass' : r === 'skipped' ? '⏭️ Skipped' : '❌ Fail'


### PR DESCRIPTION
Replaces #164 (auto-closed when its base branch was deleted after #163 merged).

## Why

The v0.3.0 production deploy broke at Flyway V41 because the migration referenced a Hibernate-generated FK constraint **hash name** (`fk5nearhompurfhv6qrt792v4pj`) that differs per database. Our existing CI used H2 + JPA `create-drop` with Flyway **disabled**, so it never executed any migration SQL — the bug was undetectable until prod tried to run it.

#163 (already merged → v0.3.1) is the V41 fix. This PR is the guard so it can't happen again.

## What this adds

A new `migrations` job in `ci.yml`:

**Step 1 — Grep guard (instant, cheap)**

Fails CI if any migration matches `CONSTRAINT[[:space:]]+fk[a-z0-9]{20,}`:

```sql
ALTER TABLE event_category DROP CONSTRAINT fk5nearhompurfhv6qrt792v4pj;  -- ❌ blocked
```

Forces dynamic lookup via `pg_constraint` instead.

**Step 2 — Full migration run against Postgres 15**

Spins up `postgres:15-alpine` as a service and runs `flyway migrate` over all `V*.sql` files. Verified locally end-to-end: 47 migrations apply in ~270ms.

Catches:
- Hash-named constraints (via the grep)
- SQL syntax errors, missing tables, FK violations, anything else Postgres rejects (via the full run)

Defense in depth.

## Notes

- Single commit, rebased onto current master (post-#165).
- Was originally PR #164; auto-closed when its base `hotfix/v41-dynamic-fk-name` was deleted during the #163 merge. Same diff, fresh PR.