### PR TITLE
fix: slot-machine animation cycles the real audition pool, not 1..N

### DIFF
--- a/BES-frontend/src/views/AuditionNumber.vue
+++ b/BES-frontend/src/views/AuditionNumber.vue
@@ -76,7 +76,13 @@ function animateSlot(slotId, msg) {
     slot.person.categories.push(cat)
   }
 
-  const poolSize = msg.poolSize ?? 99
+  // Use the actual remaining-pool list when provided so the animation
+  // cycles through real numbers (e.g. {3, 15}) instead of the trivial
+  // 1..poolSize range. Fallback to 1..poolSize for older messages.
+  const pool = (Array.isArray(msg.pool) && msg.pool.length > 0)
+    ? msg.pool
+    : Array.from({ length: msg.poolSize ?? 99 }, (_, i) => i + 1)
+  const poolSize = pool.length
 
   // Skip animation if only one number is available
   if (poolSize === 1) {
@@ -92,7 +98,7 @@ function animateSlot(slotId, msg) {
   rollingCounters[intervalKey] = 0
   rollingIntervals[intervalKey] = setInterval(() => {
     rollingCounters[intervalKey] = (rollingCounters[intervalKey] + 1) % poolSize
-    fakeNums.value = { ...fakeNums.value, [intervalKey]: rollingCounters[intervalKey] + 1 }
+    fakeNums.value = { ...fakeNums.value, [intervalKey]: pool[rollingCounters[intervalKey]] }
   }, 80)
 
   setTimeout(() => {

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1150,7 +1150,10 @@ const checkinConfirm = ref({ show: false, participant: null, phase: 'confirm', r
 const dialogFakeNums = ref({})
 const dialogRollingIntervals = {}
 const dialogNumberQueue = []
-const categoryPoolSizes = ref({}) // { categoryName: poolSize }
+// { categoryName: number[] } — actual remaining-number pool, used to drive
+// the slot-machine animation so it cycles real numbers (e.g. {3, 15}) and
+// not 1..poolSize.
+const categoryPools = ref({})
 
 function processNextDialogNumber() {
   if (dialogNumberQueue.length === 0) {
@@ -1161,7 +1164,11 @@ function processNextDialogNumber() {
   const g = checkinConfirm.value.participant?.categories.find(x => x.categoryName === category)
   if (!g) { processNextDialogNumber(); return }
 
-  const poolSize = categoryPoolSizes.value[category] ?? 99
+  const pool = categoryPools.value[category]
+  const effectivePool = (Array.isArray(pool) && pool.length > 0)
+    ? pool
+    : Array.from({ length: 99 }, (_, i) => i + 1)
+  const poolSize = effectivePool.length
 
   // Skip animation if only one number is available
   if (poolSize === 1) {
@@ -1174,7 +1181,8 @@ function processNextDialogNumber() {
   g.rolling = true
   clearInterval(dialogRollingIntervals[category])
   dialogRollingIntervals[category] = setInterval(() => {
-    dialogFakeNums.value = { ...dialogFakeNums.value, [category]: Math.floor(Math.random() * poolSize) + 1 }
+    const pick = effectivePool[Math.floor(Math.random() * poolSize)]
+    dialogFakeNums.value = { ...dialogFakeNums.value, [category]: pick }
   }, 80)
 
   setTimeout(() => {
@@ -1216,14 +1224,14 @@ const closeCheckinDialog = () => {
   if (checkinConfirm.value.qrImageUrl) {
     URL.revokeObjectURL(checkinConfirm.value.qrImageUrl)
   }
-  // Clear pool sizes from completed check-in
+  // Clear pools from completed check-in
   if (checkinConfirm.value.participant) {
     checkinConfirm.value.participant.categories.forEach(g => {
       const key = g.categoryName
-      if (key in categoryPoolSizes.value) {
-        const next = { ...categoryPoolSizes.value }
+      if (key in categoryPools.value) {
+        const next = { ...categoryPools.value }
         delete next[key]
-        categoryPoolSizes.value = next
+        categoryPools.value = next
       }
     })
   }
@@ -1365,9 +1373,15 @@ onMounted(async () => {
     let refreshPending = false
     subscribeToChannel(wsClient, '/topic/audition/', (msg) => {
       if (msg.eventName !== props.eventName) return
-      // Store pool size for modal animation
-      if (msg.category && msg.poolSize !== undefined) {
-        categoryPoolSizes.value = { ...categoryPoolSizes.value, [msg.category]: msg.poolSize }
+      // Store the actual pool (array of remaining numbers) for the modal
+      // animation. Falls back gracefully when only poolSize is sent.
+      if (msg.category) {
+        if (Array.isArray(msg.pool)) {
+          categoryPools.value = { ...categoryPools.value, [msg.category]: msg.pool }
+        } else if (msg.poolSize !== undefined) {
+          const synthetic = Array.from({ length: msg.poolSize }, (_, i) => i + 1)
+          categoryPools.value = { ...categoryPools.value, [msg.category]: synthetic }
+        }
       }
       const participant = checkinList.value.find(p => p.participantId === msg.participantId)
       if (participant) {

--- a/BES/src/main/java/com/example/BES/services/EventCategoryParticipantService.java
+++ b/BES/src/main/java/com/example/BES/services/EventCategoryParticipantService.java
@@ -228,6 +228,10 @@ public class EventCategoryParticipantService {
             auditMsg.put("refCode", refCode != null ? refCode : "");
             auditMsg.put("format", participantInEventCategory.getFormat() != null ? participantInEventCategory.getFormat() : "");
             auditMsg.put("poolSize", pool.size());
+            // Send the actual pool of remaining numbers so the slot-machine
+            // animation cycles through what's truly available (e.g. {3, 15})
+            // instead of the trivial 1..poolSize range.
+            auditMsg.put("pool", new ArrayList<>(pool));
             messagingTemplate.convertAndSend("/topic/audition/", auditMsg);
         } else {
             messagingTemplate.convertAndSend("/topic/error/",


### PR DESCRIPTION
## Bug

When drawing audition numbers, the reel animation cycled \`1, 2, ..., poolSize\` where \`poolSize\` was the **count** of remaining numbers. If the actual remaining pool was \`{3, 15}\`, the reels showed \`1\` and \`2\` — visually wrong and inconsistent with the number that eventually landed.

## Fix

- **Backend** (\`EventCategoryParticipantService\`) — sends the actual \`pool\` array of remaining numbers in the \`/topic/audition/\` WebSocket message alongside the existing \`poolSize\`.
- **AuditionNumber.vue** — reads \`msg.pool\` and cycles through it. Falls back to \`1..poolSize\` if \`pool\` is absent, so a deploy-skew client still works during the transition.
- **EventDetails.vue** — same change for the check-in confirmation dialog. \`categoryPoolSizes\` (just the count) was renamed to \`categoryPools\` (the actual array).

## Verification

- \`npm run lint\` clean
- \`npm test\` — 129 tests pass
- \`mvn test\` — 235 tests pass
- Manual logic check: when only 3 and 15 remain, reel will now show \`3\` and \`15\` rotating, landing on the chosen one.