### PR TITLE
feat: judge concurrent sessions, reset scores, admin audition number reset

### DIFF
--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -424,6 +424,23 @@ export const resetJudgeFeedback = async (eventName, categoryName, judgeName) => 
   } catch (e) { console.log(e) }
 }
 
+// Admin-only. Returns the parsed response: { message } on success or
+// { error, status } on failure. Caller surfaces failures to the user.
+export const resetAuditionNumbers = async (eventName) => {
+  try {
+    const res = await fetch(`${domain}/api/v1/event/${encodeURIComponent(eventName)}/audition-numbers`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    const body = await res.json().catch(() => ({}))
+    if (!res.ok) return { ok: false, status: res.status, error: body.error || 'Reset failed' }
+    return { ok: true, message: body.message }
+  } catch (e) {
+    console.error(e)
+    return { ok: false, error: 'Unable to reach server. Check your connection and try again.' }
+  }
+}
+
 export const getBattleJudges = async(eventName = '') =>{
   try{
     const url = eventName

--- a/BES-frontend/src/utils/api.js
+++ b/BES-frontend/src/utils/api.js
@@ -1734,6 +1734,39 @@ export const getActiveEmceeCategories = async (eventName) => {
   } catch (e) { console.error(e); return [] }
 }
 
+export const judgeActiveElsewhere = async (judgeId) => {
+  try {
+    const res = await fetch(
+      `${domain}/api/v1/auth/judge/active-elsewhere?judgeId=${judgeId}`,
+      { credentials: 'include', headers: { 'Accept': 'application/json' } }
+    )
+    if (!res.ok) return false
+    const body = await res.json()
+    return !!body.activeElsewhere
+  } catch (e) {
+    console.error(e)
+    return false
+  }
+}
+
+export const claimJudgeActive = async () => {
+  try {
+    await fetch(`${domain}/api/v1/auth/judge/claim`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+  } catch (e) { console.error(e) }
+}
+
+export const releaseJudgeActive = async () => {
+  try {
+    await fetch(`${domain}/api/v1/auth/judge/release`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+  } catch (e) { console.error(e) }
+}
+
 // Event-scoped feedback taxonomy (#157). Returns merged groups: global +
 // event-scoped, with event-scoped overriding global by group name. Each group
 // and tag carries a `scope` field of "GLOBAL" or "EVENT".

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -153,7 +153,13 @@ const confirmReset = () => {
     if (resetConfirmText.value.trim().toUpperCase() !== 'RESET') return
     resetSaving.value = true
     await resetJudgeScores(selectedEvent.value, selectedCategory.value, currentJudge.value)
-    await loadScoresFromDb(selectedEvent.value, selectedCategory.value, currentJudge.value)
+    // loadScoresFromDb early-returns when the backend has no rows (post-reset state),
+    // so it can't clear stale in-memory scores. Wipe locally to match the DB.
+    participants.value = participants.value.map(p => {
+      if (p.categoryName !== selectedCategory.value) return p
+      if (hasJudge.value && p.judgeName !== currentJudge.value) return p
+      return { ...p, score: 0, criteriaScores: {}, submitted: false }
+    })
     resetSaving.value = false
     isResetModal.value = false
     showModal.value = false
@@ -1146,18 +1152,22 @@ onMounted(async () => {
     @accept="() => { dynamicCallBack() }"
     @close="() => { showModal = false; isResetModal = false }"
   >
-    <p class="type-body text-content-secondary">{{ modalMessage }}</p>
-    <div v-if="isResetModal" class="mt-4">
-      <p class="type-label text-content-muted mb-2">Type <span class="type-name text-red-400" style="letter-spacing:0.12em">RESET</span> to confirm:</p>
-      <input
-        v-model="resetConfirmText"
-        type="text"
-        class="w-full px-3 py-2 bg-surface-900 border border-surface-600 text-content-primary type-name focus:outline-none focus:border-red-400"
-        style="clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%);letter-spacing:0.1em"
-        placeholder="RESET"
-        autocomplete="off"
-        spellcheck="false"
-      />
+    <!-- Wrap in a single flex-1 block so the warning chip's flex row doesn't lay
+         the body text and the typed-confirm input side-by-side on narrow screens. -->
+    <div class="flex-1 min-w-0">
+      <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+      <div v-if="isResetModal" class="mt-4">
+        <p class="type-label text-content-muted mb-2">Type <span class="type-name text-red-400" style="letter-spacing:0.12em">RESET</span> to confirm:</p>
+        <input
+          v-model="resetConfirmText"
+          type="text"
+          class="w-full px-3 py-2 bg-surface-900 border border-surface-600 text-content-primary type-name focus:outline-none focus:border-red-400"
+          style="clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%);letter-spacing:0.1em"
+          placeholder="RESET"
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </div>
     </div>
   </ActionDoneModal>
 

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -1,7 +1,7 @@
 <script setup>
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
 import ReusableDropdown from '@/components/ReusableDropdown.vue';
-import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, claimEmceeCategory, releaseEmceeCategory, getActiveEmceeCategories, getEventFeedbackTags } from '@/utils/api';
+import { getRegisteredParticipantsByEvent, submitParticipantScore, getParticipantScore, whoami, getJudgingMode, setJudgingMode, getFeedbackEnabled, submitAuditionFeedback, getAuditionFeedback, getScoringCriteria, getCategoriesByEvent, getJudgesByDivision, claimEmceeCategory, releaseEmceeCategory, getActiveEmceeCategories, getEventFeedbackTags, resetJudgeScores } from '@/utils/api';
 import { createClient, subscribeToChannel, deactivateClient } from '@/utils/websocket';
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { RouterLink, useRouter, useRoute, onBeforeRouteLeave } from 'vue-router';
@@ -134,6 +134,29 @@ const confirmSubmit = async (title, message) => {
     showModal.value = false;
     await submitScore(selectedEvent.value, selectedCategory.value,
       currentJudge.value, filteredParticipantsForJudge.value);
+  }
+}
+
+const isResetModal = ref(false)
+const resetConfirmText = ref('')
+const resetSaving = ref(false)
+
+const confirmReset = () => {
+  resetConfirmText.value = ''
+  resetSaving.value = false
+  isResetModal.value = true
+  modalTitle.value = 'Reset Scores'
+  modalMessage.value = `This wipes all of your scores for "${selectedCategory.value}". Submitted scores will also be cleared. This cannot be undone.`
+  modalVariant.value = 'warning'
+  showModal.value = true
+  dynamicCallBack.value = async () => {
+    if (resetConfirmText.value.trim().toUpperCase() !== 'RESET') return
+    resetSaving.value = true
+    await resetJudgeScores(selectedEvent.value, selectedCategory.value, currentJudge.value)
+    await loadScoresFromDb(selectedEvent.value, selectedCategory.value, currentJudge.value)
+    resetSaving.value = false
+    isResetModal.value = false
+    showModal.value = false
   }
 }
 
@@ -744,6 +767,14 @@ onMounted(async () => {
             title="Find participant"
             aria-label="Find participant"
           ><i class="pi pi-search text-sm sm:text-xs" aria-hidden="true"></i></button>
+          <button
+            v-if="currentJudge && selectedCategory"
+            @click="confirmReset"
+            class="para-chip-sm px-3 py-2.5 sm:px-2 sm:py-1 type-label text-content-muted hover:text-red-400 transition-all"
+            style="min-width:44px"
+            title="Reset my scores in this category"
+            aria-label="Reset my scores in this category"
+          ><i class="pi pi-undo text-sm sm:text-xs" aria-hidden="true"></i></button>
         </template>
         <button
           v-if="isAdmin || isOrganiser"
@@ -1110,10 +1141,24 @@ onMounted(async () => {
     :show="showModal"
     :title="modalTitle"
     :variant="modalVariant"
+    :accept-label="isResetModal ? (resetSaving ? 'Resetting…' : 'Reset Scores') : 'OK'"
+    :disable-accept="isResetModal && (resetSaving || resetConfirmText.trim().toUpperCase() !== 'RESET')"
     @accept="() => { dynamicCallBack() }"
-    @close="() => { showModal = false }"
+    @close="() => { showModal = false; isResetModal = false }"
   >
     <p class="type-body text-content-secondary">{{ modalMessage }}</p>
+    <div v-if="isResetModal" class="mt-4">
+      <p class="type-label text-content-muted mb-2">Type <span class="type-name text-red-400" style="letter-spacing:0.12em">RESET</span> to confirm:</p>
+      <input
+        v-model="resetConfirmText"
+        type="text"
+        class="w-full px-3 py-2 bg-surface-900 border border-surface-600 text-content-primary type-name focus:outline-none focus:border-red-400"
+        style="clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%);letter-spacing:0.1em"
+        placeholder="RESET"
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </div>
   </ActionDoneModal>
 
   <FeedbackPopout

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -984,18 +984,29 @@ const doResetAuditionNumbers = async () => {
   resetAuditionSaving.value = true
   resetAuditionError.value = ''
   const result = await resetAuditionNumbers(props.eventName)
+  resetAuditionSaving.value = false
+  showResetAuditionModal.value = false
+
   if (!result?.ok) {
-    resetAuditionError.value = result?.error || 'Reset failed'
-    resetAuditionSaving.value = false
+    // Surface failure in the shared result popup so it's hard to miss even
+    // after the confirmation dialog closes.
+    modalTitle.value = 'Reset Failed'
+    modalMessage.value = result?.error || 'Reset failed. Please try again.'
+    modalVariant.value = 'warning'
+    showModal.value = true
     return
   }
+
   // Reload the data that exposes audition_number so the UI reflects the wipe
   // without a manual refresh. Scores/feedback/battle state are not surfaced
   // on this page so no extra reload is needed for those.
   verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
   verifiedFormParticipants.value = await getVerifiedParticipantsByEvent(eventName.value)
-  resetAuditionSaving.value = false
-  showResetAuditionModal.value = false
+
+  modalTitle.value = 'Audition Numbers Reset'
+  modalMessage.value = result.message || `All audition numbers, scores, feedback, and battle state for "${props.eventName}" have been cleared.`
+  modalVariant.value = 'success'
+  showModal.value = true
 }
 
 const loadSessionTokens = async () => {
@@ -3003,7 +3014,6 @@ onUnmounted(() => {
           :disabled="resetAuditionSaving"
         />
       </div>
-      <p v-if="resetAuditionError" class="type-prose-sm text-red-400 mt-3">{{ resetAuditionError }}</p>
     </div>
   </ActionDoneModal>
 

--- a/BES-frontend/src/views/EventDetails.vue
+++ b/BES-frontend/src/views/EventDetails.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted, onBeforeUnmount, watch, computed } from 'vue';
 import ActionDoneModal from './ActionDoneModal.vue';
-import { checkTableExist, getFileId, getResponseDetails, getCategoriesByEvent, getVerifiedParticipantsByEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantCategory, addCategoryToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventCategoryFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled, getJudgingMode, setJudgingMode, getReleaseScore, setReleaseScore, getParticipantRefs, insertEventInTable, getEventFeedbackTags, createEventFeedbackGroup, createEventFeedbackTag, updateEventFeedbackTag, deleteEventFeedbackTag, deleteEventFeedbackGroup } from '@/utils/api';
+import { checkTableExist, getFileId, getResponseDetails, getCategoriesByEvent, getVerifiedParticipantsByEvent, addParticipantToSystem, getSheetSize, getRegisteredParticipantsByEvent, removeParticipantCategory, addCategoryToParticipant, getUnverifiedParticipantsDB, verifyPayment, verifyPaymentBatch, updateEventCategoryFormat, getJudgesByEvent, getJudgesByDivision, addJudgeToEvent, assignJudgeToDivision, removeJudgeFromDivision, removeEventJudge, getScoringCriteria, fetchAllFolderEvents, fetchAllEvents, getCheckinList, checkInParticipant, sendCheckinPreview, getCheckinPreviews, addDivision, renameDivision, updateDivisionSoloAllowed, deleteDivision, getSheetCategories, getSessionTokens, revokeSessionToken, generateToken, getFeedbackEnabled, setFeedbackEnabled, getJudgingMode, setJudgingMode, getReleaseScore, setReleaseScore, getParticipantRefs, insertEventInTable, getEventFeedbackTags, createEventFeedbackGroup, createEventFeedbackTag, updateEventFeedbackTag, deleteEventFeedbackTag, deleteEventFeedbackGroup, resetAuditionNumbers } from '@/utils/api';
 import { setActiveEvent, useAuthStore } from '@/utils/auth';
 import { useDelay } from '@/utils/utils';
 
@@ -957,7 +957,46 @@ const isAdminOrOrganiser = computed(() => {
   return auth === 'ROLE_ADMIN' || auth === 'ROLE_ORGANISER'
 })
 
+const isAdmin = computed(() => authStore.user?.role?.[0]?.authority === 'ROLE_ADMIN')
+
 const isHelper = computed(() => authStore.user?.role?.[0]?.authority === 'ROLE_HELPER')
+
+// ── Danger Zone: Reset Audition Numbers ───────────────────────────────────
+const showResetAuditionModal = ref(false)
+const resetAuditionConfirmText = ref('')
+const resetAuditionSaving = ref(false)
+const resetAuditionError = ref('')
+
+const openResetAuditionModal = () => {
+  resetAuditionConfirmText.value = ''
+  resetAuditionError.value = ''
+  resetAuditionSaving.value = false
+  showResetAuditionModal.value = true
+}
+
+const closeResetAuditionModal = () => {
+  if (resetAuditionSaving.value) return
+  showResetAuditionModal.value = false
+}
+
+const doResetAuditionNumbers = async () => {
+  if (resetAuditionConfirmText.value.trim() !== props.eventName) return
+  resetAuditionSaving.value = true
+  resetAuditionError.value = ''
+  const result = await resetAuditionNumbers(props.eventName)
+  if (!result?.ok) {
+    resetAuditionError.value = result?.error || 'Reset failed'
+    resetAuditionSaving.value = false
+    return
+  }
+  // Reload the data that exposes audition_number so the UI reflects the wipe
+  // without a manual refresh. Scores/feedback/battle state are not surfaced
+  // on this page so no extra reload is needed for those.
+  verifiedDbParticipants.value = await getRegisteredParticipantsByEvent(eventName.value)
+  verifiedFormParticipants.value = await getVerifiedParticipantsByEvent(eventName.value)
+  resetAuditionSaving.value = false
+  showResetAuditionModal.value = false
+}
 
 const loadSessionTokens = async () => {
   if (!dbEventId.value) return
@@ -1357,7 +1396,7 @@ onMounted(async () => {
       await Promise.all(eventCategories.value.map(loadJudgesForDivision))
       // Restore per-event setup sub-tab + auto-expand the first division.
       const savedSub = localStorage.getItem(`setupSubTab_${props.eventName}`)
-      if (savedSub === 'categories' || savedSub === 'genres' || savedSub === 'judges' || savedSub === 'links' || savedSub === 'feedback' || savedSub === 'scoring') {
+      if (savedSub === 'categories' || savedSub === 'genres' || savedSub === 'judges' || savedSub === 'links' || savedSub === 'feedback' || savedSub === 'scoring' || savedSub === 'danger') {
         setupSubTab.value = savedSub
       } else if (savedSub === 'judging-mode') {
         // Legacy key renamed to 'scoring' — migrate transparently.
@@ -1782,13 +1821,17 @@ onUnmounted(() => {
         { key: 'scoring', label: 'Scoring Settings' },
         { key: 'feedback', label: 'Feedback Tags' },
         { key: 'links',  label: 'Share Links' },
+        ...(isAdmin ? [{ key: 'danger', label: 'Danger Zone' }] : []),
       ]"
       :key="sub.key"
       role="tab"
       :aria-selected="setupSubTab === sub.key"
       @click="setupSubTab = sub.key; localStorage.setItem(`setupSubTab_${props.eventName}`, sub.key)"
       class="tab-item"
-      :class="{ 'is-active': setupSubTab === sub.key }"
+      :class="[
+        { 'is-active': setupSubTab === sub.key },
+        sub.key === 'danger' ? 'tab-item-danger' : ''
+      ]"
     >{{ sub.label }}</button>
   </div>
 
@@ -2519,6 +2562,39 @@ onUnmounted(() => {
   </template>
   <!-- ── END Feedback Tags sub-tab ────────────────────────────────────────── -->
 
+  <!-- ── Sub-tab: Danger Zone (admin only) ────────────────────────────────── -->
+  <template v-if="setupSubTab === 'danger' && isAdmin">
+    <div class="card-hover p-5 relative mt-6" style="border-color:rgba(248,113,113,0.25);background:rgba(248,113,113,0.04)">
+      <div class="corner-bar-tl" style="background:#f87171"></div>
+      <div class="section-rule mb-3">
+        <span class="section-rule-label" style="color:#f87171">Reset audition numbers</span>
+        <div class="section-rule-line" style="background:rgba(248,113,113,0.2)"></div>
+      </div>
+      <p class="type-prose mb-4">
+        Clears every audition number across <span class="type-name text-content-primary">{{ props.eventName }}</span> and wipes everything tied to those numbers:
+      </p>
+      <ul class="type-prose-sm text-content-muted mb-4 space-y-1 pl-4" style="list-style:disc">
+        <li>All judge scores across every category</li>
+        <li>All audition feedback (notes + tags)</li>
+        <li>Battle bracket / 7-to-smoke state and the active battle category</li>
+      </ul>
+      <p class="type-prose-sm text-content-muted mb-5">
+        Participant registrations, team rosters, judge assignments, payment status, and verification flags are preserved. This action cannot be undone.
+      </p>
+      <button
+        @click="openResetAuditionModal"
+        class="para-chip px-5 py-3 type-label transition-colors"
+        style="border:1px solid rgba(248,113,113,0.5);color:#f87171;background:rgba(248,113,113,0.06)"
+        @mouseenter="$event.currentTarget.style.background='rgba(248,113,113,0.14)'"
+        @mouseleave="$event.currentTarget.style.background='rgba(248,113,113,0.06)'"
+      >
+        <i class="pi pi-undo text-xs mr-2" aria-hidden="true"></i>
+        Reset Audition Numbers
+      </button>
+    </div>
+  </template>
+  <!-- ── END Danger Zone sub-tab ──────────────────────────────────────────── -->
+
   </template>
   <!-- ── END SETUP TAB ─────────────────────────────────────────────────────── -->
 
@@ -2893,6 +2969,41 @@ onUnmounted(() => {
           + {{ modalWarnings.length - 20 }} more
         </div>
       </div>
+    </div>
+  </ActionDoneModal>
+
+  <!-- Reset Audition Numbers — dedicated modal so the typed-confirm gate
+       doesn't collide with the slot content of the main ActionDoneModal -->
+  <ActionDoneModal
+    :show="showResetAuditionModal"
+    title="Reset Audition Numbers"
+    variant="warning"
+    :accept-label="resetAuditionSaving ? 'Resetting…' : 'Reset Audition Numbers'"
+    :disable-accept="resetAuditionSaving || resetAuditionConfirmText.trim() !== props.eventName"
+    @accept="doResetAuditionNumbers"
+    @close="closeResetAuditionModal"
+  >
+    <div class="flex-1 min-w-0">
+      <p class="type-body text-content-secondary">
+        This will wipe all scores, audition feedback, and battle state for
+        <span class="type-name text-content-primary">{{ props.eventName }}</span>, then clear every audition number. This cannot be undone.
+      </p>
+      <div class="mt-4">
+        <p class="type-label text-content-muted mb-2">
+          Type the event name (<span class="type-name text-red-400" style="letter-spacing:0.08em">{{ props.eventName }}</span>) to confirm:
+        </p>
+        <input
+          v-model="resetAuditionConfirmText"
+          type="text"
+          class="w-full px-3 py-2 bg-surface-900 border border-surface-600 text-content-primary type-name focus:outline-none focus:border-red-400"
+          style="clip-path:polygon(4px 0%,100% 0%,calc(100% - 4px) 100%,0% 100%);letter-spacing:0.05em"
+          :placeholder="props.eventName"
+          autocomplete="off"
+          spellcheck="false"
+          :disabled="resetAuditionSaving"
+        />
+      </div>
+      <p v-if="resetAuditionError" class="type-prose-sm text-red-400 mt-3">{{ resetAuditionError }}</p>
     </div>
   </ActionDoneModal>
 

--- a/BES-frontend/src/views/JudgeSessionView.vue
+++ b/BES-frontend/src/views/JudgeSessionView.vue
@@ -2,7 +2,14 @@
 import { onMounted, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore, setActiveEvent } from '@/utils/auth'
-import { getJudgeDivisions, whoami, logout } from '@/utils/api'
+import {
+  getJudgeDivisions,
+  whoami,
+  logout,
+  judgeActiveElsewhere,
+  claimJudgeActive,
+  releaseJudgeActive
+} from '@/utils/api'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -15,16 +22,17 @@ const loading = ref(true)
 const error = ref(null)
 
 // Confirm dialog
-const confirmDialog = ref({ show: false, title: '', message: '', onConfirm: null })
-const askConfirm = (title, message, onConfirm) => {
-  confirmDialog.value = { show: true, title, message, onConfirm }
+const confirmDialog = ref({ show: false, title: '', message: '', onConfirm: null, onCancel: null })
+const askConfirm = (title, message, onConfirm, onCancel = null) => {
+  confirmDialog.value = { show: true, title, message, onConfirm, onCancel }
 }
 const confirmYes = () => {
   confirmDialog.value.onConfirm?.()
-  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null }
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null }
 }
 const confirmNo = () => {
-  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null }
+  confirmDialog.value.onCancel?.()
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null }
 }
 const sessionReady = ref(false)
 
@@ -38,6 +46,29 @@ async function loadDivisions() {
     error.value = 'Failed to load divisions.'
   } finally {
     loading.value = false
+  }
+}
+
+async function checkAndClaimActive() {
+  const elsewhere = await judgeActiveElsewhere(authStore.judgeId)
+  if (elsewhere) {
+    askConfirm(
+      'Judge Already Active',
+      `"${judgeName.value}" is already signed in on another device. Continue anyway? Scores from both sessions will be saved, but two devices on the same judge can confuse the flow.`,
+      async () => {
+        await claimJudgeActive()
+        await loadDivisions()
+      },
+      async () => {
+        await releaseJudgeActive()
+        await logout()
+        authStore.logout()
+        router.push('/login')
+      }
+    )
+  } else {
+    await claimJudgeActive()
+    await loadDivisions()
   }
 }
 
@@ -61,7 +92,7 @@ onMounted(async () => {
   }
   sessionReady.value = true
   authStore.fetchEventBattleEnabled(authStore.activeEvent.name)
-  await loadDivisions()
+  await checkAndClaimActive()
 })
 
 function navigateToAudition(divisionName) {
@@ -82,6 +113,7 @@ function handleLogout() {
     'Leave Session?',
     'You will be returned to the login screen.',
     async () => {
+      await releaseJudgeActive()
       await logout()
       authStore.logout()
       router.push('/login')

--- a/BES-frontend/src/views/JudgeSessionView.vue
+++ b/BES-frontend/src/views/JudgeSessionView.vue
@@ -22,17 +22,17 @@ const loading = ref(true)
 const error = ref(null)
 
 // Confirm dialog
-const confirmDialog = ref({ show: false, title: '', message: '', onConfirm: null, onCancel: null })
-const askConfirm = (title, message, onConfirm, onCancel = null) => {
-  confirmDialog.value = { show: true, title, message, onConfirm, onCancel }
+const confirmDialog = ref({ show: false, title: '', message: '', onConfirm: null, onCancel: null, confirmLabel: 'Leave' })
+const askConfirm = (title, message, onConfirm, onCancel = null, options = {}) => {
+  confirmDialog.value = { show: true, title, message, onConfirm, onCancel, confirmLabel: options.confirmLabel ?? 'Leave' }
 }
 const confirmYes = () => {
   confirmDialog.value.onConfirm?.()
-  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null }
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null, confirmLabel: 'Leave' }
 }
 const confirmNo = () => {
   confirmDialog.value.onCancel?.()
-  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null }
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null, confirmLabel: 'Leave' }
 }
 const sessionReady = ref(false)
 
@@ -52,6 +52,7 @@ async function loadDivisions() {
 async function checkAndClaimActive() {
   const elsewhere = await judgeActiveElsewhere(authStore.judgeId)
   if (elsewhere) {
+    loading.value = false
     askConfirm(
       'Judge Already Active',
       `"${judgeName.value}" is already signed in on another device. Continue anyway? Scores from both sessions will be saved, but two devices on the same judge can confuse the flow.`,
@@ -64,7 +65,8 @@ async function checkAndClaimActive() {
         await logout()
         authStore.logout()
         router.push('/login')
-      }
+      },
+      { confirmLabel: 'Continue' }
     )
   } else {
     await claimJudgeActive()
@@ -228,7 +230,7 @@ function handleLogout() {
           <p class="type-prose mb-6" style="white-space:pre-wrap;">{{ confirmDialog.message }}</p>
           <div class="flex gap-2 justify-end">
             <button @click="confirmNo" class="para-chip-sm px-5 py-2.5 type-label text-content-muted hover:text-content-primary transition-colors min-h-[44px]">Cancel</button>
-            <button @click="confirmYes" class="para-chip-sm px-5 py-2.5 type-label text-red-400 border-[color:rgba(248,113,113,0.35)] hover:bg-[rgba(248,113,113,0.12)] transition-colors min-h-[44px]">Leave</button>
+            <button @click="confirmYes" class="para-chip-sm px-5 py-2.5 type-label text-red-400 border-[color:rgba(248,113,113,0.35)] hover:bg-[rgba(248,113,113,0.12)] transition-colors min-h-[44px]">{{ confirmDialog.confirmLabel }}</button>
           </div>
         </div>
       </div>

--- a/BES/src/main/java/com/example/BES/config/SessionExpiryListener.java
+++ b/BES/src/main/java/com/example/BES/config/SessionExpiryListener.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import com.example.BES.services.ActiveSessionStore;
 import com.example.BES.services.DemoService;
 import com.example.BES.services.EmceeCategoryStore;
+import com.example.BES.services.JudgeActiveStore;
 
 import jakarta.servlet.http.HttpSession;
 
@@ -21,12 +22,16 @@ public class SessionExpiryListener {
     private EmceeCategoryStore emceeCategoryStore;
 
     @Autowired
+    private JudgeActiveStore judgeActiveStore;
+
+    @Autowired
     private DemoService demoService;
 
     @EventListener
     public void onSessionDestroyed(HttpSessionDestroyedEvent event) {
         activeSessionStore.deregisterBySessionId(event.getId());
         emceeCategoryStore.release(event.getId());
+        judgeActiveStore.release(event.getId());
 
         // Clean up demo sandbox if this session was a demo
         try {

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -186,6 +186,7 @@ public class AuthController {
         HttpSession session = request.getSession(false);
         if (session != null) {
             activeSessionStore.deregisterBySessionId(session.getId());
+            judgeActiveStore.release(session.getId());
             session.invalidate();
         }
         SecurityContextHolder.clearContext();
@@ -333,7 +334,7 @@ public class AuthController {
     @PostMapping("/judge/claim")
     public ResponseEntity<?> claimJudgeActive(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
-        if (session == null) return ResponseEntity.status(401).build();
+        if (session == null) return ResponseEntity.status(org.springframework.http.HttpStatus.UNAUTHORIZED).build();
         Long judgeId = (Long) session.getAttribute("judgeId");
         String eventName = (String) session.getAttribute("eventName");
         if (judgeId == null || eventName == null) {

--- a/BES/src/main/java/com/example/BES/controllers/AuthController.java
+++ b/BES/src/main/java/com/example/BES/controllers/AuthController.java
@@ -31,6 +31,7 @@ import com.example.BES.config.SecurityConfig;
 import com.example.BES.services.AccountService;
 import com.example.BES.services.ActiveSessionStore;
 import com.example.BES.services.EmceeCategoryStore;
+import com.example.BES.services.JudgeActiveStore;
 import com.example.BES.dtos.GetSessionTokenDto;
 import com.example.BES.dtos.LoginDto;
 import com.example.BES.dtos.RedeemTokenDto;
@@ -68,13 +69,16 @@ public class AuthController {
     private EmceeCategoryStore emceeCategoryStore;
 
     @Autowired
+    private JudgeActiveStore judgeActiveStore;
+
+    @Autowired
     private AccountService accountService;
 
     @Autowired
     private JudgeRepo judgeRepo;
 
     private static final java.util.Set<String> UNLIMITED_ROLES =
-        java.util.Set.of("ROLE_ADMIN", "ROLE_HELPER", "ROLE_EMCEE", "ROLE_ORGANISER");
+        java.util.Set.of("ROLE_ADMIN", "ROLE_HELPER", "ROLE_EMCEE", "ROLE_ORGANISER", "ROLE_JUDGE");
 
     @Operation(summary = "Debug Session", description = "Returns current session ID and authentication context for debugging")
     @GetMapping("/debug-session")
@@ -171,6 +175,7 @@ public class AuthController {
         if (session != null) {
             activeSessionStore.heartbeat(session.getId());
             emceeCategoryStore.heartbeat(session.getId());
+            judgeActiveStore.heartbeat(session.getId());
         }
         return ResponseEntity.ok().build();
     }
@@ -305,5 +310,46 @@ public class AuthController {
     public ResponseEntity<?> revokeToken(@PathVariable String tokenId) {
         sessionTokenService.revoke(tokenId);
         return ResponseEntity.ok(Map.of("message", "Token revoked"));
+    }
+
+    @Operation(summary = "Check Judge Active Elsewhere",
+        description = "Returns true if another active session exists for the given judge (excluding caller)")
+    @PreAuthorize("hasRole('JUDGE')")
+    @GetMapping("/judge/active-elsewhere")
+    public ResponseEntity<Map<String, Boolean>> judgeActiveElsewhere(
+            @RequestParam Long judgeId,
+            HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        String mySessionId = session != null ? session.getId() : null;
+        String eventName = session != null ? (String) session.getAttribute("eventName") : null;
+        java.util.Set<String> active = judgeActiveStore.getActiveSessions(judgeId, eventName);
+        boolean elsewhere = active.stream().anyMatch(s -> !s.equals(mySessionId));
+        return ResponseEntity.ok(Map.of("activeElsewhere", elsewhere));
+    }
+
+    @Operation(summary = "Claim Judge Active",
+        description = "Registers caller's session in the judge active-store")
+    @PreAuthorize("hasRole('JUDGE')")
+    @PostMapping("/judge/claim")
+    public ResponseEntity<?> claimJudgeActive(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) return ResponseEntity.status(401).build();
+        Long judgeId = (Long) session.getAttribute("judgeId");
+        String eventName = (String) session.getAttribute("eventName");
+        if (judgeId == null || eventName == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Judge or event missing on session"));
+        }
+        judgeActiveStore.claim(session.getId(), judgeId, eventName);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "Release Judge Active",
+        description = "Removes caller's session from the judge active-store")
+    @PreAuthorize("hasRole('JUDGE')")
+    @DeleteMapping("/judge/release")
+    public ResponseEntity<?> releaseJudgeActive(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) judgeActiveStore.release(session.getId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/BES/src/main/java/com/example/BES/controllers/EventController.java
+++ b/BES/src/main/java/com/example/BES/controllers/EventController.java
@@ -968,6 +968,21 @@ public class EventController {
         }
     }
 
+    @Operation(summary = "Reset Audition Numbers", description = "Admin reset: wipes scores, audition feedback, battle bracket state, and clears all audition numbers for the event. Registrations and judge assignments are preserved.")
+    @DeleteMapping("/{eventName}/audition-numbers")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> resetAuditionNumbers(@PathVariable String eventName) {
+        try {
+            eventService.resetAuditionNumbers(eventName);
+            return ResponseEntity.ok(Map.of("message", "Audition numbers reset for '" + eventName + "'"));
+        } catch (ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(Map.of("error", e.getReason()));
+        } catch (Exception e) {
+            log.error("Error resetting audition numbers for event: {}", eventName, e);
+            return ResponseEntity.internalServerError().body(Map.of("error", "Failed to reset audition numbers: " + e.getMessage()));
+        }
+    }
+
     @Operation(summary = "Delete Event", description = "Permanently deletes an event and ALL associated data — participants, categories, scores, feedback, battle state, session tokens. Admin only.")
     @DeleteMapping("/{eventName}")
     @PreAuthorize("hasRole('ADMIN')")

--- a/BES/src/main/java/com/example/BES/respositories/AuditionFeedbackRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/AuditionFeedbackRepository.java
@@ -38,8 +38,19 @@ public interface AuditionFeedbackRepository extends JpaRepository<AuditionFeedba
         @Param("categoryName") String categoryName,
         @Param("judgeName") String judgeName);
 
+    // Use an IN (SELECT ...) subquery rather than f.eventCategoryParticipant.event.eventId.
+    // Hibernate emits a separate cleanup query for the audition_feedback_tag join table,
+    // and the multi-hop nested path loses its alias binding in that cleanup ("missing
+    // FROM-clause entry for table ecp1_0"). The subquery form keeps the inner alias
+    // scoped correctly, matching the deleteByEventNameAndCategoryNameAndJudgeName pattern
+    // above which works for the same reason.
     @Modifying
     @Transactional
-    @Query("DELETE FROM AuditionFeedback f WHERE f.eventCategoryParticipant.event.eventId = :eventId")
+    @Query("""
+        DELETE FROM AuditionFeedback f
+        WHERE f.eventCategoryParticipant IN (
+            SELECT e FROM EventCategoryParticipant e WHERE e.event.eventId = :eventId
+        )
+        """)
     int deleteByEventId(@Param("eventId") Long eventId);
 }

--- a/BES/src/main/java/com/example/BES/respositories/AuditionFeedbackRepository.java
+++ b/BES/src/main/java/com/example/BES/respositories/AuditionFeedbackRepository.java
@@ -37,4 +37,9 @@ public interface AuditionFeedbackRepository extends JpaRepository<AuditionFeedba
         @Param("eventName") String eventName,
         @Param("categoryName") String categoryName,
         @Param("judgeName") String judgeName);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM AuditionFeedback f WHERE f.eventCategoryParticipant.event.eventId = :eventId")
+    int deleteByEventId(@Param("eventId") Long eventId);
 }

--- a/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantRepo.java
+++ b/BES/src/main/java/com/example/BES/respositories/EventCategoryParticipantRepo.java
@@ -4,9 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.BES.models.Event;
 import com.example.BES.models.EventCategory;
@@ -17,6 +19,11 @@ import com.example.BES.models.EventCategoryParticipantId;
 public interface EventCategoryParticipantRepo extends JpaRepository<EventCategoryParticipant, EventCategoryParticipantId> {
     List<EventCategoryParticipant> findByEvent(Event event);
     List<EventCategoryParticipant> findByEventCategory(EventCategory eventCategory);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE EventCategoryParticipant e SET e.auditionNumber = NULL WHERE e.event.eventId = :eventId")
+    int clearAuditionNumbersByEventId(@Param("eventId") Long eventId);
 
     @Query("SELECT DISTINCT e FROM EventCategoryParticipant e LEFT JOIN FETCH e.judge WHERE e.event = :event")
     List<EventCategoryParticipant> findByEventWithJudge(@Param("event") Event event);

--- a/BES/src/main/java/com/example/BES/services/EventService.java
+++ b/BES/src/main/java/com/example/BES/services/EventService.java
@@ -316,4 +316,24 @@ public class EventService {
         // 13. Finally
         repo.delete(event);
     }
+
+    /**
+     * Admin reset: wipe everything tied to audition numbers for this event.
+     * Clears scores, audition feedback, battle bracket/active-category state,
+     * then nulls every audition_number on event_category_participant.
+     * Participant registrations, team rosters, per-participant judge assignments,
+     * walk-ins, payment/verification flags, and pickup crews are preserved.
+     */
+    @Transactional
+    public void resetAuditionNumbers(String eventName) {
+        Event event = repo.findByEventName(eventName)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+        Long eventId = event.getEventId();
+
+        scoreRepo.deleteByEventId(eventId);
+        auditionFeedbackRepository.deleteByEventId(eventId);
+        battleCategoryStateRepository.deleteAll(battleCategoryStateRepository.findByEventName(eventName));
+        battleActiveCategoryRepository.deleteByEventName(eventName);
+        eventCategoryParticipantRepo.clearAuditionNumbersByEventId(eventId);
+    }
 }

--- a/BES/src/main/java/com/example/BES/services/JudgeActiveStore.java
+++ b/BES/src/main/java/com/example/BES/services/JudgeActiveStore.java
@@ -1,0 +1,61 @@
+package com.example.BES.services;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@Component
+public class JudgeActiveStore {
+
+    private static final long IDLE_THRESHOLD_SECONDS = 60;
+
+    private static class Entry {
+        final Long judgeId;
+        final String eventName;
+        final AtomicLong lastSeen = new AtomicLong();
+
+        Entry(Long judgeId, String eventName) {
+            this.judgeId = judgeId;
+            this.eventName = eventName;
+            this.lastSeen.set(Instant.now().getEpochSecond());
+        }
+    }
+
+    private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+    public void claim(String sessionId, Long judgeId, String eventName) {
+        store.put(sessionId, new Entry(judgeId, eventName));
+    }
+
+    public void release(String sessionId) {
+        store.remove(sessionId);
+    }
+
+    public void heartbeat(String sessionId) {
+        Entry entry = store.get(sessionId);
+        if (entry != null) entry.lastSeen.set(Instant.now().getEpochSecond());
+    }
+
+    public Set<String> getActiveSessions(Long judgeId, String eventName) {
+        long now = Instant.now().getEpochSecond();
+        return store.entrySet().stream()
+            .filter(e -> Objects.equals(e.getValue().judgeId, judgeId))
+            .filter(e -> e.getValue().eventName != null
+                      && e.getValue().eventName.equalsIgnoreCase(eventName))
+            .filter(e -> now - e.getValue().lastSeen.get() <= IDLE_THRESHOLD_SECONDS)
+            .map(java.util.Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+
+    @Scheduled(fixedRate = 30_000)
+    public void pruneStale() {
+        long now = Instant.now().getEpochSecond();
+        store.entrySet().removeIf(e -> now - e.getValue().lastSeen.get() > IDLE_THRESHOLD_SECONDS);
+    }
+}

--- a/BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java
@@ -1,0 +1,102 @@
+package com.example.BES.controllers;
+
+import com.example.BES.services.JudgeActiveStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AuthControllerJudgeActiveTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private JudgeActiveStore judgeActiveStore;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+        // Clear store between tests
+        judgeActiveStore.getActiveSessions(42L, "Battle 2026").forEach(judgeActiveStore::release);
+    }
+
+    private MockHttpSession judgeSession(Long judgeId, String eventName) {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("judgeId", judgeId);
+        session.setAttribute("eventName", eventName);
+        return session;
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void activeElsewhereFalseForFreshSession() throws Exception {
+        MockHttpSession session = judgeSession(42L, "Battle 2026");
+
+        mockMvc.perform(get("/api/v1/auth/judge/active-elsewhere")
+                .param("judgeId", "42")
+                .session(session))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.activeElsewhere").value(false));
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void activeElsewhereTrueWhenAnotherSessionClaimed() throws Exception {
+        MockHttpSession sessionA = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(post("/api/v1/auth/judge/claim").session(sessionA))
+            .andExpect(status().isOk());
+
+        MockHttpSession sessionB = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(get("/api/v1/auth/judge/active-elsewhere")
+                .param("judgeId", "42")
+                .session(sessionB))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.activeElsewhere").value(true));
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void releaseClearsActiveSession() throws Exception {
+        MockHttpSession sessionA = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(post("/api/v1/auth/judge/claim").session(sessionA))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/auth/judge/release").session(sessionA))
+            .andExpect(status().isOk());
+
+        MockHttpSession sessionB = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(get("/api/v1/auth/judge/active-elsewhere")
+                .param("judgeId", "42")
+                .session(sessionB))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.activeElsewhere").value(false));
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void claimReturns400WhenSessionMissingJudgeId() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("eventName", "Battle 2026");
+
+        mockMvc.perform(post("/api/v1/auth/judge/claim").session(session))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java
+++ b/BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java
@@ -99,4 +99,19 @@ class AuthControllerJudgeActiveTest {
         mockMvc.perform(post("/api/v1/auth/judge/claim").session(session))
             .andExpect(status().isBadRequest());
     }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void activeElsewhereFalseForCallerOwnSession() throws Exception {
+        MockHttpSession sessionA = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(post("/api/v1/auth/judge/claim").session(sessionA))
+            .andExpect(status().isOk());
+
+        // Same session checks active-elsewhere — must exclude itself
+        mockMvc.perform(get("/api/v1/auth/judge/active-elsewhere")
+                .param("judgeId", "42")
+                .session(sessionA))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.activeElsewhere").value(false));
+    }
 }

--- a/BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java
+++ b/BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java
@@ -57,4 +57,13 @@ class JudgeActiveStoreTest {
 
         assertEquals(Set.of("session-A", "session-B"), active);
     }
+
+    @Test
+    void getActiveSessionsMatchesEventNameCaseInsensitively() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+
+        assertEquals(Set.of("session-A"), store.getActiveSessions(42L, "BATTLE 2026"));
+        assertEquals(Set.of("session-A"), store.getActiveSessions(42L, "battle 2026"));
+    }
 }

--- a/BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java
+++ b/BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java
@@ -1,0 +1,60 @@
+package com.example.BES.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JudgeActiveStoreTest {
+
+    @Test
+    void claimRegistersSessionForJudgeAndEvent() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+
+        Set<String> active = store.getActiveSessions(42L, "Battle 2026");
+
+        assertEquals(Set.of("session-A"), active);
+    }
+
+    @Test
+    void releaseRemovesSession() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+
+        store.release("session-A");
+
+        assertTrue(store.getActiveSessions(42L, "Battle 2026").isEmpty());
+    }
+
+    @Test
+    void getActiveSessionsExcludesDifferentJudge() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+        store.claim("session-B", 99L, "Battle 2026");
+
+        assertEquals(Set.of("session-A"), store.getActiveSessions(42L, "Battle 2026"));
+    }
+
+    @Test
+    void getActiveSessionsExcludesDifferentEvent() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+        store.claim("session-B", 42L, "Other Event");
+
+        assertEquals(Set.of("session-A"), store.getActiveSessions(42L, "Battle 2026"));
+    }
+
+    @Test
+    void multipleSessionsForSameJudgeAreAllReturned() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+        store.claim("session-B", 42L, "Battle 2026");
+
+        Set<String> active = store.getActiveSessions(42L, "Battle 2026");
+
+        assertEquals(Set.of("session-A", "session-B"), active);
+    }
+}

--- a/docs/superpowers/plans/2026-06-20-judge-active-status-prompt.md
+++ b/docs/superpowers/plans/2026-06-20-judge-active-status-prompt.md
@@ -1,0 +1,822 @@
+# Judge Active-Status Prompt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hard 409 "judge session already active" block with a soft, heartbeat-tracked confirm prompt on `JudgeSessionView`, matching the existing emcee pattern.
+
+**Architecture:** Add `ROLE_JUDGE` to `UNLIMITED_ROLES` so `redeemToken()` no longer blocks. Introduce a `JudgeActiveStore` (in-memory `ConcurrentHashMap` keyed by `sessionId`) modeled directly on `EmceeCategoryStore`, with the same 60s idle threshold and 30s pruner. Add three `AuthController` endpoints (check / claim / release), wire heartbeat through the existing `/auth/heartbeat`, and clean up on session destroy via `SessionExpiryListener`. Frontend: `JudgeSessionView` calls a check on mount and shows the existing confirm dialog when another active session exists for the same judge.
+
+**Tech Stack:** Java 17, Spring Boot 3, Spring Security, JUnit 5, MockMvc, Vue 3, Pinia, Vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-20-judge-active-status-prompt-design.md`. Spec language is authoritative when this plan and spec diverge.
+- All backend additions live under `com.example.BES.*` following the existing package layout (services, controllers, config).
+- Follow the existing emcee pattern: 60s idle threshold, 30s pruner (`@Scheduled(fixedRate = 30_000)`), `Instant.now().getEpochSecond()` timestamps. Do not invent a new convention.
+- Granularity is **per judge identity scoped to event**, not per division. Filter on both `judgeId` and `eventName`.
+- No WebSocket broadcasts. The prompt is one-shot at mount; no reactive updates needed.
+- Backend additive only. No DB migration. No Flyway file.
+- Frontend defaults to fail-open: if the active-check endpoint returns non-OK, treat as `activeElsewhere: false`.
+- Run `mvn test` from `BES/` and `npm test` from `BES-frontend/` before any push (pre-push-verify skill handles this).
+
+---
+
+### Task 1: `JudgeActiveStore` service
+
+**Files:**
+- Create: `BES/src/main/java/com/example/BES/services/JudgeActiveStore.java`
+- Test: `BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java`
+
+**Interfaces:**
+- Consumes: nothing (leaf service).
+- Produces:
+  - `void claim(String sessionId, Long judgeId, String eventName)`
+  - `void release(String sessionId)`
+  - `void heartbeat(String sessionId)`
+  - `Set<String> getActiveSessions(Long judgeId, String eventName)` — returns sessionIds whose last-seen is within 60s
+  - `void pruneStale()` — `@Scheduled(fixedRate = 30_000)` self-trigger
+
+- [ ] **Step 1: Write the failing test**
+
+Create `BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java`:
+
+```java
+package com.example.BES.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JudgeActiveStoreTest {
+
+    @Test
+    void claimRegistersSessionForJudgeAndEvent() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+
+        Set<String> active = store.getActiveSessions(42L, "Battle 2026");
+
+        assertEquals(Set.of("session-A"), active);
+    }
+
+    @Test
+    void releaseRemovesSession() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+
+        store.release("session-A");
+
+        assertTrue(store.getActiveSessions(42L, "Battle 2026").isEmpty());
+    }
+
+    @Test
+    void getActiveSessionsExcludesDifferentJudge() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+        store.claim("session-B", 99L, "Battle 2026");
+
+        assertEquals(Set.of("session-A"), store.getActiveSessions(42L, "Battle 2026"));
+    }
+
+    @Test
+    void getActiveSessionsExcludesDifferentEvent() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+        store.claim("session-B", 42L, "Other Event");
+
+        assertEquals(Set.of("session-A"), store.getActiveSessions(42L, "Battle 2026"));
+    }
+
+    @Test
+    void multipleSessionsForSameJudgeAreAllReturned() {
+        JudgeActiveStore store = new JudgeActiveStore();
+        store.claim("session-A", 42L, "Battle 2026");
+        store.claim("session-B", 42L, "Battle 2026");
+
+        Set<String> active = store.getActiveSessions(42L, "Battle 2026");
+
+        assertEquals(Set.of("session-A", "session-B"), active);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd BES && mvn test -Dtest=JudgeActiveStoreTest`
+Expected: COMPILE ERROR — `JudgeActiveStore` does not exist.
+
+- [ ] **Step 3: Implement `JudgeActiveStore`**
+
+Create `BES/src/main/java/com/example/BES/services/JudgeActiveStore.java`:
+
+```java
+package com.example.BES.services;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@Component
+public class JudgeActiveStore {
+
+    private static final long IDLE_THRESHOLD_SECONDS = 60;
+
+    private static class Entry {
+        final Long judgeId;
+        final String eventName;
+        final AtomicLong lastSeen = new AtomicLong();
+
+        Entry(Long judgeId, String eventName) {
+            this.judgeId = judgeId;
+            this.eventName = eventName;
+            this.lastSeen.set(Instant.now().getEpochSecond());
+        }
+    }
+
+    private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+    public void claim(String sessionId, Long judgeId, String eventName) {
+        store.put(sessionId, new Entry(judgeId, eventName));
+    }
+
+    public void release(String sessionId) {
+        store.remove(sessionId);
+    }
+
+    public void heartbeat(String sessionId) {
+        Entry entry = store.get(sessionId);
+        if (entry != null) entry.lastSeen.set(Instant.now().getEpochSecond());
+    }
+
+    public Set<String> getActiveSessions(Long judgeId, String eventName) {
+        long now = Instant.now().getEpochSecond();
+        return store.entrySet().stream()
+            .filter(e -> Objects.equals(e.getValue().judgeId, judgeId))
+            .filter(e -> e.getValue().eventName != null
+                      && e.getValue().eventName.equalsIgnoreCase(eventName))
+            .filter(e -> now - e.getValue().lastSeen.get() <= IDLE_THRESHOLD_SECONDS)
+            .map(java.util.Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+
+    @Scheduled(fixedRate = 30_000)
+    public void pruneStale() {
+        long now = Instant.now().getEpochSecond();
+        store.entrySet().removeIf(e -> now - e.getValue().lastSeen.get() > IDLE_THRESHOLD_SECONDS);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd BES && mvn test -Dtest=JudgeActiveStoreTest`
+Expected: PASS — 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/services/JudgeActiveStore.java \
+        BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java
+git commit -m "feat(judge-session): add JudgeActiveStore for heartbeat-tracked judge presence"
+```
+
+---
+
+### Task 2: `AuthController` — unlimited judges + claim/release/check endpoints
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/controllers/AuthController.java`
+- Test: `BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java`
+
+**Interfaces:**
+- Consumes: `JudgeActiveStore` from Task 1.
+- Produces (HTTP endpoints):
+  - `GET  /api/v1/auth/judge/active-elsewhere?judgeId={id}` → `{ "activeElsewhere": boolean }`
+  - `POST /api/v1/auth/judge/claim` → 200 on success, 400 if `judgeId`/`eventName` missing on session, 401 if no session
+  - `DELETE /api/v1/auth/judge/release` → 200
+- Produces (behavior): redeeming a judge token a second time in another browser no longer returns 409.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java`:
+
+```java
+package com.example.BES.controllers;
+
+import com.example.BES.services.JudgeActiveStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AuthControllerJudgeActiveTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private JudgeActiveStore judgeActiveStore;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+        // Clear store between tests
+        judgeActiveStore.getActiveSessions(42L, "Battle 2026").forEach(judgeActiveStore::release);
+    }
+
+    private MockHttpSession judgeSession(Long judgeId, String eventName) {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("judgeId", judgeId);
+        session.setAttribute("eventName", eventName);
+        return session;
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void activeElsewhereFalseForFreshSession() throws Exception {
+        MockHttpSession session = judgeSession(42L, "Battle 2026");
+
+        mockMvc.perform(get("/api/v1/auth/judge/active-elsewhere")
+                .param("judgeId", "42")
+                .session(session))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.activeElsewhere").value(false));
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void activeElsewhereTrueWhenAnotherSessionClaimed() throws Exception {
+        MockHttpSession sessionA = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(post("/api/v1/auth/judge/claim").session(sessionA))
+            .andExpect(status().isOk());
+
+        MockHttpSession sessionB = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(get("/api/v1/auth/judge/active-elsewhere")
+                .param("judgeId", "42")
+                .session(sessionB))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.activeElsewhere").value(true));
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void releaseClearsActiveSession() throws Exception {
+        MockHttpSession sessionA = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(post("/api/v1/auth/judge/claim").session(sessionA))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/auth/judge/release").session(sessionA))
+            .andExpect(status().isOk());
+
+        MockHttpSession sessionB = judgeSession(42L, "Battle 2026");
+        mockMvc.perform(get("/api/v1/auth/judge/active-elsewhere")
+                .param("judgeId", "42")
+                .session(sessionB))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.activeElsewhere").value(false));
+    }
+
+    @Test
+    @WithMockUser(roles = "JUDGE")
+    void claimReturns400WhenSessionMissingJudgeId() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("eventName", "Battle 2026");
+
+        mockMvc.perform(post("/api/v1/auth/judge/claim").session(session))
+            .andExpect(status().isBadRequest());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd BES && mvn test -Dtest=AuthControllerJudgeActiveTest`
+Expected: FAIL — 404 on all three new endpoints (they don't exist yet).
+
+- [ ] **Step 3: Modify `AuthController.java` — add `ROLE_JUDGE` to `UNLIMITED_ROLES`**
+
+In `BES/src/main/java/com/example/BES/controllers/AuthController.java`, find line 76–77:
+
+```java
+    private static final java.util.Set<String> UNLIMITED_ROLES =
+        java.util.Set.of("ROLE_ADMIN", "ROLE_HELPER", "ROLE_EMCEE", "ROLE_ORGANISER");
+```
+
+Replace with:
+
+```java
+    private static final java.util.Set<String> UNLIMITED_ROLES =
+        java.util.Set.of("ROLE_ADMIN", "ROLE_HELPER", "ROLE_EMCEE", "ROLE_ORGANISER", "ROLE_JUDGE");
+```
+
+- [ ] **Step 4: Inject `JudgeActiveStore` and wire into heartbeat**
+
+In `AuthController.java`, add the import alongside the existing service imports near the top:
+
+```java
+import com.example.BES.services.JudgeActiveStore;
+```
+
+Add the field below the existing `emceeCategoryStore` autowire (around line 67–68):
+
+```java
+    @Autowired
+    private JudgeActiveStore judgeActiveStore;
+```
+
+Find the existing `/heartbeat` endpoint (around line 167–176):
+
+```java
+    @PostMapping("/heartbeat")
+    public ResponseEntity<?> heartbeat(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            activeSessionStore.heartbeat(session.getId());
+            emceeCategoryStore.heartbeat(session.getId());
+        }
+        return ResponseEntity.ok().build();
+    }
+```
+
+Add the judge heartbeat call:
+
+```java
+    @PostMapping("/heartbeat")
+    public ResponseEntity<?> heartbeat(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            activeSessionStore.heartbeat(session.getId());
+            emceeCategoryStore.heartbeat(session.getId());
+            judgeActiveStore.heartbeat(session.getId());
+        }
+        return ResponseEntity.ok().build();
+    }
+```
+
+- [ ] **Step 5: Add the three judge endpoints**
+
+Insert these methods inside `AuthController` (just before the closing brace of the class, after `redeemToken`):
+
+```java
+    @Operation(summary = "Check Judge Active Elsewhere",
+        description = "Returns true if another active session exists for the given judge (excluding caller)")
+    @PreAuthorize("hasRole('JUDGE')")
+    @GetMapping("/judge/active-elsewhere")
+    public ResponseEntity<Map<String, Boolean>> judgeActiveElsewhere(
+            @RequestParam Long judgeId,
+            HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        String mySessionId = session != null ? session.getId() : null;
+        String eventName = session != null ? (String) session.getAttribute("eventName") : null;
+        java.util.Set<String> active = judgeActiveStore.getActiveSessions(judgeId, eventName);
+        boolean elsewhere = active.stream().anyMatch(s -> !s.equals(mySessionId));
+        return ResponseEntity.ok(Map.of("activeElsewhere", elsewhere));
+    }
+
+    @Operation(summary = "Claim Judge Active",
+        description = "Registers caller's session in the judge active-store")
+    @PreAuthorize("hasRole('JUDGE')")
+    @PostMapping("/judge/claim")
+    public ResponseEntity<?> claimJudgeActive(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) return ResponseEntity.status(401).build();
+        Long judgeId = (Long) session.getAttribute("judgeId");
+        String eventName = (String) session.getAttribute("eventName");
+        if (judgeId == null || eventName == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Judge or event missing on session"));
+        }
+        judgeActiveStore.claim(session.getId(), judgeId, eventName);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "Release Judge Active",
+        description = "Removes caller's session from the judge active-store")
+    @PreAuthorize("hasRole('JUDGE')")
+    @DeleteMapping("/judge/release")
+    public ResponseEntity<?> releaseJudgeActive(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) judgeActiveStore.release(session.getId());
+        return ResponseEntity.ok().build();
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd BES && mvn test -Dtest=AuthControllerJudgeActiveTest`
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 7: Run the full backend test suite for regression**
+
+Run: `cd BES && mvn test`
+Expected: All existing tests pass; the change to `UNLIMITED_ROLES` does not break any existing `AuthController` test.
+
+If any pre-existing test asserted the 409 conflict for a judge token re-redeem, update it: the new expectation is 200 OK on second redeem. (No such test is currently expected based on the spec.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/controllers/AuthController.java \
+        BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java
+git commit -m "feat(judge-session): allow concurrent judge sessions, add active-elsewhere check"
+```
+
+---
+
+### Task 3: `SessionExpiryListener` — release on session destroy
+
+**Files:**
+- Modify: `BES/src/main/java/com/example/BES/config/SessionExpiryListener.java`
+
+**Interfaces:**
+- Consumes: `JudgeActiveStore.release(String sessionId)` from Task 1.
+- Produces: nothing (event handler side-effect only).
+
+- [ ] **Step 1: Modify the listener**
+
+In `BES/src/main/java/com/example/BES/config/SessionExpiryListener.java`, add the import next to the existing service imports:
+
+```java
+import com.example.BES.services.JudgeActiveStore;
+```
+
+Add the autowire below the existing `emceeCategoryStore` autowire:
+
+```java
+    @Autowired
+    private JudgeActiveStore judgeActiveStore;
+```
+
+In `onSessionDestroyed`, add the release call beneath the existing `emceeCategoryStore.release(...)` call:
+
+```java
+        emceeCategoryStore.release(event.getId());
+        judgeActiveStore.release(event.getId());
+```
+
+Final relevant block of `onSessionDestroyed`:
+
+```java
+    @EventListener
+    public void onSessionDestroyed(HttpSessionDestroyedEvent event) {
+        activeSessionStore.deregisterBySessionId(event.getId());
+        emceeCategoryStore.release(event.getId());
+        judgeActiveStore.release(event.getId());
+
+        // Clean up demo sandbox if this session was a demo
+        try {
+            HttpSession session = event.getSession();
+            if (session != null) {
+                String eventName = (String) session.getAttribute("eventName");
+                if (eventName != null && eventName.startsWith("Kyrove Demo-")) {
+                    Long eventId = (Long) session.getAttribute("eventId");
+                    if (eventId != null) {
+                        demoService.purgeSandbox(eventId);
+                    }
+                }
+            }
+        } catch (IllegalStateException e) {
+            // Session already invalidated — cannot read attributes, skip demo cleanup
+        }
+    }
+```
+
+- [ ] **Step 2: Verify the change compiles and full suite still passes**
+
+Run: `cd BES && mvn test`
+Expected: All tests pass. (No new test added — this is a one-line wiring change that's exercised when integration tests destroy mock sessions; manual verification covers the production path.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES/src/main/java/com/example/BES/config/SessionExpiryListener.java
+git commit -m "feat(judge-session): release judge active-store on session destroy"
+```
+
+---
+
+### Task 4: Frontend API helpers
+
+**Files:**
+- Modify: `BES-frontend/src/utils/api.js`
+
+**Interfaces:**
+- Consumes: the three judge endpoints from Task 2.
+- Produces:
+  - `judgeActiveElsewhere(judgeId) -> Promise<boolean>` — fail-open, returns `false` on any non-OK / network error
+  - `claimJudgeActive() -> Promise<void>`
+  - `releaseJudgeActive() -> Promise<void>`
+
+- [ ] **Step 1: Add the three helpers**
+
+In `BES-frontend/src/utils/api.js`, locate the emcee active-category helpers (around lines 1706–1730) and append the judge helpers right below them:
+
+```javascript
+export const judgeActiveElsewhere = async (judgeId) => {
+  try {
+    const res = await fetch(
+      `${domain}/api/v1/auth/judge/active-elsewhere?judgeId=${judgeId}`,
+      { credentials: 'include', headers: { 'Accept': 'application/json' } }
+    )
+    if (!res.ok) return false
+    const body = await res.json()
+    return !!body.activeElsewhere
+  } catch (e) {
+    console.error(e)
+    return false
+  }
+}
+
+export const claimJudgeActive = async () => {
+  try {
+    await fetch(`${domain}/api/v1/auth/judge/claim`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+  } catch (e) { console.error(e) }
+}
+
+export const releaseJudgeActive = async () => {
+  try {
+    await fetch(`${domain}/api/v1/auth/judge/release`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+  } catch (e) { console.error(e) }
+}
+```
+
+- [ ] **Step 2: Smoke-build the frontend to catch syntax errors**
+
+Run: `cd BES-frontend && npm run build`
+Expected: Build succeeds. Vite reports no syntax errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BES-frontend/src/utils/api.js
+git commit -m "feat(judge-session): add judge active-elsewhere/claim/release API helpers"
+```
+
+---
+
+### Task 5: `JudgeSessionView` — mount-time check, confirm prompt, release on logout
+
+**Files:**
+- Modify: `BES-frontend/src/views/JudgeSessionView.vue`
+
+**Interfaces:**
+- Consumes: `judgeActiveElsewhere`, `claimJudgeActive`, `releaseJudgeActive` from Task 4.
+- Produces: UX behavior — judge sees confirm dialog when another session is active for their identity on the same event.
+
+- [ ] **Step 1: Update the imports**
+
+In `BES-frontend/src/views/JudgeSessionView.vue`, find the existing import line near the top of `<script setup>`:
+
+```javascript
+import { getJudgeDivisions, whoami, logout } from '@/utils/api'
+```
+
+Replace with:
+
+```javascript
+import {
+  getJudgeDivisions,
+  whoami,
+  logout,
+  judgeActiveElsewhere,
+  claimJudgeActive,
+  releaseJudgeActive
+} from '@/utils/api'
+```
+
+- [ ] **Step 2: Extend `askConfirm` to support an onCancel callback**
+
+Current `askConfirm` / `confirmNo` (around lines 17–28):
+
+```javascript
+const confirmDialog = ref({ show: false, title: '', message: '', onConfirm: null })
+const askConfirm = (title, message, onConfirm) => {
+  confirmDialog.value = { show: true, title, message, onConfirm }
+}
+const confirmYes = () => {
+  confirmDialog.value.onConfirm?.()
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null }
+}
+const confirmNo = () => {
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null }
+}
+```
+
+Replace with:
+
+```javascript
+const confirmDialog = ref({ show: false, title: '', message: '', onConfirm: null, onCancel: null })
+const askConfirm = (title, message, onConfirm, onCancel = null) => {
+  confirmDialog.value = { show: true, title, message, onConfirm, onCancel }
+}
+const confirmYes = () => {
+  confirmDialog.value.onConfirm?.()
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null }
+}
+const confirmNo = () => {
+  confirmDialog.value.onCancel?.()
+  confirmDialog.value = { show: false, title: '', message: '', onConfirm: null, onCancel: null }
+}
+```
+
+- [ ] **Step 3: Add a helper that performs the active-elsewhere check + claim**
+
+Add this function below `loadDivisions()` (before `onMounted`), around line 42:
+
+```javascript
+async function checkAndClaimActive() {
+  const elsewhere = await judgeActiveElsewhere(authStore.judgeId)
+  if (elsewhere) {
+    askConfirm(
+      'Judge Already Active',
+      `"${judgeName.value}" is already signed in on another device. Continue anyway? Scores from both sessions will be saved, but two devices on the same judge can confuse the flow.`,
+      async () => {
+        await claimJudgeActive()
+        await loadDivisions()
+      },
+      async () => {
+        await releaseJudgeActive()
+        await logout()
+        authStore.logout()
+        router.push('/login')
+      }
+    )
+  } else {
+    await claimJudgeActive()
+    await loadDivisions()
+  }
+}
+```
+
+- [ ] **Step 4: Wire `checkAndClaimActive` into `onMounted`**
+
+Locate the current `onMounted` (around lines 44–65). The structure is roughly:
+
+```javascript
+onMounted(async () => {
+  if (!isJudgeSession.value) {
+    // restore via whoami...
+  }
+  // existing: loadDivisions()
+})
+```
+
+Read the current contents and update so that:
+- The existing whoami-restore block runs first.
+- After session is confirmed (`isJudgeSession.value` is true), call `await checkAndClaimActive()` instead of `await loadDivisions()`.
+
+Concretely — the call site that used to be `await loadDivisions()` becomes `await checkAndClaimActive()`. Do not add a second `loadDivisions` call: `checkAndClaimActive` handles both branches.
+
+If the existing code has `loadDivisions()` called unconditionally at the end of `onMounted`, replace that single call with `checkAndClaimActive()`. Leave the rest of the whoami / session-restore logic unchanged.
+
+- [ ] **Step 5: Update `handleLogout` to release before logout**
+
+Current `handleLogout` (around lines 80–90):
+
+```javascript
+function handleLogout() {
+  askConfirm(
+    'Leave Session?',
+    'You will be returned to the login screen.',
+    async () => {
+      await logout()
+      authStore.logout()
+      router.push('/login')
+    }
+  )
+}
+```
+
+Replace with:
+
+```javascript
+function handleLogout() {
+  askConfirm(
+    'Leave Session?',
+    'You will be returned to the login screen.',
+    async () => {
+      await releaseJudgeActive()
+      await logout()
+      authStore.logout()
+      router.push('/login')
+    }
+  )
+}
+```
+
+- [ ] **Step 6: Smoke-build to catch syntax errors**
+
+Run: `cd BES-frontend && npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 7: Manual verification**
+
+Start the app via `docker compose up -d --build` (no `--no-cache` — Dockerfile / pom / package.json unchanged), then:
+
+1. Generate a judge session link from `/events/<eventName>` → Session Links.
+2. Open the link in Browser A (e.g. Chrome). Verify divisions load, no prompt.
+3. Open the same link in Browser B (e.g. Safari, or a private window). Verify:
+   - The 409 redirect to "Link invalid" does NOT happen.
+   - On `/judge/session`, a confirm dialog appears: "Judge X is already signed in on another device. Continue anyway?".
+   - **Continue** → divisions load; both browsers can navigate to audition list.
+   - Reload Browser B and choose **Cancel** → returned to `/login`.
+4. In Browser A, click Logout. In Browser B, refresh `/judge/session` — no prompt this time (A released its claim).
+5. Same browser, refresh the tab — no prompt (the caller's own sessionId is excluded).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add BES-frontend/src/views/JudgeSessionView.vue
+git commit -m "feat(judge-session): prompt instead of block when judge active elsewhere"
+```
+
+---
+
+### Task 6: End-to-end check and PR
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run pre-push verification**
+
+Invoke the pre-push-verify skill (or run manually):
+- `cd BES && mvn test`
+- `cd BES-frontend && npm test`
+- `cd BES-frontend && npm run build`
+
+Expected: all green.
+
+- [ ] **Step 2: Push the branch and open PR**
+
+Standard flow — push current branch and `gh pr create` with title "feat(judge-session): replace hard session limit with active-status prompt" and body summarising the change with a link to the spec:
+
+```
+## Summary
+- Add `ROLE_JUDGE` to `UNLIMITED_ROLES` — second device on the same judge token no longer hits 409
+- New `JudgeActiveStore` (in-memory, 60s idle threshold, mirrors `EmceeCategoryStore`)
+- `AuthController`: new `/auth/judge/active-elsewhere`, `/auth/judge/claim`, `/auth/judge/release`; heartbeat now refreshes judge presence
+- `SessionExpiryListener`: release judge claim on session destroy
+- `JudgeSessionView`: mount-time check; confirm dialog when same judge is active on another device
+
+Spec: docs/superpowers/specs/2026-06-20-judge-active-status-prompt-design.md
+
+## Test plan
+- [ ] Backend `mvn test` passes (incl. new `JudgeActiveStoreTest`, `AuthControllerJudgeActiveTest`)
+- [ ] Frontend `npm test` and `npm run build` pass
+- [ ] Manual: two browsers, same judge token — second sees prompt, not 409
+- [ ] Manual: refresh same tab — no prompt
+- [ ] Manual: logout from one device — other device sees no prompt on reload
+```
+
+---
+
+## Self-review
+
+**Spec coverage check** — every spec section is covered:
+- `JudgeActiveStore` (spec §"Backend changes" → store): Task 1 ✓
+- `ROLE_JUDGE` in UNLIMITED_ROLES + heartbeat wiring + 3 endpoints: Task 2 ✓
+- `SessionExpiryListener` release: Task 3 ✓
+- Frontend API helpers (3): Task 4 ✓
+- `JudgeSessionView` mount-time check, confirm dialog, release on logout: Task 5 ✓
+- Testing (backend store test, backend controller test, manual): Tasks 1, 2, 5 ✓
+- Behavior matrix (rows: first device OK, second prompts, refresh same tab silent, logout releases, network drop expires after 60s): covered by combination of Tasks 1–5; manual verification in Task 5 ✓
+- Non-goals (password login, per-division granularity, WS broadcast): explicitly skipped, no tasks ✓
+
+**Placeholder scan:** No "TBD", no "add appropriate error handling", no "similar to Task N". Every code-changing step shows actual code.
+
+**Type / name consistency:**
+- `JudgeActiveStore` methods (`claim`, `release`, `heartbeat`, `getActiveSessions`, `pruneStale`) used in Tasks 1, 2, 3 — match across all tasks.
+- Frontend helper names (`judgeActiveElsewhere`, `claimJudgeActive`, `releaseJudgeActive`) — match between Task 4 (definition) and Task 5 (consumption).
+- Endpoint paths (`/auth/judge/active-elsewhere`, `/auth/judge/claim`, `/auth/judge/release`) — match between Task 2 (controller) and Task 4 (frontend).
+
+No issues found.

--- a/docs/superpowers/specs/2026-06-20-judge-active-status-prompt-design.md
+++ b/docs/superpowers/specs/2026-06-20-judge-active-status-prompt-design.md
@@ -1,0 +1,284 @@
+# Judge Active-Status Prompt (replace hard session limit)
+
+**Date:** 2026-06-20
+**Status:** Design approved, awaiting plan
+
+## Problem
+
+Judges authenticate via permanent per-judge session-token links (e.g. `/auth/token?t=...`). Today, `AuthController.redeemToken()` enforces a one-active-session-per-token rule for any role not in `UNLIMITED_ROLES`. `ROLE_JUDGE` is the only session-link role that is NOT unlimited — `ADMIN`, `EMCEE`, `HELPER`, `ORGANISER` are all whitelisted. As a result, if a judge opens their token link on a second device (or even a second tab where the cookie didn't carry over), they hit a hard 409 `"This session link is already active in another browser"` and cannot proceed without the first session expiring.
+
+This is a problem in practice: judges legitimately move between phone / tablet / shared tablet during an event, and the hard block forces an organiser to regenerate the token or wait for session expiry.
+
+Emcees already have a softer pattern. They are unlimited at redeem; `EmceeCategoryStore` tracks who is actively running which category via heartbeat, and `EmceeSessionView` shows an "ACTIVE" badge plus a confirm dialog when a second emcee picks a category that another emcee is already running. Continue-anyway is allowed; the user just gets a clear warning.
+
+## Goal
+
+Apply the same UX to judges. Remove the hard block; replace it with a heartbeat-tracked "active elsewhere" check and a confirm prompt on the judge session landing page.
+
+Granularity is **per judge identity** (not per division). A single confirm prompt on `JudgeSessionView` is enough; we do not need ACTIVE badges per division. Rationale: judges score independently per (judge × participant × category), so a duplicate session is a UX confusion risk, not a data-integrity risk. One prompt at entry captures the case without spamming the UI.
+
+## Non-goals
+
+- Per-(judge × division) tracking. Deferred — can be added later if we observe real confusion mid-event.
+- Password-login judges. Judges authenticate via token only; the `/auth/login` path is N/A.
+- WebSocket broadcast of the active set. The prompt is one-shot at session entry; reactive updates are unnecessary.
+- Changing emcee, helper, or organiser session behavior. This spec is judge-only.
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  Browser A (Judge Alice's phone)                              │
+│   /auth/token?t=… → /judge/session                            │
+│     ├ judgeActiveElsewhere(judgeId) → { activeElsewhere: false }
+│     └ claimJudgeActive() → registered                         │
+│  (heartbeat every 30s via existing /auth/heartbeat)           │
+└───────────────────────────────────────────────────────────────┘
+                                │
+┌───────────────────────────────▼───────────────────────────────┐
+│  Backend                                                      │
+│    AuthController                                             │
+│      - UNLIMITED_ROLES now includes ROLE_JUDGE                │
+│      - GET  /auth/judge/active-elsewhere?judgeId={id}         │
+│      - POST /auth/judge/claim                                 │
+│      - DELETE /auth/judge/release                             │
+│      - /auth/heartbeat also calls judgeActiveStore.heartbeat  │
+│                                                               │
+│    JudgeActiveStore (NEW, in-memory)                          │
+│      Map<sessionId, Entry(judgeId, eventName, lastHeartbeat)> │
+│      90s grace window before considered inactive              │
+│                                                               │
+│    SessionExpiryListener                                      │
+│      On session destroyed → judgeActiveStore.release(id)      │
+└───────────────────────────────▲───────────────────────────────┘
+                                │
+┌───────────────────────────────────────────────────────────────┐
+│  Browser B (Judge Alice's tablet, second device)              │
+│   /auth/token?t=… → /judge/session                            │
+│     ├ judgeActiveElsewhere(judgeId) → { activeElsewhere: true }
+│     ├ ConfirmDialog: "Judge Alice is already active…"         │
+│     │    Continue → claimJudgeActive() → divisions load       │
+│     │    Cancel   → releaseJudgeActive() + logout() → /login  │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Backend changes
+
+### `BES/src/main/java/com/example/BES/services/JudgeActiveStore.java` (NEW)
+
+Mirror of `EmceeCategoryStore`. Single in-memory map; not persisted.
+
+```java
+@Service
+public class JudgeActiveStore {
+    private static final Duration GRACE = Duration.ofSeconds(90);
+
+    private record Entry(Long judgeId, String eventName, Instant lastHeartbeat) {}
+
+    private final ConcurrentHashMap<String, Entry> bySession = new ConcurrentHashMap<>();
+
+    public void claim(String sessionId, Long judgeId, String eventName) {
+        bySession.put(sessionId, new Entry(judgeId, eventName, Instant.now()));
+    }
+
+    public void release(String sessionId) {
+        bySession.remove(sessionId);
+    }
+
+    public void heartbeat(String sessionId) {
+        bySession.computeIfPresent(sessionId,
+            (k, v) -> new Entry(v.judgeId(), v.eventName(), Instant.now()));
+    }
+
+    /** sessionIds currently active for this (judge, event), excluding stale heartbeats. */
+    public Set<String> getActiveSessions(Long judgeId, String eventName) {
+        Instant cutoff = Instant.now().minus(GRACE);
+        return bySession.entrySet().stream()
+            .filter(e -> e.getValue().lastHeartbeat().isAfter(cutoff))
+            .filter(e -> Objects.equals(e.getValue().judgeId(), judgeId))
+            .filter(e -> Objects.equals(e.getValue().eventName(), eventName))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+}
+```
+
+### `BES/src/main/java/com/example/BES/controllers/AuthController.java`
+
+1. Add `"ROLE_JUDGE"` to `UNLIMITED_ROLES`. The 409 conflict in `redeemToken()` (and `login()`) no longer applies to judges. The `activeSessionStore.register()` call still runs — it just becomes informational, no longer enforced.
+
+2. Inject `JudgeActiveStore`. Update `/auth/heartbeat` to also call `judgeActiveStore.heartbeat(session.getId())` alongside the existing `activeSessionStore.heartbeat` and `emceeCategoryStore.heartbeat`.
+
+3. New endpoints, all `@PreAuthorize("hasRole('JUDGE')")`:
+
+   ```java
+   @GetMapping("/judge/active-elsewhere")
+   public ResponseEntity<Map<String, Boolean>> judgeActiveElsewhere(
+           @RequestParam Long judgeId,
+           HttpServletRequest request) {
+       HttpSession session = request.getSession(false);
+       String mySessionId = session != null ? session.getId() : null;
+       String eventName = session != null ? (String) session.getAttribute("eventName") : null;
+       Set<String> active = judgeActiveStore.getActiveSessions(judgeId, eventName);
+       boolean elsewhere = active.stream().anyMatch(s -> !s.equals(mySessionId));
+       return ResponseEntity.ok(Map.of("activeElsewhere", elsewhere));
+   }
+
+   @PostMapping("/judge/claim")
+   public ResponseEntity<?> claimJudge(HttpServletRequest request) {
+       HttpSession session = request.getSession(false);
+       if (session == null) return ResponseEntity.status(401).build();
+       Long judgeId = (Long) session.getAttribute("judgeId");
+       String eventName = (String) session.getAttribute("eventName");
+       if (judgeId == null || eventName == null) {
+           return ResponseEntity.badRequest().body(Map.of("error", "Judge or event missing on session"));
+       }
+       judgeActiveStore.claim(session.getId(), judgeId, eventName);
+       return ResponseEntity.ok().build();
+   }
+
+   @DeleteMapping("/judge/release")
+   public ResponseEntity<?> releaseJudge(HttpServletRequest request) {
+       HttpSession session = request.getSession(false);
+       if (session != null) judgeActiveStore.release(session.getId());
+       return ResponseEntity.ok().build();
+   }
+   ```
+
+### `BES/src/main/java/com/example/BES/config/SessionExpiryListener.java`
+
+Mirror the emcee wiring: when a Spring session is destroyed, also call `judgeActiveStore.release(sessionId)`. This handles the case where the judge closes the tab without explicit logout.
+
+## Frontend changes
+
+### `BES-frontend/src/utils/api.js`
+
+Three new helpers, following the same pattern as `claimEmceeCategory` / `releaseEmceeCategory` / `getActiveEmceeCategories`:
+
+```javascript
+export const judgeActiveElsewhere = async (judgeId) => {
+  try {
+    const res = await fetch(
+      `${domain}/api/v1/auth/judge/active-elsewhere?judgeId=${judgeId}`,
+      { credentials: 'include', headers: { 'Accept': 'application/json' } }
+    );
+    if (!res.ok) return false;
+    const body = await res.json();
+    return !!body.activeElsewhere;
+  } catch { return false; }
+};
+
+export const claimJudgeActive = async () => {
+  try {
+    await fetch(`${domain}/api/v1/auth/judge/claim`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch (e) { console.error(e); }
+};
+
+export const releaseJudgeActive = async () => {
+  try {
+    await fetch(`${domain}/api/v1/auth/judge/release`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+  } catch (e) { console.error(e); }
+};
+```
+
+On failure of the check (network error / non-200), default to `false` — fail open. A transient blip should not block a judge from scoring.
+
+### `BES-frontend/src/views/JudgeSessionView.vue`
+
+Mount-time sequence after `whoami` restore succeeds:
+
+```
+1. Wait until isJudgeSession is true (judgeId + judgeName resolved)
+2. const elsewhere = await judgeActiveElsewhere(authStore.judgeId)
+3. If elsewhere:
+     askConfirm(
+       'Judge Already Active',
+       `"${judgeName}" is already signed in on another device. Continue anyway?
+        Scores from both sessions will be saved, but two devices on the
+        same judge can confuse the flow.`,
+       async () => {
+         await claimJudgeActive();
+         await loadDivisions();
+       }
+     )
+     // Cancel path is wired via existing confirmNo + a new escape:
+     //   on cancel → releaseJudgeActive() + logout() + router.push('/login')
+   Else:
+     await claimJudgeActive();
+     await loadDivisions();
+```
+
+The existing `confirmNo` function clears the dialog only. We add a `cancelCallback` slot to the dialog (or call `handleLogout` directly inline) so cancel triggers logout. Keep the change minimal: the cleanest fit is to inline a second callback parameter on `askConfirm`.
+
+Update `handleLogout` to call `releaseJudgeActive()` before `logout()`, mirroring `releaseEmceeCategory()` in `EmceeSessionView.handleLogout`.
+
+Wording reuses the emcee dialog's tone for consistency.
+
+## Behavior matrix
+
+| Scenario | Before | After |
+|---|---|---|
+| Judge opens token link on first device | OK | OK; claimed in store |
+| Judge opens same token on second device | 409 hard block | Lands on `/judge/session`, sees confirm prompt. Continue → both claimed. Cancel → released + back to login. |
+| Judge refreshes their own tab | OK (sameSession in `redeemToken`) | OK. The check excludes the caller's own sessionId; `activeElsewhere` is false. |
+| First device closes tab | First session held until container timeout | `SessionExpiryListener` releases the claim immediately. Second device sees no conflict. |
+| First device drops network (no clean close) | Stuck until container timeout | Heartbeat gap exceeds 90s → considered inactive on next check. |
+| Two devices, judge clicks Logout on one | Other device unaffected | Other device still active (its own session, its own claim). Expected. |
+
+## Edge cases
+
+- **`/auth/heartbeat` is fire-and-forget on the frontend.** If a heartbeat call fails, the next one succeeds and refreshes the timestamp. 90s grace covers a few missed beats. No special handling required.
+- **`getActiveSessions` filters on both `judgeId` AND `eventName`.** A judge token is per-(event, judge), so cross-event collisions are impossible — but the filter is cheap and defensive.
+- **Race: two devices land on `/judge/session` simultaneously.** Both call `judgeActiveElsewhere` before either has called `claim`. Both get `activeElsewhere: false` and continue silently. This is acceptable — the prompt is best-effort UX, not a lock. The window is small (sub-second), and the cost is one missed warning, not a data issue.
+- **No `eventName` on session.** The redeem path always sets `eventName` from the token's event. If it's missing, `/judge/claim` returns 400; the frontend treats this as a soft failure and continues without claiming. Logged for diagnostics.
+
+## Testing
+
+### Backend (`BES/src/test/...`)
+
+- `JudgeActiveStoreTest` — unit test the store directly:
+  - `claim` + `getActiveSessions` returns the session
+  - `release` removes it
+  - Stale heartbeat (> 90s) excluded from `getActiveSessions`
+  - Different `judgeId` or `eventName` excluded
+- `AuthControllerJudgeActiveTest` — MockMvc integration:
+  - `GET /auth/judge/active-elsewhere` returns `false` for fresh session
+  - After a second session claims, the first session sees `activeElsewhere: true`
+  - `DELETE /auth/judge/release` clears it
+  - Token redeem no longer returns 409 for a duplicate judge token (the original block check)
+
+### Frontend (`BES-frontend/src/utils/__tests__/...`)
+
+- `judgeActiveElsewhere` returns `false` on non-OK response (fail-open)
+- `JudgeSessionView` mount flow: when `judgeActiveElsewhere` resolves `true`, the confirm dialog is shown; when `false`, divisions load directly. (Component test with mocked api module.)
+
+### Manual
+
+- Two devices on the same judge token: verify prompt + continue + cancel paths.
+- Refresh same tab: verify no prompt.
+- Close first tab without logout: verify second device's next `active-elsewhere` call returns `false` after a few seconds (session destroy event) or after ~90s (heartbeat timeout).
+
+## Migration / rollout
+
+- Pure additive changes; no DB migration.
+- The removal of the 409 path is the only behavior change. There is no client today that depends on receiving 409 for a judge token re-redeem (`TokenAuth.vue` treats any non-authenticated response as an error and shows "Link invalid"), so we may want to verify no other caller surfaces a special-case 409 message. Spot check: `redeemToken` in `api.js` returns `{ authenticated: false, status, error }` — callers only branch on `authenticated`.
+- No flag-gating. The new behavior is strictly more permissive and matches the existing emcee UX.
+
+## Files touched (summary)
+
+| File | Kind |
+|---|---|
+| `BES/src/main/java/com/example/BES/services/JudgeActiveStore.java` | NEW |
+| `BES/src/main/java/com/example/BES/controllers/AuthController.java` | MOD — add `ROLE_JUDGE` to `UNLIMITED_ROLES`, 3 new endpoints, heartbeat hook |
+| `BES/src/main/java/com/example/BES/config/SessionExpiryListener.java` | MOD — release on session destroy |
+| `BES/src/test/java/com/example/BES/services/JudgeActiveStoreTest.java` | NEW |
+| `BES/src/test/java/com/example/BES/controllers/AuthControllerJudgeActiveTest.java` | NEW |
+| `BES-frontend/src/utils/api.js` | MOD — 3 new helpers |
+| `BES-frontend/src/views/JudgeSessionView.vue` | MOD — mount-time check + claim, release on logout |
+| `BES-frontend/src/utils/__tests__/JudgeSessionView.spec.js` | NEW (or extend existing) |


### PR DESCRIPTION
## Summary

### Judge session — replace hard session limit with active-status prompt
- Add `ROLE_JUDGE` to `UNLIMITED_ROLES` — a second device on the same judge token no longer hits 409 at redeem
- New `JudgeActiveStore` (in-memory, 60s idle threshold, 30s pruner) mirrors `EmceeCategoryStore`
- `AuthController`: new `GET /auth/judge/active-elsewhere`, `POST /auth/judge/claim`, `DELETE /auth/judge/release`; existing `/auth/heartbeat` now refreshes judge presence; `/auth/logout` also releases the claim
- `SessionExpiryListener`: release judge claim on session destroy (belt-and-suspenders with logout)
- `JudgeSessionView`: mount-time check; confirm dialog ("Continue" / "Cancel") when the same judge is already active on another device; cancel logs the user out cleanly

### Judge session — restore Reset score button
- Adds a Reset Scores button to the judge's AuditionList context bar (judge-only, visible only when a category + currentJudge are set)
- Typed `RESET` confirmation gate; clears all of the judge's scores for the active category
- After the DELETE, wipes in-memory participant scores immediately so the UI reflects the reset without a page refresh

### EventDetails — admin Danger Zone tab: Reset Audition Numbers
- New "Danger Zone" sub-tab on EventDetails (admin only)
- `DELETE /api/v1/event/{eventName}/audition-numbers` cascades: scores → audition feedback → battle_category_state → battle_active_category → null out every `audition_number`
- Typed event-name gate in the confirmation modal; success/failure shown in a result popup after the modal closes
- Registrations, team rosters, per-participant judge assignments, walk-ins, payment flags, and verification status are preserved

Spec: `docs/superpowers/specs/2026-06-20-judge-active-status-prompt-design.md`

## Test plan

- [x] Backend `mvn test` — 246/246 passing
- [x] Frontend `npm test` — 131/131 passing; `npm run build` clean
- [ ] Manual: two browsers, same judge token — second sees "Continue/Cancel" prompt, not 409
- [ ] Manual: refresh same tab — no prompt
- [ ] Manual: logout from one device — other device sees no prompt on reload
- [ ] Manual: judge Reset Scores button — modal appears, typing RESET enables confirm, scores clear immediately
- [ ] Manual: admin EventDetails → Danger Zone tab — Reset Audition Numbers card visible (hidden for non-admin)
- [ ] Manual: reset flow — type event name, confirm, success popup appears, audition numbers cleared in participant list

## Known minor follow-ups (logged, not blocking)

- `judgeActiveElsewhere` trusts the `judgeId` query param rather than reading from session (low info-leak, matches existing api.js pattern)
- Frontend `claimJudgeActive`/`releaseJudgeActive` swallow non-OK responses (consistent with CLAUDE.md Pitfall #2)
- `AuthControllerJudgeActiveTest` `@BeforeEach` teardown filters via `getActiveSessions` 60s idle window — could theoretically miss stale entries in a slow test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)