### PR TITLE
ui: tighten gap between category header and participant names on audition display

### DIFF
--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -169,7 +169,7 @@ onUnmounted(() => {
     </div>
 
     <!-- ACTIVE display -->
-    <div v-else class="active-container" :style="currentSlots.length >= 3 ? { paddingTop: '18vh' } : {}">
+    <div v-else class="active-container">
 
       <!-- Main area: event/category header, round counter, number+name+timer -->
       <div class="main-area">
@@ -373,7 +373,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
   height: 100%;
   padding: 40px;
@@ -385,7 +385,7 @@ onUnmounted(() => {
   align-items: center;
   width: 100%;
   gap: 10px;
-  margin-top: 12vh;
+  margin-top: 20vh;
 }
 
 /* Event name + category — pinned to top, independent of the centred content */


### PR DESCRIPTION
## Summary
- Switched `.active-container` from `justify-content: center` to `flex-start` so content anchors below the header instead of centering in the viewport
- Set `.main-area` `margin-top` to `20vh` (clears the header height) instead of the previous `12vh` offset from center
- Removed the 3-way slot inline `paddingTop: 18vh` override — no longer needed

## Test plan
- [ ] Open `/audition/display?event=X&category=Y` and confirm participant names sit close below the category line
- [ ] Check SOLO mode, PAIR mode (2 participants), and 3-way PAIR mode all look correct
- [ ] Confirm UP NEXT section at bottom is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)