### PR TITLE
ui: emcee timer redesign, audition display fixes, post-event feedback

### DIFF
--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -29,6 +29,7 @@ function resetTimer() {
   // running timer and the sticky baseline so the next category starts clean.
   timerRef.value?.clearAll?.()
   baselineDuration.value = null
+  timerRemaining.value = null
   timerVisible.value = false
 }
 
@@ -73,6 +74,26 @@ const currentRoundSlots  = computed(() => rounds.value[currentRound.value - 1] ?
 
 const lastTimerState = ref({})
 
+// ── Timer display state (drives NOW card header progress bar) ─────────────────
+const timerRemaining = ref(null)
+
+const headerDisplayTime = computed(() => {
+  if (lastTimerState.value.running && timerRemaining.value !== null) return String(timerRemaining.value)
+  if (baselineDuration.value) return String(baselineDuration.value)
+  return null
+})
+
+const headerProgressPct = computed(() => {
+  if (lastTimerState.value.running && lastTimerState.value.duration) {
+    return Math.max(0, ((timerRemaining.value ?? 0) / lastTimerState.value.duration) * 100)
+  }
+  return baselineDuration.value ? 100 : 0
+})
+
+const headerTimerNearEnd = computed(() =>
+  lastTimerState.value.running && timerRemaining.value !== null && timerRemaining.value <= 10 && timerRemaining.value > 0
+)
+
 function buildStatePayload(timerState = {}) {
   const current = currentRoundSlots.value.map(slot => ({
     auditionNumber: slot.auditionNumber,
@@ -114,19 +135,20 @@ function publishState(timerState = {}) {
 }
 
 function onTimerStarted(detail) {
-  // Picking a preset implicitly establishes the baseline for this category.
   baselineDuration.value = detail.duration
+  timerRemaining.value = detail.duration
   lastTimerState.value = { startedAt: detail.startedAt, duration: detail.duration, running: true }
   publishState(lastTimerState.value)
 }
 
 function onTimerStopped() {
+  timerRemaining.value = null
   lastTimerState.value = { startedAt: null, duration: null, running: false }
   publishState(lastTimerState.value)
 }
 
 function onTimerTick(detail) {
-  // Preserve startedAt from the started event so round-change publishes keep the timer alive
+  timerRemaining.value = detail.remaining
   lastTimerState.value = {
     startedAt: detail.running ? (lastTimerState.value.startedAt ?? null) : null,
     duration: detail.total,
@@ -154,6 +176,7 @@ onMounted(async () => {
     if (remaining > 0) {
       await new Promise(r => setTimeout(r, 100))
       timerRef.value?.resumeTimer(remaining, state.timerDuration)
+      timerRemaining.value = remaining
       lastTimerState.value = { startedAt: state.timerStartedAt, duration: state.timerDuration, running: true }
     }
   }
@@ -296,12 +319,19 @@ const swipeHint = computed(() => {
             style="box-shadow: 0 0 0 1px rgba(255,255,255,0.06), 0 8px 32px rgba(0,0,0,0.6); touch-action: none;"
           >
             <div class="corner-bar-tl"></div>
-            <div class="flex items-center justify-between px-3 pt-2 pb-1.5 border-b border-white/8">
-              <div class="flex items-center gap-2">
+            <div
+              class="now-card-header"
+              :class="{ 'now-card-header--near-end': headerTimerNearEnd, 'now-card-header--running': lastTimerState.running }"
+              :style="{ '--progress': headerProgressPct + '%' }"
+            >
+              <div class="flex items-center gap-2 z-10 relative">
                 <span class="glow-dot"></span>
                 <span class="type-label text-content-muted">Now on Stage</span>
               </div>
-              <span class="type-label text-content-muted">
+              <span v-if="headerDisplayTime" class="now-card-timer z-10 relative" :class="{ 'now-card-timer--near-end': headerTimerNearEnd }">
+                {{ headerDisplayTime }}
+              </span>
+              <span class="type-label text-content-muted z-10 relative">
                 Rd {{ currentRound }} / {{ totalRounds }}
               </span>
             </div>
@@ -431,6 +461,44 @@ const swipeHint = computed(() => {
   .emcee-now {
     flex: none;
   }
+}
+
+/* ── NOW card header — doubles as a progress bar ────────────────────── */
+.now-card-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  overflow: hidden;
+}
+/* fill layer — drains left to right as time runs out */
+.now-card-header::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(255,255,255,0.07);
+  width: var(--progress, 0%);
+  transition: width 0.25s linear, background 0.3s ease;
+  pointer-events: none;
+}
+.now-card-header--near-end::before {
+  background: rgba(239, 68, 68, 0.18);
+}
+
+/* Timer number inside the header */
+.now-card-timer {
+  font-family: 'Oswald', sans-serif;
+  font-size: clamp(1.4rem, 4vw, 2rem);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255,255,255,0.85);
+  transition: color 0.3s ease;
+}
+.now-card-timer--near-end {
+  color: #ef4444;
 }
 
 /* ── Nav buttons ────────────────────────────────────────────────────── */

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -237,7 +237,7 @@ const swipeHint = computed(() => {
 </script>
 
 <template>
-  <div class="emcee-root w-full flex flex-col h-full touch-manipulation" style="background: #111111; overflow: hidden;">
+  <div class="emcee-root w-full flex flex-col touch-manipulation" style="background: #111111;">
 
     <!-- ── Queue ──────────────────────────────────────────────────────────────
          flex-col-reverse: stack from bottom (near NOW) upward.
@@ -246,8 +246,8 @@ const swipeHint = computed(() => {
          the "Up Next" emphasis is preserved; deeper rounds stay readable.
     ──────────────────────────────────────────────────────────────────────── -->
     <div
-      class="emcee-queue flex-1 px-3 pt-2 pb-1"
-      style="display: flex; flex-direction: column-reverse; justify-content: flex-start; overflow-y: auto; scrollbar-width: none; overscroll-behavior: contain;"
+      class="emcee-queue px-3 pt-2 pb-1"
+      style="display: flex; flex-direction: column-reverse; justify-content: flex-start; min-height: 30vh; scrollbar-width: none;"
     >
       <div class="flex flex-col gap-1.5">
         <div

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -255,7 +255,7 @@ const swipeHint = computed(() => {
           :key="roundNumber"
           class="queue-item para-chip-sm overflow-hidden flex-shrink-0"
           :class="uIdx === visibleRounds.length - 1 ? 'border-white/15 bg-white/5' : 'border-white/5 bg-transparent'"
-          :style="{ opacity: uIdx === visibleRounds.length - 1 ? '1' : uIdx === visibleRounds.length - 2 ? '0.6' : uIdx === visibleRounds.length - 3 ? '0.45' : '0.35' }"
+          style="opacity: 0.65"
         >
           <div class="flex items-center justify-between px-2 py-1">
             <span class="type-label text-content-muted">

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -272,9 +272,9 @@ const swipeHint = computed(() => {
                 #{{ slot.auditionNumber }} — Not Registered
               </div>
               <div v-else class="flex items-start gap-2">
-                <span class="type-stat text-[18px] flex-shrink-0" :class="uIdx === visibleRounds.length - 1 ? 'text-content-primary' : 'text-content-muted'">#{{ slot.auditionNumber }}</span>
+                <span class="type-stat text-[18px] flex-shrink-0" :class="uIdx === visibleRounds.length - 1 ? 'text-content-secondary' : 'text-content-muted'">#{{ slot.auditionNumber }}</span>
                 <div class="min-w-0 flex-1">
-                  <span class="type-name block" style="font-size:18px" :class="uIdx === visibleRounds.length - 1 ? 'text-content-primary' : 'text-content-muted'">{{ slot.participantName }}</span>
+                  <span class="type-name block" style="font-size:18px" :class="uIdx === visibleRounds.length - 1 ? 'text-content-secondary' : 'text-content-muted'">{{ slot.participantName }}</span>
                   <span v-if="slot.memberNames?.length" class="type-prose text-content-muted block" style="font-size:14px;">{{ slot.memberNames.join(' · ') }}</span>
                 </div>
                 <!-- Position badge right-aligned (PAIR mode only) -->

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -272,9 +272,9 @@ const swipeHint = computed(() => {
                 #{{ slot.auditionNumber }} — Not Registered
               </div>
               <div v-else class="flex items-start gap-2">
-                <span class="type-stat text-[18px] flex-shrink-0" :class="uIdx === visibleRounds.length - 1 ? 'text-content-secondary' : 'text-content-muted'">#{{ slot.auditionNumber }}</span>
+                <span class="type-stat text-[18px] flex-shrink-0 text-content-muted">#{{ slot.auditionNumber }}</span>
                 <div class="min-w-0 flex-1">
-                  <span class="type-name block" style="font-size:18px" :class="uIdx === visibleRounds.length - 1 ? 'text-content-secondary' : 'text-content-muted'">{{ slot.participantName }}</span>
+                  <span class="type-name block text-content-muted" style="font-size:18px">{{ slot.participantName }}</span>
                   <span v-if="slot.memberNames?.length" class="type-prose text-content-muted block" style="font-size:14px;">{{ slot.memberNames.join(' · ') }}</span>
                 </div>
                 <!-- Position badge right-aligned (PAIR mode only) -->

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -237,7 +237,7 @@ const swipeHint = computed(() => {
 </script>
 
 <template>
-  <div class="emcee-root w-full flex flex-col touch-manipulation" style="background: #111111;">
+  <div class="emcee-root w-full flex flex-col h-full touch-manipulation" style="background: #111111; overflow: hidden;">
 
     <!-- ── Queue ──────────────────────────────────────────────────────────────
          flex-col-reverse: stack from bottom (near NOW) upward.
@@ -246,8 +246,8 @@ const swipeHint = computed(() => {
          the "Up Next" emphasis is preserved; deeper rounds stay readable.
     ──────────────────────────────────────────────────────────────────────── -->
     <div
-      class="emcee-queue px-3 pt-2 pb-1"
-      style="display: flex; flex-direction: column-reverse; justify-content: flex-start; min-height: 30vh; scrollbar-width: none;"
+      class="emcee-queue flex-1 px-3 pt-2 pb-1"
+      style="display: flex; flex-direction: column-reverse; justify-content: flex-start; overflow-y: auto; scrollbar-width: none; overscroll-behavior: contain;"
     >
       <div class="flex flex-col gap-1.5">
         <div

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -329,10 +329,7 @@ const swipeHint = computed(() => {
                 <span class="type-label text-content-muted">Now on Stage</span>
               </div>
               <span v-if="headerDisplayTime" class="now-card-timer z-10 relative" :class="{ 'now-card-timer--near-end': headerTimerNearEnd }">
-                {{ headerDisplayTime }}
-              </span>
-              <span class="type-label text-content-muted z-10 relative">
-                Rd {{ currentRound }} / {{ totalRounds }}
+                <i class="pi pi-clock mr-1" style="font-size:0.75em;opacity:0.7;"></i>{{ headerDisplayTime }}
               </span>
             </div>
             <div class="p-3">

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -237,7 +237,7 @@ const swipeHint = computed(() => {
 </script>
 
 <template>
-  <div class="emcee-root w-full flex flex-col h-full touch-manipulation" style="background: #111111; overflow: hidden;">
+  <div class="emcee-root w-full flex flex-col h-full touch-manipulation" style="background: #111111; overflow-y: auto;">
 
     <!-- ── Queue ──────────────────────────────────────────────────────────────
          flex-col-reverse: stack from bottom (near NOW) upward.

--- a/BES-frontend/src/components/EmceeRoundView.vue
+++ b/BES-frontend/src/components/EmceeRoundView.vue
@@ -255,7 +255,7 @@ const swipeHint = computed(() => {
           :key="roundNumber"
           class="queue-item para-chip-sm overflow-hidden flex-shrink-0"
           :class="uIdx === visibleRounds.length - 1 ? 'border-white/15 bg-white/5' : 'border-white/5 bg-transparent'"
-          style="opacity: 0.65"
+          style="opacity: 0.45"
         >
           <div class="flex items-center justify-between px-2 py-1">
             <span class="type-label text-content-muted">

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -201,68 +201,41 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="flex flex-col items-center gap-1 select-none">
-    <div class="text-center leading-none">
-      <div
-        class="type-stat transition-colors duration-300"
-        style="font-size: clamp(4rem, 14vh, 8rem); line-height: 1;"
-        :class="{
-          'text-red-500 animate-pulse': isNearEnd,
-          'text-content-muted':         isFinished && !isNearEnd,
-          'text-green-400':             countUp && !isNearEnd && !isFinished,
-          'text-content-primary':       !isNearEnd && !isFinished && !countUp,
-        }"
-      >{{ displayTime }}</div>
-      <div class="type-label text-content-muted">
-        {{ selectedTime > 0 ? `OF ${selectedTime}S` : 'SECONDS' }}
-      </div>
-    </div>
-
-    <!-- Progress bar -->
-    <div class="w-full max-w-xs h-px bg-white/8 overflow-hidden">
-      <div
-        class="h-full transition-[width] duration-200"
-        :class="isNearEnd ? 'bg-red-500' : countUp ? 'bg-green-400' : 'bg-white/50'"
-        :style="{ width: progressPct + '%' }"
-      ></div>
-    </div>
-
-    <!-- Controls -->
-    <div class="flex items-center gap-2 flex-wrap justify-center">
-      <button
-        @click="toggleMode"
-        class="para-chip px-6 py-4 type-body transition-all duration-150 active:scale-95"
-        style="font-size:18px"
-        :class="countUp
-          ? 'text-accent border-[color:var(--accent-muted)]'
+  <!-- Controls only — timer number and progress bar live in the EmceeRoundView NOW card header -->
+  <div class="flex items-center gap-2 justify-center select-none flex-wrap">
+    <button
+      @click="toggleMode"
+      class="para-chip px-5 py-3 type-body transition-all duration-150 active:scale-95"
+      style="font-size:16px"
+      :class="countUp
+        ? 'text-accent border-[color:var(--accent-muted)]'
+        : 'text-content-muted hover:text-content-primary'"
+    >
+      <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-1"></i>
+      {{ countUp ? 'Up' : 'Down' }}
+    </button>
+    <div class="w-px h-6 bg-white/12"></div>
+    <button
+      v-for="t in [45, 60, 90]"
+      :key="t"
+      @click="startTimer(t)"
+      class="para-chip px-5 py-3 type-body transition-all duration-150 active:scale-95"
+      style="font-size:16px"
+      :class="selectedTime === t && isRunning
+        ? 'text-accent border-[color:var(--accent-muted)]'
+        : selectedTime === t
+          ? 'text-content-secondary border-white/15'
           : 'text-content-muted hover:text-content-primary'"
-      >
-        <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-1"></i>
-        {{ countUp ? 'Up' : 'Down' }}
-      </button>
-      <div class="w-px h-8 bg-white/12"></div>
-      <button
-        v-for="t in [45, 60, 90]"
-        :key="t"
-        @click="startTimer(t)"
-        class="para-chip px-6 py-4 type-body transition-all duration-150 active:scale-95"
-        style="font-size:18px"
-        :class="selectedTime === t && isRunning
-          ? 'text-accent border-[color:var(--accent-muted)]'
-          : selectedTime === t
-            ? 'text-content-secondary border-white/15'
-            : 'text-content-muted hover:text-content-primary'"
-      >{{ t }}s</button>
-      <button
-        @click="reset"
-        class="para-chip px-5 py-4 type-body transition-all duration-150 active:scale-95 text-content-muted hover:text-content-primary"
-        style="font-size:16px"
-        title="Stop timer and reset display to picked duration"
-        :disabled="selectedTime === 0"
-        :class="{ 'opacity-40 pointer-events-none': selectedTime === 0 }"
-      >
-        <i class="pi pi-refresh"></i>
-      </button>
-    </div>
+    >{{ t }}s</button>
+    <button
+      @click="reset"
+      class="para-chip px-5 py-3 type-body transition-all duration-150 active:scale-95 text-content-muted hover:text-content-primary"
+      style="font-size:15px"
+      title="Stop timer"
+      :disabled="selectedTime === 0"
+      :class="{ 'opacity-40 pointer-events-none': selectedTime === 0 }"
+    >
+      <i class="pi pi-stop-circle mr-1"></i>STOP
+    </button>
   </div>
 </template>

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 
 const props = defineProps({
   baselineDuration: { type: Number, default: null },

--- a/BES-frontend/src/components/Timer.vue
+++ b/BES-frontend/src/components/Timer.vue
@@ -1,9 +1,7 @@
 <script setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, watch, onMounted, onBeforeUnmount } from "vue";
 
 const props = defineProps({
-  // Externally-supplied baseline (e.g. restored from backend state on mount).
-  // When set and the timer is idle, the display shows this value instead of '—'.
   baselineDuration: { type: Number, default: null },
 })
 
@@ -11,40 +9,11 @@ const emit = defineEmits(['started', 'stopped', 'tick'])
 
 const selectedTime = ref(0)
 const timeLeft = ref(0)
-const countUp = ref(false)
 const running = ref(false)
 let timer = null
-// Anchor wall-clock time used to recompute timeLeft on every tick.
-// Replacing "increment by 1 every interval" with "diff Date.now()" keeps
-// the timer accurate even when the tab is backgrounded and setInterval is
-// throttled by the browser (iOS Safari throttles to ~1/minute).
 let startedAtMs = 0
 
 const isRunning = computed(() => running.value)
-const isFinished = computed(() => running.value && selectedTime.value > 0 && timeLeft.value >= selectedTime.value)
-const isNearEnd = computed(() =>
-  running.value &&
-  !countUp.value &&
-  selectedTime.value > 0 &&
-  timeLeft.value >= selectedTime.value - 5 &&
-  !isFinished.value
-)
-
-const displayTime = computed(() => {
-  // Idle (not running): show the sticky baseline so the audience-facing
-  // display and the emcee timer both park on the last picked duration
-  // instead of going blank.
-  if (!running.value) {
-    if (selectedTime.value > 0) return String(selectedTime.value)
-    return '—'
-  }
-  if (countUp.value) {
-    return String(Math.min(timeLeft.value, selectedTime.value))
-  }
-  const remaining = selectedTime.value - timeLeft.value
-  if (remaining <= 0) return '0'
-  return String(remaining)
-})
 
 // Adopt externally-supplied baseline (used on page-refresh restore from backend).
 watch(() => props.baselineDuration, (val) => {
@@ -52,11 +21,6 @@ watch(() => props.baselineDuration, (val) => {
     selectedTime.value = val
   }
 }, { immediate: true })
-
-const progressPct = computed(() => {
-  if (selectedTime.value === 0) return 0
-  return Math.min((timeLeft.value / selectedTime.value) * 100, 100)
-})
 
 function startTimer(seconds) {
   if (timer) clearInterval(timer)
@@ -71,8 +35,6 @@ function startTimer(seconds) {
       const remaining = selectedTime.value - timeLeft.value
       emit('tick', { remaining, total: selectedTime.value, running: true })
     } else {
-      // Natural expiry: snap timeLeft back to 0 so the display shows the
-      // picked baseline (selectedTime), not "0".
       timeLeft.value = 0
       clearInterval(timer)
       timer = null
@@ -84,22 +46,7 @@ function startTimer(seconds) {
   emit('started', { duration: seconds, startedAt: startedAtMs })
 }
 
-function toggleMode() {
-  if (timer) {
-    clearInterval(timer)
-    timer = null
-  }
-  selectedTime.value = 0
-  timeLeft.value = 0
-  running.value = false
-  countUp.value = !countUp.value
-  emit('stopped')
-}
-
-// Reset = stop running countdown AND snap the display back to the picked
-// baseline. Does NOT clear selectedTime — that's the whole point: the
-// audience and the emcee both still see "45" (or whatever was picked)
-// instead of a blank.
+// Reset = stop and park display at the picked baseline.
 function reset() {
   if (timer) {
     clearInterval(timer)
@@ -131,12 +78,6 @@ function stop() {
   }
 }
 
-/**
- * Resume a countdown timer from a specific remaining time.
- * Called by EmceeRoundView on mount when recovering timer state after refresh.
- * @param {number} remainingSeconds - seconds left on the clock
- * @param {number} totalDuration - original total duration in seconds
- */
 function resumeTimer(remainingSeconds, totalDuration) {
   if (timer) clearInterval(timer)
   if (remainingSeconds <= 0) {
@@ -171,9 +112,6 @@ function resumeTimer(remainingSeconds, totalDuration) {
 
 defineExpose({ reset, stop, clearAll, resumeTimer })
 
-// When the tab returns from background, force an immediate recompute so
-// the display catches up to the real elapsed time without waiting for the
-// next interval tick.
 function onVisibilityChange() {
   if (document.visibilityState !== 'visible' || !timer || selectedTime.value === 0) return
   const elapsed = Math.floor((Date.now() - startedAtMs) / 1000)
@@ -203,18 +141,6 @@ onBeforeUnmount(() => {
 <template>
   <!-- Controls only — timer number and progress bar live in the EmceeRoundView NOW card header -->
   <div class="flex items-center gap-2 justify-center select-none flex-wrap">
-    <button
-      @click="toggleMode"
-      class="para-chip px-5 py-3 type-body transition-all duration-150 active:scale-95"
-      style="font-size:16px"
-      :class="countUp
-        ? 'text-accent border-[color:var(--accent-muted)]'
-        : 'text-content-muted hover:text-content-primary'"
-    >
-      <i :class="countUp ? 'pi pi-arrow-up' : 'pi pi-arrow-down'" class="mr-1"></i>
-      {{ countUp ? 'Up' : 'Down' }}
-    </button>
-    <div class="w-px h-6 bg-white/12"></div>
     <button
       v-for="t in [45, 60, 90]"
       :key="t"

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -171,13 +171,14 @@ onUnmounted(() => {
     <!-- ACTIVE display -->
     <div v-else class="active-container">
 
-      <!-- Main area: event/category header, round counter, number+name+timer -->
+      <!-- Event name + category — flows in column, always above content -->
+      <div class="event-header">
+        <span class="event-header-name">{{ eventLabel }}</span>
+        <span class="event-header-category">{{ categoryName }}<template v-if="categoryRoundLabel"> &nbsp;|&nbsp; {{ categoryRoundLabel }}</template></span>
+      </div>
+
+      <!-- Main area: number+name+timer — centres in remaining space -->
       <div class="main-area">
-        <!-- Event name + category stacked above everything -->
-        <div class="event-header">
-          <span class="event-header-name">{{ eventLabel }}</span>
-          <span class="event-header-category">{{ categoryName }}<template v-if="categoryRoundLabel"> &nbsp;|&nbsp; {{ categoryRoundLabel }}</template></span>
-        </div>
 
         <!-- PAIR mode: stacked names left | timer right -->
         <div v-if="mode === 'PAIR'" class="pair-row">
@@ -380,24 +381,24 @@ onUnmounted(() => {
 }
 
 .main-area {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   width: 100%;
   gap: 10px;
-  margin-top: 20vh;
 }
 
-/* Event name + category — pinned to top, independent of the centred content */
+/* Event name + category — flows in the column, always above participant content */
 .event-header {
-  position: absolute;
-  top: 5vh;
-  left: 0;
-  right: 0;
+  width: 100%;
+  padding-top: 5vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2px;
+  flex-shrink: 0;
 }
 .event-header-name {
   font-family: 'Oswald', sans-serif;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -82,7 +82,6 @@ const categoryRoundLabel = computed(() => state.value?.roundLabel || 'Preliminar
 const numberColor   = computed(() => state.value?.numberColor ?? null)
 
 const currentSlots  = computed(() => state.value?.currentSlots ?? [])
-const nextSlots     = computed(() => state.value?.nextSlots ?? [])
 const isNearEnd     = computed(() => displayTimeLeft.value <= 10 && displayTimeLeft.value > 0 && state.value?.timerRunning)
 const isFinished    = computed(() => state.value?.timerRunning && displayTimeLeft.value <= 0 && state.value?.timerDuration > 0)
 // Show the live countdown when running, otherwise the sticky baseline
@@ -246,25 +245,6 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- UP NEXT (secondary area) -->
-      <div v-if="nextSlots.length > 0" class="up-next-area">
-        <div class="section-rule mb-2">
-          <span class="section-rule-label type-label text-content-muted">UP NEXT</span>
-        </div>
-        <div class="next-slots">
-          <template v-for="(slot, sIdx) in nextSlots" :key="sIdx">
-            <div v-if="slot.placeholder" class="type-label" style="opacity:0.3;font-size:16px">
-              #{{ slot.auditionNumber }} — TBD
-            </div>
-            <div v-else class="next-slot-entry">
-              <span class="type-stat" style="font-size:24px;opacity:0.5">#{{ slot.auditionNumber }}</span>
-              <span class="next-slot-name" style="margin-left:8px">{{ slot.participantName }}</span>
-              <span v-if="slot.memberNames?.length" class="next-slot-members" style="margin-left:8px">{{ slot.memberNames.join(' · ') }}</span>
-            </div>
-            <span v-if="mode === 'PAIR' && sIdx < nextSlots.length - 1" style="opacity:0.2;margin:0 8px">&amp;</span>
-          </template>
-        </div>
-      </div>
     </div>
 
     <!-- Operator overlay — always visible to logged-in operators, even in standby -->
@@ -583,43 +563,6 @@ onUnmounted(() => {
 @keyframes pulse {
   from { opacity: 1; transform: scale(1); }
   to   { opacity: 0.7; transform: scale(1.03); }
-}
-
-/* ── UP NEXT ─────────────────────────────────────────────────────────────── */
-.up-next-area {
-  position: absolute;
-  bottom: 60px;
-  left: 0;
-  right: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.next-slots {
-  display: flex;
-  align-items: center;
-}
-
-.next-slot-entry {
-  display: flex;
-  align-items: baseline;
-}
-
-/* Up Next: name + members shown as typed (sentence case) */
-.next-slot-name {
-  font-family: 'Oswald', sans-serif;
-  font-size: 22px;
-  letter-spacing: 0.02em;
-  text-transform: none;
-  color: rgba(255,255,255,0.55);
-}
-.next-slot-members {
-  font-family: 'Oswald', sans-serif;
-  font-size: 14px;
-  letter-spacing: 0.02em;
-  text-transform: none;
-  color: rgba(255,255,255,0.30);
 }
 
 /* ── Section rule (defined locally since this is a standalone page) ───────── */

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -84,6 +84,15 @@ const numberColor   = computed(() => state.value?.numberColor ?? null)
 const currentSlots  = computed(() => state.value?.currentSlots ?? [])
 const isNearEnd     = computed(() => displayTimeLeft.value <= 10 && displayTimeLeft.value > 0 && state.value?.timerRunning)
 const isFinished    = computed(() => state.value?.timerRunning && displayTimeLeft.value <= 0 && state.value?.timerDuration > 0)
+
+// ── Circular ring progress ────────────────────────────────────────────────────
+const RING_R = 96
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_R  // ~603.2
+const timerProgressPct = computed(() => {
+  if (!state.value?.timerRunning || !state.value?.timerDuration) return 1
+  return Math.max(0, displayTimeLeft.value / state.value.timerDuration)
+})
+const ringDashoffset = computed(() => RING_CIRCUMFERENCE * (1 - timerProgressPct.value))
 // Show the live countdown when running, otherwise the sticky baseline
 // the emcee picked for this category. Only blank when neither is set.
 const timerLabel    = computed(() => {
@@ -213,8 +222,12 @@ onUnmounted(() => {
             </template>
           </div>
 
-          <!-- Right: timer -->
-          <div class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+          <!-- Right: timer with circular progress ring -->
+          <div class="timer-ring-wrap" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+            <svg class="timer-ring-svg" viewBox="0 0 220 220" fill="none">
+              <circle cx="110" cy="110" :r="RING_R" class="ring-track" />
+              <circle cx="110" cy="110" :r="RING_R" class="ring-fill" :style="{ strokeDashoffset: ringDashoffset }" />
+            </svg>
             <div class="type-stat timer-number">{{ timerLabel || '0' }}</div>
           </div>
         </div>
@@ -239,7 +252,11 @@ onUnmounted(() => {
               </div>
             </div>
           </div>
-          <div v-if="timerLabel" class="timer-display" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+          <div v-if="timerLabel" class="timer-ring-wrap" :class="{ 'timer-near-end': isNearEnd, 'timer-finished': isFinished }">
+            <svg class="timer-ring-svg" viewBox="0 0 220 220" fill="none">
+              <circle cx="110" cy="110" :r="RING_R" class="ring-track" />
+              <circle cx="110" cy="110" :r="RING_R" class="ring-fill" :style="{ strokeDashoffset: ringDashoffset }" />
+            </svg>
             <div class="type-stat timer-number">{{ timerLabel }}</div>
           </div>
         </div>
@@ -531,19 +548,45 @@ onUnmounted(() => {
   opacity: 0.4;
 }
 
-/* ── Timer ────────────────────────────────────────────────────────────────── */
-.timer-display {
+/* ── Timer ring ───────────────────────────────────────────────────────────── */
+.timer-ring-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(180px, 24vw, 300px);
+  height: clamp(180px, 24vw, 300px);
   flex-shrink: 0;
-  /* Inherit timer font-size so min-width in ch scales with the digits.
-     2.5ch covers typical 2-digit timers (30-90s); tabular-nums
-     prevents intra-digit jitter without reserving excess space. */
-  font-size: clamp(100px, 18vw, 220px);
-  min-width: 2.5ch;
-  text-align: center;
 }
 
+.timer-ring-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.ring-track {
+  stroke: rgba(255,255,255,0.07);
+  stroke-width: 4;
+}
+
+.ring-fill {
+  stroke: rgba(255,255,255,0.55);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-dasharray: 603.2;
+  transition: stroke-dashoffset 0.25s linear, stroke 0.3s ease;
+}
+
+.timer-near-end .ring-fill  { stroke: #ef4444; }
+.timer-finished .ring-fill  { stroke: rgba(255,255,255,0.1); stroke-dashoffset: 603.2; }
+
 .timer-number {
-  font-size: inherit;
+  position: relative;
+  z-index: 1;
+  font-size: clamp(80px, 15vw, 180px);
   line-height: 1;
   letter-spacing: 0.02em;
   font-variant-numeric: tabular-nums;

--- a/BES-frontend/src/views/AuditionDisplay.vue
+++ b/BES-frontend/src/views/AuditionDisplay.vue
@@ -92,7 +92,7 @@ const timerProgressPct = computed(() => {
   if (!state.value?.timerRunning || !state.value?.timerDuration) return 1
   return Math.max(0, displayTimeLeft.value / state.value.timerDuration)
 })
-const ringDashoffset = computed(() => RING_CIRCUMFERENCE * (1 - timerProgressPct.value))
+const ringDashoffset = computed(() => -(RING_CIRCUMFERENCE * (1 - timerProgressPct.value)))
 // Show the live countdown when running, otherwise the sticky baseline
 // the emcee picked for this category. Only blank when neither is set.
 const timerLabel    = computed(() => {
@@ -576,12 +576,12 @@ onUnmounted(() => {
   stroke: rgba(255,255,255,0.55);
   stroke-width: 4;
   stroke-linecap: round;
-  stroke-dasharray: 603.2;
+  stroke-dasharray: 603.2 603.2;
   transition: stroke-dashoffset 0.25s linear, stroke 0.3s ease;
 }
 
 .timer-near-end .ring-fill  { stroke: #ef4444; }
-.timer-finished .ring-fill  { stroke: rgba(255,255,255,0.1); stroke-dashoffset: 603.2; }
+.timer-finished .ring-fill  { stroke: rgba(255,255,255,0.1); stroke-dashoffset: -603.2; }
 
 .timer-number {
   position: relative;

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -586,24 +586,7 @@ const isJudgeSession = computed(() => !!authStore.judgeName && !!authStore.judge
 const wsClients = []
 
 watch(hasActiveSession, (active) => {
-  if (active) {
-    document.documentElement.style.overflow = 'hidden'
-    document.documentElement.style.height = '100dvh'
-    document.documentElement.style.touchAction = 'manipulation'
-    document.body.style.position = 'fixed'
-    document.body.style.overflow = 'hidden'
-    document.body.style.width = '100%'
-    document.body.style.height = '100dvh'
-    window.scrollTo(0, 0)
-  } else {
-    document.documentElement.style.overflow = ''
-    document.documentElement.style.height = ''
-    document.documentElement.style.touchAction = ''
-    document.body.style.position = ''
-    document.body.style.overflow = ''
-    document.body.style.width = ''
-    document.body.style.height = ''
-  }
+  document.documentElement.style.touchAction = active ? 'manipulation' : ''
 }, { immediate: true })
 
 // Reset the audition timer when navigating away (e.g., to Score page).
@@ -739,7 +722,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="page-container relative" :style="hasActiveSession ? { display: 'flex', flexDirection: 'column', height: 'calc(100dvh - 64px)', overflow: 'hidden', padding: '8px 16px' } : {}">
+  <div class="page-container relative" :style="hasActiveSession ? { display: 'flex', flexDirection: 'column', minHeight: 'calc(100dvh - 64px)', padding: '8px 16px' } : {}">
     <div class="color-bleed"></div>
 
     <!-- Context bar (active session: category + role both selected) -->
@@ -981,7 +964,7 @@ onMounted(async () => {
     </div>
 
     <!-- Emcee view: Timer + round view -->
-    <div class="flex-1 min-h-0" style="overflow: hidden;">
+    <div class="flex-1 min-h-0">
 
     <!-- Loading state — full-viewport overlay so nothing bleeds through -->
     <LoadingOverlay v-if="loading">Loading audition data…</LoadingOverlay>

--- a/BES-frontend/src/views/AuditionList.vue
+++ b/BES-frontend/src/views/AuditionList.vue
@@ -586,7 +586,24 @@ const isJudgeSession = computed(() => !!authStore.judgeName && !!authStore.judge
 const wsClients = []
 
 watch(hasActiveSession, (active) => {
-  document.documentElement.style.touchAction = active ? 'manipulation' : ''
+  if (active) {
+    document.documentElement.style.overflow = 'hidden'
+    document.documentElement.style.height = '100dvh'
+    document.documentElement.style.touchAction = 'manipulation'
+    document.body.style.position = 'fixed'
+    document.body.style.overflow = 'hidden'
+    document.body.style.width = '100%'
+    document.body.style.height = '100dvh'
+    window.scrollTo(0, 0)
+  } else {
+    document.documentElement.style.overflow = ''
+    document.documentElement.style.height = ''
+    document.documentElement.style.touchAction = ''
+    document.body.style.position = ''
+    document.body.style.overflow = ''
+    document.body.style.width = ''
+    document.body.style.height = ''
+  }
 }, { immediate: true })
 
 // Reset the audition timer when navigating away (e.g., to Score page).
@@ -722,7 +739,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="page-container relative" :style="hasActiveSession ? { display: 'flex', flexDirection: 'column', minHeight: 'calc(100dvh - 64px)', padding: '8px 16px' } : {}">
+  <div class="page-container relative" :style="hasActiveSession ? { display: 'flex', flexDirection: 'column', height: 'calc(100dvh - 64px)', overflow: 'hidden', padding: '8px 16px' } : {}">
     <div class="color-bleed"></div>
 
     <!-- Context bar (active session: category + role both selected) -->
@@ -964,7 +981,7 @@ onMounted(async () => {
     </div>
 
     <!-- Emcee view: Timer + round view -->
-    <div class="flex-1 min-h-0">
+    <div class="flex-1 min-h-0" style="overflow: hidden;">
 
     <!-- Loading state — full-viewport overlay so nothing bleeds through -->
     <LoadingOverlay v-if="loading">Loading audition data…</LoadingOverlay>


### PR DESCRIPTION
## Summary

- **AuditionDisplay**: Fixed name/category overlap by replacing `position:absolute` + `margin-top:20vh` with proper flex-col layout. Added circular SVG progress ring around the countdown timer (drains clockwise, turns red in the last 10s). Removed UP NEXT section — not useful for the audience.
- **EmceeRoundView**: Timer countdown number moved into the NOW card header, which doubles as a draining progress bar (header background fills/drains behind the text). Controls collapse to a compact single row `[45s] [60s] [90s] [■ STOP]`, freeing vertical space so the next pair is always visible in the queue. Queue items unified to the same opacity/colour so NOW card clearly dominates. Count-up mode removed — countdown only.
- **Timer**: Removed standalone number display and progress bar (now in card header). Reset button changed to stop icon + STOP label to clarify it stops without restarting.
- **Scroll fix**: `overflow-y: auto` on EmceeRoundView root so small phones can scroll to reach timer controls when the layout is tight.

## Test plan
- [ ] Emcee audition list: NOW card header shows timer countdown with progress bar background draining left-to-right
- [ ] Clock icon visible next to timer number in header
- [ ] Timer controls (45s/60s/90s/STOP) always reachable — scroll down on a small phone if needed
- [ ] Queue items all same opacity; NOW card text clearly brighter
- [ ] AuditionDisplay (OBS): participant name never overlaps category header across screen sizes
- [ ] AuditionDisplay: circular ring drains clockwise, turns red at ≤10s
- [ ] AuditionDisplay: no UP NEXT section shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)