### PR TITLE
fix(score): tie-breaker resolved pool reaches BattleControl + category tab bar

### DIFF
--- a/BES-frontend/src/components/LiveMatchPanel.vue
+++ b/BES-frontend/src/components/LiveMatchPanel.vue
@@ -18,7 +18,6 @@ const smokeFormatTimerRef = ref(null)
 const props = defineProps({
   selectedEvent:             { type: String,  required: true },
   selectedCategory:          { type: String,  required: true },
-  uniqueCategories:          { type: Array,   default: () => [] },
   battlePhase:               { type: String,  required: true },
   battleJudges:              { type: Array,   default: () => [] },
   currentBattle:             { type: Array,   default: () => [] },
@@ -34,8 +33,6 @@ const props = defineProps({
   finalTieBlocked:           { type: Boolean, default: false },
   isReadonly:                { type: Boolean, default: false },
   isViewingNonActive:        { type: Boolean, default: false },
-  liveCategoryName:          { type: String,  default: '' },
-  livePhase:                 { type: String,  default: 'IDLE' },
   categoryChampions:         { type: Object,  default: () => ({}) },
   stompClient:               { type: Object,  default: null },
   overlayConfig:             { type: Object,  default: () => ({ leftColor: '#dc2626', rightColor: '#2563eb' }) },
@@ -47,7 +44,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits([
-  'request-category-change',
   'open-voting',
   'get-score',
   'submit-revote',
@@ -117,21 +113,6 @@ watch(() => props.battlePhase, (phase) => {
 const formatTimerSelectedMinutes = computed(() => smokeFormatTimerRef.value?.selectedMinutes ?? 30)
 
 defineExpose({ triggerFormatTimerStart, formatTimerSelectedMinutes, isFormatTimerExpired, checkFormatWinnerIfExpired })
-
-// ── Category status dot ──────────────────────────────────────────
-// Returns 'champion' | 'active' | 'idle'
-function categoryStatusDot(c) {
-  if (props.categoryChampions[c]) return 'champion'
-  // In view-only mode selectedCategory is the viewed category, not the live one.
-  // Use liveCategoryName + livePhase to correctly mark the live category's dot.
-  if (props.isViewingNonActive && props.liveCategoryName) {
-    if (c === props.liveCategoryName && ['LOCKED', 'VOTING', 'REVEALED'].includes(props.livePhase)) return 'active'
-    return 'idle'
-  }
-  const phase = c === props.selectedCategory ? props.battlePhase : 'IDLE'
-  if (['LOCKED', 'VOTING', 'REVEALED'].includes(phase)) return 'active'
-  return 'idle'
-}
 
 // ── Round tab status ──────────────────────────────────────────────
 // Returns 'done' | 'active' | 'idle'
@@ -310,40 +291,6 @@ const viewedPairList = computed(() => {
     >
       <div class="w-2 h-2 rounded-full flex-shrink-0" style="background:var(--accent-color);box-shadow:0 0 8px var(--accent-muted)"></div>
       <span class="type-body flex-1">You control the battle flow. Start the timer when battlers are on stage.</span>
-    </div>
-
-    <!-- Category switcher -->
-    <div class="card px-4 sm:px-5 py-3 flex flex-wrap items-center gap-2 mb-3">
-      <span class="type-label text-content-muted" style="font-size:10px;letter-spacing:0.18em">CATEGORY</span>
-      <span
-        v-if="isViewingNonActive"
-        class="type-label px-2 py-0.5"
-        style="font-size:9px;letter-spacing:0.22em;color:rgba(239,68,68,0.85);border:1px solid rgba(239,68,68,0.3);background:rgba(239,68,68,0.07);clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%)"
-      >VIEW ONLY</span>
-      <div class="flex flex-wrap gap-2">
-        <button
-          v-for="c in uniqueCategories"
-          :key="c"
-          @click="$emit('request-category-change', c)"
-          class="para-chip-sm px-4 sm:px-3 py-3 sm:py-1.5 type-name-sm transition-all duration-150 inline-flex items-center gap-1.5"
-          :class="[
-            selectedCategory === c
-              ? 'text-accent border-[color:var(--accent-muted)]'
-              : 'text-content-muted hover:text-content-primary'
-          ]"
-        >
-          <template v-if="categoryStatusDot(c) === 'champion'">
-            <i class="pi pi-star-fill text-[9px] text-amber-400"></i>
-          </template>
-          <template v-else-if="categoryStatusDot(c) === 'active'">
-            <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" style="box-shadow:0 0 6px rgba(245,158,11,0.7)"></span>
-          </template>
-          <template v-else>
-            <span class="inline-block w-1.5 h-1.5 rounded-full bg-surface-400/40"></span>
-          </template>
-          {{ c }}
-        </button>
-      </div>
     </div>
 
     <!-- Live match card -->

--- a/BES-frontend/src/utils/__tests__/liveMatchPanel.test.js
+++ b/BES-frontend/src/utils/__tests__/liveMatchPanel.test.js
@@ -5,7 +5,6 @@ import LiveMatchPanel from '@/components/LiveMatchPanel.vue'
 const defaultProps = {
   selectedEvent: 'Test Event',
   selectedCategory: 'Hip Hop',
-  uniqueCategories: ['Hip Hop', 'Popping'],
   battlePhase: 'IDLE',
   battleJudges: [],
   currentBattle: [],
@@ -24,12 +23,6 @@ const defaultProps = {
 }
 
 describe('LiveMatchPanel', () => {
-  it('renders category switcher', () => {
-    const wrapper = mount(LiveMatchPanel, { props: defaultProps })
-    expect(wrapper.text()).toContain('Hip Hop')
-    expect(wrapper.text()).toContain('Popping')
-  })
-
   it('renders phase badge', () => {
     const wrapper = mount(LiveMatchPanel, { props: defaultProps })
     expect(wrapper.text()).toContain('Standby')

--- a/BES-frontend/src/utils/__tests__/scoreTiePool.test.js
+++ b/BES-frontend/src/utils/__tests__/scoreTiePool.test.js
@@ -66,6 +66,28 @@ describe('computeNextEligibleAdd', () => {
     const all = new Set(['Drift', 'Echo', 'Halo', 'Pulse', 'Mirage'])
     expect(computeNextEligibleAdd(allRows, all)).toBeNull()
   })
+
+  it('with maxScore: skips rows at or above the cutoff and returns first below', () => {
+    // Tie breaker at 7.3 — Drift & Echo (7.3) are above cutoff, Halo (7.2) is first below
+    const included = new Set(['Drift', 'Echo']) // tie base at cutoff
+    const result = computeNextEligibleAdd(allRows, included, 7.3)
+    expect(result.participantName).toBe('Halo')
+    expect(result.totalScore).toBe(7.2)
+  })
+
+  it('with maxScore: respects auditionNumber tiebreak among below-cutoff rows', () => {
+    // Tie breaker at 7.3 — Halo (#7) and Pulse (#22) are both at 7.2, Halo should come first
+    const included = new Set(['Drift', 'Echo'])
+    const result = computeNextEligibleAdd(allRows, included, 7.3)
+    expect(result.participantName).toBe('Halo')
+    expect(result.auditionNumber).toBe(7)
+  })
+
+  it('with maxScore: returns null when no one is below the cutoff', () => {
+    // Cutoff at 7.0 — everyone is at or above
+    const included = new Set()
+    expect(computeNextEligibleAdd(allRows, included, 7.0)).toBeNull()
+  })
 })
 
 describe('computeNextEligibleRemove', () => {

--- a/BES-frontend/src/utils/scoreTiePool.js
+++ b/BES-frontend/src/utils/scoreTiePool.js
@@ -14,9 +14,10 @@ export function sortRowsForPool(rows) {
   return [...rows].sort(cmp)
 }
 
-export function computeNextEligibleAdd(allRows, includedNames) {
+export function computeNextEligibleAdd(allRows, includedNames, maxScore = Infinity) {
   const sorted = sortRowsForPool(allRows)
   for (const r of sorted) {
+    if (r.totalScore >= maxScore) continue
     if (!includedNames.has(r.participantName)) return r
   }
   return null

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -166,7 +166,12 @@ const hydrateFromState = (state) => {
   }
   if (state.resolvedParticipants && state.resolvedParticipants !== '') {
     try {
-      resolvedParticipants.value = JSON.parse(state.resolvedParticipants)
+      // getBattleState returns a JSON string; getCategoryStateFromDb returns an
+      // already-deserialised array. Handle both so resolved participants survive
+      // regardless of which REST endpoint the caller used.
+      resolvedParticipants.value = Array.isArray(state.resolvedParticipants)
+        ? state.resolvedParticipants
+        : JSON.parse(state.resolvedParticipants)
     } catch (_) { resolvedParticipants.value = null }
   }
   if (state.timer) {
@@ -599,7 +604,10 @@ const bracketPool = computed(() => {
   } else if (preFormedTeams.value.length > 0) {
     pool = preFormedTeams.value.map(t => t.name)
   } else {
-    pool = topNParticipants.value
+    // Use resolved tie-breaker list directly when bracket size matches the
+    // resolved Top N. (topNParticipants has the same logic but the computed
+    // chain sometimes evaluates before hydration and doesn't re-propagate.)
+    pool = basePool.value
   }
   // Include battle guests not already in pool so they appear in bracket slot dropdowns
   const guestNames = guestsForCurrentCategory.value.map(g => g.guestName).filter(n => !pool.includes(n))
@@ -625,9 +633,9 @@ const poolParticipants = computed(() => {
   const guestSet = new Set(guestsForCurrentCategory.value.map(g => g.guestName))
   const slots = bracketSize.value - guestSet.size
   if (slots <= 0) return []
-  const eligible = bracketPool.value.filter(n => !guestSet.has(n)).slice(0, slots)
+  const eligible = basePool.value.filter(n => !guestSet.has(n)).slice(0, slots)
   const placed = participantsInFirstRound.value
-  return eligible
+  const result = eligible
     .filter(n => !placed.has(n))
     .map(name => {
       const p = participants.value.find(x => x.participantName === name)
@@ -638,6 +646,16 @@ const poolParticipants = computed(() => {
       return { name, score: c ? (crewSortMode.value === 'leader' ? c.leaderScore : c.avgScore) ?? 0 : 0 }
     })
     .sort((a, b) => b.score - a.score)
+  return result
+})
+
+// Resolved-aware base pool (no guests). Returns the tie-breaker-resolved list
+// when its length matches bracketSize, otherwise falls back to topParticipants.
+// Used by bracketPool, poolParticipants, and all fill methods so they stay in sync.
+const basePool = computed(() => {
+  const rp = resolvedParticipants.value
+  if (rp && rp.length === bracketSize.value) return rp
+  return topNParticipants.value
 })
 
 // Bracket seeding
@@ -676,7 +694,7 @@ const autoFillSeeds = () => {
     const orderedPick = rankAsc.value ? [...pickup].reverse() : pickup
     seeds.value = [...fillHalf(orderedPre, half), ...fillHalf(orderedPick, half)]
   } else {
-    const pool = bracketPool.value.filter(n => !guestSet.has(n)).slice(0, freeSlots)
+    const pool = basePool.value.filter(n => !guestSet.has(n)).slice(0, freeSlots)
     const ordered = rankAsc.value ? [...pool].reverse() : pool
     seeds.value = [...ordered, ...Array(Math.max(0, freeSlots - ordered.length)).fill(null)]
   }
@@ -703,7 +721,7 @@ const highVsLowFill = () => {
       ...hvl(sortedPickupCrews.value.map(c => c.crewName).filter(n => !guestSet.has(n)), half),
     ]
   } else {
-    seeds.value = hvl(bracketPool.value.filter(n => !guestSet.has(n)).slice(0, freeSlots), freeSlots)
+    seeds.value = hvl(basePool.value.filter(n => !guestSet.has(n)).slice(0, freeSlots), freeSlots)
   }
   activeSeedIdx.value = null
   applyToFirstRound()
@@ -718,7 +736,7 @@ const randomFill = () => {
     const pickup = [...sortedPickupCrews.value.map(c => c.crewName).filter(n => !guestSet.has(n))].sort(() => Math.random() - 0.5)
     seeds.value = [...fillHalf(preformed, half), ...fillHalf(pickup, half)]
   } else {
-    const pool = [...bracketPool.value.filter(n => !guestSet.has(n)).slice(0, freeSlots)].sort(() => Math.random() - 0.5)
+    const pool = [...basePool.value.filter(n => !guestSet.has(n)).slice(0, freeSlots)].sort(() => Math.random() - 0.5)
     seeds.value = [...pool, ...Array(Math.max(0, freeSlots - pool.length)).fill(null)]
   }
   activeSeedIdx.value = null
@@ -1194,6 +1212,7 @@ const restoreAndBroadcastCategoryBattle = async (_category) => {
   currentRound.value = 0
   currentWinner.value = -2
   battlePhase.value = 'IDLE'
+  resolvedParticipants.value = null  // reset per-category; hydrateFromState will repopulate if present
 
   // Fetch state from REST as immediate source; WS will keep it in sync thereafter
   const state = await getBattleState()
@@ -1210,7 +1229,17 @@ const restoreAndBroadcastCategoryBattle = async (_category) => {
 const jumpToRecoveredPair = async () => {
   if (!recoveryState.value) return
   markSaving()
-  const { currentPair, currentRoundIndex, battlePhase: restoredPhase, bracket, champion: restoredChampion } = recoveryState.value
+  const { currentPair, currentRoundIndex, battlePhase: restoredPhase, bracket, champion: restoredChampion, resolvedParticipants: resolvedParts } = recoveryState.value
+
+  // Restore resolved participants (tie-breaker / Top N qualifier).
+  // hydrateFromState is skipped when the recovery path fires, so reprocess here.
+  if (resolvedParts && resolvedParts !== '') {
+    try {
+      resolvedParticipants.value = Array.isArray(resolvedParts)
+        ? resolvedParts
+        : JSON.parse(resolvedParts)
+    } catch (_) { resolvedParticipants.value = null }
+  }
 
   // Restore topSize from DB bracket state
   if (bracket?.topSize !== undefined) {
@@ -1719,6 +1748,7 @@ watch(selectedCategory, async (newVal, oldVal) => {
     currentRound.value  = 0
     currentWinner.value = -2
     battlePhase.value   = 'IDLE'
+    resolvedParticipants.value = null
 
     const viewedState = await getCategoryStateFromDb(selectedEvent.value, newVal)
     if (viewedState && Object.keys(viewedState).length > 0) {

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -306,6 +306,19 @@ const isViewingNonActive = computed(() =>
   selectedCategory.value !== liveCategoryName.value
 )
 
+// ── Category status dot for tab bar ──────────────────────────────
+// Returns 'champion' | 'active' | 'idle'
+function categoryStatusDot(c) {
+  if (categoryChampions.value[c]) return 'champion'
+  if (isViewingNonActive.value && liveCategoryName.value) {
+    if (c === liveCategoryName.value && ['LOCKED', 'VOTING', 'REVEALED'].includes(livePhase.value)) return 'active'
+    return 'idle'
+  }
+  const phase = c === selectedCategory.value ? battlePhase.value : 'IDLE'
+  if (['LOCKED', 'VOTING', 'REVEALED'].includes(phase)) return 'active'
+  return 'idle'
+}
+
 const HEX_RE = /^#[0-9A-Fa-f]{6}$/
 const overlayConfigError = ref('')
 const pushOverlayConfig = async () => {
@@ -2078,26 +2091,6 @@ onUnmounted(() => {
         <i class="pi pi-external-link text-xs text-content-muted"></i>
       </a>
       <a
-        :href="selectedEvent ? `/battle/overlay?event=${encodeURIComponent(selectedEvent)}&isSmoke=true` : '/battle/overlay?isSmoke=true'"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
-      >
-        <i class="pi pi-desktop text-xs"></i>
-        Smoke Overlay
-        <i class="pi pi-external-link text-xs text-content-muted"></i>
-      </a>
-      <a
-        :href="selectedEvent ? `/battle/judge?event=${encodeURIComponent(selectedEvent)}` : '/battle/judge'"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="para-chip-sm inline-flex items-center gap-2 px-4 py-2.5 type-body text-content-secondary hover:text-accent hover:border-[color:var(--accent-muted)] transition-all duration-200"
-      >
-        <i class="pi pi-users text-xs"></i>
-        Judge View
-        <i class="pi pi-external-link text-xs text-content-muted"></i>
-      </a>
-      <a
         :href="selectedEvent ? `/battle/bracket?event=${encodeURIComponent(selectedEvent)}` : '/battle/bracket'"
         target="_blank"
         rel="noopener noreferrer"
@@ -2144,7 +2137,42 @@ onUnmounted(() => {
       </div>
     </Transition>
 
-    <!-- NOTE: Category switcher is rendered inside LiveMatchPanel below -->
+    <!-- Category tabs — navigate between divisions. All content below
+         (setup, seeding, bracket, live match) is scoped to the active tab. -->
+    <div class="card overflow-x-auto" style="border-bottom:none">
+      <div class="flex min-w-max" role="tablist" aria-label="Categories">
+        <button
+          v-for="c in uniqueCategories"
+          :key="c"
+          role="tab"
+          :aria-selected="selectedCategory === c"
+          @click="requestCategoryChange(c)"
+          class="relative flex-1 sm:flex-initial px-5 sm:px-7 py-4 type-label text-center transition-all duration-150 whitespace-nowrap select-none"
+          :class="selectedCategory === c
+            ? 'text-accent'
+            : 'text-content-muted hover:text-content-primary'"
+        >
+          <span class="inline-flex items-center gap-2">
+            <template v-if="categoryStatusDot(c) === 'champion'">
+              <i class="pi pi-star-fill text-amber-400" style="font-size:11px;filter:drop-shadow(0 0 4px rgba(251,191,36,0.5))"></i>
+            </template>
+            <template v-else-if="categoryStatusDot(c) === 'active'">
+              <span class="inline-block w-2 h-2 rounded-full bg-amber-400 animate-pulse" style="box-shadow:0 0 6px rgba(245,158,11,0.7)"></span>
+            </template>
+            <template v-else>
+              <span class="inline-block w-2 h-2 rounded-full bg-surface-400/40"></span>
+            </template>
+            <span class="tracking-wide">{{ c }}</span>
+          </span>
+          <!-- Active indicator bar -->
+          <div
+            v-if="selectedCategory === c"
+            class="absolute bottom-0 left-3 right-3 h-0.5 rounded-full transition-all duration-200"
+            style="background:var(--accent-color);box-shadow:0 0 10px var(--accent-muted)"
+          ></div>
+        </button>
+      </div>
+    </div>
 
     <!-- Setup panel — hidden in view-only mode (mutations would target the live category, not the viewed category) -->
     <div v-if="isAdminOrOrganiser && !isViewingNonActive" class="card overflow-hidden">
@@ -2834,7 +2862,6 @@ onUnmounted(() => {
       ref="lmpRef"
       :selectedEvent="selectedEvent"
       :selectedCategory="selectedCategory"
-      :uniqueCategories="uniqueCategories"
       :battlePhase="battlePhase"
       :battleJudges="battleJudges?.judges ?? []"
       :currentBattle="currentBattle"
@@ -2850,8 +2877,6 @@ onUnmounted(() => {
       :finalTieBlocked="finalTieBlocked"
       :isReadonly="!isAdminOrOrganiser"
       :isViewingNonActive="isViewingNonActive"
-      :liveCategoryName="liveCategoryName"
-      :livePhase="livePhase"
       :categoryChampions="categoryChampions"
       :stompClient="wsClient"
       :overlayConfig="overlayConfig"
@@ -2860,7 +2885,6 @@ onUnmounted(() => {
       :recoveryTimer="recoveredTimer"
       :recoveryFormatTimer="recoveredFormatTimer"
       :guestsForCurrentCategory="guestsForCurrentCategory"
-      @request-category-change="requestCategoryChange"
       @open-voting="openVoting"
       @get-score="submitGetScore"
       @submit-revote="startRevote"

--- a/BES-frontend/src/views/BattleControl.vue
+++ b/BES-frontend/src/views/BattleControl.vue
@@ -605,28 +605,6 @@ const entryRoundOptions = computed(() =>
   roundSizes.value.map(s => `Top${s}`)
 )
 
-// Pool used by bracket slot dropdowns, seeding picker, and all sort/fill functions.
-// When pre-formed teams exist, exclude raw individual names from the pool — team names only.
-const bracketPool = computed(() => {
-  let pool
-  if (isMixedBracket.value) {
-    pool = [
-      ...preFormedTeams.value.map(t => t.name),
-      ...sortedPickupCrews.value.map(c => c.crewName),
-    ]
-  } else if (preFormedTeams.value.length > 0) {
-    pool = preFormedTeams.value.map(t => t.name)
-  } else {
-    // Use resolved tie-breaker list directly when bracket size matches the
-    // resolved Top N. (topNParticipants has the same logic but the computed
-    // chain sometimes evaluates before hydration and doesn't re-propagate.)
-    pool = basePool.value
-  }
-  // Include battle guests not already in pool so they appear in bracket slot dropdowns
-  const guestNames = guestsForCurrentCategory.value.map(g => g.guestName).filter(n => !pool.includes(n))
-  return [...pool, ...guestNames]
-})
-
 const participantsInFirstRound = computed(() => {
   if (isSmoke.value) {
     // Smoke rounds are a flat array of { name, score }
@@ -664,7 +642,7 @@ const poolParticipants = computed(() => {
 
 // Resolved-aware base pool (no guests). Returns the tie-breaker-resolved list
 // when its length matches bracketSize, otherwise falls back to topParticipants.
-// Used by bracketPool, poolParticipants, and all fill methods so they stay in sync.
+// Used by poolParticipants and all fill methods so they stay in sync.
 const basePool = computed(() => {
   const rp = resolvedParticipants.value
   if (rp && rp.length === bracketSize.value) return rp

--- a/BES-frontend/src/views/Score.vue
+++ b/BES-frontend/src/views/Score.vue
@@ -221,9 +221,12 @@ watch(selectedCategory, async (newVal) => {
     }
   }
 }, { immediate: true });
-watch(selectedTabulation, (newVal) => {
+watch(selectedTabulation, (newVal, oldVal) => {
   if (newVal) { localStorage.setItem(tabKey(selectedEvent.value), newVal); selectedTopN.value = '' }
-  resetTieBreaker()
+  // Only reset on actual changes, not initial load — oldVal is undefined on
+  // the immediate invocation, which would wipe the persisted tie-breaker state
+  // before loadTieBreaker has a chance to read it.
+  if (oldVal !== undefined) resetTieBreaker()
 }, { immediate: true });
 // Load persisted tie-breaker state from backend whenever the view context changes.
 // Debounce by chaining off the same dependencies as the old localStorage tbKey.
@@ -301,9 +304,10 @@ const addedToPoolOrdered = computed(() =>
 )
 
 // Next eligible to add — drives "+ INCLUDE <name> · <score>" button label.
+// Only considers participants whose score is strictly below the tie-breaker cutoff.
 const nextEligibleAdd = computed(() =>
   topNResult.value.hasTieBreaker
-    ? computeNextEligibleAdd(allRowsForPool.value, eligibilityPoolNames.value)
+    ? computeNextEligibleAdd(allRowsForPool.value, eligibilityPoolNames.value, topNResult.value.tieBreakerScore)
     : null
 )
 
@@ -329,7 +333,13 @@ const confirmTieBreaker = async () => {
     // Save resolved names server-side FIRST so BattleControl can read them from DB.
     // Only confirm locally after the API succeeds — prevents false-positive UI state
     // when the server call fails silently.
-    const resolved = finalRows.value.map(r => r.participantName)
+    // Compute resolved list directly — do NOT rely on finalRows, which returns ALL
+    // rows when tieBreakerConfirmed is false (chicken-and-egg: it only filters to
+    // winners AFTER we set confirmed=true below).
+    const above = topNResult.value.rows.slice(0, topNResult.value.aboveCount)
+    const poolRows = [...tiedParticipants.value, ...addedToPoolOrdered.value]
+    const winners = poolRows.filter(r => tieBreakerWinners.value.has(r.participantName))
+    const resolved = [...above, ...winners].map(r => r.participantName)
     const res = await setResolvedParticipants(selectedEvent.value, selectedCategory.value, resolved)
     if (res && res.ok) {
       tieBreakerConfirmed.value = true
@@ -400,8 +410,11 @@ const inCutStandardRows = computed(() => {
 })
 
 // Eliminated rows (below the cut), only computed when expanded.
+// Excludes participants already pulled into the tie-breaker pool so they
+// don't appear twice (once in the pool, once in the original ranking).
 const eliminatedRows = computed(() => {
   const visible = new Set(finalRows.value.map(r => r.participantName))
+  for (const n of addedToPool.value) visible.add(n)
   return allRowsForPool.value
     .filter(r => !visible.has(r.participantName))
     .map((r, i) => ({ ...r, id: finalRows.value.length + i + 1 }))
@@ -429,6 +442,7 @@ const statusBanner = computed(() => {
 const eliminatedSummary = computed(() => {
   const all = allRowsForPool.value
   const visible = new Set(finalRows.value.map(r => r.participantName))
+  for (const n of addedToPool.value) visible.add(n)
   const eliminated = all.filter(r => !visible.has(r.participantName))
   if (eliminated.length === 0) return null
   const lowestScore = Math.min(...eliminated.map(r => r.totalScore))
@@ -533,17 +547,19 @@ function transformForScore(data) {
     const byTotal = {}
 
     if (isMultiAspect) {
-      // Group by participant → judge → aspect; track participantId
+      // Group by participant → judge → aspect; track participantId + auditionNumber
       const grouped = {}
       data.forEach(d => {
-        if (!grouped[d.participantName]) grouped[d.participantName] = { participantId: d.participantId }
+        if (!grouped[d.participantName]) grouped[d.participantName] = { participantId: d.participantId, auditionNumber: d.auditionNumber }
         if (!grouped[d.participantName][d.judgeName]) grouped[d.participantName][d.judgeName] = {}
         grouped[d.participantName][d.judgeName][d.aspect] = d.score
       })
       Object.entries(grouped).forEach(([name, judgeMap]) => {
         const participantId = judgeMap.participantId
-        byTotal[name] = { participantName: name, totalScore: 0, participantId }
+        const auditionNumber = judgeMap.auditionNumber
+        byTotal[name] = { participantName: name, totalScore: 0, participantId, auditionNumber }
         delete judgeMap.participantId
+        delete judgeMap.auditionNumber
         Object.entries(judgeMap).forEach(([judge, aspects]) => {
           const agg = aggregateJudgeScore(aspects)
           byTotal[name][judge] = Number(agg.toFixed(2))
@@ -553,7 +569,7 @@ function transformForScore(data) {
     } else {
       data.forEach(d => {
         if (!byTotal[d.participantName]) {
-          byTotal[d.participantName] = { participantName: d.participantName, totalScore: 0, participantId: d.participantId }
+          byTotal[d.participantName] = { participantName: d.participantName, totalScore: 0, participantId: d.participantId, auditionNumber: d.auditionNumber }
         }
         byTotal[d.participantName][d.judgeName] = d.score
         byTotal[d.participantName].totalScore += d.score


### PR DESCRIPTION
## Summary
- Fix: tie-breaker resolved pool from Score.vue now propagates into BattleControl. Hydration handles both serialised and pre-deserialised `resolvedParticipants`, and seeding/fill paths read from a new `basePool` computed that prefers the resolved list when its size matches the bracket.
- UI: promote the category switcher to a full-width tab bar at the top of BattleControl (above setup/bracket/live-match), with champion/active/idle status dots and an active-tab underline. Removes the duplicated switcher inside `LiveMatchPanel`.
- Cleanup: drop now-unused Smoke Overlay and Judge View header quick links, and the orphaned `bracketPool` computed.

## Test plan
- [ ] On a category with a tie at the cutoff, resolve in Score → open BattleControl → seed bracket fills with the resolved pool (not the pre-tie list).
- [ ] Refresh BattleControl mid-state — resolved pool survives both REST hydration paths (`getBattleState` + `getCategoryStateFromDb`).
- [ ] Multi-category event: tab bar shows champion star / pulsing active dot / idle dot correctly; switching tabs scopes setup/seeding/live-match to the selected category.
- [ ] `npm run lint`, `npm test`, `mvn test` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)