### PR TITLE
fix: dedupe session tokens — at most one active token per recipient

### DIFF
--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1346,7 +1346,7 @@ onMounted(async () => {
       verifiedFormParticipants.value = await getVerifiedParticipantsByEvent(eventName.value)
       unverifiedParticipants.value = await getUnverifiedParticipantsDB(props.eventName)
       await fetchCheckinList()
-      loadSessionTokens()
+      await loadSessionTokens()
       const fb = await getFeedbackEnabled(props.eventName)
       if (fb && typeof fb.feedbackEnabled === 'boolean') feedbackEnabled.value = fb.feedbackEnabled
       await fetchJudgingMode()

--- a/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/SessionTokenRepository.java
@@ -16,4 +16,10 @@ public interface SessionTokenRepository extends JpaRepository<SessionToken, Stri
     List<SessionToken> findByEvent_EventIdAndRevokedFalse(Long eventId);
 
     List<SessionToken> findByEvent_EventId(Long eventId);
+
+    List<SessionToken> findByEvent_EventIdAndRoleAndJudge_JudgeIdAndRevokedFalse(
+        Long eventId, String role, Long judgeId);
+
+    List<SessionToken> findByEvent_EventIdAndRoleAndJudgeIsNullAndRevokedFalse(
+        Long eventId, String role);
 }

--- a/BES/src/main/java/com/example/BES/services/SessionTokenService.java
+++ b/BES/src/main/java/com/example/BES/services/SessionTokenService.java
@@ -51,6 +51,17 @@ public class SessionTokenService {
             }
         }
 
+        // Revoke any existing active token for the same (event, role, judge) tuple.
+        // Keeps the invariant: at most one active token per recipient. Prevents
+        // duplicates from concurrent loadSessionTokens auto-repair runs.
+        List<SessionToken> existing = (judgeId != null)
+            ? sessionTokenRepository.findByEvent_EventIdAndRoleAndJudge_JudgeIdAndRevokedFalse(eventId, role, judgeId)
+            : sessionTokenRepository.findByEvent_EventIdAndRoleAndJudgeIsNullAndRevokedFalse(eventId, role);
+        for (SessionToken old : existing) {
+            old.setRevoked(true);
+        }
+        if (!existing.isEmpty()) sessionTokenRepository.saveAll(existing);
+
         SessionToken token = new SessionToken();
         token.setTokenId(UUID.randomUUID().toString());
         token.setRole(role);

--- a/BES/src/main/resources/db/migration/V48__revoke_duplicate_session_tokens.sql
+++ b/BES/src/main/resources/db/migration/V48__revoke_duplicate_session_tokens.sql
@@ -1,0 +1,25 @@
+-- V48: Revoke duplicate session tokens
+--
+-- Historical bug: SessionTokenService.generateToken always created a new row
+-- without revoking an existing matching token, and EventDetails.vue had an
+-- auto-repair path that could fire concurrently. The result was multiple
+-- active JUDGE tokens for the same (event, judge), plus occasionally
+-- multiple EMCEE/HELPER tokens per event.
+--
+-- Going forward generateToken revokes existing matches first. This migration
+-- cleans up the historical duplicates: for each (event, role, judge)
+-- group with more than one active token, keep the most recently created
+-- one and mark the rest revoked.
+
+WITH ranked AS (
+    SELECT token_id,
+           ROW_NUMBER() OVER (
+               PARTITION BY event_id, role, judge_id
+               ORDER BY created_at DESC, token_id DESC
+           ) AS rn
+    FROM   session_token
+    WHERE  revoked = FALSE
+)
+UPDATE session_token
+SET    revoked = TRUE
+WHERE  token_id IN (SELECT token_id FROM ranked WHERE rn > 1);

--- a/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AuthControllerIntegrationTest.java
@@ -21,8 +21,10 @@ import com.example.BES.dtos.LoginDto;
 import com.example.BES.dtos.RedeemTokenDto;
 import com.example.BES.models.Event;
 import com.example.BES.models.Judge;
+import com.example.BES.models.SessionToken;
 import com.example.BES.respositories.EventRepo;
 import com.example.BES.respositories.JudgeRepo;
+import com.example.BES.respositories.SessionTokenRepository;
 import com.example.BES.services.SessionTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -46,6 +48,9 @@ public class AuthControllerIntegrationTest {
 
     @Autowired
     private SessionTokenService sessionTokenService;
+
+    @Autowired
+    private SessionTokenRepository sessionTokenRepository;
 
     private Event testEvent;
     private Judge testJudge;
@@ -155,6 +160,33 @@ public class AuthControllerIntegrationTest {
                 .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    public void testGenerateTokenRevokesExistingActiveTokenForSameJudge() throws Exception {
+        String firstTokenId  = sessionTokenService.generateToken("JUDGE", testEvent.getEventId(), testJudge.getJudgeId(), 7);
+        String secondTokenId = sessionTokenService.generateToken("JUDGE", testEvent.getEventId(), testJudge.getJudgeId(), 7);
+
+        SessionToken first  = sessionTokenRepository.findById(firstTokenId).orElseThrow();
+        SessionToken second = sessionTokenRepository.findById(secondTokenId).orElseThrow();
+
+        // Existing token must be revoked so at most one active token survives.
+        org.junit.jupiter.api.Assertions.assertTrue(first.isRevoked(),
+            "previous token for same (event, judge) should be revoked");
+        org.junit.jupiter.api.Assertions.assertFalse(second.isRevoked(),
+            "new token should be active");
+    }
+
+    @Test
+    public void testGenerateTokenRevokesExistingActiveEmceeTokenForEvent() throws Exception {
+        String firstTokenId  = sessionTokenService.generateToken("EMCEE", testEvent.getEventId(), null, 7);
+        String secondTokenId = sessionTokenService.generateToken("EMCEE", testEvent.getEventId(), null, 7);
+
+        SessionToken first  = sessionTokenRepository.findById(firstTokenId).orElseThrow();
+        SessionToken second = sessionTokenRepository.findById(secondTokenId).orElseThrow();
+
+        org.junit.jupiter.api.Assertions.assertTrue(first.isRevoked());
+        org.junit.jupiter.api.Assertions.assertFalse(second.isRevoked());
     }
 
     @Test


### PR DESCRIPTION
## The bug

You had 5 judges but the Session Links list showed 8 entries — one judge (Rei) had 4 tokens. Root cause:

\`SessionTokenService.generateToken\` always created a fresh \`SessionToken\` row, never revoking an existing match. Combined with \`EventDetails.vue\`'s auto-repair path (which auto-creates missing JUDGE/EMCEE/HELPER tokens), and a missing \`await\` on one of its triggers, concurrent runs each saw "this judge needs a token" and each made one.

So yes — the reset/refresh hypothesis was correct. Any flow that re-triggers \`loadSessionTokens\` while a prior one is in flight produces a duplicate.

## Fix

**Service layer (single source of truth):**

\`SessionTokenService.generateToken\` now finds any existing active token for the same \`(event, role, judge)\` tuple and revokes it before creating the new one. Two \`SessionTokenRepository\` finders added:
- \`findByEvent_EventIdAndRoleAndJudge_JudgeIdAndRevokedFalse\` — for JUDGE tokens
- \`findByEvent_EventIdAndRoleAndJudgeIsNullAndRevokedFalse\` — for EMCEE / HELPER tokens (null judge)

**Frontend race tightening:**

- \`EventDetails.vue\` line 1349: added the missing \`await\` on \`loadSessionTokens()\` in the initial page-load chain.

**Historical data cleanup (V48 migration):**

Revokes existing duplicate tokens in prod. For each \`(event_id, role, judge_id)\` group with multiple active tokens, keeps the most recently created and marks the rest revoked. Rei's 3 extra tokens get swept up here.

\`\`\`sql
WITH ranked AS (
    SELECT token_id,
           ROW_NUMBER() OVER (
               PARTITION BY event_id, role, judge_id
               ORDER BY created_at DESC, token_id DESC
           ) AS rn
    FROM session_token
    WHERE revoked = FALSE
)
UPDATE session_token SET revoked = TRUE
WHERE token_id IN (SELECT token_id FROM ranked WHERE rn > 1);
\`\`\`

## Tests

Two new integration tests in \`AuthControllerIntegrationTest\`:
- \`testGenerateTokenRevokesExistingActiveTokenForSameJudge\`
- \`testGenerateTokenRevokesExistingActiveEmceeTokenForEvent\`

Local: 13/13 pass (11 prior + 2 new).

Ships as v0.4.3.