### PR TITLE
chore: k6 load test scaffold for role-based concurrent users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.pem
 credentials.json
 
+# Load test artifacts
+loadtest/results/
+
 # IDE
 .vscode/
 .idea/

--- a/loadtest/.env.example
+++ b/loadtest/.env.example
@@ -1,0 +1,39 @@
+# Copy to loadtest/.env and fill in. .env is gitignored.
+
+# Prod base URL — no trailing slash
+BASE_URL=https://kyrove.app
+
+# Test event — create a dedicated throwaway event in prod first.
+# All writes target this event. Do NOT point at a real event.
+EVENT_NAME=LOADTEST-2026-06-19
+
+# Categories — one per emcee VU (5 emcees, 5 categories).
+# Comma-separated, no spaces around commas.
+CATEGORIES=Cat-A,Cat-B,Cat-C,Cat-D,Cat-E
+
+# Session tokens (generate from EventDetails → Session Links).
+# HELPER + EMCEE are shared across the 5 VUs of each role (UNLIMITED_ROLES
+# in AuthController — the same token works in multiple sessions).
+HELPER_TOKEN=
+EMCEE_TOKEN=
+
+# Judge tokens — must be 5 distinct per-judge tokens.
+# JUDGE roles are NOT in UNLIMITED_ROLES, so each VU needs its own.
+# judgeId is derived from the redeem response — no separate ID env var needed.
+JUDGE_TOKEN_1=
+JUDGE_TOKEN_2=
+JUDGE_TOKEN_3=
+JUDGE_TOKEN_4=
+JUDGE_TOKEN_5=
+
+# Organiser password-auth
+ORGANISER_USERNAME=
+ORGANISER_PASSWORD=
+
+# Test duration (k6 format: 30s, 2m, 5m)
+DURATION=5m
+
+# Set to "true" to enable WRITE operations (check-ins, score submissions,
+# battle phase changes). Default "false" = read-only polling + heartbeats.
+# Writes pollute the test event; clear it after the run.
+ENABLE_WRITES=false

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,98 @@
+# Kyrove Load Test
+
+Simulates concurrent role-based load against a Kyrove deployment.
+
+| Role       | VUs | Auth          |
+|------------|-----|---------------|
+| Helper     | 5   | HELPER token  |
+| Emcee      | 5   | EMCEE token   |
+| Judge      | 5   | per-judge token (×5) |
+| Organiser  | 1   | username/password |
+
+Each role runs as its own k6 scenario script. `run-all.sh` launches all four in parallel.
+
+## Prerequisites
+
+1. **k6** — `brew install k6`
+2. **Dedicated test event on prod** — do NOT target a live event. Create one named e.g. `LOADTEST-2026-06-19` with at least 5 categories and a few participants.
+3. **Organiser tier** — set to MAX in `/admin` so battle endpoints respond instead of 403.
+4. **Session tokens** — open EventDetails → Session Links and generate:
+   - 1 EMCEE token (shared across all 5 emcee VUs)
+   - 1 HELPER token (shared across all 5 helper VUs)
+   - 5 per-judge tokens (one per judge)
+
+## Setup
+
+```bash
+cp loadtest/.env.example loadtest/.env
+# Fill in BASE_URL, EVENT_NAME, tokens, organiser creds
+```
+
+## Run
+
+```bash
+cd loadtest
+./run-all.sh
+```
+
+Default duration is 5 minutes (`DURATION` in `.env`). All four scenarios run in parallel; logs and JSON summaries are written to `loadtest/results/`.
+
+## What gets exercised
+
+**Read-only (default, `ENABLE_WRITES=false`):**
+- Auth (token redeem + password login)
+- Heartbeat (every iteration on emcee, every ~6 on helper, every iteration on organiser)
+- Active-emcee polling
+- Check-in list polling
+- Judge divisions + scores polling
+- Battle state polling
+
+**Writes (`ENABLE_WRITES=true`):**
+- Score submissions (idempotent; safe to repeat)
+- Battle phase flips (writes to `battlePhase` in `BattleService`)
+- Check-ins (commented out — requires participant pool, see TODO)
+
+Default is read-only because (a) writes pollute the test event DB row and (b) most production traffic is reads anyway. Flip the flag when you want to stress the write path.
+
+## Reading results
+
+Per scenario, k6 prints a summary like:
+
+```
+http_req_duration..............: avg=120ms  p(95)=380ms
+http_req_failed................: 0.21%   ✓ 5  ✗ 2410
+checks.........................: 100.00% ✓ 1205
+```
+
+Watch for:
+- `http_req_failed` > 5% — server is rejecting requests (check Spring logs)
+- `http_req_duration p(95)` > thresholds in each script's `options.thresholds`
+- Threshold failures cause the script to exit non-zero — `run-all.sh` propagates this
+
+JSON summaries in `results/$timestamp.<role>.json` are k6's machine-readable export — pipe them into Grafana or just read by eye.
+
+## What each VU does (with WebSocket)
+
+Each VU now opens one persistent STOMP WebSocket (raw WS, no SockJS — confirmed in `WebSocketConfig.java:19`) and runs periodic HTTP polls from inside the WS event loop. One VU = one socket + a poller. That's the same shape as a real browser tab.
+
+| Role | Subscribes to | HTTP polls |
+|------|---------------|------------|
+| Helper    | `/topic/app-config` | `GET /event/{event}/checkin-list` every 5s, heartbeat 30s |
+| Emcee     | `/topic/emcee/active-categories/{event}`, `/topic/battle/state`, `/topic/battle/{event}/overlay-config`, `/topic/app-config` | `GET /emcee/active-categories` every 5s, heartbeat 30s |
+| Judge     | `/topic/battle/state`, `/topic/app-config` | `GET /event/{event}/judge/{id}/divisions` + `GET /event/scores/{event}` every 3s |
+| Organiser | `/topic/battle/state`, `/topic/app-config`, `/topic/emcee/active-categories/{event}` | `GET /battle/state` + `GET /auth/me` every 5s, heartbeat 30s |
+
+Cookies from the per-VU HTTP jar are passed manually into `ws.connect` headers — k6 does not share its cookie jar with `k6/ws` automatically. See `stomp.js:cookieHeader()`.
+
+## Limitations
+
+- **No real participant data.** Score writes use synthetic participant names — the backend may reject if it validates against the participant table. Provision participants on the test event first if you turn writes on.
+- **No CSRF.** Confirmed disabled in `SecurityConfig` (see `docs/test-scripts/battle-e2e.js`). If that ever changes, all POST/DELETE requests will start failing with 403.
+- **STOMP frame parsing is one-way.** We send CONNECT/SUBSCRIBE/DISCONNECT and detect the inbound `CONNECTED` ack by string prefix, but we don't parse `MESSAGE` payloads. That's fine for a load test — the broadcast fanout cost is paid by the server regardless.
+
+## Teardown
+
+After the run, on prod:
+1. Delete the test event (cascades participant + score rows)
+2. Revoke the session tokens (EventDetails → Session Links → delete each)
+3. Optional: switch the organiser back to PRO tier if it was bumped to MAX just for testing

--- a/loadtest/k6/auth.js
+++ b/loadtest/k6/auth.js
@@ -1,0 +1,35 @@
+// Auth helpers — redeem session token or username/password login.
+// Both write the session cookie into k6's per-VU cookie jar so subsequent
+// requests are authenticated automatically.
+
+import http from 'k6/http';
+import { check, fail } from 'k6';
+import { BASE_URL, JSON_HEADERS } from './config.js';
+
+export function redeemToken(tokenId) {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/token`,
+    JSON.stringify({ tokenId }),
+    { headers: JSON_HEADERS, tags: { name: 'auth:token' } },
+  );
+  const ok = check(res, { 'token redeem 200': (r) => r.status === 200 });
+  if (!ok) fail(`token redeem failed: status=${res.status} body=${res.body}`);
+  return res.json();
+}
+
+export function passwordLogin(username, password) {
+  const res = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    JSON.stringify({ username, password }),
+    { headers: JSON_HEADERS, tags: { name: 'auth:login' } },
+  );
+  const ok = check(res, { 'login 200': (r) => r.status === 200 });
+  if (!ok) fail(`login failed: status=${res.status} body=${res.body}`);
+  return res.json();
+}
+
+export function heartbeat() {
+  return http.post(`${BASE_URL}/api/v1/auth/heartbeat`, null, {
+    tags: { name: 'auth:heartbeat' },
+  });
+}

--- a/loadtest/k6/config.js
+++ b/loadtest/k6/config.js
@@ -1,0 +1,35 @@
+// Shared env loading + helpers. Imported by every scenario script.
+//
+// k6 exposes env vars via __ENV. The run-all.sh script source's .env and
+// passes them through with -e KEY=VALUE.
+
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost';
+export const EVENT_NAME = __ENV.EVENT_NAME || 'LOADTEST';
+export const CATEGORIES = (__ENV.CATEGORIES || '').split(',').filter(Boolean);
+export const DURATION = __ENV.DURATION || '5m';
+export const ENABLE_WRITES = __ENV.ENABLE_WRITES === 'true';
+
+export const HELPER_TOKEN = __ENV.HELPER_TOKEN || '';
+export const EMCEE_TOKEN = __ENV.EMCEE_TOKEN || '';
+
+export const JUDGE_TOKENS = [
+  __ENV.JUDGE_TOKEN_1, __ENV.JUDGE_TOKEN_2, __ENV.JUDGE_TOKEN_3,
+  __ENV.JUDGE_TOKEN_4, __ENV.JUDGE_TOKEN_5,
+].filter(Boolean);
+
+export const ORGANISER_USERNAME = __ENV.ORGANISER_USERNAME || '';
+export const ORGANISER_PASSWORD = __ENV.ORGANISER_PASSWORD || '';
+
+export const JSON_HEADERS = {
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+};
+
+// k6's http.CookieJar is per-VU by default. Cookies set on login persist
+// for subsequent requests in the same VU. No manual cookie handling needed.
+
+export function requireEnv(...names) {
+  for (const n of names) {
+    if (!__ENV[n]) throw new Error(`Missing env var: ${n}. Copy loadtest/.env.example to loadtest/.env and fill it in.`);
+  }
+}

--- a/loadtest/k6/emcee.js
+++ b/loadtest/k6/emcee.js
@@ -1,0 +1,113 @@
+// EMCEE scenario — 5 VUs, one category each
+//
+// Per VU: redeem EMCEE token → claim category → open STOMP WS subscribed
+// to active-categories + battle/state + overlay-config → heartbeat every
+// 30s → poll active-categories every 5s.
+
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check } from 'k6';
+import {
+  BASE_URL, EVENT_NAME, CATEGORIES, DURATION, ENABLE_WRITES,
+  EMCEE_TOKEN, JSON_HEADERS, requireEnv,
+} from './config.js';
+import { redeemToken, heartbeat } from './auth.js';
+import {
+  wsUrl, hostOf, connectFrame, subscribeFrame, disconnectFrame,
+  cookieHeader, isConnected,
+} from './stomp.js';
+
+export const options = {
+  scenarios: {
+    emcees: {
+      executor: 'per-vu-iterations',
+      vus: 5,
+      iterations: 1,
+      maxDuration: DURATION,
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:emcee:active-categories}': ['p(95)<1500'],
+    'http_req_failed': ['rate<0.05'],
+    'ws_connecting': ['p(95)<2000'],
+  },
+};
+
+export function setup() {
+  requireEnv('EMCEE_TOKEN', 'EVENT_NAME', 'CATEGORIES');
+  if (CATEGORIES.length < 5) {
+    throw new Error(`Need at least 5 CATEGORIES; got ${CATEGORIES.length}`);
+  }
+  return {};
+}
+
+export default function () {
+  const myCategory = CATEGORIES[(__VU - 1) % CATEGORIES.length];
+
+  redeemToken(EMCEE_TOKEN);
+  http.post(
+    `${BASE_URL}/api/v1/emcee/active-category`,
+    JSON.stringify({ eventName: EVENT_NAME, categoryName: myCategory }),
+    { headers: JSON_HEADERS, tags: { name: 'emcee:claim' } },
+  );
+
+  const host = hostOf(BASE_URL);
+  const params = { headers: { Cookie: cookieHeader() } };
+
+  const res = ws.connect(wsUrl(), params, (socket) => {
+    socket.on('open', () => socket.send(connectFrame(host)));
+
+    socket.on('message', (msg) => {
+      if (isConnected(msg)) {
+        socket.send(subscribeFrame(0, `/topic/emcee/active-categories/${EVENT_NAME}`));
+        socket.send(subscribeFrame(1, '/topic/battle/state'));
+        socket.send(subscribeFrame(2, `/topic/battle/${EVENT_NAME}/overlay-config`));
+        socket.send(subscribeFrame(3, '/topic/app-config'));
+      }
+    });
+
+    socket.setInterval(() => {
+      http.get(
+        `${BASE_URL}/api/v1/emcee/active-categories?eventName=${encodeURIComponent(EVENT_NAME)}`,
+        { tags: { name: 'emcee:active-categories' } },
+      );
+    }, 5000);
+    socket.setInterval(() => heartbeat(), 30000);
+
+    if (ENABLE_WRITES) {
+      // Phase flip every 30s — exercises BattleService.setBattlePhaseService
+      // and the /topic/battle/state broadcast fanout.
+      let phaseIdx = 0;
+      const phases = ['IDLE', 'LOCKED', 'VOTING', 'REVEALED'];
+      socket.setInterval(() => {
+        http.post(
+          `${BASE_URL}/api/v1/battle/phase`,
+          JSON.stringify({ phase: phases[phaseIdx++ % 4], eventName: EVENT_NAME }),
+          { headers: JSON_HEADERS, tags: { name: 'emcee:phase' } },
+        );
+      }, 30000);
+    }
+
+    const runMs = durationToMs(DURATION) - 2000;
+    socket.setTimeout(() => {
+      socket.send(disconnectFrame());
+      socket.close();
+    }, runMs);
+
+    socket.on('error', (e) => console.error(`ws error: ${e.error()}`));
+  });
+
+  check(res, { 'ws handshake 101': (r) => r && r.status === 101 });
+
+  // Best-effort release after WS closes
+  http.del(`${BASE_URL}/api/v1/emcee/active-category`, null, {
+    tags: { name: 'emcee:release' },
+  });
+}
+
+function durationToMs(s) {
+  const m = String(s).match(/^(\d+)\s*(ms|s|m|h)?$/);
+  if (!m) return 60000;
+  const n = Number(m[1]);
+  return { ms: n, s: n * 1000, m: n * 60000, h: n * 3600000 }[m[2] || 's'];
+}

--- a/loadtest/k6/helper.js
+++ b/loadtest/k6/helper.js
@@ -1,0 +1,87 @@
+// HELPER scenario — 5 VUs
+//
+// Real-world load per VU: one persistent STOMP WS subscribed to global
+// broadcasts (app config) + periodic HTTP polls of the check-in list +
+// heartbeat. HELPER token shared across all 5 VUs (ROLE_HELPER is in
+// UNLIMITED_ROLES).
+
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check } from 'k6';
+import {
+  BASE_URL, EVENT_NAME, DURATION, ENABLE_WRITES, HELPER_TOKEN, requireEnv,
+} from './config.js';
+import { redeemToken, heartbeat } from './auth.js';
+import {
+  wsUrl, hostOf, connectFrame, subscribeFrame, disconnectFrame,
+  cookieHeader, isConnected,
+} from './stomp.js';
+
+export const options = {
+  scenarios: {
+    helpers: {
+      executor: 'per-vu-iterations',
+      vus: 5,
+      iterations: 1,
+      maxDuration: DURATION,
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:checkin:list}': ['p(95)<1500'],
+    'http_req_failed': ['rate<0.05'],
+    'ws_connecting': ['p(95)<2000'],
+  },
+};
+
+export function setup() {
+  requireEnv('HELPER_TOKEN', 'EVENT_NAME');
+  return {};
+}
+
+export default function () {
+  redeemToken(HELPER_TOKEN);
+
+  const host = hostOf(BASE_URL);
+  const params = { headers: { Cookie: cookieHeader() } };
+
+  const res = ws.connect(wsUrl(), params, (socket) => {
+    socket.on('open', () => socket.send(connectFrame(host)));
+
+    socket.on('message', (msg) => {
+      if (isConnected(msg)) {
+        socket.send(subscribeFrame(0, '/topic/app-config'));
+      }
+    });
+
+    // Poll every 5s, heartbeat every 30s.
+    socket.setInterval(() => {
+      http.get(
+        `${BASE_URL}/api/v1/event/${encodeURIComponent(EVENT_NAME)}/checkin-list`,
+        { tags: { name: 'checkin:list' } },
+      );
+    }, 5000);
+    socket.setInterval(() => heartbeat(), 30000);
+
+    // Close when the iteration's maxDuration is about to elapse.
+    const runMs = durationToMs(DURATION) - 2000;
+    socket.setTimeout(() => {
+      socket.send(disconnectFrame());
+      socket.close();
+    }, runMs);
+
+    socket.on('error', (e) => console.error(`ws error: ${e.error()}`));
+  });
+
+  check(res, { 'ws handshake 101': (r) => r && r.status === 101 });
+
+  if (ENABLE_WRITES) {
+    // Optional check-in writes — requires participant pool. See README TODO.
+  }
+}
+
+function durationToMs(s) {
+  const m = String(s).match(/^(\d+)\s*(ms|s|m|h)?$/);
+  if (!m) return 60000;
+  const n = Number(m[1]);
+  return { ms: n, s: n * 1000, m: n * 60000, h: n * 3600000 }[m[2] || 's'];
+}

--- a/loadtest/k6/judge.js
+++ b/loadtest/k6/judge.js
@@ -1,0 +1,114 @@
+// JUDGE scenario — 5 VUs, distinct tokens
+//
+// Per VU: redeem own JUDGE token → open STOMP WS subscribed to battle/state
+// → poll divisions + scores every 3s → score-write every 6s (if enabled).
+
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check } from 'k6';
+import {
+  BASE_URL, EVENT_NAME, CATEGORIES, DURATION, ENABLE_WRITES,
+  JUDGE_TOKENS, JSON_HEADERS, requireEnv,
+} from './config.js';
+import { redeemToken } from './auth.js';
+import {
+  wsUrl, hostOf, connectFrame, subscribeFrame, disconnectFrame,
+  cookieHeader, isConnected,
+} from './stomp.js';
+
+export const options = {
+  scenarios: {
+    judges: {
+      executor: 'per-vu-iterations',
+      vus: 5,
+      iterations: 1,
+      maxDuration: DURATION,
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:judge:scores-read}': ['p(95)<2000'],
+    'http_req_failed': ['rate<0.05'],
+    'ws_connecting': ['p(95)<2000'],
+  },
+};
+
+export function setup() {
+  requireEnv('EVENT_NAME', 'CATEGORIES');
+  if (JUDGE_TOKENS.length < 5) throw new Error(`Need 5 JUDGE_TOKEN_1..5; got ${JUDGE_TOKENS.length}`);
+  return {};
+}
+
+export default function () {
+  const token = JUDGE_TOKENS[(__VU - 1) % JUDGE_TOKENS.length];
+  const myCategory = CATEGORIES[(__VU - 1) % CATEGORIES.length];
+
+  // judgeId + judgeName come back in the redeem response — no separate env var needed.
+  const me = redeemToken(token);
+  const judgeId = me.judgeId;
+  const judgeName = me.judgeName || '';
+  if (!judgeId) throw new Error(`JUDGE_TOKEN_${__VU} redeemed but no judgeId in response — is it a per-judge token?`);
+
+  const host = hostOf(BASE_URL);
+  const params = { headers: { Cookie: cookieHeader() } };
+
+  const res = ws.connect(wsUrl(), params, (socket) => {
+    socket.on('open', () => socket.send(connectFrame(host)));
+
+    socket.on('message', (msg) => {
+      if (isConnected(msg)) {
+        socket.send(subscribeFrame(0, '/topic/battle/state'));
+        socket.send(subscribeFrame(1, '/topic/app-config'));
+      }
+    });
+
+    socket.setInterval(() => {
+      http.get(
+        `${BASE_URL}/api/v1/event/${encodeURIComponent(EVENT_NAME)}/judge/${judgeId}/divisions`,
+        { tags: { name: 'judge:divisions' } },
+      );
+      http.get(
+        `${BASE_URL}/api/v1/event/scores/${encodeURIComponent(EVENT_NAME)}`,
+        { tags: { name: 'judge:scores-read' } },
+      );
+    }, 3000);
+
+    if (ENABLE_WRITES && judgeName) {
+      let i = 0;
+      socket.setInterval(() => {
+        const auditionNumber = ((__VU - 1) * 100) + ((i++) % 16) + 1;
+        const payload = {
+          eventName: EVENT_NAME,
+          categoryName: myCategory,
+          judgeName,
+          participantScore: [{
+            participantName: `LOADTEST P${auditionNumber}`,
+            auditionNumber,
+            score: 5 + (i % 5),
+          }],
+        };
+        http.post(
+          `${BASE_URL}/api/v1/event/scores`,
+          JSON.stringify(payload),
+          { headers: JSON_HEADERS, tags: { name: 'judge:scores-write' } },
+        );
+      }, 6000);
+    }
+
+    const runMs = durationToMs(DURATION) - 2000;
+    socket.setTimeout(() => {
+      socket.send(disconnectFrame());
+      socket.close();
+    }, runMs);
+
+    socket.on('error', (e) => console.error(`ws error: ${e.error()}`));
+  });
+
+  check(res, { 'ws handshake 101': (r) => r && r.status === 101 });
+}
+
+function durationToMs(s) {
+  const m = String(s).match(/^(\d+)\s*(ms|s|m|h)?$/);
+  if (!m) return 60000;
+  const n = Number(m[1]);
+  return { ms: n, s: n * 1000, m: n * 60000, h: n * 3600000 }[m[2] || 's'];
+}

--- a/loadtest/k6/organiser.js
+++ b/loadtest/k6/organiser.js
@@ -1,0 +1,83 @@
+// ORGANISER scenario — 1 VU
+//
+// Per VU: password login → open STOMP WS subscribed to battle/state +
+// app-config → poll battle state every 5s → heartbeat every 30s.
+
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check } from 'k6';
+import {
+  BASE_URL, EVENT_NAME, DURATION,
+  ORGANISER_USERNAME, ORGANISER_PASSWORD, requireEnv,
+} from './config.js';
+import { passwordLogin, heartbeat } from './auth.js';
+import {
+  wsUrl, hostOf, connectFrame, subscribeFrame, disconnectFrame,
+  cookieHeader, isConnected,
+} from './stomp.js';
+
+export const options = {
+  scenarios: {
+    organiser: {
+      executor: 'per-vu-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: DURATION,
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:organiser:battle-state}': ['p(95)<1500'],
+    'http_req_failed': ['rate<0.05'],
+    'ws_connecting': ['p(95)<2000'],
+  },
+};
+
+export function setup() {
+  requireEnv('ORGANISER_USERNAME', 'ORGANISER_PASSWORD', 'EVENT_NAME');
+  return {};
+}
+
+export default function () {
+  passwordLogin(ORGANISER_USERNAME, ORGANISER_PASSWORD);
+
+  const host = hostOf(BASE_URL);
+  const params = { headers: { Cookie: cookieHeader() } };
+
+  const res = ws.connect(wsUrl(), params, (socket) => {
+    socket.on('open', () => socket.send(connectFrame(host)));
+
+    socket.on('message', (msg) => {
+      if (isConnected(msg)) {
+        socket.send(subscribeFrame(0, '/topic/battle/state'));
+        socket.send(subscribeFrame(1, '/topic/app-config'));
+        socket.send(subscribeFrame(2, `/topic/emcee/active-categories/${EVENT_NAME}`));
+      }
+    });
+
+    socket.setInterval(() => {
+      http.get(
+        `${BASE_URL}/api/v1/battle/state?eventName=${encodeURIComponent(EVENT_NAME)}`,
+        { tags: { name: 'organiser:battle-state' } },
+      );
+      http.get(`${BASE_URL}/api/v1/auth/me`, { tags: { name: 'organiser:me' } });
+    }, 5000);
+    socket.setInterval(() => heartbeat(), 30000);
+
+    const runMs = durationToMs(DURATION) - 2000;
+    socket.setTimeout(() => {
+      socket.send(disconnectFrame());
+      socket.close();
+    }, runMs);
+
+    socket.on('error', (e) => console.error(`ws error: ${e.error()}`));
+  });
+
+  check(res, { 'ws handshake 101': (r) => r && r.status === 101 });
+}
+
+function durationToMs(s) {
+  const m = String(s).match(/^(\d+)\s*(ms|s|m|h)?$/);
+  if (!m) return 60000;
+  const n = Number(m[1]);
+  return { ms: n, s: n * 1000, m: n * 60000, h: n * 3600000 }[m[2] || 's'];
+}

--- a/loadtest/k6/stomp.js
+++ b/loadtest/k6/stomp.js
@@ -1,0 +1,60 @@
+// STOMP-over-raw-WebSocket helpers for k6.
+//
+// Kyrove's WebSocketConfig.java does NOT use .withSockJS() — clients open
+// a raw WS at /ws and speak STOMP text frames directly.
+//
+// STOMP frame format: COMMAND\n  header:value\n  ...  \n  body  \0
+// We never send a body, so most frames are just headers.
+
+import http from 'k6/http';
+import { BASE_URL } from './config.js';
+
+const NULL = String.fromCharCode(0);
+
+export function wsUrl() {
+  return BASE_URL.replace(/^http/, 'ws') + '/ws';
+}
+
+// k6's goja runtime has no WHATWG URL constructor, so strip the scheme
+// and any path with a regex instead of `new URL(BASE_URL).host`.
+export function hostOf(url) {
+  return String(url).replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+}
+
+export function connectFrame(host) {
+  return [
+    'CONNECT',
+    'accept-version:1.2',
+    `host:${host}`,
+    'heart-beat:10000,10000',
+    '', '',
+  ].join('\n').replace(/\n$/, NULL);
+}
+
+export function subscribeFrame(id, destination) {
+  return [
+    'SUBSCRIBE',
+    `id:sub-${id}`,
+    `destination:${destination}`,
+    '', '',
+  ].join('\n').replace(/\n$/, NULL);
+}
+
+export function disconnectFrame() {
+  return ['DISCONNECT', '', ''].join('\n').replace(/\n$/, NULL);
+}
+
+// Spring Security session lives in JSESSIONID cookie. The HTTP cookie jar
+// is per-VU but is NOT auto-shared with k6/ws — pass cookies explicitly.
+export function cookieHeader() {
+  const jar = http.cookieJar();
+  const cookies = jar.cookiesForURL(BASE_URL);
+  return Object.entries(cookies)
+    .map(([k, vs]) => `${k}=${Array.isArray(vs) ? vs[0] : vs}`)
+    .join('; ');
+}
+
+// True when an inbound STOMP frame is a CONNECTED ack.
+export function isConnected(frame) {
+  return typeof frame === 'string' && frame.startsWith('CONNECTED');
+}

--- a/loadtest/run-all.sh
+++ b/loadtest/run-all.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run all four k6 scenarios in parallel. Exit status is the OR of all four.
+#
+# Usage:
+#   cd loadtest && ./run-all.sh
+#
+# Prerequisites:
+#   - k6 installed (brew install k6 / https://k6.io/docs/get-started/installation)
+#   - loadtest/.env filled in (copy from .env.example)
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ ! -f .env ]]; then
+  echo "ERROR: loadtest/.env not found. Copy .env.example to .env and fill it in." >&2
+  exit 1
+fi
+
+# Export every var in .env so k6 child processes inherit them via __ENV
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+mkdir -p results
+ts=$(date +%Y%m%d-%H%M%S)
+
+# Pass env explicitly so k6 sees them under __ENV regardless of shell quirks
+env_flags=(
+  -e BASE_URL="$BASE_URL"
+  -e EVENT_NAME="$EVENT_NAME"
+  -e CATEGORIES="$CATEGORIES"
+  -e DURATION="$DURATION"
+  -e ENABLE_WRITES="$ENABLE_WRITES"
+  -e HELPER_TOKEN="$HELPER_TOKEN"
+  -e EMCEE_TOKEN="$EMCEE_TOKEN"
+  -e JUDGE_TOKEN_1="$JUDGE_TOKEN_1"
+  -e JUDGE_TOKEN_2="$JUDGE_TOKEN_2"
+  -e JUDGE_TOKEN_3="$JUDGE_TOKEN_3"
+  -e JUDGE_TOKEN_4="$JUDGE_TOKEN_4"
+  -e JUDGE_TOKEN_5="$JUDGE_TOKEN_5"
+  -e ORGANISER_USERNAME="$ORGANISER_USERNAME"
+  -e ORGANISER_PASSWORD="$ORGANISER_PASSWORD"
+)
+
+echo "==> Starting load test against $BASE_URL (event=$EVENT_NAME, duration=$DURATION, writes=$ENABLE_WRITES)"
+echo "==> Results will be written to loadtest/results/$ts.*"
+
+pids=()
+k6 run "${env_flags[@]}" --summary-export "results/$ts.helper.json"     k6/helper.js     > "results/$ts.helper.log"     2>&1 & pids+=($!)
+k6 run "${env_flags[@]}" --summary-export "results/$ts.emcee.json"      k6/emcee.js      > "results/$ts.emcee.log"      2>&1 & pids+=($!)
+k6 run "${env_flags[@]}" --summary-export "results/$ts.judge.json"      k6/judge.js      > "results/$ts.judge.log"      2>&1 & pids+=($!)
+k6 run "${env_flags[@]}" --summary-export "results/$ts.organiser.json"  k6/organiser.js  > "results/$ts.organiser.log"  2>&1 & pids+=($!)
+
+rc=0
+for pid in "${pids[@]}"; do
+  if ! wait "$pid"; then rc=1; fi
+done
+
+echo
+echo "==> Done. Per-scenario logs + summaries in loadtest/results/$ts.*"
+if [[ $rc -ne 0 ]]; then
+  echo "==> One or more scenarios failed thresholds — inspect the .log files." >&2
+fi
+exit "$rc"


### PR DESCRIPTION
## Summary

- Adds a `loadtest/` scaffold built on k6 that simulates the production user mix — 5 helpers, 5 emcees, 5 judges, 1 organiser — concurrently against any deployment.
- Each VU opens one persistent **raw-WebSocket STOMP** session subscribed to the topics its real UI listens to (per `WebSocketConfig.java:19` — no SockJS wrapper), and runs periodic HTTP polls from inside the WS event loop. Same shape as a real browser tab.
- `ENABLE_WRITES` flag toggles the score-write and battle-phase-write paths; default is read-only to keep test events clean.
- Verified end-to-end against prod: a 30-minute write-enabled run pushed 12,000+ HTTP requests + 16 persistent STOMP sockets with 0 read failures, expected emcee phase rejection pattern (~25% of phase POSTs — likely `REVEALED` without a pair), and totally flat latency.

## Files

| Path | Purpose |
|------|---------|
| `loadtest/k6/{helper,emcee,judge,organiser}.js` | One scenario per role |
| `loadtest/k6/{auth,stomp,config}.js` | Shared helpers (token/login, STOMP frames, env loading) |
| `loadtest/run-all.sh` | Parallel-launches all four scenarios, writes summaries to `loadtest/results/` |
| `loadtest/.env.example` | Setup template — copy to `.env`, fill in tokens + creds |
| `loadtest/README.md` | Setup, run, results, teardown |
| `.gitignore` | Excludes `loadtest/results/` (and `.env` already gitignored globally) |

## Test plan

- [x] 30s smoke run — auth + WS handshake on all four roles
- [x] 15m read-only run — 0 failures across 5,483 requests, 16 STOMP sockets held for ~15m
- [x] 30m write-enabled run — judge score writes (1,500+) all accepted; emcee phase writes mostly accepted with the expected validation-driven rejection pattern; no latency drift
- [ ] Optional follow-up: bump VU counts to find actual ceiling
- [ ] Optional follow-up: wire helper check-in writes (currently stubbed — needs a participant pool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)