### PR TITLE
fix: pin session-role users (Judge/Emcee/Helper) to their token's event

### DIFF
--- a/BES-frontend/src/router/index.js
+++ b/BES-frontend/src/router/index.js
@@ -25,7 +25,7 @@ import JudgeSessionView from "@/views/JudgeSessionView.vue";
 import EmceeSessionView from "@/views/EmceeSessionView.vue";
 import HelperSessionView from "@/views/HelperSessionView.vue";
 import { whoami } from "@/utils/api";
-import { getActiveEvent, useAuthStore } from "@/utils/auth";
+import { getActiveEvent, setActiveEvent, useAuthStore } from "@/utils/auth";
 import { resolveBattleEnabled } from "@/utils/useTierAccess";
 
 const routes = [
@@ -227,6 +227,28 @@ router.beforeEach(async (to) => {
         }
         if (userRole === 'ROLE_HELPER' && to.name === 'Main') {
             return { name: 'HelperSession' }
+        }
+
+        // Session roles are PINNED to the event embedded in their token.
+        // The auth response (whoami / token redemption) carries user.eventId
+        // and user.eventName. If a session-role user opens a new tab or
+        // pastes a URL that resolves to a different event (i.e. sessionStorage
+        // has no activeEvent, or it points at the wrong event), force-set the
+        // activeEvent back to their token's event. Without this, an authed
+        // session user could navigate to any event whose route allows their
+        // role. Also block EventSelector for session roles — they have no
+        // legitimate reason to switch events.
+        const SESSION_ROLES = ['ROLE_JUDGE', 'ROLE_EMCEE', 'ROLE_HELPER']
+        if (SESSION_ROLES.includes(userRole) && user.eventId && user.eventName) {
+            const active = getActiveEvent()
+            if (!active || Number(active.id) !== Number(user.eventId)) {
+                setActiveEvent(user.eventId, user.eventName)
+            }
+            if (to.name === 'EventSelector') {
+                if (userRole === 'ROLE_JUDGE')  return { name: 'JudgeSession' }
+                if (userRole === 'ROLE_EMCEE')  return { name: 'EmceeSession' }
+                if (userRole === 'ROLE_HELPER') return { name: 'HelperSession' }
+            }
         }
 
         if (to.meta?.requiresEvent && !getActiveEvent()) {


### PR DESCRIPTION
## Security bug

A Helper / Emcee / Judge authed via a session link could paste an event-scoped URL into a new tab and end up viewing a **different event**. The new tab has its own \`sessionStorage\` so \`activeEvent\` was missing; the existing \`requiresEvent\` guard then redirected to \`EventSelector\` where the user could pick any event their role allows. Result: a session link tied to Event A let the user reach Event B.

## Fix

The auth response (\`whoami\` / token redemption) already carries \`user.eventId\` and \`user.eventName\` for session roles. The router guard now uses that as the single source of truth:

- **If \`activeEvent\` is missing or != \`user.eventId\`**, force-set it from \`user.eventId\` / \`user.eventName\` before evaluating any further guards.
- **Block \`EventSelector\` for session roles** — they have no legitimate reason to switch events, and exposing the picker re-introduces the bug. Redirect to their session hub instead.

## Scope note (defence in depth)

The proper backend fix is to constrain every event-scoped endpoint to \`user.eventId\` for session roles. That's a broader change. This PR closes the **immediate frontend leak** so a session link cannot bleed across events via UI navigation. I'll file a follow-up issue for the backend enforcement.

## Verification

- \`npm run lint\` clean
- \`npm test\` — 129 tests pass
- Manual: log in as Helper for Event A, paste \`/event/score\` into a new tab — now lands back on \`/helper/session\` for Event A instead of being able to pick Event B.