### PR TITLE
fix: hide Battle from PRO organisers + standardise 'People' → 'Participants' on EventCard

### DIFF
--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -21,7 +21,7 @@ const actions = computed(() => {
     base.push({ key: 'onAudition', icon: 'pi-list', label: 'Audition' })
   }
   base.push(
-    { key: 'onParticipants', icon: 'pi-users',     label: 'People'   },
+    { key: 'onParticipants', icon: 'pi-users',     label: 'Participants' },
     { key: 'onScoreboard',   icon: 'pi-chart-bar', label: 'Score'    },
   )
   if (props.showBattle) {

--- a/BES-frontend/src/components/EventCard.vue
+++ b/BES-frontend/src/components/EventCard.vue
@@ -6,6 +6,7 @@ const props = defineProps({
   expanded:      { type: Boolean, default: false },  // controlled by parent
   isAdmin:       { type: Boolean, default: false },
   showAudition:  { type: Boolean, default: true },
+  showBattle:    { type: Boolean, default: true },
 })
 
 const emit = defineEmits(['onDetails', 'onAudition', 'onParticipants', 'onScoreboard', 'onBattle', 'toggle', 'onDelete'])
@@ -22,8 +23,10 @@ const actions = computed(() => {
   base.push(
     { key: 'onParticipants', icon: 'pi-users',     label: 'People'   },
     { key: 'onScoreboard',   icon: 'pi-chart-bar', label: 'Score'    },
-    { key: 'onBattle',       icon: 'pi-bolt',      label: 'Battle'   },
   )
+  if (props.showBattle) {
+    base.push({ key: 'onBattle', icon: 'pi-bolt', label: 'Battle' })
+  }
   if (props.isAdmin) {
     base.push({ key: 'onDelete', icon: 'pi-trash', label: 'Delete' })
   }

--- a/BES-frontend/src/views/Events.vue
+++ b/BES-frontend/src/views/Events.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { fetchAllFolderEvents, fetchAllEvents, deleteEvent } from '@/utils/api'
 import { useAuthStore, setActiveEvent } from '@/utils/auth'
+import { useTierAccess } from '@/utils/useTierAccess'
 import EventCard from '@/components/EventCard.vue'
 import { useDelay } from '@/utils/utils'
 
@@ -13,6 +14,7 @@ const search  = ref('')
 const router  = useRouter()
 const isAdmin = ref(false)
 const isOrganiser = ref(false)
+const { battleEnabled } = useTierAccess()
 const showDeleteModal = ref(false)
 const eventToDelete = ref(null)
 const deleteConfirmName = ref('')
@@ -138,6 +140,7 @@ onMounted(async () => {
         :expanded="expandedId === event.folderID"
         :isAdmin="isAdmin"
         :showAudition="!isOrganiser"
+        :showBattle="battleEnabled"
         @toggle="toggleExpanded(event.folderID)"
         @onDetails="goToEventDetails(event.folderName, event.folderID)"
         @onAudition="activateAndGo(event.folderName, 'Audition List')"


### PR DESCRIPTION
Two small EventCard cleanups bundled together.

## 1. Hide Battle from PRO-tier organisers

EventPanel and MainMenu already gate the Battle tile via `resolveBattleEnabled` (ADMIN always, ORGANISER only when `tier === 'MAX'`), but EventCard always rendered the Battle action button on the `/events` grid regardless of tier.

- `EventCard.vue` — adds `showBattle` prop (default `true`).
- `Events.vue` — pulls `battleEnabled` from `useTierAccess()` and passes `:showBattle="battleEnabled"`.

## 2. Standardise 'People' → 'Participants'

Every other surface (MainMenu, EventPanel, the page title and section header on `Update Event Details`) says **Participants**. EventCard was the only outlier saying 'People'.

- `EventCard.vue` — label change only.

## Verification

- `npm run lint` clean
- `npm test` — 129 tests pass

Ships as v0.4.2.