### PR TITLE
fix: three PAIR-mode rendering / selection bugs

### DIFF
--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -51,14 +51,22 @@ const rounds = computed(() => {
   return sorted.map(p => [p])
 })
 
-// Missing numbers between the current round and the next round
+// Missing numbers between the current round and the next round.
+// Guard against all-placeholder rounds: Math.max/min on an empty array
+// returns -Infinity/Infinity, which would turn the for-loop below into
+// an infinite loop (i = -Infinity, -Infinity + 1 === -Infinity in JS)
+// and freeze the tab. Easy to trigger in PAIR mode when both slots of a
+// round are unregistered (e.g. #51 + #52 both "Not Registered").
 const gapAfterCurrent = computed(() => {
   const current = currentRoundSlots.value
   if (!current.length) return []
   const nextRound = rounds.value[currentRound.value] // next round (0-indexed = currentRound)
   if (!nextRound || !nextRound.length) return []
-  const lastCurrent = Math.max(...current.filter(s => !s._placeholder).map(s => s.auditionNumber))
-  const firstNext = Math.min(...nextRound.filter(s => !s._placeholder).map(s => s.auditionNumber))
+  const currentReals = current.filter(s => !s._placeholder).map(s => s.auditionNumber)
+  const nextReals = nextRound.filter(s => !s._placeholder).map(s => s.auditionNumber)
+  if (!currentReals.length || !nextReals.length) return []
+  const lastCurrent = Math.max(...currentReals)
+  const firstNext = Math.min(...nextReals)
   if (firstNext - lastCurrent <= 1) return []
   const missing = []
   for (let i = lastCurrent + 1; i < firstNext; i++) missing.push(i)

--- a/BES-frontend/src/components/MiniScoreMenu.vue
+++ b/BES-frontend/src/components/MiniScoreMenu.vue
@@ -5,7 +5,7 @@ const props = defineProps({
   title: { type: String, default: 'Find Participant' },
 })
 
-const emit = defineEmits(['moveTo', 'close'])
+const emit = defineEmits(['moveTo', 'close', 'select'])
 
 // Snap stride = card width + gap. Cards are `width:100%` inside a
 // `px-2 gap-2` flex container, so each card is `clientWidth - 16` wide
@@ -33,6 +33,10 @@ const moveTo = (index) => {
     const el = pairSlides[pairIndex]
     if (el) scrollTo(el.parentElement, pairIndex)
   }
+  // Tell the parent which specific card was picked. In pair mode this
+  // lets PairScoreCards select the right slot (#54 instead of falling
+  // back to #53 — the default "first non-placeholder in pair").
+  emit('select', card)
   emit('close')
 }
 </script>

--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -126,32 +126,57 @@ const activeCard = computed(() =>
 // the upcoming currentIndex change (from the smooth-scroll settling)
 // honours the specific number the user tapped, instead of defaulting
 // to the first non-placeholder (i.e. always the odd one in a pair).
+//
+// We track the EXPECTED pair index too, because smooth-scroll fires
+// `scroll` events at every intermediate position. The watcher must
+// ignore those intermediates (they'd consume `pendingActiveNum` on the
+// very first transit) and only commit when we land on the right pair.
 const pendingActiveNum = ref(null)
+const pendingPairIndex = ref(null)
+let pendingTimeoutId = null
+
+const clearPending = () => {
+  pendingActiveNum.value = null
+  pendingPairIndex.value = null
+  if (pendingTimeoutId) { clearTimeout(pendingTimeoutId); pendingTimeoutId = null }
+}
 
 watch(currentIndex, () => {
   if (pendingActiveNum.value != null) {
+    // Still in transit — wait for the scroll to land on the expected
+    // pair. Don't reset activeParticipantNum mid-flight.
+    if (currentIndex.value !== pendingPairIndex.value) return
     const inPair = activePair.value.some(
       c => !c._placeholder && c.auditionNumber === pendingActiveNum.value
     )
     if (inPair) {
       activeParticipantNum.value = pendingActiveNum.value
-      pendingActiveNum.value = null
-      return
+    } else {
+      const first = activePair.value.find(c => !c._placeholder)
+      activeParticipantNum.value = first?.auditionNumber ?? null
     }
-    pendingActiveNum.value = null
+    clearPending()
+    return
   }
+  // Normal user-swipe: default to first non-placeholder
   const first = activePair.value.find(c => !c._placeholder)
   activeParticipantNum.value = first?.auditionNumber ?? null
 }, { immediate: true })
 
 // Called by the parent when the Find Participant menu picks a specific
-// audition number. Sets both the active value (so the UI updates if
-// we're already on the right pair) and a pending value (so any imminent
-// currentIndex change from the smooth scroll preserves the choice).
+// audition number. Sets the value immediately for instant feedback, and
+// stashes a pending intent so the watcher leaves it alone during the
+// smooth-scroll animation.
 function selectParticipant(auditionNumber) {
   if (auditionNumber == null) return
   pendingActiveNum.value = auditionNumber
+  pendingPairIndex.value = Math.floor((auditionNumber - 1) / 2)
   activeParticipantNum.value = auditionNumber
+  // Fail-safe: if the scroll never lands at the expected pair (e.g. the
+  // user interrupts by swiping), clear pending after 2s so normal
+  // auto-default behaviour resumes.
+  if (pendingTimeoutId) clearTimeout(pendingTimeoutId)
+  pendingTimeoutId = setTimeout(clearPending, 2000)
 }
 
 defineExpose({ selectParticipant })

--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -82,10 +82,17 @@ const pairs = computed(() => {
   return result
 })
 
+// Snap stride matches SwipeableCardsV2 / MiniScoreMenu: cards are
+// `width:100%` inside a `px-2 gap-2` flex container, so each pair takes
+// `clientWidth - 16` and the per-pair stride is `(clientWidth - 16) + 8`
+// = `clientWidth - 8`. Using `clientWidth + 8` underestimates the stride;
+// at higher indices the computed idx lags the actually-snapped pair by
+// 1, so the v-if-gated card body silently disappears (visible as a
+// blank "Select a participant" card around pair ~20+ on mobile).
 const getPairIndexFromScroll = () => {
   const container = scrollRef.value
   if (!container) return 0
-  const snapPoint = container.clientWidth + 8
+  const snapPoint = container.clientWidth - 8
   const biased = container.scrollLeft + snapPoint * 0.25
   const idx = Math.round(biased / snapPoint)
   return Math.max(0, Math.min(idx, pairs.value.length - 1))

--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -122,10 +122,39 @@ const activeCard = computed(() =>
   activePair.value.find(c => !c._placeholder && c.auditionNumber === activeParticipantNum.value) ?? null
 )
 
+// "Pending" desired participant — set by the Find Participant menu so
+// the upcoming currentIndex change (from the smooth-scroll settling)
+// honours the specific number the user tapped, instead of defaulting
+// to the first non-placeholder (i.e. always the odd one in a pair).
+const pendingActiveNum = ref(null)
+
 watch(currentIndex, () => {
+  if (pendingActiveNum.value != null) {
+    const inPair = activePair.value.some(
+      c => !c._placeholder && c.auditionNumber === pendingActiveNum.value
+    )
+    if (inPair) {
+      activeParticipantNum.value = pendingActiveNum.value
+      pendingActiveNum.value = null
+      return
+    }
+    pendingActiveNum.value = null
+  }
   const first = activePair.value.find(c => !c._placeholder)
   activeParticipantNum.value = first?.auditionNumber ?? null
 }, { immediate: true })
+
+// Called by the parent when the Find Participant menu picks a specific
+// audition number. Sets both the active value (so the UI updates if
+// we're already on the right pair) and a pending value (so any imminent
+// currentIndex change from the smooth scroll preserves the choice).
+function selectParticipant(auditionNumber) {
+  if (auditionNumber == null) return
+  pendingActiveNum.value = auditionNumber
+  activeParticipantNum.value = auditionNumber
+}
+
+defineExpose({ selectParticipant })
 
 const _aggregateDisplay = computed(() => {
   if (!hasCriteria.value || !activeCard.value) return null

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -40,6 +40,16 @@ const showModal = ref(false)
 const showMiniMenu = ref(false)
 const dynamicCallBack = ref(() => {})
 const emceeRoundRef = ref(null)
+const pairCardsRef = ref(null)
+
+// Find Participant menu picked a specific card. In PAIR mode we have to
+// tell PairScoreCards explicitly, otherwise its currentIndex watcher
+// snaps the active participant back to the first non-placeholder in the
+// pair (= always the odd number).
+function onFindParticipantSelect(card) {
+  if (!card || judgingMode.value !== 'PAIR') return
+  pairCardsRef.value?.selectParticipant(card.auditionNumber)
+}
 
 
 const dynamicRole = async () => {
@@ -1014,9 +1024,11 @@ onMounted(async () => {
         :show="showMiniMenu"
         title="Find Participant"
         @close="showMiniMenu = false"
+        @select="onFindParticipantSelect"
       />
       <PairScoreCards
         v-if="judgingMode === 'PAIR'"
+        ref="pairCardsRef"
         :cards="filteredParticipantsForJudge"
         :feedbackData="feedbackGiven"
         :criteria="criteria"


### PR DESCRIPTION
## Summary

Three related PAIR-mode bugs surfaced after v0.5.0. Bundled here since each fix is small.

### 1. Emcee tab freeze when a round is all placeholders (`EmceeRoundView.vue`)

When the current (or next) round had **every slot unregistered** — e.g. PAIR mode where both `#51` and `#52` are "Not Registered" — `gapAfterCurrent` computed `Math.max(...[])` which returns `-Infinity` in JS. The trailing for-loop became:

```js
for (let i = -Infinity + 1; i < firstNext; i++)
```

`-Infinity + 1 === -Infinity` in JS, so `i` never incremented, the condition stayed true forever, and the render hung mid-component. Symptom: entire NOW card (incl. PREV / NEXT buttons) never appeared, tab froze.

**Fix:** bail out of `gapAfterCurrent` early when either round has no real entries.

### 2. Judge PAIR card body blank at higher pair indices (`PairScoreCards.vue`)

`getPairIndexFromScroll` used `clientWidth + 8` for the snap stride — same class of bug already fixed in `MiniScoreMenu`. Cards are `width:100%` inside a `px-2 gap-2` container, so the real stride is `clientWidth - 8`. The wrong stride underestimates by 16 px per pair; at higher indices the computed `currentIndex` lags the actually-snapped pair by 1, breaking around pair 20 on mobile.

When `currentIndex` is wrong, `isActivePair(pairIdx)` returns false for the visible pair, the `v-if`-gated card body doesn't render, and the user sees a blank "Select a participant" card with audition-number selector buttons floating on the right.

**Fix:** use `clientWidth - 8` to match the other scroll-snap consumers.

### 3. Find Participant doesn't honour even-numbered pick in PAIR mode

Tapping an even-numbered participant (e.g. #54) in the Find Participant menu correctly scrolls to the right pair (#53/#54) but the active participant snapped to #53. The reason: `MiniScoreMenu` only scrolled the container; `PairScoreCards`' `currentIndex` watcher then fired on scroll-settle and force-set `activeParticipantNum` to the *first* non-placeholder in the pair — which is always the odd number when both slots are real.

**Fix:**
- `MiniScoreMenu` now emits a `select` event with the picked card.
- `PairScoreCards` exposes `selectParticipant(num)` which sets both the active value and a "pending" value that survives the imminent `currentIndex` change.
- `AuditionList` wires the two via a ref. No-op in SOLO mode.

## Test plan

**Emcee:**
- [ ] PAIR mode, round with both slots unregistered → NOW card renders, PREV/NEXT buttons visible, tab does not freeze.
- [ ] Sanity: a real + placeholder pair still shows gap markers as expected.

**Judge PAIR:**
- [ ] Swipe to pair 25+ → card body renders the score keypad, not just the selector buttons.
- [ ] Find Participant → tap an even-numbered participant (e.g. #54, #68) → scrolls to correct pair AND that specific participant is the active one (the buttons on the right reflect the highlight).
- [ ] Find Participant → tap an odd-numbered participant → still works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)