### PR TITLE
fix: restart timer when same preset clicked while running

### DIFF
--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -59,11 +59,6 @@ const progressPct = computed(() => {
 })
 
 function startTimer(seconds) {
-  // Clicking the active preset while running resets the timer
-  if (selectedTime.value === seconds && timer) {
-    reset()
-    return
-  }
   if (timer) clearInterval(timer)
   selectedTime.value = seconds
   timeLeft.value = 0


### PR DESCRIPTION
## Summary
- Clicking the same timer preset (e.g. 30s) while it was counting down would reset to that duration but not restart — requiring a second click to begin counting
- Root cause: an early-return guard in `startTimer()` called `reset()` and bailed out when `selectedTime === seconds && timer` was truthy
- Fix: removed the early-return block; the existing `if (timer) clearInterval(timer)` at the top of the function already handles cleanup for both same-duration and different-duration clicks

## Test plan
- [ ] Start a 30s countdown → click 30s again → timer resets to 30s and starts immediately (no second click needed)
- [ ] Start a 30s countdown → click 45s → still resets to 45s and starts (existing behaviour unbroken)
- [ ] Let timer reach 0 → click any preset → starts fresh countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)