### PR TITLE
fix: hide Audition List from Organiser on Events grid and route

### DIFF
--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -2,9 +2,10 @@
 import { ref, computed } from 'vue'
 
 const props = defineProps({
-  buttonName: { type: String, required: true, default: '' },
-  expanded:   { type: Boolean, default: false },  // controlled by parent
-  isAdmin:    { type: Boolean, default: false },
+  buttonName:    { type: String,  required: true, default: '' },
+  expanded:      { type: Boolean, default: false },  // controlled by parent
+  isAdmin:       { type: Boolean, default: false },
+  showAudition:  { type: Boolean, default: true },
 })
 
 const emit = defineEmits(['onDetails', 'onAudition', 'onParticipants', 'onScoreboard', 'onBattle', 'toggle', 'onDelete'])
@@ -14,11 +15,15 @@ const isHovered = ref(false)  // desktop only
 const actions = computed(() => {
   const base = [
     { key: 'onDetails',      icon: 'pi-cog',      label: 'Details'  },
-    { key: 'onAudition',     icon: 'pi-list',      label: 'Audition' },
+  ]
+  if (props.showAudition) {
+    base.push({ key: 'onAudition', icon: 'pi-list', label: 'Audition' })
+  }
+  base.push(
     { key: 'onParticipants', icon: 'pi-users',     label: 'People'   },
     { key: 'onScoreboard',   icon: 'pi-chart-bar', label: 'Score'    },
     { key: 'onBattle',       icon: 'pi-bolt',      label: 'Battle'   },
-  ]
+  )
   if (props.isAdmin) {
     base.push({ key: 'onDelete', icon: 'pi-trash', label: 'Delete' })
   }
@@ -63,7 +68,7 @@ const actions = computed(() => {
         style="clip-path: polygon(6px 0%,100% 0%,calc(100% - 6px) 100%,0% 100%)"
         @click.stop="emit('toggle')"
       >
-        <div :class="['grid', props.isAdmin ? 'grid-cols-6' : 'grid-cols-5']">
+        <div class="grid" :style="{ gridTemplateColumns: `repeat(${actions.length}, minmax(0, 1fr))` }">
           <button
             v-for="action in actions"
             :key="action.key"

--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -66,7 +66,7 @@ const routes = [
         path: '/event/audition-list',
         name: 'Audition List',
         component: AuditionList,
-        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_ORGANISER', 'ROLE_EMCEE', 'ROLE_JUDGE'], requiresEvent: true }
+        meta: { allowedRoles: ['ROLE_ADMIN', 'ROLE_EMCEE', 'ROLE_JUDGE'], requiresEvent: true }
     },
     {
         path: '/event/score',

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -12,6 +12,7 @@ const dbEvents = ref([])
 const search  = ref('')
 const router  = useRouter()
 const isAdmin = ref(false)
+const isOrganiser = ref(false)
 const showDeleteModal = ref(false)
 const eventToDelete = ref(null)
 const deleteConfirmName = ref('')
@@ -79,7 +80,9 @@ async function confirmDelete() {
 
 onMounted(async () => {
   const authStore = useAuthStore()
-  isAdmin.value = authStore.user?.role?.[0]?.authority === 'ROLE_ADMIN'
+  const role = authStore.user?.role?.[0]?.authority
+  isAdmin.value = role === 'ROLE_ADMIN'
+  isOrganiser.value = role === 'ROLE_ORGANISER'
   events.value = await fetchAllFolderEvents()
   dbEvents.value = await fetchAllEvents() ?? []
 })
@@ -134,6 +137,7 @@ onMounted(async () => {
         :buttonName="event.folderName"
         :expanded="expandedId === event.folderID"
         :isAdmin="isAdmin"
+        :showAudition="!isOrganiser"
         @toggle="toggleExpanded(event.folderID)"
         @onDetails="goToEventDetails(event.folderName, event.folderID)"
         @onAudition="activateAndGo(event.folderName, 'Audition List')"


### PR DESCRIPTION
The v0.4.0 access-management work only hid the Audition tile on the **MainMenu home screen**. Organisers could still reach Audition List via:

1. **The action button on every EventCard** in the `/events` grid — not role-gated.
2. **Direct URL navigation** to `/event/audition-list` — router meta still included `ROLE_ORGANISER` in `allowedRoles`.

## Changes

- `EventCard.vue` — adds `showAudition` prop (default `true`). Grid template switched from `grid-cols-5/6` to a `repeat(N, ...)` style so it adapts to the variable action count.
- `Events.vue` — derives `isOrganiser` from the auth store and passes `:showAudition="!isOrganiser"`.
- `router/index.js` — drops `ROLE_ORGANISER` from the `Audition List` route's `allowedRoles`.

EventPanel (the navbar event chip dropdown) was already correct — Organiser was never in its audition tile roles. With this PR all four UI surfaces agree.

## Verification

- `npm run lint` clean
- `npm test` — 13 files, 129 tests pass

Ships as v0.4.1.