### PR TITLE
fix: hide side badge for solo mode, standardize position labels

### DIFF
--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, onMounted } from 'vue';
 import Timer from './Timer.vue';
 import { postAuditionDisplayState, getAuditionDisplayState } from '@/utils/api';
-import { buildPairs, getPositionLabel } from '@/utils/auditionPairs'
+import { buildPairs, getPositionDisplay } from '@/utils/auditionPairs'
 
 const props = defineProps({
   participants: { type: Array, required: true },
@@ -254,17 +254,12 @@ const swipeHint = computed(() => {
                   <span class="type-name block" style="font-size:18px" :class="uIdx === visibleRounds.length - 1 ? 'text-content-primary' : 'text-content-muted'">{{ slot.participantName }}</span>
                   <span v-if="slot.memberNames?.length" class="type-prose text-content-muted block" style="font-size:14px;">{{ slot.memberNames.join(' · ') }}</span>
                 </div>
-                <!-- Position badge right-aligned (BATTLE mode only) -->
+                <!-- Position badge right-aligned (PAIR mode only) -->
                 <span
-                  v-if="pairSubMode === 'BATTLE'"
-                  class="type-label px-1 py-0.5 flex-shrink-0 ml-auto self-center"
-                  style="clip-path: polygon(3px 0%, 100% 0%, calc(100% - 3px) 100%, 0% 100%); font-size: 9px; border: 1px solid currentColor; opacity: 0.5;"
-                  :class="{
-                    'text-amber-400':     getPositionLabel(sIdx, slots.length) === 'LEFT',
-                    'text-accent':        getPositionLabel(sIdx, slots.length) === 'MIDDLE',
-                    'text-content-muted': getPositionLabel(sIdx, slots.length) === 'RIGHT',
-                  }"
-                >{{ getPositionLabel(sIdx, slots.length) }}</span>
+                  v-if="mode === 'PAIR'"
+                  class="type-label px-1 py-0.5 flex-shrink-0 ml-auto self-center text-amber-300"
+                  style="clip-path: polygon(3px 0%, 100% 0%, calc(100% - 3px) 100%, 0% 100%); font-size: 9px; border: 1px solid currentColor; opacity: 0.85; text-transform: none;"
+                >{{ getPositionDisplay(sIdx, slots.length) }}</span>
                 <span v-if="mode === 'PAIR' && sIdx === 0 && pairSubMode !== 'BATTLE'" class="text-white/20 text-xs">&amp;</span>
               </div>
             </template>
@@ -320,17 +315,12 @@ const swipeHint = computed(() => {
                   <div class="flex items-baseline gap-2">
                     <span class="type-stat" style="font-size: 2rem;">#{{ slot.auditionNumber }}</span>
                     <span class="type-name text-content-primary" style="font-size: clamp(1.5rem, 6vw, 2.8rem);">{{ slot.participantName }}</span>
-                    <!-- Position badge (BATTLE mode only) — right-aligned -->
+                    <!-- Position badge (PAIR mode only) — right-aligned -->
                     <span
-                      v-if="pairSubMode === 'BATTLE'"
-                      class="type-label px-1.5 py-0.5 flex-shrink-0 ml-auto"
-                      style="clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%); font-size: 10px; border: 1px solid currentColor; opacity: 0.85;"
-                      :class="{
-                        'text-amber-400':       getPositionLabel(sIdx, currentRoundSlots.length) === 'LEFT',
-                        'text-accent':          getPositionLabel(sIdx, currentRoundSlots.length) === 'MIDDLE',
-                        'text-content-muted':   getPositionLabel(sIdx, currentRoundSlots.length) === 'RIGHT',
-                      }"
-                    >{{ getPositionLabel(sIdx, currentRoundSlots.length) }}</span>
+                      v-if="mode === 'PAIR'"
+                      class="type-label px-1.5 py-0.5 flex-shrink-0 ml-auto text-amber-300"
+                      style="clip-path: polygon(4px 0%, 100% 0%, calc(100% - 4px) 100%, 0% 100%); font-size: 10px; border: 1px solid currentColor; opacity: 0.85; text-transform: none;"
+                    >{{ getPositionDisplay(sIdx, currentRoundSlots.length) }}</span>
                   </div>
                   <div v-if="slot.memberNames?.length" class="type-prose text-content-muted mt-0.5 pl-1" style="font-size:14px;">{{ slot.memberNames.join(' · ') }}</div>
                   <div v-if="slot.judgeName" class="text-xs text-white/25 mt-0.5 pl-1">{{ slot.judgeName }}</div>

--- a/BES-frontend/src/components/PairScoreCards.vue
+++ b/BES-frontend/src/components/PairScoreCards.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, nextTick, onMounted, watch } from 'vue';
-import { buildPairs, getPositionLabel } from '@/utils/auditionPairs'
+import { buildPairs, getPositionDisplay } from '@/utils/auditionPairs'
 
 const props = defineProps({
   cards:           { type: Array,   required: true },
@@ -288,12 +288,13 @@ const isActivePair = (pairIdx) => pairIdx === currentIndex.value
                         ? 'font-size: 1.6rem; background: rgba(245,158,11,0.08)'
                         : 'font-size: 1.6rem; background: rgba(255,255,255,0.06)'"
               >
-                <!-- Position label (BATTLE mode only) -->
+                <!-- Position label (PAIR mode) -->
                 <span
-                  v-if="pairSubMode === 'BATTLE' && !card._placeholder"
+                  v-if="!card._placeholder"
                   class="type-label leading-none mb-1"
-                  style="font-size: 9px; letter-spacing: 0.18em; opacity: 0.75; color: inherit;"
-                >{{ getPositionLabel(slotIdx, pair.length) }}</span>
+                  :class="activeParticipantNum === card.auditionNumber && isActivePair(pairIdx) ? 'text-black/50' : 'text-amber-300'"
+                  style="font-size: 9px; letter-spacing: 0.18em; opacity: 0.9; text-transform: none;"
+                >{{ getPositionDisplay(slotIdx, pair.length) }}</span>
                 <span class="type-stat leading-none" style="font-size: 1.6rem; color: inherit">#{{ card.auditionNumber }}</span>
               </button>
             </div>

--- a/BES-frontend/src/utils/auditionPairs.js
+++ b/BES-frontend/src/utils/auditionPairs.js
@@ -55,3 +55,8 @@ export function getPositionLabel(slotIndex, roundLength) {
   }
   return slotIndex === 0 ? 'LEFT' : 'RIGHT'
 }
+
+const POSITION_DISPLAY = { LEFT: "Judge's Left", MIDDLE: 'Middle', RIGHT: "Judge's Right" }
+export function getPositionDisplay(slotIndex, roundLength) {
+  return POSITION_DISPLAY[getPositionLabel(slotIndex, roundLength)]
+}

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -4,7 +4,7 @@ import { useRoute } from 'vue-router'
 import { getAuditionDisplayState, getCategoriesByEvent, updateCategoryNumberColor } from '@/utils/api'
 import { createClient, deactivateClient, subscribeToChannel } from '@/utils/websocket'
 import { useAuthStore } from '@/utils/auth'
-import { getPositionLabel } from '@/utils/auditionPairs'
+import { getPositionLabel, getPositionDisplay } from '@/utils/auditionPairs'
 
 const route = useRoute()
 const authStore = useAuthStore()
@@ -84,7 +84,7 @@ const roundLabel    = computed(() => {
 })
 const categoryRoundLabel = computed(() => state.value?.roundLabel || 'Preliminary Round')
 const numberColor   = computed(() => state.value?.numberColor ?? null)
-const pairSubMode   = computed(() => state.value?.pairSubMode ?? 'SHOWCASE')
+
 const currentSlots  = computed(() => state.value?.currentSlots ?? [])
 const nextSlots     = computed(() => state.value?.nextSlots ?? [])
 const isNearEnd     = computed(() => displayTimeLeft.value <= 10 && displayTimeLeft.value > 0 && state.value?.timerRunning)
@@ -207,21 +207,20 @@ onUnmounted(() => {
                     <span v-if="slot.placeholder" class="participant-name" style="opacity:0.3">TBD</span>
                     <span v-else class="type-body participant-name">{{ slot.participantName }}</span>
                   </div>
-                  <!-- Member names below -->
-                  <div v-if="!slot.placeholder && slot.memberNames?.length" class="pair-member-names">
-                    {{ slot.memberNames.join(' · ') }}
+                  <!-- Member names + position label on same row -->
+                  <div v-if="!slot.placeholder" class="pair-member-names" style="display:flex;align-items:center;gap:8px;">
+                    <span v-if="slot.memberNames?.length">{{ slot.memberNames.join(' · ') }}</span>
+                    <span v-if="slot.memberNames?.length" style="opacity:0.2;font-size:0.9em;">|</span>
+                    <span
+                      class="position-label"
+                      :class="{
+                        'position-left':   getPositionLabel(sIdx, currentSlots.length) === 'LEFT',
+                        'position-middle': getPositionLabel(sIdx, currentSlots.length) === 'MIDDLE',
+                        'position-right':  getPositionLabel(sIdx, currentSlots.length) === 'RIGHT',
+                      }"
+                    >{{ getPositionDisplay(sIdx, currentSlots.length) }}</span>
                   </div>
                 </div>
-                <!-- Position label (BATTLE mode only) — right-aligned -->
-                <span
-                  v-if="pairSubMode === 'BATTLE'"
-                  class="position-label"
-                  :class="{
-                    'position-left':   getPositionLabel(sIdx, currentSlots.length) === 'LEFT',
-                    'position-middle': getPositionLabel(sIdx, currentSlots.length) === 'MIDDLE',
-                    'position-right':  getPositionLabel(sIdx, currentSlots.length) === 'RIGHT',
-                  }"
-                >{{ getPositionLabel(sIdx, currentSlots.length) }}</span>
               </div>
               <!-- Divider between entries (including 3-way) -->
               <div v-if="sIdx < currentSlots.length - 1" class="pair-divider" aria-hidden="true"></div>
@@ -275,7 +274,7 @@ onUnmounted(() => {
               <span class="next-slot-name" style="margin-left:8px">{{ slot.participantName }}</span>
               <span v-if="slot.memberNames?.length" class="next-slot-members" style="margin-left:8px">{{ slot.memberNames.join(' · ') }}</span>
             </div>
-            <span v-if="mode === 'PAIR' && sIdx === 0 && nextSlots.length > 1" style="opacity:0.2;margin:0 8px">&amp;</span>
+            <span v-if="mode === 'PAIR' && sIdx < nextSlots.length - 1" style="opacity:0.2;margin:0 8px">&amp;</span>
           </template>
         </div>
       </div>
@@ -521,16 +520,16 @@ onUnmounted(() => {
 /* ── Battle position labels ──────────────────────────────────────────────── */
 .position-label {
   font-family: 'Oswald', sans-serif;
-  font-size: clamp(11px, 1.2vw, 16px);
+  font-size: clamp(13px, 1.5vw, 20px);
   letter-spacing: 0.22em;
-  text-transform: uppercase;
-  opacity: 0.55;
+  text-transform: none;
+  opacity: 0.85;
   flex-shrink: 0;
   align-self: center;
 }
-.position-left   { color: rgb(251, 191, 36); } /* amber-400 */
-.position-middle { color: var(--accent-color); }
-.position-right  { color: rgba(255, 255, 255, 0.6); }
+.position-left   { color: rgb(252, 211, 77); text-transform: none; }  /* amber-300 */
+.position-middle { color: rgb(252, 211, 77); text-transform: none; }  /* amber-300 */
+.position-right  { color: rgb(252, 211, 77); text-transform: none; }  /* amber-300 */
 
 /* ── SOLO layout: slot | timer ────────────────────────────────────────────── */
 .slot-timer-row {


### PR DESCRIPTION
## Summary
- **Solo mode**: Judge's Left / Judge's Right badge is now hidden for SOLO categories across AuditionDisplay, EmceeRoundView, and PairScoreCards — only shown for PAIR mode (both showcase and battle audition subtypes)
- **Label text**: Renamed LEFT/RIGHT to "Judge's Left" / "Judge's Right" via a new `getPositionDisplay` helper in `auditionPairs.js`
- **Colour**: Standardized to amber-300 gold across all sites; PairScoreCards flips to `text-black/50` when card is selected (white background) for readability
- **AuditionDisplay layout**: Position label moved inline beside member names with a `|` pipe separator; bumped opacity to 0.85 and size for visual parity with emcee view
- **3-way fix**: Fixed missing `&` separator between 2nd and 3rd slot in UP NEXT row (condition was `sIdx === 0`, changed to `sIdx < nextSlots.length - 1`)

## Test plan
- [ ] Open a SOLO category in AuditionList (emcee/judge view) — no Left/Right badge visible
- [ ] Open a PAIR category — badge shows "Judge's Left" / "Judge's Right" in gold for both showcase and battle subtypes
- [ ] Check AuditionDisplay OBS source with a PAIR category — label appears inline beside member names
- [ ] Check AuditionDisplay with a 3-way PAIR — both `&` separators appear in UP NEXT row
- [ ] In PairScoreCards, select a card (white background) — badge text is dark, not washed-out gold

🤖 Generated with [Claude Code](https://claude.com/claude-code)